### PR TITLE
refactor(gui): drop the superseded "Auto-sort files" preference

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -620,8 +620,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -632,7 +632,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr ""
 
@@ -691,111 +691,111 @@ msgstr ""
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -929,14 +929,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -947,72 +947,72 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1169,7 +1169,7 @@ msgid "Disconnected"
 msgstr ""
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1322,19 +1322,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1361,7 +1361,7 @@ msgid "Queue Full"
 msgstr ""
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr ""
 
@@ -1552,7 +1552,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr ""
@@ -1627,45 +1627,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr ""
 
@@ -2536,57 +2536,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2701,7 +2701,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr ""
 
@@ -2719,7 +2719,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3131,8 +3131,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr ""
 
@@ -3272,7 +3272,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr ""
 
@@ -3378,7 +3378,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3387,15 +3387,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr ""
 
@@ -3633,7 +3633,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3707,7 +3707,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3727,7 +3727,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4045,7 +4045,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr ""
 
@@ -4161,413 +4161,405 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4575,11 +4567,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4589,222 +4581,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5162,187 +5154,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:52+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -631,8 +631,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -644,7 +644,7 @@ msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "فصل"
 
@@ -654,7 +654,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "إتصال"
 
@@ -704,112 +704,112 @@ msgstr "هل تريد حقا الخروج من البرنامج؟"
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "رسائل"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "احصائات"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "اعدادت"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -950,14 +950,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -968,73 +968,73 @@ msgstr ""
 msgid "Unknown"
 msgstr "غير معرف"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "بانتظار اﻻتصال ..."
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "طلب:"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 msgstr[1] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 msgstr[1] "إحصائية الملفات لهذة الجلسة: قبل %d من %d طلب , %s تم نقله \n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "طلب ملف غير معروف"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1191,7 +1191,7 @@ msgid "Disconnected"
 msgstr "فصل الإتصال"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1345,19 +1345,19 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1384,7 +1384,7 @@ msgid "Queue Full"
 msgstr "اﻻنتظار ممتلئ"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "في اﻻنتظار"
 
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "Size"
 msgstr "حجم"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "نقل"
 
@@ -1577,7 +1577,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "ذاتي"
@@ -1652,45 +1652,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr "&فتح الملف"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "تحميل (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "اصدقاء"
 
@@ -2567,57 +2567,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "اغلق"
 
@@ -2752,7 +2752,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "واضح"
@@ -3170,8 +3170,8 @@ msgstr "ايجاد المصدر :"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "غير متوفر"
 
@@ -3314,7 +3314,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "عنوان :"
 
@@ -3420,7 +3420,7 @@ msgstr "اسم المستخدم :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "اضف"
@@ -3429,15 +3429,15 @@ msgstr "اضف"
 msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "الحالي"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "معدل العمل"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "معدل الجلسة"
 
@@ -3676,7 +3676,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3750,7 +3750,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4088,7 +4088,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "اختر"
 
@@ -4206,417 +4206,409 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "عوامل اﻻتصال الخارجي"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "اقبل اتصال خارجي"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "زمن تحديث الصفحة (بالثانية)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr " Gzipتمكين ضغط نوع"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "موافق"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "تعليق :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "مجلد القادم"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "تغير الأولوية للملفات الحديثة :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "ﻻ تغير"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "قم بالضغط على هذا الزر لتحديث قائمة الخادمات من العنوان ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "قائمة الخادمات"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "عنوان شبكي :منفذ"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "اضف خادم يدويا )قم بمل الخانة على اليسار اوﻻ)..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "سجل aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "معلومات الخادم"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "الكل"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "تمكين التوقيع الشبكي"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "نسبة المصادر :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "مصدر"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4624,11 +4616,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4638,233 +4630,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "التحميل"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "ربط تلقائي عند بدء التشغيل"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "أكتسب بواسطة الضغط :"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&فتح الملف"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "إنتظار..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "رفع نشط :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 #, fuzzy
 msgid "Percent of total files"
 msgstr "مجموع الملفات"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "ملفات مشاركة"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "إختر فلتر العرض"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "رفع نشط"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "اعد تحميل"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "ارسل"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
 
@@ -5226,191 +5218,191 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "اﻹفتراضية بالنظام"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "العربيه"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "البلغاريه"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "الدانماركيه"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "الهولنديه"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "الفلنديه"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "الفرنسية"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "الألمانيه"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "الهنغاريه"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "الايطاليه"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "الكوريه"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "الليتوانيه"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "البرتغاليه"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "الأستونيه"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "الروسيه"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "الإسبانيه"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "الغة"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "غير متوفر"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:52+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -649,8 +649,8 @@ msgstr "Kad: Apagada"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -661,7 +661,7 @@ msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Desconeutar"
 
@@ -670,7 +670,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Coneutar"
 
@@ -721,112 +721,112 @@ msgstr "Daveres quies colar de aMule?"
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargues"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Ficheros compartíos"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Ensin rede"
 
@@ -965,14 +965,14 @@ msgstr "Enllaz non válidu o yá ta na llista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo direutoriu '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -983,72 +983,72 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 msgid "Unknown"
 msgstr "Desconocíu"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Guetando a un collaciu con conexón idbaxa"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versión Falsa eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Falsu eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsu eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basáu en eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nomatu:  %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitáu: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques de ficheru pa esta sesión: %d Aceutada de %d petición, %s tresfería\n"
 msgstr[1] "Estadístiques de ficheru pa esta sesión: %d Aceutaes de %d peticiones, %s tresferíes\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques de ficheru pa toles sesiones: %d Aceutada de %d petición, %s tresfería\n"
 msgstr[1] "Estadístiques de ficheru pa toles sesiones: %d Aceutaes de %d peticiones, %s tresferíes\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Solicitáu un ficheru desconocíu"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensax fieltráu de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nuevu mensax de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos del direutoriu %s-> Refugada"
@@ -1206,7 +1206,7 @@ msgid "Disconnected"
 msgstr "Desconeutáu"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1360,19 +1360,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1399,7 +1399,7 @@ msgid "Queue Full"
 msgstr "Cola enllena"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Na cola"
 
@@ -1464,7 +1464,7 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1536,7 +1536,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamañu"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Tresferío"
 
@@ -1593,7 +1593,7 @@ msgstr ""
 "Reaición dende: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1668,34 +1668,34 @@ msgstr "Asignar a categoría"
 msgid "&Open the file"
 msgstr "&Abrir el ficheru"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Introduza'l nuevu nome pa esti ficheru:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Renomar ficheru"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargues (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1704,11 +1704,11 @@ msgstr ""
 "Pa prevenir l'apaición d'esta alvertencia en cada vista previa,\n"
 "afita'l to reproductor de vídeos nes preferencies (%s por defeutu)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Previsualizar"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR:¡Fallu al executar un reproductor de medios esternu! Comandu: `%s'"
@@ -2273,7 +2273,7 @@ msgstr "¡ Nun pudo abrise'l ficheru de collacios 'emfriends.met' pa la so escri
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICU - ensin veceru en sesión charra d'aniciu"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Collacios"
 
@@ -2621,57 +2621,57 @@ msgstr[1] "Escritos %d contautos Kad"
 msgid "Kad user"
 msgstr "Rede Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nome ficheru"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Tamañu ficheru"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Media compartío"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Pidío"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Aceutao"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fontes completes"
 
@@ -2787,7 +2787,7 @@ msgid "WARNING: "
 msgstr "AVISU:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Zarrar"
 
@@ -2805,7 +2805,7 @@ msgid "Paste"
 msgstr "Apegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Llimpiar"
@@ -3227,8 +3227,8 @@ msgstr "Fontes completes"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3373,7 +3373,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Títulu :"
 
@@ -3482,7 +3482,7 @@ msgstr "Nome d'usuariu :"
 msgid "Userhash :"
 msgstr "Hash del usuariu :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Amestar"
@@ -3491,15 +3491,15 @@ msgstr "Amestar"
 msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Media d'execución"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3740,7 +3740,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Introduz el nome del to restolador. Déxalo ermo si quies usar el que hai por defeutu."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3814,7 +3814,7 @@ msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Namái usuarios avanzaos: Si tu tienes múltiples tarxetes de rede, introduz la direición de la tarxeta, que aMule tendrá d'usar."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Señes IP llocal de enllaz: (erma pa cualesquiera):"
@@ -3835,7 +3835,7 @@ msgstr "Máx. conexones al empar:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4155,7 +4155,7 @@ msgstr "Kad-nodos executando"
 msgid "Kad-nodes session"
 msgstr "Kad-nodos sesión"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Seleicionar"
 
@@ -4274,425 +4274,417 @@ msgstr "Planu"
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto-ordenar ficheros (Alta CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule ordenará automáticamente les columnes na to llista de descargues"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parámetros de conexón esterna"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Aceutar conexones esternes"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP de la interface que ta escuchando"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduz una IP válida de la interface que ta escuchando. Un campu ermu o 0.0.0.0 significará cualesquier interface."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar UPnP port forwarding nel puertu EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Puertu TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contraseña\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parámetros del sirvidor web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Aniciar sirvidor web al entamu"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Plantía Web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Contraseña alministrador"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Activar invitáu"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Contraseña invitáu"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Usar forwarding de puertos UPnP nel puertu del sirvidor web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puertu HTTP del sirvidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Tiempu d'actualización de páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Activar compresión gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Por defeutu"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Aceutar"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentariu : "
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Direutoriu entrante :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleiciona color pa esta categoría (seleicionada) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Calca esti botón pa llimpiar el registru."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de sirvidores dende una URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Llista de sirvidores"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduz la url a un ficheru server.met y calca'l botón de la esquierda p'actualizar la llista de sirvidores conocíos."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Amestar sirvidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Introduz el nome del nuevu sirvidor"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puertu"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Introduz el puertu del sirvidor"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Amestar manualmente un sirvidor (rellena los campos) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Rexistru"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Info. sirvidores"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Info ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Click nesti botón p'actualizar la llista de nodos dende la URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduz equí la url al ficheru nodes.dat y calca'l botón de la esquierda, p'actualizar la llista de nodos conocíos."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Coneutar"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nuevu nodu"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Puertu:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Coneutar dende \n"
 "veceros conocíos"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Desconeutar Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Usar Identificación Segura d'Usuariu"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Encamiéntase a activar esta opción. Nun recibirá créditos si la ISU (Identificación Segura d'Usuariu) nun ta habilitada."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Sofitu d'ofuscación de protocolu"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolu, y fai que aMule aceute conexones ofuscaes de otros veceros."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación pa conexones salientes"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use ofuscación de protocolu cuando se coneuten otros veceros/sirvidores."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Aceutar namái conexones ofuscaes"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esa opción fai que aMule namái aceute conexones ofuscaes. Tendrá menos fontes, pero tol so tráficu sedrá ofuscáu."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Toos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Dengún"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Quién pue adicar los mios ficheros compartíos:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleiciona quién pue solicitar adicar la nuesa llista de ficheros compartíos."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Fieltráu de IPs"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Fieltru veceros"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de veceros definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Fieltru sirvidores"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar fieltráu de IPs de sirvidores definíu nel ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar llista de fieltráu de IPs dende ficheru ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Nivel de fieltráu:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Fieltrar siempres IP's de LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Control paranoicu de IPs non comprobaes"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat de sistema si ta disponible"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si nun s'alcuentra un ficheru ipfilter.dat llocal, permitir l'usu d'un ficheru ipfilter de sistema"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Activar Robla online"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar la escritura de ficheros del SO, suel usase pa criar robles por aplicaciones esternes."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia d'actualización (segs):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de l'actualización de la robla-online"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Guardar ficheru de robla online en: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Click equí pa seleicionar el direutoriu que contién los ficheros de robles-online."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Fluxu de datos :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4700,11 +4692,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4714,232 +4706,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargáu:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar el fieltráu de IPs al entamu"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Fieltrar mensaxes entrantes (sacantes conversación actual):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Fieltrar tolos mensaxes"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Fieltrar mensaxes de xente que nun ta na to llista de collacios"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Fieltrar mensaxes de veceros desconocíos"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Fieltrar mensaxes que contienen (usa ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amiesta equí les pallabres que amule tien de fieltrar y bloquiar mensaxes incluyíos"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Amosar mensaxes recibíos nel rexistru"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fieltrar comentarios que contengan (usar ',' como separtador):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Habilitar autentificación"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nome d'usuariu:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar pa coneutar al proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Habilitar Proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Triba Proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Sirvidor Proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Puertu Proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "El puertu del proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Coneutar a:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nome usuariu:"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita mou estendíu de depuración al aniciu"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir el ficheru"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Mensaxes de categoríes:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Amestar imports"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Reintentar seleicionáu"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Desaniciar seleicionáu"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipos Eventos"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Anubre los ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Seleicionar fieltru de vistes"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Xubes actives"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Recargar llista"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Recargar los tos ficheros compartíos"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Unviar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Unviar un mensax específicu."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fich compartíos"
 
@@ -5299,191 +5291,191 @@ msgstr "Descargáu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Por defeutu"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturianu"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Búlgaru"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinu (simplificáu)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinu (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Checu"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estoniu"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Gallegu"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Griegu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebréu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Húngaru"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italianu"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreanu"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituanu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegu"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polacu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rusu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Eslovenu"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suecu"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turcu"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucranianu"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Llingua: "
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Non disponible"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "opciones non disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Puertu TCP nun pue ser más altu de 65532 darréu que'l socket del sirvidor UDP ye TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puertu por defeutu que s'usará (%d)"
@@ -8452,6 +8444,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto-ordenar ficheros (Alta CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule ordenará automáticamente les columnes na to llista de descargues"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Refugar paquetes si la ip del veceru ye diferente de la ip dende au el paquete ye recibíu. Usar con curiáu."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:52+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -629,8 +629,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -642,7 +642,7 @@ msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Разкачи"
 
@@ -652,7 +652,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Връзка"
 
@@ -702,112 +702,112 @@ msgstr "Наистина ли желаете да изключите aМуле?"
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Съобщения"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Няма мрежа"
 
@@ -945,14 +945,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -963,73 +963,73 @@ msgstr ""
 msgid "Unknown"
 msgstr "Неизвестен"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "изчакване за свързване..."
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Fake съревновавам)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "Поискан:"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 msgstr[1] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 msgstr[1] "Статистика за текущата сесия : Приети %d от %d заявки,%s осъществени\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Заявен е несъществуващ файл"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1186,7 +1186,7 @@ msgid "Disconnected"
 msgstr "Връзката е разпадната"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1340,19 +1340,19 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1379,7 +1379,7 @@ msgid "Queue Full"
 msgstr "Опашката е пълна"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "На опашката"
 
@@ -1444,7 +1444,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1515,7 +1515,7 @@ msgstr ""
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Пренесен"
 
@@ -1572,7 +1572,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Автоматично"
@@ -1647,45 +1647,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Файлове за сваляне (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2222,7 +2222,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Приятели"
 
@@ -2561,57 +2561,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Име на файл"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Размер на файла"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "признат"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2727,7 +2727,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Затвори"
 
@@ -2745,7 +2745,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Изчисти"
@@ -3162,8 +3162,8 @@ msgstr "Намерени източници: %i"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Няма"
 
@@ -3305,7 +3305,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Заглавие :"
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавяне"
@@ -3420,15 +3420,15 @@ msgstr "Добавяне"
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Текущ"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3741,7 +3741,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3761,7 +3761,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4080,7 +4080,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Избор"
 
@@ -4196,415 +4196,407 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "парола"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Всеки"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Източници"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4612,11 +4604,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4626,229 +4618,229 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Изтегляне"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Изчакване"
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Общо файлове"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Всички файлове"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Избор на филтър"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Активни качвания: %i"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Качване"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Изпраща"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5208,187 +5200,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "албанец"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "арабски"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Астурия"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "баска"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "български"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Каталунски"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Китайски (опростен)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Китайски (традиционен)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "хърватски"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "чешки"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "датски"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "холандски"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "естонски"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "фински"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Френски"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "галисийски"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Немски"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Гръцки"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "иврит"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "унгарски"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Италиански"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "японски"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "корейски"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "литовски"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "норвежки (Съвременен)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "полски"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "португалски"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "португалски (бразилски)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "румънски"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Руски"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "словенски"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "шведски"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Турски"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "украински"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Смени езика"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -619,8 +619,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -631,7 +631,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr ""
 
@@ -690,111 +690,111 @@ msgstr ""
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -928,14 +928,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -946,72 +946,72 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1168,7 +1168,7 @@ msgid "Disconnected"
 msgstr ""
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1321,19 +1321,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1360,7 +1360,7 @@ msgid "Queue Full"
 msgstr ""
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr ""
@@ -1626,45 +1626,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr ""
 
@@ -2535,57 +2535,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2700,7 +2700,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3130,8 +3130,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr ""
 
@@ -3271,7 +3271,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3386,15 +3386,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr ""
 
@@ -3632,7 +3632,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3706,7 +3706,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3726,7 +3726,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4044,7 +4044,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr ""
 
@@ -4160,413 +4160,405 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4574,11 +4566,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4588,222 +4580,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5161,187 +5153,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:53+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -649,8 +649,8 @@ msgstr "Kad: Inativa"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -661,7 +661,7 @@ msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Desconnecta"
 
@@ -670,7 +670,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Connecta"
 
@@ -720,111 +720,111 @@ msgstr "Esteu segur que voleu eixir de %s?"
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Xarxes"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Baixades"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Compartits"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Missatges"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadístiques"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferències"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Cap xarxa"
 
@@ -963,14 +963,14 @@ msgstr "L'enllaç és invàlid o ja és present a la llista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantindrà el directori '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -981,72 +981,72 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Buscant amic per connexió amb ID Baixa"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versió d'eMule falsa %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (eMule fals)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule fals)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basat en l'eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Sobrenom: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Demanat: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques dels fitxers per a aquesta sessió: %d petició acceptada de %d, %s transferida\n"
 msgstr[1] "Estadístiques dels fitxers per a aquesta sessió: %d peticions acceptades de %d, %s transferides\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadístiques dels fitxers per a totes les sessions: %d petició acceptada de %d, %s transferida\n"
 msgstr[1] "Estadístiques dels fitxers per a totes les sessions: %d peticions acceptades de %d, %s transferides\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "S'ha demanat un fitxer desconegut"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Missatge filtrat de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nou missatge de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'usuari %s (%u) ha demanat la llista de fitxers compartits del directori inexistent '%s' -> Ignorat"
@@ -1203,7 +1203,7 @@ msgid "Disconnected"
 msgstr "Desconnectat"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1357,19 +1357,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1396,7 +1396,7 @@ msgid "Queue Full"
 msgstr "Cua plena"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Cua"
 
@@ -1461,7 +1461,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Part"
 msgid "Size"
 msgstr "Mida"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferit"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "Retroacció des de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1665,34 +1665,34 @@ msgstr "Assigna a una categoria"
 msgid "&Open the file"
 msgstr "&Obre el fitxer"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Introduïu un nom nou per al fitxer:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Reanomena"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%d/%m/%y %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Baixades (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1701,11 +1701,11 @@ msgstr ""
 "Per a evitar que en cada previsualització aparegui aquest avís, configureu\n"
 "un reproductor de vídeo a les preferències (per defecte s'usa %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Previsualització"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR: No s'ha pogut executar un reproductor multimèdia extern! Ordre: `%s'"
@@ -2267,7 +2267,7 @@ msgstr "No s'ha pogut obrir el fitxer amb la llista d'amics 'emfriends.met' per 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - no hi ha client a l'Inici de Sessió del Xat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amics"
 
@@ -2611,57 +2611,57 @@ msgstr[1] "S'han escrit %d contactes Kad"
 msgid "Kad user"
 msgstr "Xarxa Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nom del fitxer"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Mida"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Ràtio"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Peticions"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Acceptades"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fonts completes"
 
@@ -2777,7 +2777,7 @@ msgid "WARNING: "
 msgstr "AVÍS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Tanca"
 
@@ -2795,7 +2795,7 @@ msgid "Paste"
 msgstr "Enganxa"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Neteja"
@@ -3216,8 +3216,8 @@ msgstr "Fonts del fitxer:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/D"
 
@@ -3362,7 +3362,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Títol:"
 
@@ -3471,7 +3471,7 @@ msgstr "Usuari:"
 msgid "Userhash :"
 msgstr "Resum de l'usuari:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Afegeix"
@@ -3480,15 +3480,15 @@ msgstr "Afegeix"
 msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Mitjana total"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Mitjana de la sessió"
 
@@ -3728,7 +3728,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Introdueix el nom del teu navegador. Deixa el camp buit per usar el navegador per defecte del sistema."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3802,7 +3802,7 @@ msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Només usuaris avançats: Si disposeu de multiples interfícies de xarxa, entreu l'adreça de la interfície a la que l'aMule hauria d'estar vinculada."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincula l'adreça local a l'IP (buit per qualsevol):"
@@ -3823,7 +3823,7 @@ msgstr "Nombre màxim de connexions simultànies:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4143,7 +4143,7 @@ msgstr "Nodes-Kad funcionant"
 msgid "Kad-nodes session"
 msgstr "Nodes-Kad de la sessió"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Selecciona"
 
@@ -4261,421 +4261,413 @@ msgstr "Plana"
 msgid "Round"
 msgstr "Arrodonida"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto ordena els fitxers (Alta CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "L'aMule ordenarà automàticament les columnes de la llista de baixades"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Paràmetres de la connexió externa "
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Accepta connexions externes"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP de la interfície que rep connexions:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduïu una IP vàlida amb format a.b.c.d per a la interfície EC que escolta. Un camp buit o 0.0.0.0 significarà qualsevol interfície."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activa l'encaminament UPnP al port de connexions externes"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasenya"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "S'està comprovant la contrasenya\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Paràmetres del servidor web "
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executa el servidor web a l'inici"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Contrasenya de l'administrador:"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Habilita l'usuari convidat"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Contrasenya del convidat:"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activa redirecció de ports UPnP en el port del servidor web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP del servidor web (Opcional):"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Temps de refresc de la pàgina (en segons):"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Habilita la compressió Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminat"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Feu clic per a aplicar qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentari:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Dir. d'entrada:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Canvia la prioritat per als nous fitxers assignats:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "No canviar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Feu clic per a reiniciar el registre."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de servidors des d'una URL ... "
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Llista de servidors"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduïu l'adreça d'un fitxer server.met i premeu el botó de l'esquerra per a actualitzar la llista de servidors coneguts."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Afegeix un servidor manualment: Nom"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Introduïu el nom del nou servidor"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Introduïu el port del servidor."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Afegeix un servidor manualment (abans omple els camps de l'esquerra) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Registre de l'aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Informació del servidor"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Feu clic en aquest botó per a actualitzar la llista de nodes des d'una URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduïu la URL d'un fitxer nodes.dat i premeu el botó de l'esquerra per a actualitzar la llista de nodes coneguts."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Arrancada"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nou node"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Inicia des dels clients coneguts"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Desconnecta Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Usa la Identificació Segura d'Usuari"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es recomana activar aquesta opció. No rebreu crèdits (punts) si la Identificació Segura d'Usuari no és habilitada."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Suport per a l'ofuscació de protocol"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Habilita l'ofuscació de protocol, i permet a l'aMule acceptar connexions ofuscades d'altres clients."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usa l'ofuscació per a les connexions sortints"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "L'aMule usarà l'ofuscació de protocol en connectar amb altres clients/servidors."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Accepta únicament les connexions ofuscades"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "L'aMule només acceptarà les connexions ofuscades. Tindreu menys fonts, però tot el tràfic serà ofuscat"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Tothom"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Ningú"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Qui pot veure els meus fitxers compartits:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecciona qui pot veure la llista de fitxers compartits."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtratge IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtra els clients"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de clients especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtra els servidors"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilita el filtratge de les IP de servidors especificades al fitxer ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recarrega la llista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarrega la llista d'IPs a filtrar des del fitxer ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "Adreça:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Actualitza ara"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Nivell de filtratge:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre les IP LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestió paranoica de les IP no corresponents"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat del sistema si està disponible"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no es troba l'ipfilter.dat local, permet l'ús del fitxer ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Habilita la signatura en línia"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita l'escriptura del fitxer de signatura, que altres aplicacions externes poden usar per a crear signatures i similars."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Freqüència d'actualització (segs):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Canvia la freqüència d'actualització (en segons) de la signatura en línia."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Desa el fitxer de signatura en línia a: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Feu clic per a seleccionar el directori que conté els fitxers de signatura en línia."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Mostra les banderes dels països per als clients"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Velocitat:"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Fonts"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4683,11 +4675,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4697,225 +4689,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Baixant: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualitza automàticament a l'inici"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra els missatges entrants (excepte el xat actual):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtra tots els missatges"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra els missatges de la gent que no és a la llista d'amics"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtra els missatges dels clients desconeguts"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra els missatges que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Els missatges que continguin aquestes paraules seran filtrats i bloquejats per l'aMule"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Mostra els missatges rebuts en el registre"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentaris"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra els comentaris que continguin (useu ',' per a separar):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Habilita l'autenticació"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nom d'usuari:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Contrasenya:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "La contrasenya per a connectar al servidor intermediari"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Habilita el servidor intermediari"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tipus de servidor:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Servidor intermediari:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Port del servidor:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "El port del servidor intermediari"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Connecta a:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nom d'usuari"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usa la compressió gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilita la depuració-registre detallats."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Només al fitxer de registre"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categories de missatge:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperant..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Afegeix"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Reintenta"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Esborra"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipus d'esdeveniments"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadístiques i clients en cua per als fitxers seleccionats: Sessió / Total"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Pujades actives"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Percentatge del total de fitxers"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Tots els fitxers"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Fitxers seleccionats"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Només pujades actives"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Recarrega:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Recarrega els compartits"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Envia"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Envia el missatge especificat."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Connecta amb qualsevol servidor i/o Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartits"
 
@@ -5276,188 +5268,188 @@ msgstr "Baixat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Predeterminat"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanès"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Àrab"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturià"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basc"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Búlgar"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Català; Valencià"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Xinès (Simplificat)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Xinès (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croat"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Txec"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danès"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandès"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglès (R.U.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonià"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finès"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francès"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Gallec"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemany"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italià"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonès"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreà"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituà"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruec"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polonès"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portuguès"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portuguès (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Romanès"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rus"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Eslovè"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Espanyol; Castellà"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suec"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucranià"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Canvi d'idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "No hi ha traduccions instal·lades per a l'aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Sense idiomes disponibles"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El port TCP no pot ser més gran que 65532 puix el sòcol UDP del servidor és TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "S'usarà el port per defecte (%d)"
@@ -8394,6 +8386,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto ordena els fitxers (Alta CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "L'aMule ordenarà automàticament les columnes de la llista de baixades"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rebutja el paquet si l'IP del client és diferent de l'IP on es rep el paquet. Useu amb prudència."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-25 19:02+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -645,8 +645,8 @@ msgstr "Kad: vypnut"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -657,7 +657,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Odpojit"
 
@@ -666,7 +666,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Připojit"
 
@@ -717,111 +717,111 @@ msgstr "Opravdu si přejete ukončit %s?"
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Sítě"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Sdílené soubory"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Zprávy"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Žádná síť"
 
@@ -960,14 +960,14 @@ msgstr "Neplatný odkaz, nebo je již v seznamu."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -978,44 +978,44 @@ msgstr ""
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Hledám kamaráda pro LowID připojení"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (falešná eMule verze %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (falešná eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (falešná eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (založeno na eMule v.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Přezdívka: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Vyžádáno: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1023,7 +1023,7 @@ msgstr[0] "Statistika souboru pro toto sezení: Přijat %d z %d požadavku, %s p
 msgstr[1] "Statistika souboru pro toto sezení: Přijato %d z %d požadavků, %s přeneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1031,21 +1031,21 @@ msgstr[0] "Statistika souboru pro všechna sezení: Přijat %d z %d požadavku, 
 msgstr[1] "Statistika souboru pro všechna sezení: Přijato %d z %d požadavků, %s přeneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Vyžádán neznámý soubor"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Zpráva od '%s' filtrována (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nová zpráva od '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Uživatel %s (%u) si vyžádal váš seznam sdílených souborů v adresáři %s -> zakázáno"
@@ -1204,7 +1204,7 @@ msgid "Disconnected"
 msgstr "Odpojeno"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1359,19 +1359,19 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1398,7 +1398,7 @@ msgid "Queue Full"
 msgstr "Plná fronta"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Ve frontě"
 
@@ -1463,7 +1463,7 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1535,7 +1535,7 @@ msgstr "Část"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Přeneseno"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Odezva od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1667,45 +1667,45 @@ msgstr "Zařadit do kategorie"
 msgid "&Open the file"
 msgstr "&Otevřít tento soubor"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Zadejte nový název pro tento soubor:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Přejmenování souboru"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Stahování (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Náhled souboru"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "CHYBA: Nezdařilo se spustit externí přehrávač! Příkaz: `%s'"
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Kamarádi"
 
@@ -2604,57 +2604,57 @@ msgstr[2] ""
 msgid "Kad user"
 msgstr "Síť Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Název souboru"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Velikost souboru"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Poměr sdílení"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Vyžádáno"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Přijato"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Kompletní zdroje"
 
@@ -2772,7 +2772,7 @@ msgid "WARNING: "
 msgstr "VAROVÁNÍ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2790,7 +2790,7 @@ msgid "Paste"
 msgstr "Vložit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Vyprázdnit"
@@ -3211,8 +3211,8 @@ msgstr "Zdroje souboru:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3357,7 +3357,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titulek:"
 
@@ -3464,7 +3464,7 @@ msgstr "Uživatelské jméno:"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Přidat"
@@ -3473,15 +3473,15 @@ msgstr "Přidat"
 msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Průměr sezení"
 
@@ -3722,7 +3722,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3816,7 +3816,7 @@ msgstr "Maximum připojení naráz:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4136,7 +4136,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Vyberte"
 
@@ -4255,421 +4255,413 @@ msgstr "Plochý"
 msgid "Round"
 msgstr "Kulatý"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Automaticky řadit soubory (žere CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule automaticky seřadí kolonky ve vaší frontě stahování"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Nastavení externího připojení"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Přijímat externí připojení"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP naslouchajícího zařízení:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Povolit UPnP port forwarding na EC portu"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Heslo"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrola hesla\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parametry webserveru"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spustit webserver při spuštění aMule"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Šablona webu"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Heslo pro plná práva"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Povolit uživatele s omezenými právy"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Heslo pro omezená práva"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Povolit UPnP port forwarding portu webserveru"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP port webserveru (volitelné)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Obnovování stránky (v sek.)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Povoliz Gzip kompresi"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Výchozí pro systém"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Budiž"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikněte zde pro aplikování změn nastavení."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Zahodí všechny změny v nastavení."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komentář:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Příchozí adresář:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Změnit prioritu pro nově přiřazené soubory:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Neměnit"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Barva pro tuto kategorii:"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Klikněte na toto tlačítko pro vynulování logu."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Seznam serverů"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Přidat server ručně: Název"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Zadejte název serveru"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Zadejte port serveru."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Log aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Info o serveru"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Aktualizuje seznam uzlů z dané URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Uzly (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nový uzel"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap od známých klientů"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Odpojit Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Použít bezpečnou uživatelskou identifikaci"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Podporuje zatemnění protokolu"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Použít zatemnění protokolu pro odchozí spojení"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Přijímat pouze zatemněná spojení"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Všichni"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nikdo"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Kdo může prohlížet moje sdílené soubory:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP filtrování"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrovat klienty"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrovat servery"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Obnovit seznam"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Obnovit"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Úroveň filtrování:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Vždy filtrovat LAN IP"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidní nakládání s nesouhlasícími IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Použít systémový ipfilter.dat, je-li dostupný"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Neexistuje-li místní ipfilter.dat, umožní použití systémového."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Povolit online podpis"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Prodleva aktualizace (sek.):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Zdroje"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4677,11 +4669,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4691,230 +4683,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Stahování: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automaticky aktualizovat IP filtr po spuštění"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrovat všechny zprávy"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrovat zprávy, které nejsou od přátel"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrovat zprávy od neznámých klientů"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrovat zprávy obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "zadejte slova, která by měla amule filtrovat a blokovat zprávy obsahující je"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Komentáře"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrovat komentáře obsahující (použijte ',' jako oddělovač):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Povolit autentizaci"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Uživatelské jméno: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Heslo:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Heslo, které se použije pro přihlášení k proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Povolit proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Hostitel proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Port proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Připojit se k:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Uživatelské jméno"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Použít gzip kompresi"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otevřít tento soubor"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čekání..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Odstranit vybrané"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Všechny sdílené soubory"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Sdílené soubory"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivní odesílání"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Obnovit:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Znovu načíst vaše sdílené soubory"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Odeslat"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Odešle zadanou zprávu."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Sdílené soubory"
 
@@ -5278,189 +5270,189 @@ msgstr "Staženo"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Výchozí pro systém"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albánština"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabský"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskičtina"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulharský"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalánština"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Čínština (zjednodušená)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Čínština (tradiční)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Chorvatština"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Česky"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dánština"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nizozemština"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angličtina (britská)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonština"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finština"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francouzština"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galicijština"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Němčina"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Řečtina"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebrejština"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Maďarština"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italština"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonština"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korejština"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litevština"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norština"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polština"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugalština"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalština (brazilská)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumunština"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ruština"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovinština"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Španělština"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Švédština"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turečtina"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukrajinština"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Změnit jazyk"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Nedostupný"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port nemůže být vyšší než 65532, protože UDP port je TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bude použit výchozí port (%d)"
@@ -8386,6 +8378,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Automaticky řadit soubory (žere CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule automaticky seřadí kolonky ve vaší frontě stahování"
 
 #~ msgid "Return the results of the previous search.\n"
 #~ msgstr "Zobrazí výsledky posledního vyhledávání.\n"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:53+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -634,8 +634,8 @@ msgstr " Kad: "
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -647,7 +647,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Afbryd"
 
@@ -657,7 +657,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Forbind"
 
@@ -707,112 +707,112 @@ msgstr "Vil du virkelig afslutte aMule?"
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Beskeder"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -953,14 +953,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -971,73 +971,73 @@ msgstr ""
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "venter pÃ¥ forbindelse..."
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Falsk eMule version-%#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " Falsk eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsk eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseret på eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "Anmodede:"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Anmodet om ukendt fil"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Bruger %s (%u) anmodede om din deleliste -> %s"
@@ -1194,7 +1194,7 @@ msgid "Disconnected"
 msgstr "Afbrudt"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1348,19 +1348,19 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1387,7 +1387,7 @@ msgid "Queue Full"
 msgstr "Kø Fuld"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "I Kø"
 
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Size"
 msgstr "Størrelse"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1580,7 +1580,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1655,45 +1655,45 @@ msgstr "Flyt til kategori"
 msgid "&Open the file"
 msgstr "&Åben filen"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Indtast nyt navn for denne fil:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Omdøb fil"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.2f MB"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2230,7 +2230,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Venner"
 
@@ -2573,57 +2573,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr "Kad startet."
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2741,7 +2741,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Luk"
 
@@ -2759,7 +2759,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ryd"
@@ -3179,8 +3179,8 @@ msgstr "Fundne Kilder :"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3324,7 +3324,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3431,7 +3431,7 @@ msgstr "Brugernavn :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Tilføj"
@@ -3440,15 +3440,15 @@ msgstr "Tilføj"
 msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Nuværende"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Nuværende Gennemsnit"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Sessions Gennemsnit"
 
@@ -3687,7 +3687,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3761,7 +3761,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4099,7 +4099,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Vælg"
 
@@ -4218,417 +4218,409 @@ msgstr "Flad"
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Ydre Forbindelses Parametre"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Accepter ydre forbindelser"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "UPnP port"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Undersøger password\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Fuld rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Aktiver lav rettigheds brugere"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Lav rettigheds kodeord"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Side Opdaterings Tid (i sek)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Aktiver Gzip komprimering"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "System standard"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Indkommende Mappe :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Tryk på denne knap for at opdatere serverlisten fra URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Server Info"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Aktiver online-signatur"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Kilder"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4636,11 +4628,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4650,232 +4642,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto forbind ved start"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Brug gzip komprimering"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Åben filen"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Venter..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Antal Filer Total"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Delte Filer"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Slettede Servere"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Opdater"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte Filer"
 
@@ -5237,191 +5229,191 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "System standard"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabic"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgarian"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danish"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Dutch"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "French"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "German"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italian"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korean"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lithuanian"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polish"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portuguese"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Estonian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russian"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spanish"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Sprog"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikke tilgængelig"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:54+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -656,8 +656,8 @@ msgstr "Kad: aus"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -668,7 +668,7 @@ msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Trennen"
 
@@ -677,7 +677,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -727,111 +727,111 @@ msgstr "%s wirklich beenden?"
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Netzwerke"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Freigegebene Dateien"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Kein Netzwerk"
 
@@ -972,14 +972,14 @@ msgstr "Ungültiger Verweis oder schon auf der Liste"
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nutze weiter das Verzeichnis '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -990,72 +990,72 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Suche Kumpel für Verbindung mit niedriger ID"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Fake eMule version %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Fake eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Fake eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basiert auf eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Spitzname: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Angefordert: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Dateistatistik dieser Sitzung: %d von %d Anfrage akzeptiert, %s übertragen\n"
 msgstr[1] "Dateistatistik dieser Sitzung: %d von %d Anfragen akzeptiert, %s übertragen\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Dateistatistik aller Sitzungen: %d von %d Anfrage akzeptiert, %s übertragen\n"
 msgstr[1] "Dateistatistik aller Sitzungen: %d von %d Anfragen akzeptiert, %s übertragen\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Unbekannte Datei angefordert"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Nachricht gefiltert von '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Neue Nachricht von '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Benutzer %s (%u) hat die Liste freigegebener Dateien für das nicht vorhandene Verzeichnis '%s' angefordert -> Ignoriert"
@@ -1212,7 +1212,7 @@ msgid "Disconnected"
 msgstr "Verbindung getrennt"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1366,19 +1366,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1405,7 +1405,7 @@ msgid "Queue Full"
 msgstr "Warteschlange voll"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "in Warteschlange"
 
@@ -1470,7 +1470,7 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1541,7 +1541,7 @@ msgstr "Teil"
 msgid "Size"
 msgstr "Größe"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Übertragen"
 
@@ -1598,7 +1598,7 @@ msgstr ""
 "Rückmeldung von: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatisch"
@@ -1673,34 +1673,34 @@ msgstr "Einer Kategorie hinzufügen"
 msgid "&Open the file"
 msgstr "&Oeffne diese Datei"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Einen neuen Namen für diese Datei eingeben:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Datei umbenennen"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1709,11 +1709,11 @@ msgstr ""
 "Bitte trage deinen bevorzugten Videoplayer in den Einstellungen ein.\n"
 "Bis dahin wird aMule versuchen, %s zu starten, und bei jeder Vorschau wird diese Warnung angezeigt werden."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Dateivorschau"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEHLER: Konnte externen Mediaplayer nicht starten!Befehl: `%s'"
@@ -2273,7 +2273,7 @@ msgstr "Konnte Freundes-Liste 'emfriends.met' nicht schreiben!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISCH - kein Client bei StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Freunde"
 
@@ -2616,57 +2616,57 @@ msgstr[1] "%d Kad-Kontakte geschrieben."
 msgid "Kad user"
 msgstr "Kad-Netzwerk"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Dateiname"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Dateigröße"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Tauschverhältnis"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Angefordert"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Akzeptiert"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "vollständige Quellen"
 
@@ -2782,7 +2782,7 @@ msgid "WARNING: "
 msgstr "WARNUNG: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Schließen"
 
@@ -2800,7 +2800,7 @@ msgid "Paste"
 msgstr "Einfügen"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Leeren"
@@ -3214,8 +3214,8 @@ msgstr "Dateiquellen:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
@@ -3360,7 +3360,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titel:"
 
@@ -3469,7 +3469,7 @@ msgstr "Benutzername:"
 msgid "Userhash :"
 msgstr "Benutzerprüfsumme:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hinzufügen"
@@ -3478,15 +3478,15 @@ msgstr "Hinzufügen"
 msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "gleitender Mittelwert"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Sitzungsdurchschnitt"
 
@@ -3726,7 +3726,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Gib den Namen des gewünschten Browsers hier ein. Bei einem leeren Feld wird der voreingestellte Systembrowser benutzt."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3800,7 +3800,7 @@ msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Nur für fortgeschrittene Benutzer: Wenn es mehrere Netzwerkverbindungen gibt, hier die Adresse der Verbindung, mit der aMule verknüpft werden soll, eingeben."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Verknüpfe lokale Adresse mit IP (Leer für beliebige):"
@@ -3821,7 +3821,7 @@ msgstr "Maximale gleichzeitige Verbindungen:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4141,7 +4141,7 @@ msgstr "Laufende Kad-Knoten"
 msgid "Kad-nodes session"
 msgstr "Kad-Knoten Sitzung"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Auswahl"
 
@@ -4259,420 +4259,412 @@ msgstr "Flach"
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "sortiere Dateien automatisch (hohe CPU-Auslastung)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule sortiert automatisch die Spalten der Downloadliste"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parameter für externe Verbindungen"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Externe Verbindungen annehmen"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP der lauschenden Schnittstelle:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Hier eine gültige IP im Format a.b.c.d für das lauschende EC-Interface eingeben. Ein leeres Feld oder 0.0.0.0 bedeutet ein beliebiges Interface."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung zu EC-Port"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passwort"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-Port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Prüfe Passwort\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Webserver-Parameter"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Starte Webserver mit aMule"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Webvorlage"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Kennwort für Vollzugriff"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Eingeschränkten Benutzer aktivieren"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Kennwort für eingeschränkten Zugriff"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktiviere UPnP-Port-Weiterleitung des Webserverports"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserver UPnP-TCP-Port (optional)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Aktualisierungsintervall in Sekunden"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Gzip-Kompression an"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemvorgabe"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hier klicken, um alle Einstellungsänderungen zu übernehmen."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Kommentar:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Verzeichnis für eingehende Dateien:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Nicht ändern"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Drücke diesen Knopf, um das Log zurückzusetzen."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Hier klicken, um die Serverliste über die angegebene URL zu aktualisieren"
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Serverliste"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Hier die URL einer server.met eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Serverliste zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Server manuell hinzufügen: Name"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Gib den Namen das neuen Servers hier ein"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Hier den Serverport eingeben."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Einen Server manuell hinzufügen (vorher bitte links die Felder ausfüllen)..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule-Log"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "eD2k-Info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Zum Aktualisieren der nodes.dat von URL diese Schaltfläche drücken."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Knoten (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Hier die URL einer nodes.dat eingeben, und dann den Knopf links vom Eingabefeld drücken, um die Liste der bekannten Knoten zu aktualisieren."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Neuer Knoten"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap von bekannten Clients"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Kad trennen"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Benutze sichere Benutzeridentifikation"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Es wird empfohlen diese Option zu aktivieren. Du wirst keine Credits erhalten, wenn SUI nicht aktiviert ist."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Unterstütze Protokollverschleierung"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Diese Option aktiviert die Protokollverschleierung und verfügt aMule, verschleierte Verbindungen von anderen Clients anzunehmen."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Verschleiere ausgehende Verbindungen"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Diese Option verfügt aMule, Protokollverschleierung zu verwenden bei der Verbindung zu anderen Clients und/oder Servern."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Akzeptiere ausschließlich verschleierte Verbindungen"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Diese Option verfügt aMule, ausschließlich verschleierte Verbindungen zu akzeptieren. Das führt zu weniger Quellen, jedoch ist sämtlicher Verkehr verschleiert."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Jeder"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Wer kann freigegebene Dateien sehen:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wähle, wer deine freigegebenen Dateien einsehen darf."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-Filterung"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtere Clients"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere die Filterung von Client-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtere Server"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktiviere das Filtern von Server-IPs, die in der Datei ~/.aMule/ipfilter.dat definiert sind."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Aktualisieren der Liste"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Aktualisiert die Liste der zu filternden IPs in der ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Jetzt aktualisieren"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Filterstufe:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "LAN-IP-Adressen immer filtern"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoides Handhaben nicht-passender IP-Adressen"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Erlaube die Benutzung der systemweiten ipfilter-Datei, falls keine lokale ipfilter.dat gefunden wird."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Online-Signatur aktivieren"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiviert das Schreiben der Online-Signaturdatei, die von externen Programmen verwendet werden kann, um Signaturen o.ä. zu erstellen."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Aktualisierungsintervall (Sekunden):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändern des Online-Signatur-Aktualisierungsintervalls (in Sekunden)."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Speichere Online-Signatur-Datei in:"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Hier klicken, um das Verzeichnis mit den Dateien für die Online-Signatur auszuwählen."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Landesflaggen für Clients anzeigen"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Datenrate:"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Quellen"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4680,11 +4672,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4694,224 +4686,224 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "IP-Filter beim Start automatisch aktualisieren"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Eingehende Nachrichten filtern (außer momentanen Chats):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtere alle Nachrichten"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtere Nachrichten von Benutzern, die nicht auf deiner Freundesliste stehen"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtere Nachrichten von unbekannten Clients"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtere Nachrichten, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Hier die Worte eingeben, die aMule filtern soll, und um Nachrichten abzuweisen, in denen sie vorkommen"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Zeige empfangene Nachrichten im Log an"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Kommentare"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtere Komentare, die folgende Worte enthalten (benutze ',' als Trenner):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Authentifizierung aktivieren"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Benutzername:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Passwort:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-Verbindungspasswort"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Proxy aktivieren"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Proxy-Typ:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Proxy-Host:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Proxy-Port:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Der Port des Proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Verbinde zu:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Benutzername"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "ZLIB-Kompression erzwingen"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Nur in Logdatei"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Nachrichtenkategorien:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wartend..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Füge Importe hinzu"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Versuche Ausgewähltes noch einmal"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Auswahl entfernen"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Ereignisarten"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiken und Clients in der Warteschlange für ausgewählte Datei(en): Sitzung / Insgesamt"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Prozent aller Dateien"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Ausgewählte Dateien"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Nur aktive Uploads"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Aktualisieren:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Freigegebene Dateien neu laden"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Senden"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Sendet die angegebene Nachricht."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Freigaben"
 
@@ -5271,188 +5263,188 @@ msgstr "Heruntergeladen"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Systemvorgabe"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinesisch (vereinfacht)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dänisch"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holländisch"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englisch (UK)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Französisch"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galizisch"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Deutsch"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Griechisch"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italienisch"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norwegisch"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polnisch"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugiesisch (Brasilianisch)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Sprache ändern"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Für aMule sind keine Übersetzungen installiert"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Keine Sprachen verfügbar"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-Port kann nicht größer als 65532 sein, da der Server-UDP-Port=TCP-Port+3 ist"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standard-Port wird verwendet (%d)"
@@ -8407,6 +8399,12 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "sortiere Dateien automatisch (hohe CPU-Auslastung)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule sortiert automatisch die Spalten der Downloadliste"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Weise Paket zurück, wenn die Client-IP abweicht von der IP, von der das Paket empfangen wurde. Mit Vorsicht zu benutzen."

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:54+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -654,8 +654,8 @@ msgstr "Kad: Εκτός"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -666,7 +666,7 @@ msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
@@ -675,7 +675,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Σύνδεση"
 
@@ -726,112 +726,112 @@ msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Δίκτυα"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Μηνύματα"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Στατιστικές"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 
@@ -974,14 +974,14 @@ msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -992,72 +992,72 @@ msgstr ""
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Πλασματική έκδοση eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Πλασματικό eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Πλασματικό eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (βασισμένο στο eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Παρατσούκλι: %s Ταυτότητα: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Ζητήθηκε: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Στατιστικές αρχείων για αυτή τη συνεδρία: Δεκτό %d από %d αίτηση, %s μεταφέρθηκε\n"
 msgstr[1] "Στατιστικές αρχείων για αυτή τη συνεδρία: Δεκτά %d από %d αίτησεις, %s μεταφέρθηκαν\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Στατιστικές αρχείων για όλες τις συνεδρίες: Δεκτό %d από %d αίτηση, %s μεταφέρθηκε\n"
 msgstr[1] "Στατιστικές αρχείων για όλες τις συνεδρίες: Δεκτά %d από %d αίτησεις, %s μεταφέρθηκαν\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Αναζητήθηκε άγνωστο αρχείο"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Φιλτραρίστηκε το μήνυμα από τον '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Καινούριο μήνυμα από τον '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Ο χρήστης %s (%u) ζήτησε λίστα κοινόχρηστων αρχείων του κατάλογου %s -> Απορρίφθηκε"
@@ -1215,7 +1215,7 @@ msgid "Disconnected"
 msgstr "Αποσυνδεδεμένο"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1368,19 +1368,19 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1407,7 +1407,7 @@ msgid "Queue Full"
 msgstr "Ουρά γεμάτη"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Εν αναμονή"
 
@@ -1472,7 +1472,7 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1544,7 +1544,7 @@ msgstr "Μέρος"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
@@ -1601,7 +1601,7 @@ msgstr ""
 "Αντίδραση από %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Αυτόματη"
@@ -1676,34 +1676,34 @@ msgstr "Ανάθεση σε κατηγορία"
 msgid "&Open the file"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Δώστε νέο όνομα γι αυτό το αρχείο:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Μετονομασία αρχείου"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Κατεβασμένα (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1712,11 +1712,11 @@ msgstr ""
 "Για να μην εμφανίζεται αυτή η προειδοποίηση σε κάθε προεπισκόπιση,\n"
 "θέστε το προτιμητέο πρόγραμμα βίντεο στις ρυθμίσεις (ο %s είναι προεπιλεγμένος)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Προεπισκόπηση αρχείου"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία εκτέλεσης του εξωτερικού προγράμματος εμφάνισης πολυμέσων! Εντολή: `%s'"
@@ -2282,7 +2282,7 @@ msgstr "Αποτυχία γραψίματος στο αρχείο της λίσ�
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Φίλοι"
 
@@ -2630,57 +2630,57 @@ msgstr[1] "Γράψιμο %d επαφών Kad"
 msgid "Kad user"
 msgstr "Δίκτυο Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Όνομα αρχείου"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Μέγεθος αρχείου"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Λόγος μοιράσματος"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Ζητήθηκε:"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Έγινε δεκτό"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Ολοκλήρωση πηγών"
 
@@ -2798,7 +2798,7 @@ msgid "WARNING: "
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -2816,7 +2816,7 @@ msgid "Paste"
 msgstr "Επικόλληση"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Καθαρισμός"
@@ -3238,8 +3238,8 @@ msgstr "Ολοκλήρωση πηγών"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Δεν υπάρχει"
 
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Τίτλος:"
 
@@ -3493,7 +3493,7 @@ msgstr "Όνομα χρήστη :"
 msgid "Userhash :"
 msgstr "Τεμάχιο χρήστη :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Προσθήκη"
@@ -3502,15 +3502,15 @@ msgstr "Προσθήκη"
 msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Τρέχων"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Μέσο τρεξίματος"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Μέσο περιόδου"
 
@@ -3751,7 +3751,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Εισάγετε το όνομα το περιηγητή ιστολελίδων. Αφήστε αυτό το πεδίο κενό για τον προεπιλεγμένο περιηγητή."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3825,7 +3825,7 @@ msgstr "Συνέδεσε την τοπική διεύθυνση στην διε�
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Μόνο για προχωρημένους χρήστες: Αν έχετε πολλαπλά δικτυακά περιβάλλοντα, εισάγετε την διεύθυνση του περιβάλλοντος με το οποίο το aMule πρέπει να συνδεθεί."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Συνέδεσε την τοπική διεύθυνση στην διεύθυνση (κενό για όλες):"
@@ -3846,7 +3846,7 @@ msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4166,7 +4166,7 @@ msgstr "Σύνδεσμοι-Kad τρέχοντες"
 msgid "Kad-nodes session"
 msgstr "Σύνδεσμοι-Kad συνεδρία"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Επέλεξε"
 
@@ -4285,425 +4285,417 @@ msgstr "Επίπεδη"
 msgid "Round"
 msgstr "Στρογγυλή"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Αυτόματη ταξινόμηση αρχείων (υψηλή απαίτηση σε υπολογική ισχύη)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "Το aMule θα ταξινομήσει τις στήλες τις λίστας κατεβασμάτων αυτόματα."
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Παράμετροι εξωτερικών συνδέσεων"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Να γίνονται αποδεκτές οι εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "Η διεύθυνση του εισακούοντος περιβάλλοντος:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Εισάγετε μία έγκυρη διεύθυνση με φόρμα a.b.c.d για σύνδεση με το περιβάλλον EC. Άδειο πεδίου ή 0.0.0.0 συμβολίζει όλα τα περιβάλλοντα."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας UPnP στην θύρα EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Κωδικός"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Θύρα TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Έλεγχος κωδικού\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Παράμετροι διακομιστή ιστού"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Έναρξη του εξυπηρετητή ιστού κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Πρότυπη σελίδα"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Κωδικός πλήρων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Ενεργοποίηση χρήστη μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Κωδικός μειωμένων δικαιωμάτων"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ενεργοποίηση της προώθησης της θύρας του εξηπηρετητή ιστού στη θύρα UPnP"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Θύρα UPnP TCP του εξυπηρετητή (Προαιρετική)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Χρόνος ανανέωσης σελίδας (σε δευτερόλεπτα)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Ενεργοποίηση συμπίεσης Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Εντάξει"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Κλικ εδώ για εφαρμογή των αλλαγών που έγιναν στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Σχόλιο:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Κατάλογος εισερχομένων :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Πατήστε αυτό το κουμπί για το καθάρισμα του αρχείου καταγραφής."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Πατήστε αυτό το αρχείο για να ανανεώσετε την λίστα διακομιστών από την URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Λίστα διακομιστών"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Εισάγετε την url ενός αρχείου server.met και πατήστε το κουμπί στα αριστερά για να ανανεώσετε τη λίστα με τους γνωστούς διακομιστές"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Προσθήκη διακομιστή: Όνομα"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Γράψτε το όνομα του νέου διακομιστή εδώ"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "Διεύθυνση:Θύρα"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Βάλτε τον διακομιστή με το χέρι (γεμίστε πρώτα τα πεδία στα αριστερά) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Αρχείο καταγραφής aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Πληροφορίες διακομιστή"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Πληροφορίες ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Πατήστε το κουμπί για να ανανεώσετε την λίστα των κόμβων από την URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Κόμβοι (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Βάλτε εδώ την url ενός αρχείου nodes.dat και πατήστε το κουμπί στα αριστερά για να ανανεώσετε την λίστα των γνωστών κόμβων."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Εκκινητήρας"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Καινούριος κόμβος"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Θύρα:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Εκκίνηση από\n"
 "γνωστούς πελάτες"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Αποσυνδεδεμένο Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Χρήση Ασφαλούς Ταυτοποίησης χρήστη"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ενδείκνυται να ενεργοποιήσετε αυτήν την προτίμηση. Δεν θα λάβετε πίστωση αν το SUI δεν είναι ενεργοποιημένο."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Συσκότιση πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Υποστήριξη συσκότισης πρωτοκόλλου"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Αυτή η επιλογή ενεργοποίησε την συσκότιση πρωτοκόλλου και κάνει το aMule να δέχεται συσκοτισμένες συνδέσεις από άλλους πελάτες"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Χρήση συσκότισης για εξωτερικές συνδέσεις"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Αυτή η επιλογή κάνει το aMule να χρησιμοποιεί συσκότιση πρωτοκόλλου όταν συνδέεται σε άλλους πελάτες/διακομιστές."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Να γίνονται δεκτές μόνο συσκοτισμένες συνδέσεις"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Αυτή η επιλογή κάνει το aMule να δέχεται μόνο συσκοτισμένες συνδέσεις. Θα υπάρχουν λιγότερες πηγές αλλά όλη η κυκλοφορία θα είναι συσκοτισμένη"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Οι πάντες"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Κανείς"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Ποίος μπορεί να δεί τα κοινόχρηστα αρχεία μου:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Επιλέξτε ποίος μπορεί να ζητήσει να δει τη λίστα με τα κοινόχρηστα αρχεία σας."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Φίλτρο IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Φιλτράρισμα πελατών"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των πελατών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Φιλτράρισμα διακομιστών"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ενεργοποίηση φίλτρου του IP των διακομιστών όπως ορίζεται στο ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Επαναφόρτωση για φιλτράρισμα της λίστας των IP από το ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Ανανέωσε τώρα"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Επίπεδο φιλτραρίσματος:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Πάντα φίλτραρε τις IP του τοπικού δικτύου"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Παρανοϊκή διαχείριση των αταίριαστων διευθύνσεων IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Χρήση του ipfilter.dat όλου του συστήματος αν αυτό υπάρχει"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Αν δεν βρεθεί τοπικό ipfilter.dat, να γίνει επιτρεπτή η χρήση του αρχείου ipfilter (φίλτρο διευθύνσεων) όλου του συστήματος."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Ενεργοποίηση συνδεδεμένων υπογραφών"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ενεργοποίηση γραψίματος του αρχείου συστήματος, το οποίο μπορεί να χρησιμοποιηθεί από εξωτερικές εφαρμογές για τη δημιουργία υπογραφών κτλ."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Συχνότητα ανανέωσης (δευτερόλεπτα):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Αλλαγή της συχνότητας (σε δευτερόλεπτα) για την ενημέρωση Συνδεδεμένων υπογραφών."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Αποθύκευση του αρχείου συνδεδεμένων υπογραφών σε:"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Κλικ εδώ για την επιλογή του καταλόγου που περιέχει τα αρχεία Συνδεδεμένων Υπογραφών."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Ρυθμός ροής δεδομένων :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Αρ. πηγών"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4711,11 +4703,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4725,232 +4717,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Μεταφόρτωση"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Αυτόματη ανανέωση του ipfilter κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Φιλτράρισμα εισερχομένων μηνυμάτων (εκτός από την τρέχουσα συνομιλία):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Διήθηση όλων των μηνυμάτων"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Διήθηση των μηνυμάτων από μέλη εκτός της λίστας φίλων"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Διήθηση μηνυμάτων από άγνωστους πελάτες"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Διήθηση των μηνυμάτων που περιέχουν (χρήση ',' ως διαχωριστικού):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "προσθήκη σε αυτό το σημείο των λέξεων που το aMule πρέπει να φιλτράρει και μπλοκάρισμα μηνυμάτων που το περιέχουν"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Εμφάνιση των ληφθέντων μηνυμάτων στο αρχείο καταγραφής"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Σχόλια"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Φιλτράρισμα σχολίων που περιέχουν (χρησιμοποίηση ',' ως διαχωριστή):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Ενεργοποίηση πιστοποίησης"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Όνομα χρήστη:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Κωδικός:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Ο κωδικός που χρειάζεται για τη σύνδεση με τον μεσολαβητή"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Ενεργοποίηση διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Τύπος διαμεσολάβησης"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Θύρα διακομιστή μεσολάβησης:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Η θύρα διακομιστή μεσολάβησης"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Σύνδεση με:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Όνομα χρήστη"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Χρήση συμπίεσης τύπου gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ενεργοποίηση λεπτομερούς καταγραφής για έλεγχο σφαλμάτων"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Άνοιγμα αρχείου"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Κατηγορίες μηνυμάτων:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Αναμονή..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Προσθήκη εισακτέων"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Επαναπροσπάθεια των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Αφαίρεση των επιλεγμένων"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Τύποι συμβάντων"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Κρύψιμο των κοινόχρηστων αρχείων "
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Επιλογή φίλτρου εμφάνισης"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ενεργά ανεβάσματα"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Επαναφόρτωση λίστας"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Αποστολή"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Αποστολή του προσδιορισμένου μηνύματος."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
 
@@ -5311,192 +5303,192 @@ msgstr "Έχει κατεβεί"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Εργοστασιακές ρυθμίσεις"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Αραβικά"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Βάσκικα"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Βουλγάρικα"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Καταλανικά"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Κινέζικα (απλοποιημένα)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Κινέζικα (Παραδοσιακά)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Κροατικά"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Τσέχικα"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Δανέζικα"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Ολλανδικά"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Αγγλικά (Ην. Βασίλειο)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Εσθονικά"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Φιλανδικά"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Γαλλικά"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Γαλικιακά"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Γερμανικά"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Εβραϊκά"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ουγγαρέζικα"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Ιταλικά"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Γιαπωνέζικα"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Κορεάτικα"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Λιθουανικά"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Νορβηγικά"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Πολωνέζικα"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Πορτογαλλικά"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Πορτογαλλικά (Βραζιλίας)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Αλβανικά"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Σλοβένικα"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Ισπανικά"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Σουηδικά"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Τούρκικα"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Γλώσσα"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Η θύρα TCP δεν μπορεί να είναι μεγαλύτερη από 65532, διότι η θύρα UDP του διακομιστή είναι TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Θα χρησιμοποιηθεί η στάνταρ θύρα (%d)"
@@ -8471,6 +8463,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Αυτόματη ταξινόμηση αρχείων (υψηλή απαίτηση σε υπολογική ισχύη)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "Το aMule θα ταξινομήσει τις στήλες τις λίστας κατεβασμάτων αυτόματα."
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Απορρίπτει τα πακέτα αν η IP του πελάτη είναι διαφορετική από την IP από την οποία ελήφθη το πακέτο. Χρήση με προσοχή."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -620,8 +620,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -632,7 +632,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr ""
 
@@ -691,111 +691,111 @@ msgstr ""
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -929,14 +929,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -947,72 +947,72 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1169,7 +1169,7 @@ msgid "Disconnected"
 msgstr ""
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1322,19 +1322,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1361,7 +1361,7 @@ msgid "Queue Full"
 msgstr ""
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr ""
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr ""
 
@@ -1552,7 +1552,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr ""
@@ -1627,45 +1627,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr ""
 
@@ -2536,57 +2536,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2701,7 +2701,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr ""
 
@@ -2719,7 +2719,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3131,8 +3131,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr ""
 
@@ -3272,7 +3272,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr ""
 
@@ -3378,7 +3378,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3387,15 +3387,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr ""
 
@@ -3633,7 +3633,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3707,7 +3707,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3727,7 +3727,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4045,7 +4045,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr ""
 
@@ -4161,413 +4161,405 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4575,11 +4567,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4589,222 +4581,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5162,187 +5154,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-26 06:07+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -661,8 +661,8 @@ msgstr "Kad: apagado"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -673,7 +673,7 @@ msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -682,7 +682,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Conectar"
 
@@ -732,111 +732,111 @@ msgstr "¿Realmente desea cerrar %s?"
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Compartidos"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mensajes"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "No hay red"
 
@@ -976,14 +976,14 @@ msgstr "El enlace no es válido o ya está en la lista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantiene el directorio '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -994,72 +994,72 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Buscando un amigo para conexión con Id Baja"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versión falsa de eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Falso eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (falso eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basado en eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alias: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitado: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadísticas de archivo para esta sesión: aceptada %d de %d petición, %s transferidos\n"
 msgstr[1] "Estadísticas de archivo para esta sesión: aceptadas %d de %d peticiones, %s transferidos\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estadísticas de archivo para todas las sesiones: aceptada %d de %d petición, %s transferidos\n"
 msgstr[1] "Estadísticas de archivo para todas las sesiones: aceptadas %d de %d peticiones, %s transferidos\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Se ha pedido un archivo desconocido"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensaje filtrado de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nuevo mensaje de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "El usuario %s (%u) ha pedido la lista de archivos compartidos de un directorio que no existe, '%s' -> Se ignora"
@@ -1216,7 +1216,7 @@ msgid "Disconnected"
 msgstr "Desconectado"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1369,19 +1369,19 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1408,7 +1408,7 @@ msgid "Queue Full"
 msgstr "Cola llena"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "En cola"
 
@@ -1473,7 +1473,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1544,7 +1544,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1601,7 +1601,7 @@ msgstr ""
 "Reacción desde: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automática"
@@ -1676,34 +1676,34 @@ msgstr "Asignar a la categoría"
 msgid "&Open the file"
 msgstr "&Abrir el archivo"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Introduzca el nuevo nombre para el archivo:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Renombrar el archivo"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr "la terminal predeterminada de Windows"
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1712,11 +1712,11 @@ msgstr ""
 "Para evitar la aparición de este aviso en cada previsualización,\n"
 "defina el reproductor de vídeo en las preferencias (%s por defecto)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Previsualizar el archivo"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR: ¡no se ha podido ejecutar el reproductor de medios externo! Comando: `%s'"
@@ -2276,7 +2276,7 @@ msgstr "¡Error al abrir el archivo de amigos 'emfriends.met' para escritura!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - no hay clientes en el inicio de sesión chat"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2618,57 +2618,57 @@ msgstr[1] "Escritos %d contactos Kad"
 msgid "Kad user"
 msgstr "Usuario Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: Kad no está conectado."
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: ya hay una búsqueda de notas en ejecución para este archivo"
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: el archivo no está en la lista de compartidos, en la cola de descargas ni en los resultados de búsqueda"
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: otra búsqueda Kad (por ejemplo, una búsqueda de fuentes) ya está usando el hash de este archivo. Inténtelo de nuevo en breve"
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "La búsqueda de notas Kad para '%s' no se inició: PrepareLookup falló"
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nombre del archivo"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Tamaño del archivo"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Media de compartición"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Pedido"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Aceptado"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fuentes completas"
 
@@ -2783,7 +2783,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Cerrar"
 
@@ -2801,7 +2801,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpiar"
@@ -3213,8 +3213,8 @@ msgstr "Fuentes del archivo:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/D"
 
@@ -3354,7 +3354,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Álbum :"
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Título:"
 
@@ -3462,7 +3462,7 @@ msgstr "Nombre del usuario:"
 msgid "Userhash :"
 msgstr "Hash del usuario:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Añadir"
@@ -3471,15 +3471,15 @@ msgstr "Añadir"
 msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Media de ejecución"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Media de la sesión"
 
@@ -3717,7 +3717,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Introduzca el nombre de su navegador. Déjelo en blanco si quiere usar el predefinido del sistema."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3791,7 +3791,7 @@ msgstr "Dirección IP local de enlace (vacía para cualquiera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo usuarios avanzados: si tiene varias tarjetas de red, introduzca la dirección de la tarjeta que debe usar aMule."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr "Vincular a interfaz de red (vacío para cualquiera):"
 
@@ -3811,7 +3811,7 @@ msgstr "Número máximo de conexiones simultáneas:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4131,7 +4131,7 @@ msgstr "Nodos Kad activos"
 msgid "Kad-nodes session"
 msgstr "Nodos Kad de la sesión"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Seleccionar"
 
@@ -4247,108 +4247,100 @@ msgstr "Plana"
 msgid "Round"
 msgstr "Redondeada"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Autoordenar los archivos (uso alto de CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule ordenará automáticamente las columnas en la lista de descargas"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parámetros de la conexión externa"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Aceptar conexiones externas"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP de la interfaz que está escuchando:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduzca aquí una IP válida en la forma a.b.c.d para la interfaz EC que está escuchando. Un campo vacío o 0.0.0.0 significará cualquier interfaz."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Puerto TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar la redirección de puertos UPnP en el puerto EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contraseña"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr "Parámetros del servidor aMule API"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Ejecutar amuleapi (API REST) al iniciar"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr "Puerto HTTP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "La interfaz en la que escucha el servidor HTTP de amuleapi es 127.0.0.1 (por defecto), que solo acepta conexiones locales; utilice 0.0.0.0 o una IP específica para exponerla a otros hosts (establezca una contraseña de administrador a continuación)."
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr "Contraseña Admin"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parámetros del servidor web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr "Ejecutar webserver al iniciar (obsoleto)"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Plantilla web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Contraseña de administrador"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Permitir un invitado"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Contraseña del invitado"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar el reenvío de puertos UPnP en el puerto del servidor web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Puerto TCP del servidor web para UPnP (opcional)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalo de actualización de la página (en segundos)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Activar la compresión gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr "Restablecer a los valores por defecto"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 
@@ -4356,308 +4348,308 @@ msgstr "Restablece los ajustes de la página actual a sus valores por defecto."
 # botón para cerrar el diálogo de Preferencias guardando los cambios. La
 # traducción sería distinta en cada caso, así que hay que dejar el OK
 # original.
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Haga clic aquí para aplicar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentario:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Directorio entrante:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "No cambiar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Pulse este botón para borrar el registro."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de servidores desde un URL..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduzca la URL de un archivo server.met y pulse el botón de la izquierda para actualizar la lista de servidores conocidos."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Añadir servidor manualmente: Nombre"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Introduzca aquí el nombre del nuevo servidor"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Puerto"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Introduzca el puerto del servidor."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Añadir manualmente un servidor (rellene antes los campos de la izquierda)..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Registro de aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Información del servidor"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Información sobre ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Información sobre Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Pulse este botón para actualizar la lista de nodos desde el URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduzca la URL del archivo nodes.dat y pulse el botón de la izquierda para actualizar la lista de nodos conocidos."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Inicialización"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nuevo nodo"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Inicializar desde clientes conocidos"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Usar la Identificación Segura de Usuario (ISU)"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Se recomienda activar esta opción. No recibirá créditos si la ISU no está habilitada."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Permitir la ofuscación de protocolo"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa la ofuscación de protocolo y hace que aMule acepte conexiones ofuscadas de otros clientes."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar la ofuscación para las conexiones salientes"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción hace que aMule use la ofuscación de protocolo cuando se conecta a otros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar sólo conexiones ofuscadas"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción hace que aMule sólo acepte conexiones ofuscadas. Tendrá menos fuentes, pero todo su tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nadie"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Quién puede ver mis archivos compartidos:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quién puede solicitar ver la lista de sus archivos compartidos."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtrado de direcciones IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrar los clientes"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de clientes definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrar los servidores"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar el filtrado de las IP de servidores definidas en el archivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recargar la lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar la lista de filtrado de IP desde el archivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Actualizar ahora"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Autoactualizar el filtro de IP al inicio"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtrar siempre las IP de LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestión paranoica de las IP que no coincidan"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rechaza un paquete cuando su IP de origen es diferente de la IP que el cliente dice tener (comprobación anti-suplantación). Desactivar sólo si causa problemas de conexión."
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Si no hay un archivo ipfilter.dat local, permitir el uso de un archivo ipfilter del sistema."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Habilitar la firma digital"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita la escritura de archivos de firma digital, algo que puede ser usado por las aplicaciones externas para crear firmas y cosas parecidas."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segundos):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar la frecuencia (en segundos) de actualización de la firma digital."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Guardar el archivo de firma digital en: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Pulse aquí para seleccionar el directorio que contiene los archivos de firmas digitales."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Mostrar las banderas de los países para los clientes"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostrar la columna de la bandera del país en las vistas de transferencias, cola y búsqueda. Requiere una base de datos MMDB GeoIP válida (ver más abajo)."
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Base de datos"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "Fuente:"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratis, sin crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, requiere crear una cuenta)"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "URL personalizada"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Elige qué proveedor ofrece la base de datos GeoIP MMDB. DB-IP es la opción predeterminada; no se necesita cuenta. MaxMind requiere una cuenta gratuita y una clave de licencia. Utiliza la opción 'URL personalizada' para indicar cualquier otro servidor MMDB (por ejemplo, un servidor espejo local)."
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4669,11 +4661,11 @@ msgstr ""
 "Datos IP-País de DB-IP.com - https://db-ip.com\n"
 "Licencia: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "Clave de licencia:"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4689,11 +4681,11 @@ msgstr ""
 "Licencia: EULA de MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Requiere la atribución de la fuente y el registro de una cuenta; actualizar al menos cada 30 días."
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "URL de descarga:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4703,211 +4695,211 @@ msgstr ""
 "La URL puede incluir credenciales (https://user:pass@host/...).\n"
 "Las condiciones de licencia y atribución dependen de la URL de descarga; la responsabilidad recae en ti."
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "Descarga la base de datos GeoIP de la fuente seleccionada."
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Autoactualizar al inicio"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Vuelve a descargar la base de datos GeoIP desde la fuente seleccionada cada vez que se inicie aMule."
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar los mensajes entrantes (salvo la conversación actual):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrar todos los mensajes"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar los mensajes de gente que no esté en su lista de amigos"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar los mensajes de clientes desconocidos"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar los mensajes que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "añada aquí las palabras que amule debe filtrar para bloquear los mensajes que las incluyan"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Mostrar los mensajes recibidos en el registro"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar los comentarios que contengan (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Habilitar la autentificación"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nombre de usuario: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "La contraseña a usar para conectar al proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Habilitar el proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Servidor proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Puerto del proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "El puerto del proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nombre de usuario"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "Forzar compresión ZLIB"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Habilitar el modo detallado de depuración."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Sólo al archivo de registro"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categorías de mensajes:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Esperando..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Añadir lo importado"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Reintentar seleccionado"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Borrar seleccionado"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipos de evento"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas y clientes en la cola para los archivos seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Subidas activas"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Porcentaje del total de archivos"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Archivos seleccionados"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Solo las subidas activas"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Recargar los archivos compartidos"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Envía el mensaje especificado."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a cualquier servidor y/o a Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Compartidos"
 
@@ -5267,187 +5259,187 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Por defecto"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chino (simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglés (Reino Unido)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "Inglés (EE.UU.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Gallego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Griego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonés"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr "Letón"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruego (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (brasileño)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Español"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Cambiar el idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "No hay traducciones instaladas para aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "No hay idiomas disponibles"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "El puerto TCP no puede ser mayor que 65532 debido a que el socket del servidor UDP es TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Puerto por defecto que será usado (%d)"
@@ -8388,6 +8380,12 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Autoordenar los archivos (uso alto de CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule ordenará automáticamente las columnas en la lista de descargas"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rechaza los paquetes para los que la IP del cliente es diferente de la IP desde donde se ha recibido el paquete. Úselo con cautela."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -649,8 +649,8 @@ msgstr "Kad: Väljas"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -661,7 +661,7 @@ msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
@@ -670,7 +670,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Ühenda"
 
@@ -721,111 +721,111 @@ msgstr "Kas sa tõesti tahad %s'st väljuda?"
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Jagatud failid"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Teated"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Seaded"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Võrk puudub"
 
@@ -964,14 +964,14 @@ msgstr "Vigane link või on juba loetelus."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' kataloogi."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -982,72 +982,72 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 msgid "Unknown"
 msgstr "Teadmata"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Otsin lowid ühenduse jaoks semu"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Valetatud eMule versioon %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Valetatud eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Valetatud eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseerub eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Kasutajanimi: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Küsitud: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Selle seansi failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 msgstr[1] "Selle seansi failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Kõikide seansside failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 msgstr[1] "Kõikide seansside failistatistika: Aksepteeritud %d/%d päringust, %s siirdatud\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Küsiti tundmatut faili"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s' (IP:%s) teade filtreeriti"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s' (IP:%s) saatis uue teate"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Kasutaja %s (%u) küsis sinu jagatudfailde loetelu kataloogile %s -> keeldusid"
@@ -1204,7 +1204,7 @@ msgid "Disconnected"
 msgstr "Pole ühendust"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1358,19 +1358,19 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1397,7 +1397,7 @@ msgid "Queue Full"
 msgstr "Järjekord täis"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Järjekorras"
 
@@ -1462,7 +1462,7 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1534,7 +1534,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Suurus"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Siiratud"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "Tagasiside : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1666,34 +1666,34 @@ msgstr "Määra kategooria"
 msgid "&Open the file"
 msgstr "Ava Fail"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Sisesta selle faili uus nimi:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Faili ümbernimetamine"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%H:%M:%S %d/%m/%y"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Tõmbamised (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1702,11 +1702,11 @@ msgstr ""
 "Et seda viga eelvaatuse ajal rohkem mitte näitdata \n"
 "määra oma seadetes eelistatud video mängija (vaikimisi %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Faili eelvaade"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "VIGA: Ei suutnud käivitada välist meediamängijat! Käsk: `%s'"
@@ -2268,7 +2268,7 @@ msgstr "Sõprade faili 'emfriends.met' avamine kirjutamiseks ebaõnnestus!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITILINE - StartChatSession puudub klient"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Sõbrad"
 
@@ -2612,57 +2612,57 @@ msgstr[1] "Salvestatud %d Kad kontakti"
 msgid "Kad user"
 msgstr "Kad võrk"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Faili nimi"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Faili suurus"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Üles- ja allalaadimise suhe"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Küsitud"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Aksepteeritud"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Täielikke allikaid"
 
@@ -2778,7 +2778,7 @@ msgid "WARNING: "
 msgstr "HOIATUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Sulge"
 
@@ -2796,7 +2796,7 @@ msgid "Paste"
 msgstr "Aseta"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Puhasta"
@@ -3217,8 +3217,8 @@ msgstr "Faili allikad:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3363,7 +3363,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Tiitel :"
 
@@ -3472,7 +3472,7 @@ msgstr "Kasutajanimi :"
 msgid "Userhash :"
 msgstr "Kasutaja kontrollsumma :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisa"
@@ -3481,15 +3481,15 @@ msgstr "Lisa"
 msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Hetkel"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Hetke keskmine"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Seansi keskmine"
 
@@ -3729,7 +3729,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Sisesta siia lehitsejaprogrammi nimi. Jättes välja tühjaks, kasutab süsteem vaikimisi määratud lehitsejat."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3803,7 +3803,7 @@ msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Ainult edasijõudnud kasutajatele: Kui sul on kasutada mitu võrguliidest, siis sisesta selle liidese aadress millega aMule võib ennast siduda."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Seo lokaalne aadress IP'ga (suvaliseks jäta tühjaks)"
@@ -3824,7 +3824,7 @@ msgstr "Maksimaalselt samaaegseid ühendusi:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4144,7 +4144,7 @@ msgstr "Kad-sõlmi jooksvalt"
 msgid "Kad-nodes session"
 msgstr "Kad-sõlmi seansis"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Vali"
 
@@ -4263,421 +4263,413 @@ msgstr "Lame"
 msgid "Round"
 msgstr "Ümar"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Sorteeri failid automaatselt (high CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule sorteerib tulbad tõmbamise sabas automaatselt"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Välisühenduse parameetrid"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Aksepteeri väliseid ühendusi"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "Kuulava liidese IP aadress:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sisesta siia välisühenduse liidese kehtiv ip aadress a.b.c.d formaadis. Tühi väli või 0.0.0.0 tähendab suvalist liidest."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Luba UPnP pordisuunamist EC pordile"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parool"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollin parooli\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Web serveri seaded"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käivita WEBserver koos aMulega"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "WEB näidis/mall"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Täisõiguste parool"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Luba madalate õigustega kasutaja"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Madalate õiguste parool"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Luba webservri portide UPnP pordisuunamist"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webserveri UPnP TCP port (Valikuline)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Lehekülje värskendusaeg (sekundites)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Luba Gzip pakkimine"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Sobib"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Seadetes tehtud muudatuste jõustamiseks klikka siia."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Kommentaar :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Tõmmatud failide kataloog :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Muuda uute failide prioriteeti :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Ära muuda"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vali praegu valitud kategooriale värv :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Klikates seda nuppu tühjendad logi."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sellele nupule klikates värskendad serverite loetelu URL ilt ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Serverite nimekiri"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Sisesta siia server.met faili asukoha URL ja pressi vasakul olevat nuppu tuntud serverite nimekirja värskendamiseks."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Lisa server käsitsi: Nimi"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Sisesta siia uue serveri nimi"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Sisesta siia serveri port."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Täites esiteks vasakul olevad väljad, lisa server käsitsi ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule Logi"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Serveri info"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikates sellele nupule värskendad sõlmede loetelu URL'ilt ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Sõlmed (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Sisesta siia nodes.dat faili url ja pressi vasakul olevat nuppu, et tuntud sõlmede loetelu täiendada."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Uus sõlm"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Tuntud klientide Bootstrap"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Lõpeta Kad ühendus"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Kasuta Turvalist Kasutaja tuvastamist"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "On soovitatav see omadus lubada. Sa ei saa krediiti kui SUI on välja lülitatud."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokolli Hämamine"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Protokolli Hämamine lubatud"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "See valik lülitab Protokolli Hämamise sisse ja sunnib aMule aksepteerima ainult teiste klientide hämatud ühendusi."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kasuta väljuvatel ühendustel hämamist"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "See valik sunnib aMule kasutama teiste serverite/klientidega ühendumisel Protokolli Hämamist."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Aksepteeri ainult hämatud ühendusi"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "See valik sunnib aMule aksepteerima ainult hämatud ühendusi. Sul on vähem allikaid aga kogu liiklus on hämatud."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Igaüks"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Mitte keegi"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Kes näeb minu jagatud faile:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vali, kes võib vaatamiseks küsida sinu jagatud falide nimekira."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-Filtreerimine"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtreeri kliente"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda klientide IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtreeri servereid"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Rakenda serverite IP filtreerimine failis ~/.aMule/ipfilter.dat defineeritud aadressidele."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Lae loetelu uuesti"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Taaslae filtreeritavad IP aadressid failist ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Värskenda"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Filtreerimise tase:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtreeri alati LAN IP aadresse"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Mitteklappivate IP aadresside paranoiline käitlemine"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Kasuta süsteemi ipfilter.dat kui see on saadaval"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Kui kohalik ipfilter.dat fail puudub, kasuta süsteemi globaalset ipfilter faili."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Luba Online-Allkiri"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Võimaldab kirjutada OS faile, mida saavad kasutada välised rakendused kasvõi allkirja loomiseks."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Värskenduse sagedus (Sek):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuda Online Allkirja värskendamise (sekundites) sagedust."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Salvesta online ollkirja fail: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Siin saad valida kataloogi kus asub sinu Online Allkirja fail."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Näita klientide riigi lippe"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Andmekiirus :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Allikaid"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4685,11 +4677,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4699,226 +4691,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Tõmbamine: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Käivitamisel värskenda automaatselt ipfiltrit"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtreeri saabuvaid teateid (va. käimasolev vestlus):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtreeri kõiki teateid"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtreeri sinu sõbralistiväliste kodanike teateid"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtreeri tundmatute klientide teateid"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "lisa siia sõnad mille amule peab väljafiltreerima ja bloki teated mis seda sisaldavad"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Näita logis saabunud teateid"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Kommentaarid"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtreeri teateid, mis sisaldavad (loetelus kasuta eraldajana koma):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Nõua autoriseerimist"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Kasutajanimi: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Parool:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Puhverserveri kasutamiseks vajalik parool"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Kasuta puhverserverit"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Puhverserveri tüüp:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Puhverserveri nimi:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Puhverserveri port:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Selle puhverserveri pordi number"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Ühendu :"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Kasutaja nimi"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Kasuta gzip pakkimist"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Võimalda inimkieelne Veajälitus-Logimine"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Ava Fail"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Saadetav teade:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ootan..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Lisa imporditavad"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Proovi valitutega uuesti"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Eemalda valitud"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Sündmuse tüübid"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika ja järjekorras kliendid valitud faili(de) kohta : Sessioon / Kokku"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Protsenti kogufailidest"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Kõik failid"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Valitud failid"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Ainult aktiivsed saatmised"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Taaslae:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Lae oma jagatud failid uuesti"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Saada"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Saada määratud teade."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jagatud failid"
 
@@ -5277,189 +5269,189 @@ msgstr "Allalaetud"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Süsteemi vaikeväärtus"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albaania"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Araabia"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgaaria"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Kataloonia"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Hiina (Lihtsustatud)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Hiina (Traditsiooniline)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroaatia"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tšehhi"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Taani"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Hollandi"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglise (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Eesti"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Soome"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Prantsuse"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galiitsia"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Kreeka"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Heebrea"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ungari"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Itaalia"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Jaapani"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Leedu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norra"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Poola"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brasiilia)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumeenia"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Vene"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Sloveenia"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Hispaania"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Rootsi"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Türgi"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Muuda keel"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Info puudub"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "valikud puuduvad"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port ei saa olla suuerm kui 65532, sest serveri UDP soket on TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Kasutan vaikimisi porti (%d)"
@@ -8397,6 +8389,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Sorteeri failid automaatselt (high CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule sorteerib tulbad tõmbamise sabas automaatselt"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Viskab paketi minema kui kliendi IP erineb paketi saatja IP aadressist. Kasuta ettevaatlikult."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:56+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -650,8 +650,8 @@ msgstr "Kad: Itzalia"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Konektatu"
 
@@ -722,111 +722,111 @@ msgstr "Benetan %s utzi egin nahi duzu?"
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Sareak"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Deskargak"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Partekatutako fitxategiak"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mezuak"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatistikak"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Sarerik ez"
 
@@ -965,14 +965,14 @@ msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa mantenduko da."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -983,72 +983,72 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 msgid "Unknown"
 msgstr "Ezezaguna"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Laguna bilatzen id-baxu konexiorako"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Gezurrezko eMule bertsioa %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Gezurrezko eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Gezurrezko eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (eMule v0.%u-tan oinarriturik)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Ezizena: %s ID-a: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Eskaerak: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fitxategi estatistikak saio honentzat. Onarturik %d - eskakizun %d-etik, %s transferiturik\n"
 msgstr[1] "Fitxategi estatistikak saio honentzat. Onarturik %d - %d eskakizunetik, %s transferiturik\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fitxategi estatistikak saio guztientzat: Onarturik %d eskakizun %d-etik, %s transferiturik\n"
 msgstr[1] "Fitxategi estatistikak saio guztientzat: Onarturik %d %d eskakizunetik, %s transferiturik\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Fitxategi ezezaguna eskaturik"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s'-ren mezu bat iragazi da (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s'-ren mezu berria (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "%s (%u) erabiltzaileak ez dagoen %s direktorioaren partekatutako fitxategi zerrenda eskatu du -> Ukatua"
@@ -1205,7 +1205,7 @@ msgid "Disconnected"
 msgstr "Deskonektatuta"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1359,19 +1359,19 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1398,7 +1398,7 @@ msgid "Queue Full"
 msgstr "Ilara Osoa"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Ilaran"
 
@@ -1463,7 +1463,7 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1535,7 +1535,7 @@ msgstr "Zatia"
 msgid "Size"
 msgstr "Tamaina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferituta"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Erantzuna hemendik: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1667,34 +1667,34 @@ msgstr "Ezarri kategoria bat"
 msgid "&Open the file"
 msgstr "&Ireki fitxategia"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Sar izen berri bat fitxategi honentzat:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Fitxategia berrizendatu"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Deskargak (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1703,11 +1703,11 @@ msgstr ""
 "Ohar hau aurreikuspen bakoitzean agertzea saihesteko,\n"
 "ezarri zure bideo erreproduzigailu gogokoena hobespen leihoan (lehenetsia %s da)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Fitxategi aurreikuspena"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROREA: Huts kanpo bideo erreproduzigailua abiaraztean! Komandoa: `%s'"
@@ -2269,7 +2269,7 @@ msgstr "Huts 'emfriends.met' lagun zerrenda fitxategia idazteko irekitzean!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKOA - ez dago bezerorik StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Lagunak"
 
@@ -2613,57 +2613,57 @@ msgstr[1] "Idatzi %d Kad kontaktu"
 msgid "Kad user"
 msgstr "Kad sarea"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Fitxategia"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Fitxategi tamaina"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Partekatze erlazioa"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Eskatutakoa"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Onartua"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Jatorri osoak"
 
@@ -2779,7 +2779,7 @@ msgid "WARNING: "
 msgstr "OHARRA: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Itxi"
 
@@ -2797,7 +2797,7 @@ msgid "Paste"
 msgstr "Itsatsi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Garbitu"
@@ -3218,8 +3218,8 @@ msgstr "Fitxategiaren iturburua:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "E/G"
 
@@ -3364,7 +3364,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titulua :"
 
@@ -3473,7 +3473,7 @@ msgstr "Erabiltzaile-izena :"
 msgid "Userhash :"
 msgstr "Erabiltzaile aztertze zenbakia :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Gehitu"
@@ -3482,15 +3482,15 @@ msgstr "Gehitu"
 msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Unekoa"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Funtzionamendu bataz bestekoa"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "saio batez bestekoa"
 
@@ -3730,7 +3730,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Idatzi zure nabigatzaile izena hemen. Zurian utzi sisteman lehenetsitako nabigatzailea erabiltzeko."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3804,7 +3804,7 @@ msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Erabiltzaile aurreratuak bakarrik: Sare interfaze anitz badituzu idatzi amulek erabili behar duen sare interfazearen helbidea."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lotu helbide lokala IP batetara (zurian edozeinentzat):"
@@ -3825,7 +3825,7 @@ msgstr "Aldibereko konexioa muga:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4145,7 +4145,7 @@ msgstr "Kad-nodoak martxan"
 msgid "Kad-nodes session"
 msgstr "Kad-nodo saioa"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Hautatu"
 
@@ -4263,421 +4263,413 @@ msgstr "Laua"
 msgid "Round"
 msgstr "Biribildu"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto-ordenatu fitxategiak (PUZ handia)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "Amule-k zure deskarga zerrendako zutabeak automatikoki sailkatuko ditu"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Urruneko konexio ezarpenak"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Onartu urruneko konexioak"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "Entzunean dagoen interfazearen IPa:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Idatzi hemen a.b.c.d formatuan entzun behar den interfazearen baliozko ip helbidea. Eremu huts batek edo 0.0.0.0 ezartzeak edozein interfazetan entzutea eragingo du."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP berbideraketa gaitu EC atakan"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Pasahitza"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ataka:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Pasahitz egiaztatzen\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Web zerbitzari parametroak"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Exekutatu web-zerbitzaria abioan"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web txantiloia"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Baimen osorako pasahitza"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Gaitu baimen gutxiko erabiltzailea"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Baimen baxuko pasahitza"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Gaitu web zerbitzari atakaren UPnP ataka birbidalketa"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web zerbitzari UPnP ataka (aukerakoa)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Orrialdea berritzeko denbora (segundotan)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Gaitu Gzip konpresioa"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistema lehenetsia"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Ados"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Hemen klik egin hobespenetan eginiko edozein aldaketa ezartzeko."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Iruzkina :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Deskarga direktorioa :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Aldatu lehentasuna fitxategi berrientzat :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Ez aldatu"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Botoi hau klikatu erregistroa garbitzeko."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik egin botoi honetan zerbitzari zerrenda URL-tik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Zerbitzari zerrenda"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Idatzi server.met fitxategiaren URL bat hemen eta gero ezkerreko botoia sakatu zerbitzari ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Gehitu zerbitzaria eskuz: Izena"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Idatzi zerbitzari berriaren izen hemen"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP ataka"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Gehitu zerbitzari bat eskuz (sar datuak ezkerrean lehenik) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule erregistroa"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Zerbitzari argibideak"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Argb"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikatu botoi honetan nodo zerrenda URL honetatik eguneratzeko ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodoak (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "nodes.dat fitxategi baten URL-a idatzi eta ezkerreko botoia sakatu nodo ezagunen zerrenda eguneratzeko."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Autoabioa"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nodo berria"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Ataka:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bezero ezagunetarik abiarazi"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Kad deskonektatu"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Erabili erabiltzaile identifikazio segurua"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Gomendagarri da aukera hau gaitzea. Ez duzu krediturik jasoko EIS erabiltzen ez baduzu."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Gaitu protokolo nahastea"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Aukera honek protokolo nahastea gaitzen du eta aMule-k beste bezeroetako konexio nahastuak onartzea eragite du."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Erabili nahastea kanporako konexioetan"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Aukera honek Amulek beste bezero/zerbitzarietara konektatzerakoan protokolo nahastea erabiltzea eragiten du."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Onartu nahasitako konexioak bakarrik"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Aukera honek Amulek nahasitako konexioak bakarrik onartzea eragiten du. Jatorri gutxiago izango dituzu baina zure trafiko guztia nahasia egongo da"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Edozeini"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Bat ere ez"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Nork ikusi ditzaken nire partekatutako fitxategiak:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Hautatu zure partekatutako fitxategiak nork ikus ditzakeen."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-Iragazkia"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Bezeroak iragazi"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako bezero IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Zerbitzariak iragazi"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat fitxategian ezarritako zerbitzari IP iragazketa gaitu."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Berritu zerrenda"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Berritu ~/.aMule/ipfilter.dat fitxategian ezarritako IP helbideen iragazkia"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL-a:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Eguneratu orain"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Iragazki maila:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Beti iragazi LAN IP-ak"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoia kudeaketa pareko ez diren IP helbideentzat"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Erabili sistemako ipfilter.dat eskuragarri badago"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ez bada ipfilter.dat fitxategi lokalik aurkitu, orduan onartu sistema ipfilter fitxategia erabiltzea."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Gaitu sinadura linean"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Gaitu sistemak fitxategiak idaztea, kanpo programek sinadurak sortu ahal izateko egiten da."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Eguneratu maiztasuna (Seg):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Aldatu linean sinadura eguneraketa aldia (segundotan)."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Gorde sare sinadura fitxategia hemen: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikatu hemen linean sinadurak dituen karpeta aukeratzeko."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Bistarazi estatu banderak bezeroentzat"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Data abiadura :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Jatorriak"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4685,11 +4677,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4699,226 +4691,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Deskargak: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatikoki eguneratu ip iragazkia abioan"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "sarrera mezu iragazkia (txat honetan ezik):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Mezu guztiak iragazi"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Lagun zerrendan ez daudenen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Bezero ezezagunen mezuak iragazi"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Hau duten mezuak iragazi (erabili ',' bereizle bezala):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Gehitu amulek mezuetan blokeatzea nahi dituzun hitzak"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Ikusi jasotako mezuak erregistroan"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Iruzkinak"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Fitxategi iruzkinak hau du (',' erabili bereizle gisa):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Gaitu autentifikazioa"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Erabiltzaile izena: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Pasahitza:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den pasahitza"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Proxy-a gaitu"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Proxy mota:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Proxy ostalaria:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Proxy ataka:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Proxy ataka"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Hona konektaturik:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Erabiltzaile izena"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Erabili gzip konpresioa"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Gaitu arazten luzeko saio hasiera."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Ireki fitxategia"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Mezu kategoriak:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Zain..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Gehitu"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Berriz saiatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Ezabatu hautaturikoak"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Gertaera motak"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Hautako fitxategientzat estatistika eta bezero ilara: Saioa / osotara"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "fitxategi guztien ehunekoa"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Fitxategi guztiak"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Hautatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Igoera aktiboak bakarrik"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Berritu:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Berritu zure partekatutako fitxategiak"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Bidali"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Zehaztutako mezua bidali."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
 
@@ -5277,188 +5269,188 @@ msgstr "Deskargatua"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Sistema lehenetsia"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albaniera"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabiera"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Bablea"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Euskara"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgariera"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalana"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Txinatarra (Sinplea)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Txinatarra (ohizkoa)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Txekiera"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Daniera"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nederlandera"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Ingelesa (E.B.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estoniera"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandiera"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Frantsesa"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galiziera"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemana"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grekoa"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreera"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiera"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japoniera"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreera"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituaniera"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegiera (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Poloniera"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugesa (Brasildarra)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Errumaniera"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Errusiera"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Esloveniera"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Gaztelera"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suediera"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turkiera"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraniera"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Aldatu hizkuntza"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Ez dago aMulerentzat itzulpen instalaturik"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Ez dago hizkuntza erabilgarririk"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP ataka ezin da 65532 baino altuagoa izan UDP socket-a TCP+3 bait da"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Lehenetsiriko ataka erabiliko da (%d)"
@@ -8397,6 +8389,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto-ordenatu fitxategiak (PUZ handia)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "Amule-k zure deskarga zerrendako zutabeak automatikoki sailkatuko ditu"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Paketea atzera bota bezero ip-a paketea jaso den ip-aren ezberdina bada. Kontu handiaz erabili."

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:56+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -650,8 +650,8 @@ msgstr "Kad: Pois päältä"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Yhdistä"
 
@@ -722,111 +722,111 @@ msgstr "Haluatko varmasti sulkea %sn?"
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Verkot"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Lataukset"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Jaetut tiedostot"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Viestit"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Ei verkkoa"
 
@@ -965,14 +965,14 @@ msgstr "Virheellinen linkki tai se on jo listalla."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -983,72 +983,72 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Etsitään kaveria lowid-yhteydelle"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Vale-eMule versio %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Vale-eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Vale-eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (pohjautuu eMule-versioon v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nimimerkki: %s Tunnus: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pyydetty: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Tiedostotilasto tästä sessiosta: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 msgstr[1] "Tiedostotilasto tästä sessiosta: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Tiedostotilasto kaikista sessioista: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 msgstr[1] "Tiedostotilasto kaikista sessioista: Hyväksytty %d / %d pyynnöstä, %s siirretty\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Pyydetty tuntematonta tiedostoa"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Viesti suodatettu käyttäjältä '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Viesti käyttäjältä '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista olemattomassa kansiossa '%s' -> Jätettiin huomioimatta"
@@ -1205,7 +1205,7 @@ msgid "Disconnected"
 msgstr "Yhteys katkaistu"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1359,19 +1359,19 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1398,7 +1398,7 @@ msgid "Queue Full"
 msgstr "Jono täynnä"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Jonossa"
 
@@ -1463,7 +1463,7 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1535,7 +1535,7 @@ msgstr "Osa"
 msgid "Size"
 msgstr "Koko"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Siirretty"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Palaute tullut: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automaattinen"
@@ -1667,34 +1667,34 @@ msgstr "Luokittele"
 msgid "&Open the file"
 msgstr "Avaa tied&osto"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Anna uusi nimi tälle tiedostolle:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Tiedoston uudelleennimeäminen"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f KB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lataukset (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1703,11 +1703,11 @@ msgstr ""
 "Estääksesi tämän varoituksen näyttämisen joka kerralla,\n"
 "aseta haluamasi videotoistin asetuksissa (oletuksena %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Tiedoston esikatselu"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "VIRHE: Ulkoista mediatoistinta ei voitu käynnistää! Komento: `%s'"
@@ -2269,7 +2269,7 @@ msgstr "Kaverilistatiedostoa 'emfriends.met' ei saatu avattua kirjoitettavaksi!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRIITTINEN - ei asiakasta keskustelun aloituksessa"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Kaverit"
 
@@ -2613,57 +2613,57 @@ msgstr[1] "Kirjoitettu %d Kad-kontaktia"
 msgid "Kad user"
 msgstr "Kad-verkko"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Tiedoston nimi"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Tiedostokoko"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Jakosuhde"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Pyydetty"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Hyväksytty"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Täysiä lähteitä"
 
@@ -2779,7 +2779,7 @@ msgid "WARNING: "
 msgstr "VAROITUS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Sulje"
 
@@ -2797,7 +2797,7 @@ msgid "Paste"
 msgstr "Liitä"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pyyhi"
@@ -3218,8 +3218,8 @@ msgstr "Tiedostolähteet:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Ei saatavilla"
 
@@ -3364,7 +3364,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Otsikko :"
 
@@ -3473,7 +3473,7 @@ msgstr "Käyttäjänimi :"
 msgid "Userhash :"
 msgstr "Käyttäjätarkiste :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lisää"
@@ -3482,15 +3482,15 @@ msgstr "Lisää"
 msgid "Download-Speed"
 msgstr "Latausnopeus"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Nykyinen"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Yhtäjaksoinen keskiarvo"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Session keskiarvo"
 
@@ -3730,7 +3730,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Syötä tähän selaimesi nimi. Jätä tyhjäksi jos haluat käyttää järjestelmän oletusselainta."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3804,7 +3804,7 @@ msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Vain edistyneille käyttäjille: mikäli sinulla on useampia verkkoliitäntöjä, syötä sen liitännän osoite johon haluat aMulen sidottavan."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Sido paikallinen osoite IP:hen (tyhjä sallii mihin tahansa):"
@@ -3825,7 +3825,7 @@ msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4145,7 +4145,7 @@ msgstr "Kad-yhteyksiä aktiivisena"
 msgid "Kad-nodes session"
 msgstr "Kad-yhteyksiä sessiossa"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Valitse"
 
@@ -4263,421 +4263,413 @@ msgstr "Tasainen"
 msgid "Round"
 msgstr "Pyöreä"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Järjestä tiedostot automaattisesti (iso suorittimen käyttö)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule järjestää sarakkeet latauslistassasi automaattisesti"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Etäyhteyksien asetukset"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Hyväksy etäyhteydet"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "Kuunneltavan verkkoliitännän IP:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Syötä tähän sen verkkoliitännän ip jota kuunnellaan etäyhteyksiä varten. Tyhjä tai 0.0.0.0 tarkoittaa kaikkia verkkoliitäntöjä."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Kytke päälle UPnP-portinohjaus etäyhteysportissa"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Salasana"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-portti:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Tarkistaa salasanaa\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Web-palvelimen asetukset"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Käynnistä web-palvelin käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web-sapluuna"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Täysien oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Salli rajoitettujen oikeuksien käyttäjä"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Rajoitettujen oikeuksien salasana"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Käytä UPnP-portinohjausta web-palvelimen portissa"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web-palvelimen UPnP TCP-portti (Valinnainen)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Sivun päivitysväli (sekunneissa)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Salli gzip-pakkaus"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Järjestelmän vakio"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Napsauta tästä saattaaksesi voimaan asetuksiin tehdyt muutokset."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Kommentti :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Saapuvien kansio :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Älä vaihda"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Valitse väri tälle luokalle (valittuna) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Napsauta tätä painiketta nollataksesi lokin."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi palvelinlistan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Palvelinlista"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Syötä tähän server.met-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen palvelimien listan."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Palvelimen lisäys käsin: Nimi"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Syötä uuden palvelimen nimi tähän"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Portti"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Syötä palvelimen portti tähän."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lisää palvelin käsin (täytä vasemmalla olevat kentät) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule loki"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Palvelimen tiedot"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Napsauta tätä nappia päivittääksesi yhteyspisteiden listan osoitteesta ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Yhteyspisteitä (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Syötä tähän nodes.dat-tiedostoon osoittava url ja paina nappia vasemmalla päivittääksesi tunnettujen yhteyspisteiden listan."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Yhdistämisapu"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Uusi yhteyspiste"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Katkaise Kad-yhteys"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Käytä turvattua käyttäjän tunnistusta"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Tunnistuksen käyttö on suositeltavaa. Muuten et hyödy pistejärjestelmästä."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokollan kätkeminen"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Tuki protokollan kätkemiselle"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Tämä valinta sallii aMulen ottaa vastaan kätketyn protokollan yhteyksiä muilta asiakkailta."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Käytä kätkemistä lähtevissä yhteyksissä"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Tämä valittuna aMule käyttää protokollan kätkemistä ottaessaan yhteyttä muihin asiakkaisiin/palvelimiin."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Vastaanota vain kätkettyjä yhteyksiä"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Tämä valittuna aMule hyväksyy vain kätketyt yhteydet. Lähteitä on vähemmän saatavilla mutta kaikki liikenteesi on kätketyllä protokollalla."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Kaikki"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Ei kukaan"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Ketkä voivat nähdä jaetut tiedostoni:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Valitse ketkä voivat pyytää nähtäville sinun jaettujen tiedostojen listaasi."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-suodatus"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Suodata asiakkaat"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli asiakas-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Suodata palvelimet"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Salli palvelin-IP:den suodatus kuten määritelty tiedostossa ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Uudelleenlataa lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Uudelleenlataa suodatettavien IP:den lista tiedostosta ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Päivitä nyt"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Suodatustaso:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Suodata aina lähiverkon IP:t"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Käsittele muut IP:t vainoharhaisesti"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Käytä järjestelmänlaajuista ipfilter.dat-tiedostoa mikäli saatavilla"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Mikäli paikallista ipfilter.dat:ia ei löydy, käytetään järjestelmänlaajuista ipfilter.dat-tiedostoa."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Kytke Online-Signeeraus päälle"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Kytkee päälle Online-Signeeraustiedoston kirjoittamisen, jota muut ohjelmat voivat käyttää esimerkiksi signeerauksissa."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Päivitysväli (sekuntia):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Muuttaa Online-Signeerauksen päivitysväliä, annetaan sekunteina."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Online-signeeraus-tiedoston tallennuspaikka:"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Napsauta tästä valitaksesi kansio Online-Signeerauksen tiedostoille."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Näytä asiakkaiden valtioiden liput"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Siirtonopeus :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Lähteet"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4685,11 +4677,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4699,226 +4691,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Lataus: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Päivitä ip-suodatus automaattisesti käynnistettäessä"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Suodata saapuvat viestit (ei koske keskusteluja):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Suodata kaikki viestit"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Suodata viestit ihmisiltä jotka eivät ole kaverilistallasi"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Suodata viestit tuntemattomilta asiakkailta"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Suodata viestit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Syötä tähän suodatettavat sanat ja aMule estää viestit jotka sisältävät sellaisen"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Näytä vastaanotetut viestit lokissa"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Kommentit"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Suodata kommentit jotka sisältävät (käytä merkkiä ',' erottimena):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Käytä tunnistautumista"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Käyttäjänimi: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Salasana:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Salasana tunnistautuessa välityspalvelimelle"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Käytä välityspalvelinta"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tyyppi:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Välityspalvelin:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Portti:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Välityspalvelimen portti"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Yhdistä:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Käyttäjänimi"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Käytä gzip-pakkausta"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Käytä monisanaista lokiin kirjausta."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Avaa tied&osto"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Viestien luokittelut:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Odottaa..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Lisää tuonteja"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Yritä uudelleen valittuja"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Poista valitut"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tapahtumatyypit"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Tilastot ja jonottavat asiakkaat valitu(i)lle tiedosto(i)lle: Sessiossa / Yhteensä"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Prosenttia kaikista tiedostoista"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Valitut tiedostot"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Vain aktiiviset lähetykset"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Uudelleenlataa:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Uudelleenlataa jaetut tiedostot"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Lähetä"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Lähettää annetun viestin."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
 
@@ -5277,188 +5269,188 @@ msgstr "Ladattu"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Järjestelmän vakio"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albania"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabia"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturia"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgaria"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kiina (Yksinkertaistettu)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kiina (Perinteinen)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroatia"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tsekki"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Tanska"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Hollanti"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englanti (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Viro"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Ranska"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galicia (Galego)"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Saksa"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Kreikka"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Heprea"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italia"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japani"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korea"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Liettua"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norja (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Puola"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugali"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugali (Brazilia)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Romanian"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Venäjä"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovenia"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Espanja"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Ruotsi"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turkki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Vaihda kieli"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Käännöksiä ei ole asennettuna aMulelle"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Kieliä ei saatavilla"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-portti ei voi olla korkeampi kuin 65532 koska serverin käyttämä UDP-pistukka on TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Käytetään oletusporttia (%d)"
@@ -8397,6 +8389,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Järjestä tiedostot automaattisesti (iso suorittimen käyttö)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule järjestää sarakkeet latauslistassasi automaattisesti"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Hylkää paketit mikäli asiakkaan ip on eri kuin mistä paketti saapui. Käytä varoen."

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-25 19:02+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -659,8 +659,8 @@ msgstr "Kad : Coupé"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -671,7 +671,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Déconnecter"
 
@@ -680,7 +680,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Se connecter"
 
@@ -730,111 +730,111 @@ msgstr "Voulez-vous vraiment quitter %s ?"
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Réseaux"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Téléchargements"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Fichiers partagés"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Messages"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Pas de réseau"
 
@@ -974,14 +974,14 @@ msgstr "Lien invalide ou déjà dans la liste."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on garde le répertoire '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -992,72 +992,72 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Recherche d'un pote pour une connexion lowid"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Fausse version d'eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Faux eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Faux eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basé sur eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Pseudo : %s ID : %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Demandé : %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiques des fichiers pour cette session : %d requête acceptée sur %d, %s transférés\n"
 msgstr[1] "Statistiques des fichiers pour cette session : %d requêtes acceptées sur %d, %s transférées\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiques des fichiers pour toutes les sessions : %d requête acceptée sur %d, %s transférés\n"
 msgstr[1] "Statistiques des fichiers pour toutes les sessions : %d requêtes acceptées sur %d, %s transférées\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Fichier demandé inconnu"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Message filtré de '%s' (IP : %s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nouveau message de '%s' (IP : %s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés pour le répertoire inexistant '%s' -> ignoré"
@@ -1214,7 +1214,7 @@ msgid "Disconnected"
 msgstr "Déconnecté"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1367,19 +1367,19 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1406,7 +1406,7 @@ msgid "Queue Full"
 msgstr "File d'attente pleine"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "En attente"
 
@@ -1471,7 +1471,7 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Partie"
 msgid "Size"
 msgstr "Taille"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Reçu"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 "Retour de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1674,34 +1674,34 @@ msgstr "Associer à une catégorie"
 msgid "&Open the file"
 msgstr "&Ouvrir le fichier"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Entrez un nouveau nom pour ce fichier :"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Renommer"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f Mo/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H : %M : %S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Téléchargements (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr "le gestionnaire par défaut de shell Windows"
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1710,11 +1710,11 @@ msgstr ""
 "Pour éviter que cet avertissement n'apparaisse avec chaque prévisualisation,\n"
 "indiquez votre lecteur vidéo préféré dans les préférences (%s par défaut)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Aperçu"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERREUR : Échec de l'exécution du lecteur multimédia externe ! Commande : '%s'"
@@ -2274,7 +2274,7 @@ msgstr "Échec de l'ouverture du fichier de la liste d'amis 'emfriends.met' pour
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIQUE - Pas de client dans StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amis"
 
@@ -2616,57 +2616,57 @@ msgstr[1] "%d contacts Kad écrits"
 msgid "Kad user"
 msgstr "Utilisateur Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : Kad n'est pas connecté"
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : une recherche de note est déjà en cours d'exécution pour ce fichier"
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : le fichier n'est pas dans la liste des partages, la file des téléchargements ou les résultats de recherche"
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "La recherche Kad de note pour '%s' n'a pu être démarrée : une autre recherche Kad (par exemple une recherche de source) utilise déjà le hachage de ce fichier - veuillez réessayer sous peu"
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "La recherche Kad pour '%s' n'a pu être démarrée : échec de PrepareLookup"
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nom de fichier"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Taille du fichier"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Ratio de partage"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Demandé"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Accepté"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Sources complètes"
 
@@ -2781,7 +2781,7 @@ msgid "WARNING: "
 msgstr "AVERTISSEMENT : "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Fermer"
 
@@ -2799,7 +2799,7 @@ msgid "Paste"
 msgstr "Coller"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Effacer"
@@ -3211,8 +3211,8 @@ msgstr "Sources du fichier :"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3352,7 +3352,7 @@ msgstr "Artiste :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titre :"
 
@@ -3460,7 +3460,7 @@ msgstr "Nom d'utilisateur :"
 msgid "Userhash :"
 msgstr "Hachage de l'utilisateur :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ajouter"
@@ -3469,15 +3469,15 @@ msgstr "Ajouter"
 msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Actuelle"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Moyenne totale"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Moyenne de la session"
 
@@ -3715,7 +3715,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Indiquez le nom de votre navigateur ici. Laissez ce champ vide pour utiliser le navigateur par défaut du système."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3789,7 +3789,7 @@ msgstr "Lier l'adresse locale à une IP (vide pour toutes) :"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Utilisateurs avancés uniquement : Si vous avez plusieurs interfaces réseau, entrez l'adresse de l'interface à laquelle aMule doit être lié."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr "Lier à une interface réseau (vide pour toutes) :"
 
@@ -3809,7 +3809,7 @@ msgstr "Connexions simultanées maximales :"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4129,7 +4129,7 @@ msgstr "Nœuds Kad total"
 msgid "Kad-nodes session"
 msgstr "Nœuds Kad pour la session"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Sélectionner"
 
@@ -4245,413 +4245,405 @@ msgstr "Plat"
 msgid "Round"
 msgstr "Relief"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Triage automatique des fichiers (augmente la charge du CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule triera automatiquement les colonnes dans votre liste de téléchargements"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Paramètres de Connexion Externe"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Accepter les connexions externes"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP de l'interface d'écoute :"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Entrer ici une adresse IP valide dans le format a.b.c.d pour l'interface d'écoute EC. Un champ vide ou 0.0.0.0 signifiera toutes les interfaces."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Port TCP :"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activer la redirection de ports en UPnP sur le port EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Mot de passe"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr "Paramètres du serveur aMule API"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Exécuter amuleapi (API REST) au démarrage"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr "Port HTTP :"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interface sur laquelle le serveur HTTP d'amuleapi écoute. 127.0.0.1 (par défaut) n'accepte que les connexions locales  ; utilisez 0.0.0.0 ou bien une adresse IP spécifique pour l'exposer à d'autres hôtes (définissez un mot de passe administrateur ci-dessous)."
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Paramètres du serveur Web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr "Démarrer le serveur web au démarrage (obsolète)"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Mot de passe administrateur"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Activer l'accès utilisateur sans privilèges"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Mot de passe sans privilèges"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activer la redirection de port UPnP sur le port du serveur web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port TCP UPnP du serveur web (Facultatif)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervalle de rafraîchissement (en secondes)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Activer la compression Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr "Réinitialiser la page aux valeurs par défaut"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr "Réinitialiser les réglages sur la page actuelle à leurs valeurs par défaut."
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Cliquer ici pour appliquer tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Commentaire :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Répertoire entrant :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Changer la priorité des nouveaux fichiers assignés :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Ne rien changer"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Cliquer ici pour effacer le journal."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Cliquer ici pour mettre à jour la liste des serveurs à partir de l'URL…"
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Liste des serveurs"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Entrer l'URL d'un fichier server.met et presser le bouton à gauche pour rafraîchir la liste des serveurs connus."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Ajouter un serveur manuellement : Nom"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Entrer ici le nom du nouveau serveur"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP : Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Entrer ici le port du serveur."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ajouter manuellement un serveur (remplir les champs à gauche avant)…"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Journal d'aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Infos Serveur"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Infos ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Infos Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Cliquer sur le bouton pour mettre à jour la liste des nœuds depuis l'URL…"
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nœuds (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Entrer l'URL d'un fichier nodes.dat ici et presser le bouton à gauche pour mettre à jour la liste des nœuds connus."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Amorçage"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nouveau nœud"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP :"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port :"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Amorçage depuis les clients connus"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Déconnecter Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Utiliser l'Identification Utilisateur Sécurisée (SUI)"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Il est recommandé d'activer cette option. Vous ne recevrez pas de crédits si SUI n'est pas activé."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Supporter le brouillage de protocole"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Cette option active le brouillage de protocole, cela permet à aMule d'accepter les connexions brouillées des autres clients."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utiliser le brouillage pour les connexions sortantes"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Avec cette option, aMule utilise le brouillage de protocole lors des connexions aux autres clients/serveurs."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Accepter seulement les connexions brouillées"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Avec cette option, aMule n'accepte que les connexions brouillées. Vous aurez moins de sources, mais tout votre trafic sera brouillé"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Tout le monde"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Personne"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Qui peut voir mes fichiers partagés :"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Indique qui peut voir votre liste de fichiers partagés."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtrage des IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrage des clients"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activer le filtrage des clients selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrage des serveurs"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Active le filtrage des serveurs selon les IP contenues dans le fichier ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recharger la liste"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recharge la liste des IP à filtrer à partir du fichier ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL :"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Mise à jour d' IPFilter au démarrage"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Niveau de filtrage :"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Toujours filtrer les IPs LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Prise en charge paranoïaque des IPs qui ne se correspondent pas"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejette un paquet lorsque son IP source diffère de l'IP que le client prétend avoir (vérification anti-usurpation). Désactivez seulement si cela provoque des problèmes de connexion."
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "S'il n'y a pas de fichier ipfilter.dat local, autoriser l'utilisation d'un fichier ipfilter système."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Activer la Signature En Ligne"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Active l'écriture du fichier de signature en ligne, qui peut-être utilisé par des applications extérieures pour créer des signatures, etc."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Fréquence de mise à jour (Secondes) :"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Change la fréquence des mises à jour de la signature en ligne (en secondes)."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Sauver le fichier de signature en ligne dans : "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Cliquer ici pour sélectionner le répertoire contenant le fichier de signature en ligne."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Voir les drapeaux des pays pour les clients"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Afficher la colonne des drapeaux des pays dans les vues des transferts, des files d'attente et de recherche. Nécessite une base de données MMDB GeoIP valide (cf. ci-dessous)."
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Base de données"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "Source :"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuit, pas de compte)"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuit, compte nécessaire)"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "URL personnalisé"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Choisissez quel fournisseur procure la base de données GeoIP MMDB. DB-IP est la valeur par défaut - ne nécessite pas de compte. MaxMind nécessite un compte gratuit + une clef de licence. Utilisez un URL personnalisé pour pointer vers tout autre hôte MMDB (par exemple un miroir local)."
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4663,11 +4655,11 @@ msgstr ""
 "Les données IP vers pays par DB-IP.com - https://db-ip.com\n"
 "Licence : Creative Commons Attribution 4.0 - https://creativecommons.org/licenses/by/4.0/deed.fr"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "Clef de licence :"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4683,11 +4675,11 @@ msgstr ""
 "Licence : CLUF MaxMind GeoLite2 - https://www.maxmind.com/en/geolite2/eula\n"
 "Nécessite une attribution et la création d'un compte ; actualisez au moins tous les 30 jours."
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "URL de téléchargement :"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4697,211 +4689,211 @@ msgstr ""
 "L'URL peut contenir un identifiant et mot de passe (https://utilisateur:motdepasse@hôte/...) \n"
 "La licence et les conditions d'attribution sont définies par l'URL d'origine - vous en êtes responsable."
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "Télécharger la base de données GeoIP depuis la source sélectionnée."
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Mise à jour automatique au démarrage"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Télécharger à nouveau la base de données GeoIP depuis la source sélectionnée chaque fois qu'aMule démarre."
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrer les messages entrant (sauf la discussion en cours) :"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrer tous les messages"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrer les messages des gens qui ne sont pas sur votre liste d'amis"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrer les messages des clients inconnus"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrer les messages contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "ajouter ici les mots qu'aMule doit filtrer : blocage des messages les contenant"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Afficher les messages reçus dans le journal"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Commentaires"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrer les commentaires contenant (utiliser ',' comme séparateur) :"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Activer l'authentification"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nom d'utilisateur : "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Mot de passe pour se connecter au proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Activer le Proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Type de proxy :"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Hôte du proxy :"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Port du proxy :"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Numéro du port du proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Se connecter à :"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "Forcer la compression ZLIB"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activer l'historique du mode de débogage bavard."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Seulement vers le fichier journal"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Catégories des messages :"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "En attente…"
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Ajouter des fichiers à importer"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Réessayer avec la sélection"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Supprimer la sélection"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Types d'événements"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiques et clients en attente pour le(s) fichier(s) sélectionné(s) : Session / Tous les temps"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Envois Actifs"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Pourcentage du total de fichiers"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Fichiers sélectionnés"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Envois actifs seulement"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Recharger :"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Recharge vos fichiers partagés"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Envoie le message spécifié."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fichiers partagés"
 
@@ -5261,187 +5253,187 @@ msgstr "Téléchargé"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Système par défaut"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanais"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturien"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basque"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalan"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinois (Simplifié)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinois (Traditionnel)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croate"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tchèque"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danois"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Hollandais"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Anglais (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "Anglais (É-U)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonien"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Français"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galicien"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Allemand"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grec"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hébreux"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italien"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonais"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coréen"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr "Letton"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvégien (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polonais"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugais (Brésilien)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Roumain"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russe"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suédois"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turc"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Changer de langue"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Il n'y a pas de traductions installées pour aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Pas de langues disponibles"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "pas d'option disponible"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Le port TCP ne peut pas dépasser 65532 car le socket UDP du serveur sera à TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Le port par défaut sera utilisé (%d)"
@@ -8382,6 +8374,12 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Triage automatique des fichiers (augmente la charge du CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule triera automatiquement les colonnes dans votre liste de téléchargements"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rejette le paquet si l'IP du client est différente de l'ip d'où le paquet est envoyé. À utiliser avec prudence."

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:57+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -669,8 +669,8 @@ msgstr "Kad: Apagado"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -681,7 +681,7 @@ msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -690,7 +690,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Conectar"
 
@@ -740,111 +740,111 @@ msgstr "Desexar saír de %s?"
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descargas"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mensaxes"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Sen rede"
 
@@ -985,14 +985,14 @@ msgstr "Ligazón inválida ou xa presente na lista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantendo o directorio «%s»."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -1003,72 +1003,72 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Buscando colega para unha conexión IDBaixa"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (eMule falso versión %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (eMule falso)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule falso)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado en eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alcume: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pedido: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas do ficheiro para esta sesión: Aceptada %d de %d peticións; transferida %s\n"
 msgstr[1] "Estatísticas do ficheiro para esta sesión: Aceptadas %d de %d peticións; transferidas %s\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas do ficheiro para todas as sesións: Aceptada %d de %d peticións; transferida %s\n"
 msgstr[1] "Estatísticas do ficheiro para todas as sesións: Aceptadas %d de %d peticións; transferidas %s\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Pedido ficheiro descoñecido"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensaxe filtrada de «%s» (IP: %s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nova mensaxe de «%s» (IP: %s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "O usuario %s (%u) pediu a súa lista de ficheiros compartidos do directorio inexistente «%s» -> Ignorouse"
@@ -1225,7 +1225,7 @@ msgid "Disconnected"
 msgstr "Desconectado"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1379,19 +1379,19 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1418,7 +1418,7 @@ msgid "Queue Full"
 msgstr "Cola chea"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "En cola"
 
@@ -1483,7 +1483,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1554,7 +1554,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1611,7 +1611,7 @@ msgstr ""
 "Comentarios de : %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automático"
@@ -1686,34 +1686,34 @@ msgstr "Asignar á categoría"
 msgid "&Open the file"
 msgstr "Abrir o ficheir&o"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Introducir un novo nome para este ficheiro:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Cambiar o nome do ficheiro"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1722,11 +1722,11 @@ msgstr ""
 "Para evitar a aparición deste aviso en cada vista previa,\n"
 "establece o teu reprodutor de vídeo nos axustes (%s é o predeterminado)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Previsualizar ficheiro"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Non se puido executar o reprodutor multimedia externo! Orde: «%s»"
@@ -2286,7 +2286,7 @@ msgstr "Non se puido escribir a lista de amigos ao ficheiro «emfriends.met»!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - non hai cliente en StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2629,57 +2629,57 @@ msgstr[1] "Escribíronse %d contactos Kad"
 msgid "Kad user"
 msgstr "Red Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nome de ficheiro"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Tamaño do ficheiro"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Relación enviado/descargado"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Solicitado"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Aceptado"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fontes completas"
 
@@ -2795,7 +2795,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Pechar"
 
@@ -2813,7 +2813,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3227,8 +3227,8 @@ msgstr "Fontes do ficheiro:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3373,7 +3373,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Título :"
 
@@ -3482,7 +3482,7 @@ msgstr "Nome de usuario :"
 msgid "Userhash :"
 msgstr "Hash do usuario :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Engadir"
@@ -3491,15 +3491,15 @@ msgstr "Engadir"
 msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Media de execución"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Media de sesión"
 
@@ -3739,7 +3739,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Introduza o nome do seu navegador aquí. Deixe o campo baleiro para empregar o navegador predeterminado do sistema."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3813,7 +3813,7 @@ msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Só usuarios experimentados: Se ten varias interfaces de rede, introduza a dirección da interface que quere que aMule use."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Ligar dirección local á IP (deixe baleiro para calquera):"
@@ -3834,7 +3834,7 @@ msgstr "Conexións simultáneas máximas:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4154,7 +4154,7 @@ msgstr "Nodo Kad executándose"
 msgid "Kad-nodes session"
 msgstr "Nodos Kad na sesión"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Seleccionar"
 
@@ -4272,420 +4272,412 @@ msgstr "Plana"
 msgid "Round"
 msgstr "3D"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Clasificar ficheiros automaticamente (consume bastantes recursos)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule ordenará as columnas na súa lista de descargas automaticamente"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parámetros da Conexión Externa (CE)"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Aceptar conexións externas"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP da interface na que escoitar:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduza aquí a IP (válida, no formato a.b.c.d) da interface para a CE. Un campo baleiro ou 0.0.0.0 significa calquera interface."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar a configuración de portos por UPnP para o porto de CE"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Contrasinal"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Comprobando contrasinal\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parámetros do servidor Web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Arrancar o servidor web ao iniciar"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Modelo Web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Contrasinal para o administrador"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Activar invitado"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Contrasinal para o invitado"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Configurar o porto do servidor web mediante UPnP"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP para o UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo de actualización da páxina (en segs)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Activar compresión Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predeterminado"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Vale"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Aplicar calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentario :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Cartafol de descargas :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Cambiar prioridade para os novos ficheiros asignados :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Non cambiar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Premer este botón para reiniciar o rexistro."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Premer neste botón para actualizar a lista de servidores desde a URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduza a URL dun ficheiro server.met e prema o botón da esquerda para actualizar a lista de servidores coñecidos."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Engadir servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Introduza o nome do novo servidor aquí"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Introduza o porto do servidor aquí."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Engadir servidor manualmente (antes enche os campos á esquerda) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Rexistro de aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Info. do servidor"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Info. ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Prema neste botón para actualizar a lista de nodos dende a URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodos (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduza aquí a URL ao ficheiro nodes.dat e prema o botón da esquerda, para actualizar a lista de nodos coñecidos."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Arranque autónomo (dende cero)"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Novo nodo"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes coñecidos"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Desconectar Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Empregar a Identificación Segura do Usuario"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Aconséllase habilitar esta opción. Non recibirá créditos se a ISU non se habilitou."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Aceptar a ofuscación do protocolo"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opción activa a ofuscación do protocolo, e permite que aMule acepte conexións ofuscadas doutros clientes."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscación para as conexións saíntes"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opción fai que aMule use a ofuscación de protocolo cando se conectan outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Aceptar só conexións ofuscadas"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opción fai que aMule só acepte conexións ofuscadas. Terá menos fontes, pero todo o tráfico estará ofuscado"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Ninguén"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Quen pode ver os meus ficheiros compartidos:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quen pode solicitar ver a lista de ficheiros compartidos."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtrado de IPs"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos clientes definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtrado das IPs dos servidores definidas no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recargar lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recargar a lista de filtrado de IPs desde o ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Nivel de filtrado:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre IPs LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Xestión paranoica de IPs non coincidintes"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Empregar un ipfilter.dat global se está dispoñible"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "De non atopar o ipfilter.dat local, permitir o emprego dun ipfilter global."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Activar Sinatura En liña"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilitar a escritura de ficheiros do SE. Sóese usar para crear sinaturas para aplicacións externas."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frecuencia de actualización (segs):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambiar a frecuencia (en segundos) da actualización da sinatura en liña."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Gardar o ficheiro de sinaturas en liña en: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Prema aquí para seleccionar o directorio que contén os ficheiros de sinaturas en liña."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Amosar as bandeiras do país de orixe dos clientes"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Fluxo de datos :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4693,11 +4685,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4707,225 +4699,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descargado: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-actualizar o filtrado de IPs ao iniciarse"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensaxes entrantes (excepto as da conversación actual):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensaxes"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensaxes de xente que non estea na lista de amigos"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensaxes de clientes descoñecidos"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensaxes que conteñan (use «,» como separador):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "engada aquí palabras para filtrar e bloquear as mensaxes que coincidan"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Amosar as mensaxes recibidas no rexistro"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentarios"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentarios que conteñan (empregue «,» coma separador):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Activar identificación"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nome de usuario: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Contrasinal:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "O contrasinal a empregar para conectarse ao proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Activar proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Anfitrión do proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Conectar a:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nome de usuario"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compresión gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Rexistro de Depuración Estendido."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Só ao ficheiro do rexistro"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categorías das mensaxes:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Agardando..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Engadir importados"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Tentar de novo o seleccionado"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Borrar seleccionados"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estadísticas e clientes esperando para os ficheiros seleccionados: Sesión / Total"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Envíos activos"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Porcentaxe de todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Ficheiros selecionados"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Só subidas activas"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Recargar:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Recargar os seus ficheiros compartidos"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Enviar a mensaxe especificada."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a calquera servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
 
@@ -5285,188 +5277,188 @@ msgstr "Descargado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Predeterminado"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanés"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Euskera"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinés (Simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinés (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danés"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandés"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglés (R. U.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonio"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandés"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francés"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemán"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Xaponés"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruegués (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugués (Brasileiro)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumano"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ruso"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Castelán"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Cambiar idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Non hai traducións instaladas para aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Ningunha lingua dispoñible"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP non pode ser máis alto que 65532 debido a que o socket do servidor UDP é TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Empregarase o porto predeterminado (%d)"
@@ -8417,6 +8409,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Clasificar ficheiros automaticamente (consume bastantes recursos)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule ordenará as columnas na súa lista de descargas automaticamente"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rexeitar os paquetes se a IP do cliente é distinta á da IP de onde se recibe o paquete. Usar con coidado."

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:58+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -636,8 +636,8 @@ msgstr "קאד: מכובה"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -648,7 +648,7 @@ msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "מנותק"
 
@@ -657,7 +657,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "התחבר"
 
@@ -708,112 +708,112 @@ msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "רשתות"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "הורדות"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "הודעות"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "העדפות"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -955,14 +955,14 @@ msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -973,72 +973,72 @@ msgstr ""
 msgid "Unknown"
 msgstr "לא ידוע"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr "(חיקוי אימיול בגרסת %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr "(חיקוי אימיול)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "אקס-מיול (חיקוי אימיול)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.איקס (מבוסס על אימיול בגרסת 0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "כינוי:%s מ\"ז: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "בוּקַש: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "בקשה עבור קובץ לא ידוע"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "סוננה הודעה מ '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "הודעה חדשה מ '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך בתקייה %s -> נדחה"
@@ -1196,7 +1196,7 @@ msgid "Disconnected"
 msgstr "מנותק"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1349,19 +1349,19 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1388,7 +1388,7 @@ msgid "Queue Full"
 msgstr "התור מלא"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "על התור"
 
@@ -1453,7 +1453,7 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "קאד"
@@ -1525,7 +1525,7 @@ msgstr ""
 msgid "Size"
 msgstr "גודל"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "הועברו"
 
@@ -1580,7 +1580,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "אוטמטי"
@@ -1655,45 +1655,45 @@ msgstr "ייחס לקטיגוריה"
 msgid "&Open the file"
 msgstr "&תפתח את הקובץ"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "הכנס שם חדש עבור קובץ זה"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "שינוי שם לקובץ"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.2f מ\"ב"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d·%H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "הורדות (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "תקדימון לקובץ"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "שגיאה: הרצת נגן הסרטים נכשלה! הפקודה: '%s'"
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "חברים"
 
@@ -2581,57 +2581,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr "קאד התחיל."
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "שם הקובץ"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2749,7 +2749,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "סגור"
 
@@ -2767,7 +2767,7 @@ msgid "Paste"
 msgstr "הדבק"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "נקה"
@@ -3188,8 +3188,8 @@ msgstr "מקורות שנמצאו :"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "ל\"ת"
 
@@ -3333,7 +3333,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr ""
 
@@ -3440,7 +3440,7 @@ msgstr "שם משתמש :"
 msgid "Userhash :"
 msgstr "גיבוב משתשמ :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "הוסף"
@@ -3449,15 +3449,15 @@ msgstr "הוסף"
 msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "נוכחיים"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "ממוצע רץ"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "ממוצע ההרצה הנוכחית"
 
@@ -3696,7 +3696,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3790,7 +3790,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4108,7 +4108,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr ""
 
@@ -4226,419 +4226,411 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "סיסמא"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "מבואת UPnP"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "בודק סיסמא\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "בסדר"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "אי.פי.:מבואה"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "קצב מידע :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "מקורות"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4646,11 +4638,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4660,230 +4652,230 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "מוריד: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "השמתש בדחיסת gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&תפתח את הקובץ"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "ממתין..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "קבצים משותפים"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "בחר מסנן תצוגה"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "העלאות פעילים"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "שלח"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "שולח את ההודעה המצויינת."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "קבצים משותפים"
 
@@ -5246,191 +5238,191 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "ברירת מחדל של המערכת"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "ערבית"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "בסקית"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "בולגרית"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "קטלונית"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "סינית (מופשטת)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "סינית (מסורתית)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "קרואטית"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "צ'כית"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "דנית"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "הולנדית"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "אנגלית (בריטית)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "אסטונית"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "פינית"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "צרפתית"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "גאלית"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "גרמנית"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "יוונית"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "הונגרית"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "איטלקית"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "יפנית"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "קוראינית"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "ליטאית"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "נורבגית (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "פונלית"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "פורטגזית"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "פורטגזית (ברזילאית)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "אלבני"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "רוסית"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "סלובקית"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "ספרדית"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "שוודית"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "טורקית"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "לא זמין"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "מבואת ה TCP אינה יכולה להיות גבוהה יותר מ 65532 מאחר שמבואת ה UDP של השרת היא מבואת ה TCP +3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "נשתמש במבואה שבברירת מחדך (%d)"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:58+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -636,8 +636,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -649,7 +649,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
@@ -659,7 +659,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
@@ -710,112 +710,112 @@ msgstr "Da li zaista zelite iskljuciti aMule?"
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Poruke"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistike"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Opcije"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -955,14 +955,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -973,45 +973,45 @@ msgstr ""
 msgid "Unknown"
 msgstr "Nepoznat"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "ceka na spajanje..."
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "Zahtijevan:"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1019,7 +1019,7 @@ msgstr[0] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s prene
 msgstr[1] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s preneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1027,21 +1027,21 @@ msgstr[0] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s prene
 msgstr[1] "Fajl statistike za ovu misiju: Prihvaceno %d od %d zahtjeva, %s preneseno\n"
 msgstr[2] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Zatrazen nepoznat fajl"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Korisnik %s (%u) ja zahtio tvoju listu dijeljenih fajlova za direktorij %s -> %s"
@@ -1200,7 +1200,7 @@ msgid "Disconnected"
 msgstr "Prekinuta veza"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1355,19 +1355,19 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1394,7 +1394,7 @@ msgid "Queue Full"
 msgstr "Pun red cekanja"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "U redu cekanja"
 
@@ -1459,7 +1459,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Size"
 msgstr "Velicina"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferirano"
 
@@ -1587,7 +1587,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatski"
@@ -1662,45 +1662,45 @@ msgstr "Odredi u kategoriju"
 msgid "&Open the file"
 msgstr "&Otvori fajl"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2584,57 +2584,57 @@ msgstr[2] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Naziv datoteke"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Veličina datoteke"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2751,7 +2751,7 @@ msgid "WARNING: "
 msgstr "UPOZORENJE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Zatvori"
 
@@ -2769,7 +2769,7 @@ msgid "Paste"
 msgstr "Staviti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Ocisti"
@@ -3190,8 +3190,8 @@ msgstr "Nadjeni izvori :"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3334,7 +3334,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Naziv :"
 
@@ -3440,7 +3440,7 @@ msgstr "Ime korisnika :"
 msgid "Userhash :"
 msgstr "Hash korisnika :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3449,15 +3449,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Brzina downloada"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Prosjek rada"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Prosjek misije"
 
@@ -3696,7 +3696,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3790,7 +3790,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Izaberi"
 
@@ -4228,418 +4228,410 @@ msgstr "Pljosnata"
 msgid "Round"
 msgstr "Obla"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parametri za spoljasnju vezu"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Prihvati spoljasnje veze"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Lozinka"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Sifra za puna prava"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Odobri korisnicima sa manje prava"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Sifra za manje prava"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Vrijeme obnove stranice (u sekundama)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Odobri Gzip kompresiju"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standard sistema"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Prijemni direktorij :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Promijeni prioritet za nove fajlove :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Ne mijenjaj"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikni ovdje da obnovis listu servera sa URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj servera rucno (prije ispuni polja lijevo) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule Log"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Lista servera"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Svi"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nitko"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Omoguci online potpis"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Podatak rate :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Izvori"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4647,11 +4639,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4661,233 +4653,233 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Autospajanje pri startu"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Korisničko ime:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Lozinka:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Korisničko ime"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Steceno kompresijom :"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otvori fajl"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ceka ..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktivni uploadovi :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 #, fuzzy
 msgid "Percent of total files"
 msgstr "Ukupni fajlovi"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Dijeljeni fajlovi"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Izaberi filter za gledanje"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktivni uploadovi"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Ponovno ucitati"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Posalji"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
 
@@ -5253,188 +5245,188 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Standard sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanski"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arapski"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturleonski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bugarski"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kineski"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kinesko (tradicionalno)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Hrvatski"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Češki"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danski"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nizozemski"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engleski (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonski"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finski"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galješki"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Njemački"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grčki"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebrejski"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Mađarski"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Talijanski"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japanski"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korejski"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litavski"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveški (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Poljski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumunjski"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ruski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovenski"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Španjolski"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Švedski"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turski"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukrajinski"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Promijeniti jezik"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Nema dostupnih jezika"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:58+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -650,8 +650,8 @@ msgstr "Kad: Nincs kapcsolat"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -662,7 +662,7 @@ msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
@@ -671,7 +671,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
@@ -721,111 +721,111 @@ msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Hálózatok"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Megosztott fájlok"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Nincs hálózat"
 
@@ -966,14 +966,14 @@ msgstr "Érvénytelen hivatkozás, vagy már rajta van a listán."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a '%s' könyvtár megtartva."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -984,70 +984,70 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Pajtás keresése lowid kapcsolatra"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Hamis eMule %#x verzió)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Hamis eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Hamis eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x  (az eMule v0.%u alapján)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Becenév: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Kért: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fájlstatisztika ehhez a folyamathoz: %d kérés elfogadva %d-ből, %s átmásolva\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Fájlstatisztika az összes folyamathoz: %d kérés elfogadva %d-ből, %s átmásolva\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Ismeretlen lekérdezett fájl"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Üzenet kiszűrve '%s'-től (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Új üzenet '%s'-től (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a nem létező '%s' könyvtárban megosztott fájljaid listájá -> Mellőzve"
@@ -1202,7 +1202,7 @@ msgid "Disconnected"
 msgstr "Szétkapcsolva"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1355,19 +1355,19 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1394,7 +1394,7 @@ msgid "Queue Full"
 msgstr "Várólista betelt"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Várólistások"
 
@@ -1459,7 +1459,7 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1530,7 +1530,7 @@ msgstr "Rész"
 msgid "Size"
 msgstr "Méret"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Átmásolva"
 
@@ -1587,7 +1587,7 @@ msgstr ""
 "Visszajelzés %s-től (%s):\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatikus"
@@ -1662,34 +1662,34 @@ msgstr "Hozzárendelés kategórához"
 msgid "&Open the file"
 msgstr "Fájl &megnyitása"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Írd be az új nevet ennek a fájlnak:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Fájl átnevezés"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Letöltések (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1698,11 +1698,11 @@ msgstr ""
 "Állítsd be a kedvenc videó-lejátszódat a beállításoknál,\n"
 " hogy ezt a figyemeztetést ne kapd minden előnézetnél (alapértelmezett az %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Fájl előnézet"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "HIBA: Külső média-lejátszó indítása sikertelen! Parancs: `%s'"
@@ -2260,7 +2260,7 @@ msgstr "A barátokat tartalmazó emfriends.dat fájl írásra megnyitása sikert
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIKUS - nincsen kliens a StartChatSession-en"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Barátok"
 
@@ -2598,57 +2598,57 @@ msgstr[0] "%d Kad kapcsolat kiírva"
 msgid "Kad user"
 msgstr "Kad hálózat"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Fájl név"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Fájl méret"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Megosztási arány"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Kért"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Elfogadott"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Teljes források"
 
@@ -2764,7 +2764,7 @@ msgid "WARNING: "
 msgstr "FIGYELEM: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Bezár"
 
@@ -2782,7 +2782,7 @@ msgid "Paste"
 msgstr "Beillesztés"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Törlés"
@@ -3196,8 +3196,8 @@ msgstr "Fájl források:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3342,7 +3342,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Cím :"
 
@@ -3451,7 +3451,7 @@ msgstr "User név :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Hozzáad"
@@ -3460,15 +3460,15 @@ msgstr "Hozzáad"
 msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Aktuális"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Futásátlag"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Munkafolyamatok átlaga"
 
@@ -3708,7 +3708,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Írd ide a böngésződ nevét. Hagyd üresen, hogy a rendszer alapértelmezett böngészőjéhez."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3782,7 +3782,7 @@ msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Csak haladó felhasználóknak: Ha több hálózati kártyád van, írd ide a címet, amelyhez az aMule kötve legyen."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Lokális cím IP-hez csatolása (mindet ha üres):"
@@ -3803,7 +3803,7 @@ msgstr "Max egyidejű kapcsolatok:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4123,7 +4123,7 @@ msgstr "Kad-csomópontok futó"
 msgid "Kad-nodes session"
 msgstr "Kad-csomópontok folyamat"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Kiválaszt"
 
@@ -4241,418 +4241,410 @@ msgstr "Lapos"
 msgid "Round"
 msgstr "Gömbölyű"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Fájlok automatikus rendezése (erős CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "Az aMule automatikusan rendezni fogja az oszlopokat a letöltési listádban"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Külső kapcsolatok jellemzői"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Külső kapcsolat elfogadása"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "Hallgató interfész IP-je:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Adjon meg itt egy érvényes IP címet a.b.c.d formában az EC hallgató interfésznek. Üres mező vagy 0.0.0.0 jelentése: bármelyik interfész."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "UPnP port továbbítás engedélyezése az EC porton"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Jelszó"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Jelszó ellenőrzése\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Web kiszolgáló paraméterek"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Webkiszolgáló indítása induláskor"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web minta"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Admin jelszó"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Vendég felhasználó engedélyezése"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Vendég jelszó"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "A web kiszolgáló port UPnP továbbításának engedélyezése"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web szerver UPnP TCP port (nem kötelező)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Oldal frissítésének időzítése (mp múlva)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Gzip tömörítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Alapértelmezett"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kattints ide a beállítási módosítások alkalmazásához."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Megjegyzés:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Bejövő Mappa :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Ne változzon"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Kattints erre a gombra a logfájl visszaállításához."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kattints erre a gombra a kiszolgálólista frissítéséhez  ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Kiszolgálók listája"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adj meg egy címet a server.met fájlhoz és nyomd meg a baloldali gombot az ismert kiszolgálók listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Kiszolgáló hozzáadása kézzel: Név"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Add meg az új kiszolgáló nevét"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Add meg a kiszolgáló portját."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Kiszolgáló felvétel kézzel (töltsd ki a baloldali mezőket először) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule Napló"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Kiszolgáló Infó"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K infó"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kattints erre a gombra a csomópont-lista frissítéséhez URL-ből ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Csomópontok (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Adj meg egy címet a nodes.dat fájlhoz és nyomd meg a baloldali gombot az ismert csomópontok listájának frissítéséhez."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Rendszerbetöltés"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Új csomópont (node)"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Indítás ismert kliensektől"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Leválasztás a Kad-ról"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Biztonságos azonosítás használata"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Ajánlott ezt az opciót engedélyezni. Nem fogsz kreditet kapni, ha nincs engedélyezve."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokoll zavarás"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Protokoll zavarás támogatása"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, és az aMule elfogad zavart kapcsolatokat más ügyfelektől."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Kimenő kapcsolatok zavarása"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ez az opció engedélyezi a protokoll zavarást, amikor más ügyfelekhez/kiszolgálókhoz kapcsolódik az aMule."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Csak zavart kapcsolatok elfogadása"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ezen opció hatására az aMule csak zavart kapcsolatokat fog elfogadni. Kevesebb forrásod lesz, de a teljes forgalom zavart lesz"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Mindenki"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Senki"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Ki láthatja a megosztott fájljaimat:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Válaszd ki, hogy kik kérdezhetik le megosztott fájlaid listáját."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-szűrés"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Kliensek szűrése"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kliensek szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Kiszolgálók szűrése"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "A ~/.aMule/ipfilter.dat állományban IP-jű kiszolgálók szűrésének engedélyezése."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Lista újratöltése"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "IP-k listájának újratöltése a ~/.aMule/ipfilter.dat fájlból"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Frissítés most"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "IP szűrő automatikus letöltése indításkor"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Szűrési szint:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Mindig szűrje ki a LAN IP-ket"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "A nem-megegyező IP-k paranoid kezelése"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Rendszer-szintű ipfilter.dat használatának engedélyezése"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Ha nem talál helyi ipfilter.dat fájlt, akkor engedje a rendszerszintű ipfilter fájl használatát."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Online-aláírás engedélyezése"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Az online-aláírás fájl írásának engedélyezése, amit külső alkalmazások használhatnak fel aláírások létrehozásához és így tovább."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frissítési gyakoriság (mp):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Online aláírás frissítési gyakoriságának módosítása (mp-ben)."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Online aláírási fájl kimentési helye: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kattints ide az online aláírást tartalmazó könyvtár kiválasztásához."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Kliensek országzászlajainak megjelenítése"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Adatbázis"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "Forrás:"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ingyenes, fiók nélkül)"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ingyenes, fiók szükséges)"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "Egyéni URL"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Válassza ki a GeoIP MMDB adatbázis szolgáltatóját. DB-IP az alapértelmezett - nincs szükség fiókra. MaxMind egy ingyenes fiókot és licenckulcsot igényel. Használjon egyéni URL-t bármely más MMDB host megadásához (pl. egy helyi tükörhöz)."
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4664,11 +4656,11 @@ msgstr ""
 "IP-to-Country adat DB-IP.com által - https://db-ip.com\n"
 "Licenc: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "Licenckulcs:"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4684,11 +4676,11 @@ msgstr ""
 "Licenc: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Hozzárendelést és fiókregisztrációt igényel; legalább 30 naponta frissítse."
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "Letöltési URL:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4698,211 +4690,211 @@ msgstr ""
 "Az URL tartalmazhat hitelesítő adatokat (https://user:pass@host/...).\n"
 "A licenc- és megnevezési feltételeket a felmenő URL határozza meg - ön a felelőss."
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "GeoIP adatbázis letöltése a kiválasztott forrásból."
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Automatikus frissítés indításkor"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "GeoIP adatbázis újonnani letöltése a kiválasztott forrásból minden aMule indításkor."
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Bejövő üzenetek kiszűrése (kivéve az aktuális csevegés):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Összes üzenet szűrése"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Barát listában nem szereplőktől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Ismeretlen kliensektől érkező üzenetek kiszűrése"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "A következő(ke)t tartalmazó üzenetek kiszűrése (elválasztónak ','-t használj):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Azon szavak felvétele, amelyeket az amule-nak ki kellene szűrni és blokkolni az ezeket tartalmazó üzeneteket"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "A kapott üzenetek megjelenítése a naplóban"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Megjegyzések kiszűrése, melyek tartalmazzák (',' az elválasztó):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Hitelesítés engedélyezése"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Felhasználói név: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Jelszó:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Jelszó a proxy kapcsolathoz"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Proxy engedélyezése"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Proxy típusa:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Proxy host:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Proxy port:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "A proxy port"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Kapcsolódás ehhez:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Felhasználói név"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "ZLIB tömörítés erőltetése"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Bőbeszédű hiba-naplózás engedélyezése."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Csak napló fájlba"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Üzenet kategóriák:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Várakozás..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Importálandók hozzáadása"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Kijelöltek újrapróbálása"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Kijelöltek eltávolítása"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Esemény típusok"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statisztikák és várakozó kliensek a kiválasztott fájl(ok)hoz: Folyamat / Valaha"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Összes fájl százalékaként"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Összes fájl"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Kiválasztott fájlok"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Csak aktív feltöltések"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Újratöltés:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Megosztott fájlok frissítése"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Küldés"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Megadott üzenet küldése."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
 
@@ -5258,188 +5250,188 @@ msgstr "Letöltve"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Alapértelmezett"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albán"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arab"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asztúriai"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baszk"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bolgár"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalán"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kínai (egyszerűsített)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kínai (hagyományos)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Horvát"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Cseh"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dán"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holland"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angol (Egyesült Királyság)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Észt"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finn"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francia"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Gall"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Német"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Görög"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Héber"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Olasz"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japán"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreai"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litván"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvég (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Lengyel"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugál"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugál (Brazíliai)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Román"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Orosz"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Szlovén"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spanyol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Svéd"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Török"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Nyelv megváltoztatása"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Nincsenek fordítások telepítve az aMule-hez"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Nincs elérhető nyelv"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "A TCP port nem lehet magasabb 65532-nél, mert a kiszolgáló UDP port = TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Alapértelmezett port lesz használva (%d)"
@@ -8365,6 +8357,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Fájlok automatikus rendezése (erős CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "Az aMule automatikusan rendezni fogja az oszlopokat a letöltési listádban"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Eldobja a csomagot, ha a kliens IP különbözik az IP-től, ahonnan a csomag jött. Óvatosan használd."

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-25 19:02+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -664,8 +664,8 @@ msgstr "Kad: Spento"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -676,7 +676,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Disconnetti"
 
@@ -685,7 +685,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Connetti"
 
@@ -735,111 +735,111 @@ msgstr "Vuoi veramente uscire da %s?"
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Reti"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Download"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "File condivisi"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Messaggi"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Nessuna rete"
 
@@ -979,14 +979,14 @@ msgstr "Collegamento non valido o già nella lista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mantenuta la directory '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -997,72 +997,72 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Ricerca amico per connessione con ID basso"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (falso eMule versione %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (falso eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (falso eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basato su eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nickname: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Richiesto: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiche file per questa sessione: accettata %d di %d richiesta, %s trasferita\n"
 msgstr[1] "Statistiche file per questa sessione: accettate %d di %d richieste, %s trasferite\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistiche file per tutte le sessioni: accettata %d di %d richiesta, %s trasferita\n"
 msgstr[1] "Statistiche file per tutte le sessioni: accettate %d di %d richieste, %s trasferite\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Richiesto file sconosciuto"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Messaggio filtrato da '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nuovo messaggio da '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi in una cartella inesistente '%s' -> richiesta ignorata"
@@ -1219,7 +1219,7 @@ msgid "Disconnected"
 msgstr "Disconnesso"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1372,19 +1372,19 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1411,7 +1411,7 @@ msgid "Queue Full"
 msgstr "Coda piena"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "In coda"
 
@@ -1476,7 +1476,7 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1547,7 +1547,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensione"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Trasferiti"
 
@@ -1604,7 +1604,7 @@ msgstr ""
 "Feedback da: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1679,34 +1679,34 @@ msgstr "Assegna a categoria"
 msgid "&Open the file"
 msgstr "&Apri file"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Inserisci un nuovo nome per questo file:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Rinomina file"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Download (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr "il gestore di shell predefinito di Windows"
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1715,11 +1715,11 @@ msgstr ""
 "Per prevenire questo avviso ad ogni anteprima, \n"
 "seleziona nelle preferenze il tuo lettore video preferito (di default è %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Anteprima"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRORE: Impossibile eseguire il lettore multimediale esterno! Comando: `%s'"
@@ -2279,7 +2279,7 @@ msgstr "Impossibile aprire in scrittura il file della lista degli amici 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITICO - nessun client in StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amici"
 
@@ -2621,57 +2621,57 @@ msgstr[1] "Scritti %d contatti Kad"
 msgid "Kad user"
 msgstr "Utente Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "Ricerca note Kad per '%s' non avviata: Kad non è connesso"
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "Ricerca note Kad per '%s' non avviata: una ricerca note è già in corso per questo file"
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "Ricerca note Kad per '%s' non avviata: il file non è nella lista dei condivisi, nella coda di download né nei risultati di ricerca"
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "Ricerca note Kad per '%s' non avviata: un'altra ricerca Kad (es. una ricerca di fonti) sta già usando l'hash di questo file - riprovare tra poco"
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "Ricerca note Kad per '%s' non avviata: PrepareLookup non riuscito"
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nome file"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Dimensione file"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Rapporto di condivisione"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Richiesto"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Accettato"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fonti complete"
 
@@ -2786,7 +2786,7 @@ msgid "WARNING: "
 msgstr "ATTENZIONE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Chiudi"
 
@@ -2804,7 +2804,7 @@ msgid "Paste"
 msgstr "Incolla"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pulisci"
@@ -3216,8 +3216,8 @@ msgstr "Fonti del file:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/D"
 
@@ -3357,7 +3357,7 @@ msgstr "Artista :"
 msgid "Album :"
 msgstr "Album :"
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titolo:"
 
@@ -3465,7 +3465,7 @@ msgstr "Nome utente:"
 msgid "Userhash :"
 msgstr "Hash utente:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Aggiungi"
@@ -3474,15 +3474,15 @@ msgstr "Aggiungi"
 msgid "Download-Speed"
 msgstr "Velocità download"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Corrente"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Media attuale"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Media sessione"
 
@@ -3720,7 +3720,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3794,7 +3794,7 @@ msgstr "Lega l'indirizzo locale all'IP (lascia vuoto per qualsiasi):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Solo per utenti esperti: se hai interfacce di rete multiple, inserisci l'indirizzo dell'interfaccia che aMule dovrà utilizzare."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr "Associa all'interfaccia di rete (vuoto per qualsiasi):"
 
@@ -3814,7 +3814,7 @@ msgstr "Connessioni massime simultanee:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4134,7 +4134,7 @@ msgstr "Nodi Kad attivi"
 msgid "Kad-nodes session"
 msgstr "Nodi Kad nella sessione"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Seleziona"
 
@@ -4250,413 +4250,405 @@ msgstr "Piatta"
 msgid "Round"
 msgstr "Arrotondata"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Ordina automaticamente i file (uso elevato della CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule ordinerà automaticamente le colonne nella lista dei download"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parametri connessioni esterne"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Accetta connessioni esterne"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP dell'interfaccia di ascolto:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Inserisci un IP valido nel formato a.b.c.d per l'interfaccia di ascolto EC. Lasciare il campo vuoto o inserire 0.0.0.0 significa qualsiasi interfaccia."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Abilita il port forwarding tramite UPnP sulla porta EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Password"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr "Parametri del server API di aMule"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Avvia amuleapi (REST API) all'avvio"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "L'interfaccia su cui è in ascolto il server HTTP di amuleapi. 127.0.0.1 (predefinito) accetta solo connessioni locali; usa 0.0.0.0 o un IP specifico per esporlo ad altri host (imposta una password di amministrazione qui sotto)."
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr "Password amministrazione"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parametri del server web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr "Lancia il webserver all'avvio (deprecato)"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Template web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Password per diritti completi"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Abilita utente con diritti limitati"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Password per diritti limitati"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Abilita port forwarding tramite UPnP sulla porta del server web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP del  server web per UPnP (Facoltativa)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Intervallo di aggiornamento pagina (in sec)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Abilita compressione gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr "Ripristina i valori predefiniti della pagina"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr "Ripristina le impostazioni della pagina corrente ai loro valori predefiniti."
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Fai click qui per applicare le modifiche apportate alle impostazioni."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Commento:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Directory file scaricati:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Cambia priorità per i nuovi file assegnati:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Non modificare"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Fai clic su questo pulsante per cancellare i log."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Fai clic qui per aggiornare la lista dei server dall'indirizzo..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Lista server"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Inserisci l'url di un file server.met e premi il pulsante a sinistra per aggiornare la lista dei server conosciuti."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Aggiungi un server manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Inserisci qui il nome di un nuovo server"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Inserisci qui la porta del server."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Aggiungi server (riempi campi a sinistra)..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "log di aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Informazioni server"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Informazioni ed2k"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Informazioni Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Fai clic su questo pulsante per aggiornare la lista nodi da un URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodi (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Inserisci l'URL di un file nodes.dat e premi il pulsante a sinistra per aggiornare la lista dei nodi conosciuti."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nuovo nodo"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap dai client noti"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Disconnetti rete Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Usa identificazione sicura"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "È consigliato attivare questa opzione. Non riceverai crediti se \" \"l'identificazione non sarà abilitata."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Supporta offuscamento del protocollo"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Questa opzione abilita l'offuscamento del protocollo, e fa sì che aMule accetti connessioni offuscate dagli altri client."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizza offuscamento per le connessioni in uscita"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Questa opzione fa sì che aMule utilizzi l'offuscamento del protocollo quando si collega ad altri client/server."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Accetta SOLO connessioni offuscate"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Attivando questa opzione aMule accetterà solo connessioni offuscate. Avrai meno fonti, ma tutto il tuo traffico sarà offuscato"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Chiunque"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nessuno"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Chi può vedere i miei file condivisi:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleziona chi può richiedere di vedere la lista dei tuoi file condivisi."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtraggio IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtra i client"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i client in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtra i server"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Filtra i server in base agli ip contenuti in ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Ricarica lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ricarica lista degli IP da filtrare dal file ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Aggiorna ipfilter all'avvio"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Livello filtraggio:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtra sempre gli IP di una LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Gestione paranoica degli IP non corrispondenti"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rifiuta un pacchetto quando l'IP di origine è diverso dall'IP dichiarato dal client (un controllo anti-spoofing). Disabilitare solo se causa problemi di connessione."
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se un file ipfilter.dat locale non viene trovato, consenti l'utilizzo del file ipfilter.dat di sistema."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Abilita Online Signature"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Abilita la scrittura del file OS che può essere usato da applicazioni esterne per creare firme e simili."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frequenza di aggiornamento (secondi):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Cambia la frequenza (in secondi) degli aggiornamenti dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Salva la firma in linea in: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clicca qui per selezionare la directory che contiene i file dell'Online Signature."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Mostra la nazionalità dei client"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Mostra la colonna delle bandiere dei paesi nelle viste trasferimenti, coda e ricerca. Richiede un database GeoIP MMDB valido (vedi sotto)."
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Database"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (gratuito, nessun account)"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (gratuito, richiede account)"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "URL personalizzato"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Scegli quale provider fornisce il database GeoIP MMDB. DB-IP è il default - nessun account richiesto. MaxMind richiede un account gratuito + license key. Usa URL personalizzato per puntare a qualsiasi altro host MMDB (es. un mirror locale)."
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4668,11 +4660,11 @@ msgstr ""
 "Dati IP-to-Country di DB-IP.com - https://db-ip.com\n"
 "Licenza: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "License key:"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4688,11 +4680,11 @@ msgstr ""
 "Licenza: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Richiede attribuzione e registrazione dell'account; aggiornare almeno ogni 30 giorni."
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "URL di scaricamento:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4702,211 +4694,211 @@ msgstr ""
 "L'URL può includere credenziali (https://user:pass@host/...).\n"
 "I termini di licenza e attribuzione sono definiti dall'URL upstream - ne sei responsabile."
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "Scarica il database GeoIP dalla sorgente selezionata."
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Aggiornamento automatico all'avvio"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Riscarica il database GeoIP dalla sorgente selezionata ogni volta che aMule si avvia."
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtra messaggi in arrivo (tranne per la chat in corso):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtra tutti i messaggi"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtra i messaggi da utenti che non sono nella tua lista degli amici"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtra i messaggi da client sconosciuti"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtra i messaggi che contengono (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "aggiungi qui le parole che aMule filtrerà rimuovendo i messaggi che le contengono"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Mostra nel log i messaggi ricevuti"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Commenti"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtra i commenti contenenti (usa ',' come separatore):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Abilita autenticazione"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nome utente: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Password:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "La password usata per la connessione al proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Abilita proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tipo proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Indirizzo proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Porta proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "La porta del proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Connetti a:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nome utente"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "Forza la compressione ZLIB"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Abilita il log dettagliato dei messaggi di debug."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Solamente sul file di log"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categorie messaggi:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "In attesa..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Aggiungi importazioni"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Riprova selezionati"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Rimuovi selezionati"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipi di evento"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistiche e client in coda per i(l) file selezionati(o) : Sessione / Totale"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Upload attivi"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Percentuale di file totali"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Tutti i file"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "File selezionati"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Solo upload attivi"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Ricarica lista:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Ricarica file condivisi"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Invia"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Invia messaggio specificato."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Connetti a qualsiasi server e/o a Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File condivisi"
 
@@ -5266,187 +5258,187 @@ msgstr "Scaricato"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Predefinita di sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanese"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabo"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalano"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Cinese (semplificato)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croato"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Ceco"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danese"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Olandese"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglese (Regno Unito)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "Inglese (U.S.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estone"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francese"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galiziano"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Tedesco"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Greco"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr "Lettone"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegese (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polacco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portoghese (Brasile)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Svedese"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Cambia lingua"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Non ci sono traduzioni di aMule installate"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Nessuna lingua disponibile"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "La porta TCP non può essere superiore a 65532 perché il socket UDP è fissato a TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Sarà usata la porta predefinita (%d)"
@@ -8385,6 +8377,12 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Ordina automaticamente i file (uso elevato della CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule ordinerà automaticamente le colonne nella lista dei download"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rifiuta pacchetto se l'IP del Client è diverso dall'IP da cui arriva il pacchetto. Utilizzare con cautela."

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 17:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -648,8 +648,8 @@ msgstr "Kad: オフ"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -660,7 +660,7 @@ msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "切断する"
 
@@ -669,7 +669,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "接続する"
 
@@ -720,113 +720,113 @@ msgstr "本当にaMuleを終了しますか？"
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "ダウンロード数"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "メッセージ"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "設定"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "ネットワークなし"
 
@@ -969,14 +969,14 @@ msgstr "不正なリンク、またはリンクがすでにリストに入って
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -987,70 +987,70 @@ msgstr ""
 msgid "Unknown"
 msgstr "不明"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr "（偽のeMuleバージョン %#x）"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr "（偽のeMule）"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule（偽のeMule）"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x（eMule v0.%u に基づいています）"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "NickName: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "要求：%s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "当セッションのファイル統計： %d / %d の要求を受け入れ、%s 転送された\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "全セッションのファイル統計： %d / %d の要求を受け入れ、%s 転送された\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "不明なファイルが要求されました"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "%s（IP：%s）からのメッセージがフィルタされました"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "%s（IP：%s）から新しいメッセージが届きました"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "ユーザ %s（%u）はあなたのディレクトリ %s の共有ファイル・リストを要求しました -> 拒否しました"
@@ -1206,7 +1206,7 @@ msgid "Disconnected"
 msgstr "切断"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1358,19 +1358,19 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1397,7 +1397,7 @@ msgid "Queue Full"
 msgstr "キューが一杯"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "キューに入っています"
 
@@ -1462,7 +1462,7 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "転送済み"
 
@@ -1591,7 +1591,7 @@ msgstr ""
 "フィードバック:%s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "自動"
@@ -1666,45 +1666,45 @@ msgstr "カテゴリに割り当てる"
 msgid "&Open the file"
 msgstr "ファイルを開く(&O)"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "このファイルの新しい名前を入力してください："
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "ファイルの改名"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "ダウンロード数（%i）"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "ファイル・プレビュー"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "エラー：外部メディア・プレイヤーを実行できませんでした！コマンド: `%s'"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "友達"
 
@@ -2608,57 +2608,57 @@ msgstr[0] "%d個のKadコンタクトを書き込みました"
 msgid "Kad user"
 msgstr "Kadネットワーク"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "ファイル名"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "ファイルサイズ"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "共有比"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "要求済み"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "受付済み"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "ソース完了"
 
@@ -2776,7 +2776,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "閉じる"
 
@@ -2794,7 +2794,7 @@ msgid "Paste"
 msgstr "ペースト"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "クリア"
@@ -3215,8 +3215,8 @@ msgstr "ソース完了"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "非適用"
 
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "タイトル："
 
@@ -3468,7 +3468,7 @@ msgstr "ユーザ名："
 msgid "Userhash :"
 msgstr "ユーザ・ハッシュ："
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "追加"
@@ -3477,15 +3477,15 @@ msgstr "追加"
 msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "現在"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "移動平均"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "セッション平均"
 
@@ -3726,7 +3726,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3800,7 +3800,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3820,7 +3820,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4139,7 +4139,7 @@ msgstr "動作中のKadノード数"
 msgid "Kad-nodes session"
 msgstr "セッションのKadノード数"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "選択"
 
@@ -4258,423 +4258,415 @@ msgstr "フラット"
 msgid "Round"
 msgstr "ラウンド"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMuleはダウンロードリストの列を自動的にソートする"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "外部接続のパラメタ"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "外部接続を許可にする"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "リスンしているECインターフェイス用の正当なIPアドレスをa.b.c.dのフォーマットで入力してください。空のフィールド、または0.0.0.0は任意のインターフェイスを意味します。"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "ECポートでUPnPポート転送を有効にする"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "パスワード"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "パスワードをチェック中です\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "ウェブテンプレート"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "全権限パスワード"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "低権限ユーザを有効にする"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "低権限パスワード"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "ページのリフレッシュ間隔（秒単位）"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "gzip圧縮を有効にする"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "システムの標準設定"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "設定の変更をすべて適用します。"
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "コメント："
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "受信ディレクトリ："
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "新しく割り当てられたファイルの優先度を変更する："
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "変更しない"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "このカテゴリの色を選択する（現在選択中）："
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "このボタンをクリックするとログのリセットが行います。"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "このボタンをクリックするとサーバ・リストはURLから最新化する..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "server.metファイルへのURLをここに入力してから左側のボタンをクリックすると、既知のサーバのリストがアップデートされます。"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "新しいサーバの名前をここに入力してください"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:ポート"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "サーバのポートをここに入力してください。"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動でサーバを追加する（先に左側のフィールドを入力してください）..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMuleのログ"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "サーバ情報"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K情報"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "このボタンをクリックするとノード・リストをURLからアップデートします..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "ノード数（0）"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "ここにnodes.datファイルへのURLを入力してから左側のボタンをクリックすると、既知のノード・リストをアップデートします。"
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "ノードの統計"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "ブートストラップ"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "新しいノード"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "ポート："
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "既知のクライアントから\n"
 "ブートストラップする"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Kadを切断する"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "セキュア・ユーザ保証（SUI）を使用する"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "このオプションを有効にするのは推奨されます。SUIが有効でないとあなたはクレジットを得られません。"
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "プロトコルを難読化する"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "プロトコルの難読化を有効にする"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "このオプションによってプロトコルの難読化を有効にできます。そうすると、aMuleは他のクライアントからの難読化された接続を受け入れられます。"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "外方向の接続に難読化を使用する"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "このオプションによって、aMuleは他のサーバまたはクライアントに接続する時にプロトコル難読化を使用します。"
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "難読化された接続のみを受信する"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "このオプションによって、aMuleは難読化された接続のみを受信します。ソース数が減りますが、トラフィックが全て難読化されます。"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "全員"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "あなたの共有ファイル・リストを要求できるユーザを選択してください。"
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IPフィルタリング"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "クライアントをフィルタする"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるクライアントIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "サーバをフィルタする"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.datに登録されちるサーバIPにフィルタリングをかけることを有効にします。"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "フィルタリングをかける目標のIPリストを~/.aMule/ipfilter.datから再ロードをします。"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL："
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "只今アップデートする"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "フィルタリング段階："
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "いつもLANのIPにフィルタリングをかける"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "適合しないIPを被害妄想的に扱う"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "提供されていれば、全システム応用のipfilter.datファイルを使用する"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "ローカルなipfilter.datファイルが見つからなければ、全システム応用のipfilter.datファイルを使用可能します。"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "オンライン証明を有効にする"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "OSファイルの書き込みを有効にします。このファイルは外のアプリケーションに証明等を作成するためにを使用されます。"
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "アップデート頻度（秒単位）"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "オンライン証明アップデート頻度（秒単位）を変化します。"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "ここをクリックするとオンライン証明ファイルが入っているディレクトリを選択できます。"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "データ・レート："
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "ソース数"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4682,11 +4674,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4696,232 +4688,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "ダウンロード： "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "スタートアップの時にipfilterを自動アップデートする"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "受信メッセージをフィルタする（現在のチャットを除く）："
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "全てのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "友達リストの入っていない方々からのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "知らないクライアントからのメッセージをフィルタする"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "次のストリングが入っているメッセージをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "amuleがメッセージ・フィルタ／ブロックの目標にする言葉をここに追加してください"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "コメント"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "次のストリングが入っていコメントをフィルタする（','で区分する）："
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "認証を有効にする"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "パスワード："
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "プロクシーに接続に使うパスワード"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "プロクシを有効にする"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "プロクシの種類："
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "プロクシー・ホスト："
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "プロクシー・ポート："
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "プロクシーのポート"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "次に接続する："
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "ユーザ名"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip圧縮を使用する"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "冗長なデバッグ・ロギングを有効にする"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "ファイルを開く(&O)"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "メッセージのカテゴリ："
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "待機中…"
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "インポートを追加する"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "選択したものを再試行"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "選択したものを破棄"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "共有ファイルを隠す"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "ビュー・フィルタを選択してください"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "アクティブなアップロード数"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "リストを再ロードする"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "共有ファイルを再ロードする"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "送信する"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "指示するメッセージを送信します。"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "すべてのサーバ、もしくはKadに接続する"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共有ファイル"
 
@@ -5278,192 +5270,192 @@ msgstr "ダウンロード済み"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "システムの標準設定"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "アラブ語"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "バスク語"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "中国語（簡体字）"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "中国語（繁体字）"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "クロアチア語"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "チェコ語"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "オランダ語"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語（U.K.）"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "エストニア語"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "フィンランド語"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "フランス語"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "ドイツ語"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "ギリシア語"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "イタリア語"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "日本語"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "韓国語"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "リトアニア語"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "ルウェー語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "ポルトガル語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "ポルトガル語（ブラジル）"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "アルバニア語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "ロシア語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "スロベニア語"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "スペイン語"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "言語"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "利用不可"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "サーバのUDPソケトがTCP+3であるためTCPポートを65532以上には設定できません"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "デフォルトポートを使用します (%d)"
@@ -8400,6 +8392,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMuleはダウンロードリストの列を自動的にソートする"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "クライアントIPがパケットがもともと受信されたIPと違いますとパケットを拒否します。使用するに気をつけてください。"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:00+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -651,8 +651,8 @@ msgstr " Kad: "
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -664,7 +664,7 @@ msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "연결 끊기"
 
@@ -674,7 +674,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "연결"
 
@@ -727,113 +727,113 @@ msgstr "어뮬을 종료하시겠습니까?"
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "통신망"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "내려받기"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "메시지"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "통계"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "환경설정"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -976,14 +976,14 @@ msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -994,72 +994,72 @@ msgstr ""
 msgid "Unknown"
 msgstr "알수없는"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (가짜 이뮬 버젼 %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (가짜 이뮬)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "엑스뮬(가짜 이뮬)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (이뮬 v0.%u 기반)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "별명: %s 아이디: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, fuzzy, c-format
 msgid "Requested: %s\n"
 msgstr "요청됨:"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, fuzzy, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "이 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 msgstr[1] "이 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, fuzzy, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "모든 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 msgstr[1] "모든 세션의 파일상태: %d가 수락되었습니다.(%d 요청의) %s에게 전달되었습니다.\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "알 수 없는 파일이 요청되었습니다."
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s'로부터 차단된 메시지 (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s'로부터 새로운 메시지 (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "사용자 %s(%u)가 폴더 %s의 공유파일 목록을 요청합니다. -> 거부됨"
@@ -1217,7 +1217,7 @@ msgid "Disconnected"
 msgstr "연결이 끊김"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1370,19 +1370,19 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1409,7 +1409,7 @@ msgid "Queue Full"
 msgstr "대기열이 가득참"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "대기열에"
 
@@ -1474,7 +1474,7 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "Size"
 msgstr "크기"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "전송됨"
 
@@ -1602,7 +1602,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "자동"
@@ -1677,45 +1677,45 @@ msgstr "분류로 할당"
 msgid "&Open the file"
 msgstr "파일 열기(&O)"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "새이름 넣으세요:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "파일 이름변경"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "내려받기 (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "미리보기"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, fuzzy, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "오류: 외부 재생기를 실행하지 못했습니다."
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "친구"
 
@@ -2632,57 +2632,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr "Kad를 시작했습니다."
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "파일 이름"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2800,7 +2800,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "닫기"
 
@@ -2818,7 +2818,7 @@ msgid "Paste"
 msgstr "붙이기"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "깨끗이"
@@ -3239,8 +3239,8 @@ msgstr "자료 유지"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "없음"
 
@@ -3385,7 +3385,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "제목 :"
 
@@ -3492,7 +3492,7 @@ msgstr "사용자 이름 :"
 msgid "Userhash :"
 msgstr "사용자 해시 :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "추가"
@@ -3501,15 +3501,15 @@ msgstr "추가"
 msgid "Download-Speed"
 msgstr "내려받기 속도"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "현재"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "동작중 평균"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "세션 평균"
 
@@ -3750,7 +3750,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3824,7 +3824,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3844,7 +3844,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr "카뎀리아"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4163,7 +4163,7 @@ msgstr "Kad-노드 운용"
 msgid "Kad-nodes session"
 msgstr "Kad-노드 세션"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "선택"
 
@@ -4282,422 +4282,414 @@ msgstr "평평한"
 msgid "Round"
 msgstr "둥근"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "어뮬은 내려받는 목록의 항목을 자동으로 정렬합니다."
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "외부연결 설정"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "외부연결 받아들임"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "수신대기 외부연결 인터페이스에 a.b.c.d 형식의 유효한 IP를 입력하세요. 항목이 비었거나 0.0.0.0이면 모든 인터페이스를 의미합니다."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "외부연결 포트에 UPnP 포트포워딩 활성화"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "암호"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "암호를 검사중\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "웹 템플릿"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "모든 권한 암호"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "낮은권한 사용자 활성화"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "낮은 권한 암호"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "페이지를 갱신 시간 (초)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Gzip압축을 활성화"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "기본 설정"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "확인"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 적용하려면 이곳을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "의견 :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "내려받는 폴더 :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "변경 않음"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "로그를 초기화하려면 이 버튼을 클릭하세요."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "URL로부터 서버 목록을 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "알려진 서버의 목록을 갱신하기 위해서는 이곳에 server.met파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "새로운 서버의 이름을 입력하세요."
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:포트"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "서버 수동 추가 (미리 왼쪽 부분을 채울 것) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "어뮬 로그"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "서버 정보"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2k 정보"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "URL로부터 노드를 갱신하려면 이 버튼을 클릭..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "노드 (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "알려진 노드의 목록을 갱신하기 위해서는 이곳에 nodes.dat파일의 url을 입력하고 왼쪽편의 버튼을 누르세요."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "노드 상태"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "초기적재"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "새로운 노드"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "포트:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "알려진 클라이언트로부터 \n"
 "초기적재"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Kad 끊김"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "프로토콜 난독화"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "프로토콜 난독화 지원"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "이 선택은 프로토콜 난독화를 활성화하며, 어뮬이 다른 클라이언트로부터 난독화된 연결을 받아들이도록 합니다. "
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "나가는 연결에 난독화 사용"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "이 선택은 어뮬이 다른 서버나 클라이언트에 연결할때 프로토콜 난독화를 사용하게 합니다."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "난독화된 연결만 받음"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "이 선택은 어뮬이 난독화된 연결만 받아들이도록 합니다. 더 작은 자료를 가지지만 자료교환은 난독화됩니다."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "모두"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "공유 파일 목록 보기를 요청할 수 있는 사람을 선택하세요."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP 차단"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "클라이언트 차단"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 클라이언트 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "서버 차단"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat에 기록된 서버 IP의 차단을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat 파일에서 차단할 IP의 목록을 다시 읽음"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "지금 갱신"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "차단 수준:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "랜 IP를 항상 차단"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "온라인서명을 활성화"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "서명을 생성할 수 있는 외부 응용프로그램에 의해 사용될 수 있는 운영체제 파일의 기록을 활성화합니다."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "갱신 주기(초)"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "온라인 서명 갱신 주기(초)를 바꿉니다."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "온라인서명 파일을 포함하는 폴더를 선택하려면 클릭하세요."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "데이터율 :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "자료"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4705,11 +4697,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4719,232 +4711,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "내려받기: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "시작시 IP차단을 자동 갱신"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "받는 메시지 차단(현재 채팅은 제외)"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "모든 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "친구 목록에 없는 사람으로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "알 수 없는 클라이언트로부터 메시지를 차단"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "다음 내용이 포함된 메시지를 차단 (쉼표로 분리):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "이곳에 어뮬이 차단하고 막을 메시지에 포함될 단어를 추가하세요."
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "의견들"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "인증 활성화"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "암호:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 암호"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "프록시 활성화"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "프록시 종류:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "프록시 호스트:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "프록시 포트:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "프록시 포트"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "연결함:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "사용자이름"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "gzip 압축 사용"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "상세한 디버그-로깅 활성화"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "파일 열기(&O)"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "메시지 분류:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "대기중..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "가져오기 추가"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "선택된 것을 재시도"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "선택된 것을 삭제"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "공유된 파일을 숨김"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "보기 필터 선택"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "활성화된 올려주기"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "목록 다시읽기"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "보내기"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "지정된 메시지를 보냅니다."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "서버 혹은 Kad에 연결"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "공유 파일"
 
@@ -5307,192 +5299,192 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "기본 설정"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "아랍어"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "바스크어"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "불가리아어"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "카탈로니아어"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "중국어(간체)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "중국어(번체)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "덴마크어"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "네델란드어"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "영어(영국)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "에스토니아어"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "필란드어"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "프랑스어"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "갈리시아어"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "독일어"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "헝가리어"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "이탈리아어"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "한국어"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "폴란드어"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "포르투갈어"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "포르투갈어(브라질)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "크로티아어"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "러시아어"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "슬로베니아어"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "스페인어"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "터키어"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "언어"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "유효하지 않음"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "서버 UDP 소켓이 TCP+3이 되기위해서 TCP 포트가 65532보다 커서는 안됩니다."
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "기본 포트가 사용될 것입니다.(%d)"
@@ -8454,6 +8446,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "어뮬은 내려받는 목록의 항목을 자동으로 정렬합니다."
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "클라이언트 IP가 패킷이 수신된 IP와 다르면 패킷을 거부합니다. 조심해서 사용하세요."

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:00+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -654,8 +654,8 @@ msgstr "Kad: išjungta"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -666,7 +666,7 @@ msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Atsijungti"
 
@@ -675,7 +675,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Prisijungti"
 
@@ -726,112 +726,112 @@ msgstr "Ar tikrai norite baigti darbą su aMule?"
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Tinklas"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Siuntimai"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Dalinami failai"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Žinutės"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Parinktys"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Jokio tinklo"
 
@@ -974,14 +974,14 @@ msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -992,44 +992,44 @@ msgstr ""
 msgid "Unknown"
 msgstr "Nežinoma"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (neteisinga eMule versija %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (neteisinga eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (neteisinga eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (paremta eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Slapyvardis: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Paprašė: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1037,7 +1037,7 @@ msgstr[0] "Šio seanso failų statistika: priimta %d iš %d prašymo, %s persių
 msgstr[1] "Šio seanso failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 msgstr[2] "Šio seanso failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1045,21 +1045,21 @@ msgstr[0] "Visų seansų failų statistika: priimta %d iš %d prašymo, %s persi
 msgstr[1] "Visų seansų failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 msgstr[2] "Visų seansų failų statistika: priimta %d iš %d prašymų, %s persiųsta\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Paprašė nežinomo failo"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Filtras sulaikė %s žinutę (IP %s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Naują žinutę atsiuntė %s (IP %s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų iš aplanko %s sąrašo –> atmesta"
@@ -1219,7 +1219,7 @@ msgid "Disconnected"
 msgstr "Neprisijungta"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1373,19 +1373,19 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1412,7 +1412,7 @@ msgid "Queue Full"
 msgstr "Eilė pilna"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Eilėje"
 
@@ -1477,7 +1477,7 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kademlia"
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Size"
 msgstr "Dydis"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Persiųsta"
 
@@ -1606,7 +1606,7 @@ msgstr ""
 "Atsakymas iš: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatiškas"
@@ -1681,34 +1681,34 @@ msgstr "Priskirti į kategoriją"
 msgid "&Open the file"
 msgstr "&Atverti failą"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Įrašykite naują failo pavadinimą:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Pervadinti failą"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Atsiuntimai (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1717,11 +1717,11 @@ msgstr ""
 "Norėdami nebematyti šio įspėjimo kiekvienos peržiūros metu,\n"
 "parinktyse nurodykite pageidaujamą video grotuvą (numatytas yra %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Failo peržiūra"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "KLAIDA: nepavyko paleisti išorinio vaizdo grotuvo! Komanda: „%s“"
@@ -2290,7 +2290,7 @@ msgstr "Nepavyko atverti draugų sąrašo failo „emfriends.met“ rašymui!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Draugai"
 
@@ -2643,57 +2643,57 @@ msgstr[2] "Įrašyta %d Kad kantaktų"
 msgid "Kad user"
 msgstr "Kad tinklas"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Failo pavadinimas"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Failo dydis"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Platinimo santykis"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Paprašyta"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Priimta"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Pilni šaltiniai"
 
@@ -2811,7 +2811,7 @@ msgid "WARNING: "
 msgstr "DĖMESIO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Užverti"
 
@@ -2829,7 +2829,7 @@ msgid "Paste"
 msgstr "Įterpti"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Išvalyti"
@@ -3251,8 +3251,8 @@ msgstr "Pilni šaltiniai"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Nežinoma"
 
@@ -3397,7 +3397,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Pavadinimas:"
 
@@ -3504,7 +3504,7 @@ msgstr "Naudotojo vardas:"
 msgid "Userhash :"
 msgstr "Naudotojo maišos f-ja:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Įdėti"
@@ -3513,15 +3513,15 @@ msgstr "Įdėti"
 msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Dabartinė sparta"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Dabartinis vidurkis"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Seanso vidurkis"
 
@@ -3762,7 +3762,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3836,7 +3836,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3856,7 +3856,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4175,7 +4175,7 @@ msgstr "Kademlia mazgų dabartinis vidurkis"
 msgid "Kad-nodes session"
 msgstr "Kademlia mazgų seanso vidurkis"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Nurodykite spalvą"
 
@@ -4294,424 +4294,416 @@ msgstr "Plokščia"
 msgid "Round"
 msgstr "Erdvinė"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "Įjungus šią parinktį atsiuntimo eilėje esantys failai bus rūšiuojami automatiškai"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Išorinio ryšio parinktys"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Priimti išorinius ryšius"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Įrašykite išorinių ryšių besiklausančio įrenginio IP adresą a.b.c.d forma. Tuščias laukelis arba adresas 0.0.0.0 reiškia bet kokį įrenginį."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC prievade įjungti UPnP prievadų perdavimą"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP prievadas: %d"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Tikrinamas slaptažodis\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Žiniatinklio serverio parinktys"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "www šablonas"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Pilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Įjungti nepilnos prieigos naudotoją"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Nepilnos prieigos slaptažodis"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Puslapio atnaujinimo periodas (sekundėmis)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Įjungti Gzip suspaudimą"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Numatyta"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Gerai"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Patvirtinti naujai nurodytas parinktis."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komentaras:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Atsiųstų failų aplankas:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Keisti naujai priskirtų failų prioritetą:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Nekeisti"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Nurodykite dabartinės kategorijos spalvą:"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Išvalyti įvykių žurnalą."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Paspaudę šį mygtuką atnaujinsite serverių sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Serverių sąrašas"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Įrašykite server.met failo URL ir paspaudę mygtuką kairėje atnaujinsite serverių sąrašą."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Įdėti serverį rankiniu būdu: pavadinimas"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Įrašykite serverio pavadinimą"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:prievadas"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Įrašykite serverio prievadą."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Įdėti serverį (prieš tai užpildykite laukelius kairėje)..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule žurnalas"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Serverio informacija"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K informacija"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Spragtelėję šį mygtuką atnaujinsite mazgų sąrašą iš URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Mazgai (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Įrašykite nodes.dat failo URL ir paspaudę mygtuką kairėje atnaujinsite mazgų sąrašą."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Inicializavimas"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Naujas mazgas"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Prievadas:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Inicializuoti iš \n"
 "žinomų klientų"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Atjungti Kademlia"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Naudoti saugų kliento atpažinimą"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Rekomenduojama įjungti šią parinktį. Jei išjungsite, negausite kreditų."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokolo slėpimas"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Įjungti protokolo slėpimą"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ši parinktis įjungia protokolo slėpimą. Tuomet aMule priiminės slepiamus ryšius iš kitų klientų."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Slėpti išeinančius ryšius"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Įjungus šią parinktį aMule, jungdamasi prie kitų klientų ar serverių, slėps išeinančius ryšius."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Priimti tik slepiamus ryšius"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Įjungus šią parinktį aMule priims tik slepiamus ryšius. Šaltinių bus rasta mažiau, bet visas srautas bus slepiamas"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Visi"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Niekas"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Nurodykite kas gali pamatyti dalinamų failų sąrašą."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP filtravimas"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtruoti klientus"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti klientų IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtruoti serverius"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Įjungti serverių IP adresų filtravimą, aprašytą ~/.aMule/ipfilter.dat faile."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Atnaujinti IP adresų sąrašą iš ~/.aMule/ipfilter.dat failo"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Atnaujinti dabar"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Filtravimo lygmuo:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Visuomet filtruoti LAN IP adresus"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranojiškai elgtis su neatitikusiais IP adresais"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Jei įjungtas, naudoti ipfilter.dat failą visoje sistemoje"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jei nėra vietinio ipilter.dat failo, naudoti ipfilter.dat visoje sistemoje."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Įjungti keičiamą parašą"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Įjungus šią parinktį bus įrašomas keičiamo parašo failas, kurį galite naudoti kitoje programoje parašų kūrimui ir pan."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Atnaujinimo dažnis (sekundėmis):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Keičiamo parašo atnaujinimo dažnis sekundėmis."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Nurodykite aplanką, kuriame yra keičiamo parašo failas."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Siuntimo sparta:"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Šaltiniai"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4719,11 +4711,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4733,232 +4725,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Atsiųsta: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatiškai įkelti IP filtrą paleidus programą"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruoti gaunamas žinutes (išskyrus dabartinį pokalbį):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtruoti visas žinutes"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruoti žinutes nuo naudotojų, nesančių draugų sąraše"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtruoti žinutes nuo nežinomų klientų"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruoti žinutes turinčias tekstą („,“ naudokite kaip skirtuką):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Įrašykite žodžius, kurių aMule ieškos žinutės tekste ir filtruos žinutę"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Komentarai"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruoti komentarus, turinčius (atskirkite kableliu):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Įjungti autentifikavimą"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Slaptažodis:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Slaptažodis prisijungimui prie atstovaujančio serverio"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Įjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Serverio tipas:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Serverio mazgas:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Serverio prievadas:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Atstovaujančio serverio prievadas"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Prijungti prie:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Naudotojo vardas"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Naudoti gzip pakavimą"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Įjungti išsamų klaidų taisymo žurnalą."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Atverti failą"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Žinučių kategorijos:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Laukiama..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Įdėti failus"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Pažymėtas bandyti iš naujo"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Pašalinti pažymėtas"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Slėpti dalinamus failus"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Parinkite filtrą"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktyvūs išsiuntimai"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Atnaujinti sąrašą"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Siųsti"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Išsiųsti įrašytą žinutę."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Dalinami failai"
 
@@ -5323,192 +5315,192 @@ msgstr "Atsiųsta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Numatyta"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabų"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskų"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgarų"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalonų"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kinų (supaprastinta)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kinų (tradicinė)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroatų"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Čekų"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danų"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Olandų"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglų (DB)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estų"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Suomių"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Prancūzų"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galisijos"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Vokiečių"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Graikų"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Žydų"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Vengrų"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italų"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonų"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korėjiečių"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lietuvių"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegų (naujoji norvegų)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Lenkų"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugalų"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalų (Brazilijos)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Albanų"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rusų"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovėnų"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Ispanų"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Švedų"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turkų"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Kalba"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Nėra"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP prievadas negali būti didesnis nei 65532, nes serverio UDP prievadas yra TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Bus naudojamas numatytas prievadas (%d)"
@@ -8489,6 +8481,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "Įjungus šią parinktį atsiuntimo eilėje esantys failai bus rūšiuojami automatiškai"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Atmesti paketą, jei kliento IP adresas skiriasi nuo paketo šaltinio IP adreso. Naudoti atsargiai."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:17+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -629,8 +629,8 @@ msgstr "Kad: Izslēgts"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -641,7 +641,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Atslēgties"
 
@@ -650,7 +650,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Pieslēgties"
 
@@ -700,111 +700,111 @@ msgstr "Vai tiešām vēlaties aizvērt %s?"
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Tīkli"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Lejupielādes"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Kopīgotās datnes"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Ziņojumi"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Iestatījumi"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -939,14 +939,14 @@ msgstr "Nederīga saite vai jau ir sarakstā."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nevar izveidot '%s' mapi '%s' kategorijai, turpinam izmantot '%s' mapi."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -957,72 +957,72 @@ msgstr "Nevar izveidot '%s' mapi '%s' kategorijai, turpinam izmantot '%s' mapi."
 msgid "Unknown"
 msgstr "Nezināms"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Neizdevās iegūt lietotāja '%s' kopīgoto datņu sarakstu"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Viltus eMule %#x versija)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Iesauka: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pieprasīts: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Jauns ziņojums no '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1179,7 +1179,7 @@ msgid "Disconnected"
 msgstr "Atslēgts"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1333,19 +1333,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1372,7 +1372,7 @@ msgid "Queue Full"
 msgstr "Rinda pilna"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Rindā"
 
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1508,7 +1508,7 @@ msgstr "Daļa"
 msgid "Size"
 msgstr "Izmērs"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Pārsūtīti"
 
@@ -1563,7 +1563,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr ""
@@ -1638,45 +1638,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lejupielādes (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Datnes priekšskatījums"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2211,7 +2211,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Draugi"
 
@@ -2548,57 +2548,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr "Kad tīkls"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Datnes nosaukums"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Datnes izmērs"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Augšupielādēts"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2713,7 +2713,7 @@ msgid "WARNING: "
 msgstr "BRĪDINĀJUMS: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -2731,7 +2731,7 @@ msgid "Paste"
 msgstr "Ielīmēt"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Notīrīt"
@@ -3143,8 +3143,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr "Izpildītājs :"
 msgid "Album :"
 msgstr "Albums :"
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Nosaukums :"
 
@@ -3393,7 +3393,7 @@ msgstr "Lietotājvārds :"
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Pievienot"
@@ -3402,15 +3402,15 @@ msgstr "Pievienot"
 msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Pašreizējais"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Visu laiku vidējais"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Sesijas vidējais"
 
@@ -3649,7 +3649,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Ievadiet šeit sava pārlūka nosaukumu. Atstājiet šo lauku tukšu, ja vēlaties izmantot sistēmas noklusējuma pārlūku."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3723,7 +3723,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3743,7 +3743,7 @@ msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4061,7 +4061,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Atlasīt"
 
@@ -4177,417 +4177,409 @@ msgstr "Plakana"
 msgid "Round"
 msgstr "Apaļa"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP ports:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Parole"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kad palaiž, palaist arī tīmekļa serveri"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Iespējot Gzip saspiešanu"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistēmas"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Labi"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komentārs :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Ports"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Ports:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Atslēgt Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Jebkurš"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Neviens"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Kas var skatīt manas kopīgotās datnes:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Datubāze"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4595,11 +4587,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4609,222 +4601,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Kad palaiž, automātiski atjaunināt"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Komentāri"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Lietotājvārds: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Parole:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Parole, ko lietot, kad izmanto starpniekserveri"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Izmantot starpniekserveri"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Starpniekservera tips:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Starpniekserveris:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Starpniekservera ports:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Starpniekservera ports"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Lietotājvārds"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Gaida…"
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Sūtīt"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
 
@@ -5183,187 +5175,187 @@ msgstr "Lejupielādēta"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Sistēmas"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albāņu"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arābu"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Astūriešu"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basku"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgāru"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalāņu"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Ķīniešu (vienkāršotā)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Ķīniešu (tradicionālā)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Horvātu"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Čehu"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dāņu"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nīderlandiešu"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Angļu (Apvienotās Karalistes)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "Angļu (ASV)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Igauņu"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Somu"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Franču"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galisiešu"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Vācu"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grieķu"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Ivrits"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ungāru"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Itāļu"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japāņu"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korejiešu"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lietuviešu"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvēģu (Jaunnorvēģu)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Poļu"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugāļu"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugāļu (Brazīlijas)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumāņu"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Krievu"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovēņu"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spāņu"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Zviedru"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turku"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraiņu"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Mainīt valodu"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "aMule nav uzstādīta neviena valodas datne"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Nav pieejama neviena valoda"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:01+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -651,8 +651,8 @@ msgstr "Kad: Uitgeschakeld"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -663,7 +663,7 @@ msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Verbreek"
 
@@ -672,7 +672,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -722,111 +722,111 @@ msgstr "Wilt u %s echt afsluiten?"
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Netwerken"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Gedeelde bestanden"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Berichten"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistieken"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Geen netwerk"
 
@@ -965,14 +965,14 @@ msgstr "Ongeldige link of al op de lijst."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -983,72 +983,72 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Op zoek naar buddy voor laag-ID-verbinding"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Nep eMule versie %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Nep eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Nep eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (gebaseerd op eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Bijnaam: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Aangevraagd: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Bestandsstatistieken voor deze sessie: Geaccepteerd %d van %d aanvraag, %s overgebracht\n"
 msgstr[1] "Bestandsstatistieken voor deze sessie: Geaccepteerd %d van %d aanvragen, %s overgebracht\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Bestandsstatistieken voor alle sessies: Geaccepteerd %d van %d aanvraag, %s overgebracht\n"
 msgstr[1] "Bestandsstatistieken voor alle sessies: Geaccepteerd %d van %d aanvragen, %s overgebracht\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Aangevraagd bestand is onbekend"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Bericht van '%s' gefilterd (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nieuw bericht van '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst van niet-bestaande map '%s' op -> Genegeerd"
@@ -1205,7 +1205,7 @@ msgid "Disconnected"
 msgstr "Niet verbonden"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1359,19 +1359,19 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1398,7 +1398,7 @@ msgid "Queue Full"
 msgstr "Wachtrij vol"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "In wachtrij"
 
@@ -1463,7 +1463,7 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1535,7 +1535,7 @@ msgstr "Deel"
 msgid "Size"
 msgstr "Grootte"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Overgebracht"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Feedback van: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1667,34 +1667,34 @@ msgstr "Toewijzen aan catgorie"
 msgid "&Open the file"
 msgstr "&Open het bestand"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Voer een nieuwe naam voor dit bestand in:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Naam wijzigen"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1703,11 +1703,11 @@ msgstr ""
 "Om deze waarschuwing te voorkomen bij elk voorbeeld\n"
 "dient u uw video afspeelprogramma in te stellen bij voorkeuren (standaard is %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Voorbeeld"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FOUT: Opstarten externe mediaspeler mislukt! Commando: '%s'"
@@ -2271,7 +2271,7 @@ msgstr "Kon niet schrijven naar vriendenlijst-bestand 'emfriends.met'!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIEK - geen client bij StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Vrienden"
 
@@ -2615,57 +2615,57 @@ msgstr[1] "%d Kad-contacten geschreven"
 msgid "Kad user"
 msgstr "Kad netwerk"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Bestandsnaam"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Bestandsgrootte"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Deelverhouding"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Aangevraagd"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Geaccepteerd"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Complete bronnen"
 
@@ -2781,7 +2781,7 @@ msgid "WARNING: "
 msgstr "WAARSCHUWING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Sluiten"
 
@@ -2799,7 +2799,7 @@ msgid "Paste"
 msgstr "Plakken"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wissen"
@@ -3221,8 +3221,8 @@ msgstr "Bestandsbronnen:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/B"
 
@@ -3367,7 +3367,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3476,7 +3476,7 @@ msgstr "Gebruikersnaam :"
 msgid "Userhash :"
 msgstr "Gebruikershash :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Toevoegen"
@@ -3485,15 +3485,15 @@ msgstr "Toevoegen"
 msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Huidige"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Lopende gemiddelde"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Sessie gemiddelde"
 
@@ -3733,7 +3733,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Voer hier uw browsernaam in. Laat dit veld leeg om de standaardbrowser van uw systeem te gebruiken."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3807,7 +3807,7 @@ msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Enkel voor gevorderde gebruikers: Als u meerdere netwerk-interfaces hebt, voer hier het adres in van de interface waar aMule mee verbonden moet worden."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokaal adres aan IP (laat leeg voor elk):"
@@ -3828,7 +3828,7 @@ msgstr "Max gelijktijdige verbindingen:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4148,7 +4148,7 @@ msgstr "Kad-nodes draaiende"
 msgid "Kad-nodes session"
 msgstr "Kad-nodes sessie"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Selecteer"
 
@@ -4266,421 +4266,413 @@ msgstr "Plat"
 msgid "Round"
 msgstr "Rond"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto-sorteer bestanden (hoog CPU-gebruik)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule zal de kolommen in uw downloadlijst automatisch sorteren"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Externe verbinding parameters"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Accepteer externe verbindingen"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP van de luisterende interface:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Voer hier een geldig IP in het formaat a.b.c.d in van de luisterende EV-interface. Een leeg veld of 0.0.0.0 betekent elke interface."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Schakel UPnP portforwarding van de EV-poort in"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-poort:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Controleren van wachtwoord\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Webserver parameters"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Start webserver bij het opstarten"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web-template"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Alle rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Schakel gebruiker met beperkte rechten in"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Beperkte rechten wachtwoord"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Schakel UPnP portforwarding van de webserver-poort in"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web server UPnP TCP-poort (optioneel)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Pagina verversingstijd (in seconden)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Schakel Gzip-compressie in"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systeemstandaard"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klik hier om de veranderingen gemaakt in de voorkeuren toe te passen."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Commentaar :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Binnenkomende map :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Niet veranderen"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Klik op deze knop om het logboek te wissen."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klik op deze knop om de lijst van servers te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Server-lijst"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Voer de url naar een server.met bestand hier in en druk op de knop links om de lijst met bekende servers te vernieuwen."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Voeg server handmatig toe: Naam"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Voer hier de naam van de nieuwe server in"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Poort"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Voer hier de poort van de server in."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Voeg een server handmatig toe (vul velden links in voor) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule log"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Server-info"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klik op deze knop om de nodes-lijst te updaten van URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodes (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Voer hier de url in naar een nodes.dat bestand en druk op de knop links om de lijst van bekende nodes te updaten."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Nodes stats"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nieuwe node"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Poort:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap van bekende clients"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Verbreek verbinding met Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Gebruik beveiligde gebruikersidentificatie"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Het is aan te raden om deze optie in te schakelen. U ontvangt geen credits indien SUI niet ingeschakeld is."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Ondersteun protocol-obfuscatie"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Deze optie schakelt Protocol Obfuscatie in, en zorgt er voor dat aMule geobfusceerde verbindingen van andere clients accepteert."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Gebruik obfuscatie voor uitgaande verbindingen"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Deze optie zorgt er voor dat aMule protocol-obfuscatie gebruikt bij het verbinden met andere clients/servers."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Accepteer alleen geobfusceerde verbindingen"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Deze optie zorgt er voor dat aMule alleen geobfusceerde verbindingen accepteert. U heeft minder bronnen, maar al uw verkeer is geobfusceerd"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Iedereen"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Niemand"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Wie kan mijn gedeelde bestanden zien:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecteer wie een lijst van uw gedeelde bestanden kan opvragen."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-filteren"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filter clients"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de client-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filter servers"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Schakel filteren van de server-IPs in het bestand ~/.aMule/ipfilter.dat in."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Lijst opnieuw laden"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Laadt de lijst met IPs om te filteren opnieuw uit het bestand ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Update nu"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Niveau van filteren:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filter LAN IPs altijd"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoïde behandeling van niet-kloppende IPs"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Gebruik systeemwijd ipfilter.dat indien beschikbaar"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Indien er geen lokaal ipfilter.dat gevonden wordt, sta gebruik van een systeemwijd ipfilter toe."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Schakel online handtekening in"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Schakelt het schrijven van het OH-bestand in, die kan gebruikt worden door externe applicaties om handtekeningen en dergelijke te maken."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Update-frequentie (seconden):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Verander de frequentie (in seconden) van de Online Handtekening updates."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Bewaar online-handtekeningbestand in: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klik hier om de map te selecteren die de online-handtekening-bestanden bevat."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Toon landenvlaggen voor clients"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Datasnelheid :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Bronnen"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4688,11 +4680,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4702,225 +4694,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-update ip-filter bij het starten"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filter binnenkomende berichten (behalve huidige chat):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filter alle berichten"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filter berichten van mensen niet op uw vriendenlijst"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filter berichten van onbekende clients"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filter berichten met (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "voeg hier de woorden toe die amule moet filteren en berichten daarmee blokkeren"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Toon ontvangen berichten in het logboek"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Commentaren"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filter commentaren die de volgende tekens bevatten (gebruik ',' als scheiding):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Schakel aanmelding in"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Gebruikersnaam: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Wachtwoord:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Het wachtwoord nodig om te verbinden met de proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Schakel proxy in"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Proxy-type:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Proxy-host:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Proxy-poort:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "De proxy poort"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Verbind met:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Gebruikersnaam"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Gebruik Gzip-compressie"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Schakel uitgebreide foutopsporing en logboek in."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Alleen naar logbestand"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Berichtcategorieën:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Wachtend..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Voeg geïmporteerden toe"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Probeer geselecteerde opnieuw"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Verwijder geselecteerde"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Gebeurtenistypes"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistieken en clients in wachtrij voor geselecteerd(e) bestand(en) : Sessie / Alle"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Actieve uploads"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Procent van alle bestanden"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Geselecteerde bestanden"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Alleen actieve uploads"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Opnieuw laden:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Laad uw gedeelde bestanden opnieuw"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Verstuur"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Verstuurt het opgegeven bericht."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Verbind met een server en/of Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
 
@@ -5281,188 +5273,188 @@ msgstr "Gedownload"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Systeemstandaard"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanees"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturisch"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskisch"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgaars"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalaans"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinees (Vereenvoudigd)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinees (Traditioneel)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tsjechisch"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Deens"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engels (V.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonisch"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Fins"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Frans"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Gallisch"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Duits"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grieks"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreeuws"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Hongaars"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiaans"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japans"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreaans"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litouws"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Noors"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Pools"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugees"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugees (Braziliaans)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Roemeens"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russisch"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Sloveens"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spaans"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Zweeds"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turks"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Verander taal"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Geen talen beschikbaar"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-poort kan niet hoger zijn dan 65532 omdat de server UDP-poort de TCP-poort + 3 is"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standaard poort zal worden gebruikt (%d)"
@@ -8403,6 +8395,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto-sorteer bestanden (hoog CPU-gebruik)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule zal de kolommen in uw downloadlijst automatisch sorteren"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Weigert een pakket als het client-IP anders is dan het IP waar het pakket van is ontvangen. Wees voorzichtig hiermee."

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:03+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -652,8 +652,8 @@ msgstr "Kad: Av"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -664,7 +664,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Kople frå"
 
@@ -673,7 +673,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Kople til"
 
@@ -724,112 +724,112 @@ msgstr "Vil du verkeleg avslutte aMule?"
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Nettverk"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Nedlastingar"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Delte filer"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Meldingar"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Innstillingar"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 
@@ -972,14 +972,14 @@ msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -990,72 +990,72 @@ msgstr ""
 msgid "Unknown"
 msgstr "Ukjend"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Falsk eMuleutgåve %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Falsk eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsk eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x·(basert på eMule·v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Brukarnamn: %s·ID:·%u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Etterspurt: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistikk for denne økta: Godkjende %d av %d etterspurnad, %s overført\n"
 msgstr[1] "Filstatistikk for denne økta: Godkjende %d av %d etterspurnader, %s overført\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistikk for alle økter: Godkjende %d av %d etterspurnad, %s overført\n"
 msgstr[1] "Filstatistikk for alle økter: Godkjende %d av %d etterspurnader, %s overført\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Etterspurt ukjend fil"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Melding filtrért frå '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Ny melding frå '%s'·(IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Brukar·%s (%u)·etterspurte·lista·over·delte·filer·for·katalogen·%s ->·nekta"
@@ -1213,7 +1213,7 @@ msgid "Disconnected"
 msgstr "Fråkopla"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1366,19 +1366,19 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1405,7 +1405,7 @@ msgid "Queue Full"
 msgstr "Kø full"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "I kø"
 
@@ -1470,7 +1470,7 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Overført"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 "Tilbakemelding frå: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatisk"
@@ -1674,45 +1674,45 @@ msgstr "Vel kategori"
 msgid "&Open the file"
 msgstr "&Opne fila"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Skriv nytt namn på denne fila:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Døyp om fil"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f·kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d·%H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Nedlastingar (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr "Vel ein videospelar i innstillingar for å hindre at denne åtvaringa kjem opp ved kvar førehandssyning (%s er standard)"
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Førehandssyning"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEIL: Greidde ikkje å starte ekstern mediespelar! Kommando: '%s'"
@@ -2279,7 +2279,7 @@ msgstr "Greidde ikkje å opne venelista 'enfriends.met' for skriving!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Vener"
 
@@ -2627,57 +2627,57 @@ msgstr[1] "Skreiv %d kadkontaktar"
 msgid "Kad user"
 msgstr "Kad nettverk"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Filnamn"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Filstorleik"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Delingsrate"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Etterspurt"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Godkjend"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Komplette kjelder"
 
@@ -2795,7 +2795,7 @@ msgid "WARNING: "
 msgstr "ÅTVARING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Stengje"
 
@@ -2813,7 +2813,7 @@ msgid "Paste"
 msgstr "Lim inn"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Frigjer plass"
@@ -3235,8 +3235,8 @@ msgstr "Komplette kjelder"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "I/T"
 
@@ -3381,7 +3381,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Tittel :"
 
@@ -3488,7 +3488,7 @@ msgstr "Brukarnamn :"
 msgid "Userhash :"
 msgstr "Brukarhash :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Legg til"
@@ -3497,15 +3497,15 @@ msgstr "Legg til"
 msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Novérande"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Køyregjennomsnitt"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Gjennomsnitt økt"
 
@@ -3746,7 +3746,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3820,7 +3820,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3840,7 +3840,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4159,7 +4159,7 @@ msgstr "Køyrande kadnodar"
 msgid "Kad-nodes session"
 msgstr "Kadnodar (økt)"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Velje"
 
@@ -4278,424 +4278,416 @@ msgstr "Flat"
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule sorterer kolonnene i nedlastingslista di automatisk"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parameter for ekstern kopling"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Akseptér eksterne koplingar"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Skriv in ei gyldig IP i a.b.c.d format for det lyttande EC-grensesnittet. Eit tomt felt eller 0.0.0.0 betyr samtlege grensesnitt."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivér UPnP-portvidaresending på EC-porten"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Passord"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP port: %d"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Sjekkar passord\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Vevtenarparameter"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Vevmønster"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Passord for fulle rettar"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Aktivér brukar med få rettar"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Passord for låge rettar"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Sideoppfriskingstid (i sekund)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Aktivér Gzipkompresjon"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Standardinnstillingar"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klikk her for å utføre samtlege endringar gjorde i innstillingar."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Innkomande kat:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Endre prioritet for nytileigna filer :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Ikkje endre"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Vel farge for denne kategprien (no valt)"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Klikk denne knappen for å nullstille loggen."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere tenarlista frå nettadresse ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Tenarliste"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Skriv inn nettadressa til ei server.met fil her og klikk på knappen til venstre for å oppdatere tenarlista."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Legg til tenar manuelt: Namn"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Skriv inn namnet på den nye tenaren her"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Skriv inn porten til tenaren her."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Legg til ein tenar manuelt (fyll først ut felta til venstre) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMulelogg"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Tenarinfo"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2k-info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klikk på denne knappen for å oppdatere nodelista frå internettadresse ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nodar (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Skriv inn internettadressa til ei nodes-dat fil her og klikk på knappen til venstre for å oppdatere lista over kjende nodar."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Eigenoppstart"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Ny node"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Eigenoppstart frå \n"
 "kjende klientar"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Kople frå Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Sikker brukaridentifikasjon (SUI)"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det er tilrådd å aktivere denne funksjonen. Du vil ikkje få kredittar dersom SUI ikkje er aktivert."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Støtte protokolltåkeleggjing"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Dette valet aktiverer protokolltåkeleggjing og gjer at aMule tek imot tåkelagde koplingar frå andre klientar."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Bruk tåkeleggjing for utgåande koplingar"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Dette valet får aMule til å nytte protokolltåkeleggjing ved tilkopling til andreklientar/tenarar."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Berre godta tåkelagde koplingar"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Dette valet får aMule til å berre godta tåkelagde koplingar. Du vil få færre kjelder, men all trafikken din vert tåkelagd"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Alle"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Ingen"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Vel kven som kan be om å sjå ei liste over dei delte filene dine."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrér klientar"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér IP-filterring av klientar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrér tenarar"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivér filtrering av tenarar i fila ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Last om att lista av IP`ar å filtre frå fila ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "Nettadresse:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Oppdatér no"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Filternivå:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Alltid filtrér LAN IP`ar"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid handsaming av ujamne IP`ar"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Bruk systemomspennande ipfilter.dat dersom tilgjengeleg"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Tillat bruk av ipfilter for heile systemet dersom inga lokal ipfilter-dat vert funnen"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Aktivér nettsignatur"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Aktiverer skriving av OS-fila, som kan verte nytta av eksterne program forå lage signaturar og liknande."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Oppdateringsfrekvens (sekund):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Endre frekvensen (i sekund) for oppdatering av nettsignaturar."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klikk her for å velje katalogen med nettsignaturfilene."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Datasnøggleik :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Kjelder"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4703,11 +4695,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4717,232 +4709,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Nedlasting: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Automatisk oppdatér ipfilter ved oppstart"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrér innkomande meldingar (utanom novérande samtale):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrér alle meldingar"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrér meldingar frå alle som ikkje er på kameratlista"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrér meldingar frå ukjende klientar"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrér meldingar som inneheld (bruk ','som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "legg til ord aMule skal filtrére og blokkere"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Kommentarar"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrér kommentarar som inneheld (bruk ',' som skiljeteikn):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Aktivér godkjenning"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Passord:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Passord å nytte for å kople til vikar"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Aktivér vikar"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Vikartype:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Vikarvert:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Vikarport:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Vikarport"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Kople til:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Brukarnamn"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Nytt gzipkomprimering"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivér utførleg avfeilingslogg."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Opne fila"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Meldingskategoriar:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ventar..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Importér"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Prøv om att valde"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Fjern valde"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Gøyme delte filer"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Vel synsfilter"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktive opplastingar"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Last om att lista"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Lastar inn att delte filer"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Send"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Sender meldinga."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Kople til vilkårleg tenar og/eller Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Delte filer"
 
@@ -5303,192 +5295,192 @@ msgstr "Lasta ned"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Standardinnstillingar"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskisk"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalansk"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kinesisk (forenkla)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kinesisk (tradisjonell)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tsjekkisk"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dansk"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nederlansk"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelsk (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estisk"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finsk"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Fransk"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galisisk"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Tysk"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Gresk"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebraisk"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiensk"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japansk"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreansk"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norsk (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polsk"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisisk (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russisk"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spansk"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Svensk"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Språk"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP port kan ikkje vere høgare enn 65532 fordi tenaren si UDPkopling er TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardport vert nytta (%d)"
@@ -8459,6 +8451,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule sorterer kolonnene i nedlastingslista di automatisk"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Avviser pakkar dersom klientadressa er ulik adressa pakken vert motteken frå. Vér varsam med dette."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:04+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -652,8 +652,8 @@ msgstr "Kad: Wyłączony"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -664,7 +664,7 @@ msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Rozłącz"
 
@@ -673,7 +673,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Podłącz"
 
@@ -724,111 +724,111 @@ msgstr "Czy na pewno chcesz opuścić %s?"
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Sieci"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Pobieranie"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Udostępnione pliki"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statystyki"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Brak sieci"
 
@@ -967,14 +967,14 @@ msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nadal katalog '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -985,44 +985,44 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Szukam kolegi dla połączenia lowid"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Fałszywa wersja eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Fałszywy eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Fałszywy eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (oparty na eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Użytkownik: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Zażądano:  %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1030,7 +1030,7 @@ msgstr[0] "Statystyki plików tej sesji: Zaakceptowano %d z %d żądania, %s prz
 msgstr[1] "Statystyki plików tej sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 msgstr[2] "Statystyki plików tej sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1038,21 +1038,21 @@ msgstr[0] "Statystyki plików dla wszystkich sesji: Zaakceptowano %d z %d żąda
 msgstr[1] "Statystyki plików dla wszystkich sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 msgstr[2] "Statystyki plików dla wszystkich sesji: Zaakceptowano %d z %d żądań, %s przesłano\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Zażądano nieznany plik"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Wiadomość przefiltrowana od '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nowa wiadomość od '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Użytkownik %s (%u) zażądał twojej listy plików udostępnionych w katalogu %s -> Odmówiono"
@@ -1211,7 +1211,7 @@ msgid "Disconnected"
 msgstr "Rozłączony"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1366,19 +1366,19 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1405,7 +1405,7 @@ msgid "Queue Full"
 msgstr "Pełna kolejka"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "W kolejce"
 
@@ -1470,7 +1470,7 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1542,7 +1542,7 @@ msgstr "Część"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Przesłano"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 "Informacja zwrotna od:  %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatyczny"
@@ -1674,34 +1674,34 @@ msgstr "Przydziel do kategorii"
 msgid "&Open the file"
 msgstr "&Otwórz plik"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Wprowadź nową nazwę dla tego pliku:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Zmień nazwę"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Pobieranie (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1710,11 +1710,11 @@ msgstr ""
 "Aby zapobiec pojawianiu się tego komunikatu przy każdym podglądzie,\n"
 "ustaw swój odtwarzacz wideo w preferencjach (domyślny jest %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Podgląd pliku"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "BŁĄD: Nie udało się uruchomić zewnętrznego odtwarzacza! Komenda: `%s'"
@@ -2278,7 +2278,7 @@ msgstr "Nie udało się otworzyć pliku listy przyjaciół 'emfriends.met' do za
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRYTYCZNE - brak klienta przy StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Znajomi"
 
@@ -2627,57 +2627,57 @@ msgstr[2] "Zapisano %d kontaktów Kad"
 msgid "Kad user"
 msgstr "Sieć Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nazwa pliku"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Rozmiar pliku"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Ratio wymiany"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Zażądano"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Zaakceptowano"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Pełne źródła"
 
@@ -2793,7 +2793,7 @@ msgid "WARNING: "
 msgstr "OSTRZEŻENIE: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Zamknij"
 
@@ -2811,7 +2811,7 @@ msgid "Paste"
 msgstr "Wklej"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Wyczyść"
@@ -3232,8 +3232,8 @@ msgstr "Źródła pliku:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Brak"
 
@@ -3378,7 +3378,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Tytuł :"
 
@@ -3487,7 +3487,7 @@ msgstr "Nazwa użytkownika :"
 msgid "Userhash :"
 msgstr "Skrót użytkownika :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3496,15 +3496,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Aktualna"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Bieżąca średnia"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Średnia sesji"
 
@@ -3744,7 +3744,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Podaj tutaj nazwę swojej przeglądarki. Pozostaw to pole puste, aby korzystać z domyślnej przeglądarki systemu."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3818,7 +3818,7 @@ msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Tylko zaawansowani użytkownicy: Jeśli masz kilka interfejsów sieciowych, wpisz adres interfejsu do którego powiązany powinien być aMule."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Wiąż lokalne adresy z IP (puste dla każdego):"
@@ -3839,7 +3839,7 @@ msgstr "Maksymalne połączenia jednoczesne:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4159,7 +4159,7 @@ msgstr "Działające Kad-węzły"
 msgid "Kad-nodes session"
 msgstr "Sesyjne Kad-węzły"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Wybierz"
 
@@ -4278,422 +4278,414 @@ msgstr "Płaski"
 msgid "Round"
 msgstr "Okrągły"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto-sortowanie plików (wysokie obciążenie procesora)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule będzie sortował kolumny w liście pobierania automatycznie"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parametry zewnętrznych połączeń"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Akceptuj zewnętrzne połączenia"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP z interfejsem słuchania:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Wprowadź tutaj w formacie a.b.c.d prawidłowy adres ip nasłuchującego interfejsu EC. Puste pole lub 0.0.0.0 oznacza dowolny interfejs."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Włącz forwarding portu UPnP na porcie EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Hasło"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Port TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Sprawdzam hasło\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parametry serwera sieciowego"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Uruchom serwera internetowego przy starcie"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Szablon WWW"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Hasło pełnych uprawnień"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Włącz użytkowników z niskimi uprawnieniami"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Hasło niskich uprawnień"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Włącz przekierowanie portu UPnP na port serwera internetowego"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port web serwera UPnP TCP (opcjonalnie)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Odświeżanie strony co:  (w sekundach)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Włącz kompresję Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Domyślny systemowy"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknij tu aby zastosować wszystkie zmiany dokonane w preferencjach."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komentarz :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Katalog przychodzących :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Zmień priorytet nowo przydzielonych plików :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Nie zmieniaj"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Kliknij tu aby wyczyścić logi."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknij na tym przycisku aby uaktualnić listę serwerów z URL-a ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Lista serwerów"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Wpisz tu url do pliku server.met  i przyciśnij przycisk po lewej aby zaktualizować listę znanych serwerów."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Dodaj serwer ręcznie: Nazwa"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Wpisz tu nazwę nowego serwera"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Wpisz tu port serwera."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Dodaj ręcznie serwer (wypełnij pola od lewej) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Logi aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Serwer Info"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Info eD2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknij ten przycisk, aby uaktualnić listę węzłów z adresu URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Węzły (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Wprowadź tutaj url pliku nodes.dat i naciśnij przycisk z lewej, aby zaktualizować listę znanych węzłów."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nowy węzeł"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Rozruch od znanych klientów"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Rozłącz z Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Użyj bezpiecznej identyfikacji użytkownika"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Zalecane jest włączenie tej opcji. Nic nie zyskasz wyłączając bezpieczną identyfikację użytkownika."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Maskowanie protokołu"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Obsługa maskowania protokołu"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Opcja ta włącza maskowanie protokołu i powoduje, że aMule będzie akceptował zamaskowane połączenia od innych klientów."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Użyj maskowania dla połączeń wychodzących"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Opcja ta powoduje, że aMule będzie używał maskowania protokołu podczas łączenia z innymi klientami/serwerami."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Akceptuj tylko zamaskowane połączenia"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Opcja ta powoduje, że aMule akceptuje tylko zamaskowane połączenia. Uzyskasz mniej źródeł, ale cały twój ruch będzie zamaskowany"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Wszyscy"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nikt"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Kto może widzieć moje udostępnione pliki:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Wybierz kto może zażądać pokazania listy twoich udostępnionych plików."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtrowanie IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtruj klientów"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP klientów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtruj serwery"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Włącza filtrowanie IP serwerów zdefiniowanych w pliku ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Przeładuj listę"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Przeładuj listę filtrowanych IP z pliku ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Uaktualnij teraz"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Poziom filtrowania:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Zawsze filtruj IP z LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoidalna obsługa niepasujących IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Użyj ogólno-systemowego ipfilter.dat jeśli dostępny"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Jeśli ipfilter.dat nie istnieje lokalnie, zezwól na użycie ogólno-systemowego pliku ipfilter."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Włącz podpis online"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Włącza zapisywanie pliku OS, który może być użyty przez zewnętrzne aplikacje do stworzenia sygnatury itp."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Częstotliwość odświeżania (sek):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Zmień częstotliwość (w sekundach) aktualizacji Sygnatury Online."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Zapisz podpis internetowy w pliku: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknij tu aby wskazać katalog zawierający pliki Sygnatur Online."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Prędkość transmisji danych :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Źródła"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4701,11 +4693,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4715,231 +4707,231 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Pobranych: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Uaktualniaj filtr IP przy starcie"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtruj wiadomości przychodzące (za wyjątkiem aktualnej rozmowy):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtruj wszystkie wiadomości"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtruj wiadomości od ludzi, którzy nie są na twojej liście znajomych"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtruj wiadomości od nieznanych klientów"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtruj wiadomości zawierające (jako separatora użyj ','):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "dodaj frazy które według których amule powinien filtrować i blokować wiadomości"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Pokaż otrzymane wiadomości w dzienniku"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Komentarze"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtruj komentarze zawierające (użyj ',' jako separatora):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Włącz uwierzytelnianie"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nazwa uzytkownika: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Hasło:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Hasło używane do połączeń z proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Włącz proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Typ proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Adres proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Port serwera proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Połącz z:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Używaj kompresji gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Włącz gadatliwe logowanie debugowe."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Otwórz plik"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Kategorie wiadomości:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Czekam..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Dodaj importy"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Przywróć wybrane"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Usuń wybrane"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Typy zdarzeń"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statystyki i klienty w kolejce dla wybranego plik(u-ów) : Sesja / Cały czas"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 #, fuzzy
 msgid "Percent of total files"
 msgstr "procent wszystkich plików"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Wszystkie udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Wybierz filtr przeglądania"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Aktywne wysyłania"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Przeładuj:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Przeładuj twoje udostępnione pliki"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Wysyła wybraną wiadomość."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
 
@@ -5303,189 +5295,189 @@ msgstr "Pobrano"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Domyślny systemowy"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albański"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabski"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturyjski"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskijski"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bułgarski"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Kataloński"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chiński (Uproszczony)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chiński (Tradycyjny)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Chorwacki"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Czeski"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Duński"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holenderski"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angielski (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estoński"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Fiński"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francuski"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galicyjski"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Niemiecki"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grecki"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebrajski"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Włoski"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japoński"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreański"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litewski"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norweski (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polski"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugalski"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalski (Brazylijski)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumuński"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Słoweński"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Hiszpański"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Szwedzki"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turecki"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Zmień język"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Niedostępny"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Port TCP nie może być większy niż 65532, gdyż gniazdo UDP serwera będzie TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Zostanie użyty domyślny port (%d)"
@@ -8445,6 +8437,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto-sortowanie plików (wysokie obciążenie procesora)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule będzie sortował kolumny w liście pobierania automatycznie"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Odrzuca pakiety, gdy ip klienta jest różne od ip, z którego pakiet jest otrzymywany. Używaj z ostrożnością."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-25 19:02+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -660,8 +660,8 @@ msgstr "Kad: Desligado"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -672,7 +672,7 @@ msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -681,7 +681,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Conectar"
 
@@ -731,111 +731,111 @@ msgstr "Você realmente quer sair %s?"
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Arquivos compartilhados"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Sem redes"
 
@@ -975,14 +975,14 @@ msgstr "Link inválido ou já está na lista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretório '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -993,72 +993,72 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Falha ao receber lista de compartilhamentos do usuário '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Procurando amigo para conexão lowid"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (versão de eMule falsa %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (eMule Falso)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule Falso)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado no eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nickname: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitado: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas dessa sessão: Aceito %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas dessa sessão: Aceitos %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas de todas as sessões: Aceito %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas de todas as sessões: Aceitos %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Solicitado um arquivo desconhecido"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensagem filtrada de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nova mensagem de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Usuário %s (%u) solicitou sua lista de compartilhados para pasta não existente '%s' -> Negado"
@@ -1215,7 +1215,7 @@ msgid "Disconnected"
 msgstr "Desconectado"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1368,19 +1368,19 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1407,7 +1407,7 @@ msgid "Queue Full"
 msgstr "Fila de espera cheia"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Na fila de espera"
 
@@ -1472,7 +1472,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1543,7 +1543,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1600,7 +1600,7 @@ msgstr ""
 "Resposta de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1675,34 +1675,34 @@ msgstr "Adicionar na Categoria"
 msgid "&Open the file"
 msgstr "Abrir &o arquivo"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Informe o novo nome para o arquivo:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Renomear"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr "O manipulador de shell default do Windows"
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1711,11 +1711,11 @@ msgstr ""
 "Para impedir que este aviso apareça em toda pré-visualização,\n"
 "defina seu tocador de vídeo preferido nas preferências (%s é o padrão)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Pré-visualização"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Falha ao executar o player de mídia externo! Comando: `%s'"
@@ -2275,7 +2275,7 @@ msgstr "Falha em abrir lista de amigos do arquivo 'emfriends.met' para escrita!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - nenhum cliente em StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2617,57 +2617,57 @@ msgstr[1] "Gravados %d contatos Kad"
 msgid "Kad user"
 msgstr "Usuário Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "A busca de nota em Kad por '%s' não foi iniciada: Kad não está conectada"
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "A busca de nota em Kad por '%s' não foi iniciada: uma busca de nota já está rodando para este arquivo"
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "A busca de nota por '%s' não foi iniciada: o arquivo não está na lista de compartilhamento, na fila de downloads ou nos resultados da busca"
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "A busca por nota em Kad por '%s' não foi iniciada: outra busca Kad (e.g. uma busca por fontes) já está usando o hash deste arquivo - tente novamente em breve"
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "A busca por nota em Kad por '%s' não foi iniciada: falha na preparação de busca (PrepareLookup)"
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nome do Arquivo"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Tamanho do arquivo"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Taxa de compartilhamento"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Requisitado"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Aceito"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fontes completas"
 
@@ -2782,7 +2782,7 @@ msgid "WARNING: "
 msgstr "CUIDADO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Fechar"
 
@@ -2800,7 +2800,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3212,8 +3212,8 @@ msgstr "Fontes de arquivos:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3353,7 +3353,7 @@ msgstr "Artista:"
 msgid "Album :"
 msgstr "Album:"
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Título:"
 
@@ -3461,7 +3461,7 @@ msgstr "Usuário :"
 msgid "Userhash :"
 msgstr "Hash do usuário :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3470,15 +3470,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Atual"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Média de execução"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3716,7 +3716,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Insira o nome do seu navegador aqui. Deixe vazio para usar o navegador padrão do sistema."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3790,7 +3790,7 @@ msgstr "Casar endereço local ao IP (vazio para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Somente usuários avançados: Se você tem múltiplas interfaces de rede, insira o endereço da interface com a qual o aMule deverá conectar-se."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr "Conectar a uma interface de rede (vazio equivale a todas):"
 
@@ -3810,7 +3810,7 @@ msgstr "Máximo de conexões simultâneas:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4130,7 +4130,7 @@ msgstr "Kad-nodes rodando"
 msgid "Kad-nodes session"
 msgstr "Sessões Kad-nodes"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Selecione"
 
@@ -4246,413 +4246,405 @@ msgstr "Plana"
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto-escolha de arquivo (sobrecarrega CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "O aMule vai organizar automaticamente as colunas da lista de downloads"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parâmetros de conexão externa"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Aceitar conexões externas"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP da interface ouvindo:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Informe um IP válido no formato a.b.c.d para a interface EC que ficará aguardando. Um campo vazio ou 0.0.0.0 quer dizer 'qualquer interface'."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Porta TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Habilitar redirecionamento de porta UPnP para porta EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Senha"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor da API do aMule"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Rodar o amuleapi (REST API) ao iniciar"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr "Porta HTTP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "A interface do servidor HTTP do amuleapi que escuta em 127.0.0.1 (padrão) aceita apenas conexões locais; use 0.0.0.0 or um IP específico para expô-la a outros hospedeiros (configure uma senha de administração abaixo)."
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr "Senha de administração"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parâmetros do web server"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rodar webserver ao iniciar (deprecado)"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Modelo de rede"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Password para acesso completo"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Usuário com direitos limitados"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Password para acesso limitado"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Habilitar redirecionamento de porta UPnP da porta do servidor web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porta TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Tempo atualização (secs)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Ativar compactação Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr "Retorna a página aos valores padrão"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr "Reseta as configurações na página atual para seus valores padrão."
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações feitas."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentário:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Dir incoming:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Alterar prioridade para novos arquivos:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Não alterar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selecione a cor para esta Categoria (selecionada):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Clique nesse botão para limpar o log."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de servidores..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Lista de servidores"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Informe a URL com o arquivo server.met aqui e pressione o botão a esquerda para atualizar a lista de servidores."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Informe o nome do novo servidor aqui"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Informe a porta do servidor aqui."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencha os campos ao lado antes)."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Log do aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K Info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Informação de Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique nesse botão para atualizar a lista de nodes da URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Informe uma URL para um arquivo nodes.dat e pressione o botão da esquerda para atualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Novo node"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Inicializando de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Desconectar da rede Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Usuário"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendável ativar essa opção. Você não receberá seus créditos se a identificação segura não estiver ativada."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar Obscurecimento de Protocolo"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção habilita Obscurecimento de Protocolo, e faz o aMule aceitar conexões obscuras (criptografadas) de outros clientes."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar obscurecimento para conexões externas"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz o aMule usar Obscurecimento de Protocolo quando conectando outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar somente conexões obscuras"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz o aMule aceitar somente conexões obscurecidas. Você terá menos fontes, mas todo seu tráfego será obscurecido"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nenhum"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver meus arquivos compartilhados:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selecione quem pode pedir a sua lista de compartilhamentos."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtro de IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de clientes definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Habilitar filtragem de IPs de servidores definidos no arquivo ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recarregar lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar lista de IPs a filtrar do arquivo ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Atualizar agora"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-atualizar ipfilter ao iniciar"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Níveis de Filtro:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Sempre filtrar IPs de redes LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manuseio paranoico de IPs não-casados"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "Rejeita um pacote quando o IP de sua fonte difere do IP que o cliente clama (uma checagem anti-spoofing). Desabilite apenas se causar problemas de conexão."
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global se disponível"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se nenhum ipfilter.dat local for encontrado, permita o uso de um arquivo global."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Ativar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Habilita a gravação do arquivo, que pode ser usado por programas externos."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de atualização (Seg):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar frequência (em segundos) da atualização da Assinatura."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Salvar arquivos de assinatura online em: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique aqui para definir pasta contendo os arquivos da Assinatura Online."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras nacionais para clientes"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Renderiza a coluna da bandeira do país nas transferências, filas e vistas de procura. Requer um banco de dados MMDB GeoIP válido (veja abaixo)."
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Banco de Dados"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "Fonte:"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (grátis, sem conta)"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (grátis, requer conta)"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "URL Customizada"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Escolha qual provedor fornece o banco de dados MMDB GeoIP. DB-IP é o padrão - não requer conta. MaxMind requer uma conta grátis + chave de licensa. Use uma URL Customizada para apontar para qualquer outro anfitrião MMDB (e.g. um espelho local)."
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4664,11 +4656,11 @@ msgstr ""
 "Dados de IP-to-Country por DB-IP.com - https://db-ip.com\n"
 "Licensa: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "Chave de Licensa:"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4684,11 +4676,11 @@ msgstr ""
 "Licensa: MaxMind GeoLite2 EULA - https://www.maxmind.com/en/geolite2/eula\n"
 "Requer atribuição e registro de conta; renove no mínimo a cada 30 dias."
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "URL de Download:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4698,211 +4690,211 @@ msgstr ""
 "A URL pode incluir credenciais (https://user:pass@host/...).\n"
 "License e termos de atribuição são realizados pela URL upstream - você é responsável."
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "Baixe o banco de dados GeoIP da fonte selecionada."
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Auto-atualizar ao iniciar"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "Baixe novamente o banco de dados GeoIP da fonte selecionada toda vez que o aMule iniciar."
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens (Exceto chat atual):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de pessoas que não estão em sua lista"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens contendo (use ',' como separador):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione aqui as palavras que o amule deve filtrar e bloquear nas mensagens"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no log"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários contendo (use '.' como separador):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Ativar autenticação"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Nome do usuário: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Senha:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Senha utilizada para conectar ao proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Ativar proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Host do Proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Porta do Proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Porta do Proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Conectar em:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Usuário"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "Força compressão ZLIB"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ativar log de debug detalhado."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Apenas para o arquivo de log"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Aguardando..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Adicionar importadas"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Tentar novamente selecionada"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Remover selecionada"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipos de Eventos"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e filas de clientes para arquivo(s) selecionado(s) : Sessão / Sempre"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Porcentagem de total de arquivos"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Arquivos selecionados"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Somente uploads ativos"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Atualizar lista de compartilhados"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Enviar a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Conectar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
 
@@ -5262,187 +5254,187 @@ msgstr "Baixado"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Padrão do sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croácia"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Tcheco"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglês (UK)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "Inglês (U.S.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estônia"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Hungria"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr "Letão"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituânia"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Noruega (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polonês"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Português (Portugal)"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suécia"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turquia"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Mudar Idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Não há traduções instaladas no aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Nenhum idioma disponível"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP não pode ser maior do que 65532, pois a UDP escuta em TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Porta padrão será utilizada (%d)"
@@ -8383,6 +8375,12 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto-escolha de arquivo (sobrecarrega CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "O aMule vai organizar automaticamente as colunas da lista de downloads"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rejeitar pacotes se o IP do cliente é diferente do IP onde o pacote foi recebido. Use com cuidado."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:06+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -656,8 +656,8 @@ msgstr "Kad: Desligado"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -668,7 +668,7 @@ msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Desligar"
 
@@ -677,7 +677,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Ligar"
 
@@ -728,111 +728,111 @@ msgstr "Quer mesmo fechar o %s?"
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Redes"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Downloads"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Ficheiros partilhados"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mensagens"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Sem rede"
 
@@ -971,14 +971,14 @@ msgstr "Ligação inválida ou já na lista."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Não é possível criar o directório '%s' para a categoria '%s', a manter directório '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -989,72 +989,72 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "A procurar parceiro para ligação com lowid"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versão do eMule falsa %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (eMule falso)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule falso)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado no eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alcunha: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Pedido: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas para esta sessão: Aceite %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas para esta sessão: Aceites %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Estatísticas para todas as sessões: Aceite %d de %d pedido, %s transferido\n"
 msgstr[1] "Estatísticas para todas as sessões: Aceites %d de %d pedidos, %s transferidos\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Pedido um ficheiro desconhecido"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mensagem filtrada de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nova mensagem de '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados para a pasta '%s' -> Ignorado"
@@ -1211,7 +1211,7 @@ msgid "Disconnected"
 msgstr "Desligado"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1365,19 +1365,19 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1404,7 +1404,7 @@ msgid "Queue Full"
 msgstr "Fila de Espera Cheia"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Em Fila de Espera"
 
@@ -1469,7 +1469,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1541,7 +1541,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferido"
 
@@ -1598,7 +1598,7 @@ msgstr ""
 "Comentário de: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automática"
@@ -1673,34 +1673,34 @@ msgstr "Atribuir à categoria"
 msgid "&Open the file"
 msgstr "&Abrir o ficheiro"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Insira o novo nome para este ficheiro:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Renomear ficheiro"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1709,11 +1709,11 @@ msgstr ""
 "Para evitar que este aviso apareça em cada pré-visualização,\n"
 "defina o seu leitor de vídeo nas preferências (por omissão é o %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Pré-visualização do ficheiro"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Erro na execução do leitor multimédia externo! Comando: '%s'"
@@ -2275,7 +2275,7 @@ msgstr "Erro ao abrir o ficheiro de lista de amigos 'emfriends.met' para escrita
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRÍTICO - sem cliente no StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Amigos"
 
@@ -2619,57 +2619,57 @@ msgstr[1] "Escritos %d contactos Kad"
 msgid "Kad user"
 msgstr "Rede Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Nome de ficheiro"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Tamanho do Ficheiro"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Razão de partilha"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Pedido"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Aceite"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Fontes completas"
 
@@ -2785,7 +2785,7 @@ msgid "WARNING: "
 msgstr "AVISO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Fechar"
 
@@ -2803,7 +2803,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Limpar"
@@ -3224,8 +3224,8 @@ msgstr "Fontes de ficheiros:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/D"
 
@@ -3370,7 +3370,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Título :"
 
@@ -3479,7 +3479,7 @@ msgstr "Utilizador :"
 msgid "Userhash :"
 msgstr "Chave de utilizador :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adicionar"
@@ -3488,15 +3488,15 @@ msgstr "Adicionar"
 msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Actual"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Média actual"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Média da sessão"
 
@@ -3736,7 +3736,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Indique aqui o nome do seu browser. Deixe este campo em branco para utilizar o browser por omissão do sistema."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3810,7 +3810,7 @@ msgstr "Associar endereço local ao IP (em branco para qualquer um):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Apenas para utilizadores avançados: Se possui múltiplos interfaces de rede indique o endereço do interface que o aMule deve usar."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Associar endereço local ao IP (em branco para qualquer um):"
@@ -3831,7 +3831,7 @@ msgstr "Máximo de ligações simultâneas:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4151,7 +4151,7 @@ msgstr "Nós Kad a executar"
 msgid "Kad-nodes session"
 msgstr "Nós Kad da sessão"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Seleccionar"
 
@@ -4270,421 +4270,413 @@ msgstr "Plana"
 msgid "Round"
 msgstr "Arredondada"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Ordenar ficheiros automaticamente (pode consumir muito CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "O aMule ordenará as colunas na sua lista de transferências automaticamente"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parâmetros de Ligação Externa"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Aceitar ligações externas"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP da interface a escutar:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Insira um endereço IP válido no formato a.b.c.d para a interface que irá aguardar as LE. Um campo vazio ou 0.0.0.0 significará qualquer interface."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activar UPnP para configuração do encaminhamento no porto das LE"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porto TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "A verificar a palavra-passe\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parâmetros do servidor web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Executar o servidor web no arranque"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Aspecto da página web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Palavra-passe para controlo total"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Activar utilizador com permissões reduzidas"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Palavra-passe para controlo reduzido"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activar UPnP para encaminhamento do porto do servidor web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Porto TCP UPnP do servidor web (Opcional)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Taxa de Actualização de Páginas (em segundos)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Activar compressão Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Predefinição do sistema"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Clique aqui para aplicar as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentário :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Pasta de completos :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Trocar prioridade nos novos ficheiros :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Não mudar"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Seleccionar a cor para a categoria seleccionada :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Clique para limpar o relatório."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Clique neste botão para actualizar a lista de servidores a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Lista de Servidores"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Insira a localização de um ficheiro server.met e pressione o botão à esquerda para actualizar a lista de servidores conhecidos."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Adicionar servidor manualmente: Nome"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Insira o nome do novo servidor"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porto"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Insira o porto do servidor."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adicionar manualmente um servidor (preencher os campos ao lado) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Relatório"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Informações do Servidor"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Informação ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Clique para actualizar a lista de nós a partir do endereço ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nós (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Insira o endereço de um ficheiro nodes.dat e pressione o botão à esquerda para actualizar a lista de nós conhecidos."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Estado dos nós"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Inicialização"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Novo nó"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Porto:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Arrancar a partir de clientes conhecidos"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Desligar Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Utilizar Identificação Segura de Utilizador"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "É recomendado activar esta opção. Não receberá créditos se a Identificação Segura de Utilizador não estiver activada."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Suportar a Ofuscação do Protocolo"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Esta opção activa a Ofuscação do Protocolo e faz com que o aMule aceite ligações ofuscadas de outros clientes."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Usar ofuscação em ligações para o exterior"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Esta opção faz com que o aMule use a Ofuscação do Protocolo quando ligado a outros clientes/servidores."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Aceitar apenas ligações ofuscadas"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Esta opção faz com que o aMUle aceite apenas ligações ofuscadas. Terá menos fontes, mas todo o tráfego será ofuscado"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Todos"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Ninguém"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Quem pode ver os meus ficheiros partilhados:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Seleccione quem pode pedir a lista dos seus ficheiros partilhados."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtragem de IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrar clientes"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem por IPs dos clientes definidos no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrar servidores"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activar filtragem da lista de IPs definida no ficheiro ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Recarregar a lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Recarregar a lista de IPs a filtrar a partir do ficheiro ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Actualizar agora"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Nível de filtragem:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtrar sempre endereços IP de rede local"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Tratamento paranóico de IPs sem correspondência"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizar ipfilter.dat global do sistema se disponível"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Se não existir um ficheiro ipfilter.dat, permitir a utilização de um ficheiro ipfilter global do sistema."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Activar Assinatura Online"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activa a escrita do ficheiro da AO, o qual pode ser usado por aplicações externas para criar assinaturas e afins."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frequência de Actualização (segundos):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Alterar a frequência (em segundos) das actualizações da assinatura Online."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Gravar a assinatura Online em: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Clique para seleccionar a pasta que contém os ficheiros de Assinatura Online"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Mostrar bandeiras de países para clientes"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Taxa de transferência :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Fontes"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4692,11 +4684,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4706,226 +4698,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Download: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizar o filtro de IPs automaticamente no arranque"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrar mensagens recebidas (excepto da conversa corrente):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrar todas as mensagens"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrar mensagens de utilizadores que não pertençam à lista de amigos"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrar mensagens de clientes desconhecidos"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrar mensagens que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adicione as palavras que o aMule deve filtrar e bloquear as mensagens que as contenham"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Mostrar mensagens recebidas no relatório"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentários"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrar comentários que contenham (usar ',' como separador):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Activar autenticação"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Utilizador: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Palavra-passe:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "A palavra-passe a usar para ligar ao proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Activar Proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tipo de proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Servidor:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Porto do proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "O porto do proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Ligar a:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nome de utilizador"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Usar compressão gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activar Relatório detalhado para Depuração."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Abrir o ficheiro"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categorias de Mensagens:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "A aguardar..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Adicionar importações"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Reassumir seleccionados"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Remover seleccionados"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipos de eventos"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Estatísticas e clientes em espera para o(s) ficheiro(s) seleccionado(s) : Sessão / Desde sempre"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Uploads Activos"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Percentagem dos ficheiros totais"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Ficheiros seleccionados"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Apenas os uploads activos"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Recarregar:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Recarregar os seus ficheiros partilhados"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Enviar"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Envia a mensagem especificada."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Ligar a qualquer servidor e/ou Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
 
@@ -5284,189 +5276,189 @@ msgstr "Transferido"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Predefinição do sistema"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albanês"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Árabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturiano"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Basco"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalão"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croata"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Checo"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandês"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Inglês"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francês"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galego"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Alemão"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grego"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreu"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiano"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonês"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Coreano"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norueguês (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polaco"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Português"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Português (Brasil)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Romeno"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Russo"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Sueco"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turco"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Alterar Idioma"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Indisponível"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "O porto TCP não pode ser superior a 65532 porque o socket UDP do servidor tem de ser TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "O porto predefinido será usado (%d)"
@@ -8406,6 +8398,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Ordenar ficheiros automaticamente (pode consumir muito CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "O aMule ordenará as colunas na sua lista de transferências automaticamente"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Rejeitar pacotes se o IP do cliente é diferente do IP de onde o pacote é recebido. Usar com cautela."

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:07+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -649,8 +649,8 @@ msgstr "Kad: Închis"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -661,7 +661,7 @@ msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Deconectează"
 
@@ -670,7 +670,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Conectează"
 
@@ -721,111 +721,111 @@ msgstr "Sigur doriți să închideți %s?"
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Rețele"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Descărcări"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Fișiere partajate"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mesaje"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistici"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Nicio rețea"
 
@@ -964,14 +964,14 @@ msgstr "Legătură nevalidă sau care este deja în listă."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează directorul '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -982,44 +982,44 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Se caută parteneri pentru conexiunea lowid"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Versiune eMule falsă %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (eMule fals)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule fals)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (bazat pe eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nume Nick: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Solicitat: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1027,7 +1027,7 @@ msgstr[0] "Stare fișiere pentru această sesiune: Acceptat %d din %d solicitat,
 msgstr[1] "Stare fișiere pentru această sesiune: Acceptate %d din %d solicitate, %s transferate\n"
 msgstr[2] "Stare fișiere pentru această sesiune: Acceptate %d din %d solicitate, %s transferate\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1035,21 +1035,21 @@ msgstr[0] "Stare fișiere pentru toate sesiunile: Acceptat %d din %d solicitat, 
 msgstr[1] "Stare fișiere pentru toate sesiunile: Acceptate %d din %d solicitate, %s transferate\n"
 msgstr[2] "Stare fișiere pentru toate sesiunile: Acceptate %d din %d solicitate, %s transferate\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Solicitat fișier necunoscut"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Mesaj filtrat de la '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Mesaj nou de la '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Utilizatorul %s (%u) a solicitat lista fișierelor partajate pentru un director inexistent '%s' -> se ignoră"
@@ -1208,7 +1208,7 @@ msgid "Disconnected"
 msgstr "Deconectat"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1363,19 +1363,19 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1402,7 +1402,7 @@ msgid "Queue Full"
 msgstr "Coadă plină"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "În coadă"
 
@@ -1467,7 +1467,7 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "Parte"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Transferat"
 
@@ -1596,7 +1596,7 @@ msgstr ""
 "Feedback de la: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automat"
@@ -1671,34 +1671,34 @@ msgstr "Atribuit la categoria"
 msgid "&Open the file"
 msgstr "&Deshide fișierul"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Introduceți noul nume pentru acest fișier:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Redenumire fișier"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descărcări (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1707,11 +1707,11 @@ msgstr ""
 "Pentru a preveni apariția acestui avertisment la fiecare previzualizare,\n"
 "configurați în preferințe playerul video preferat (implicit este %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Previzualizare fișier"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "EROARE: A eșuat execuția playerului media extern! Comanda: `%s'"
@@ -2273,7 +2273,7 @@ msgstr "A eșuat deschiderea fișierului listă prieteni 'emfriends.met' pentru 
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "CRITIC - niciun client în StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Prieteni"
 
@@ -2622,57 +2622,57 @@ msgstr[2] "S-au scris %d de contacte Kad"
 msgid "Kad user"
 msgstr "Rețea Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Denumire fișier"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Dimensiune fișier"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Rată de partajare"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Cerut"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Acceptat"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Surse complete"
 
@@ -2788,7 +2788,7 @@ msgid "WARNING: "
 msgstr "ATENȚIE:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Închide"
 
@@ -2806,7 +2806,7 @@ msgid "Paste"
 msgstr "Lipește"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Curăță"
@@ -3227,8 +3227,8 @@ msgstr "Surse fișier:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "NU SE APLICĂ"
 
@@ -3373,7 +3373,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titlu :"
 
@@ -3482,7 +3482,7 @@ msgstr "Nume utilizator:"
 msgid "Userhash :"
 msgstr "Index utilizator :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Adaugă"
@@ -3491,15 +3491,15 @@ msgstr "Adaugă"
 msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Curentul"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Medie rulare"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Medie sesiune"
 
@@ -3739,7 +3739,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Introduceți aici numele navigatorului. Lăsați acest câmp necompletat pentru utilizarea navigatorului implicit de sistem."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3813,7 +3813,7 @@ msgstr "Leagă adresa locală la IP (gol pentru oricare):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Numai pentru utilizatorii avansați: Dacă aveți mai multe interfețe de rețea, introduceți adresa interfeței la care aMule ar trebui să fie legat."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Leagă adresa locală la IP (gol pentru oricare):"
@@ -3834,7 +3834,7 @@ msgstr "Număr maxim de conexiuni simultane:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4154,7 +4154,7 @@ msgstr "Noduri Kad care rulează"
 msgid "Kad-nodes session"
 msgstr "Noduri Kad pe sesiune"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Selectează"
 
@@ -4272,421 +4272,413 @@ msgstr "Plat"
 msgid "Round"
 msgstr "Rotund"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Sortare automată fișiere (consum mare de CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule va sorta automat coloanele în lista descărcărilor"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parametrii conexiune externă"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Acceptă conexiuni externe"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP a interfeței de ascultare:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Introduceți aici un ip valid în formatul a.b.c.d pentru ascultarea interfeței EC. Un câmp gol sau 0.0.0.0 va însemna orice interfață."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Activează înaintarea portului UPnP pe portul EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Parolă"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "port TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Se verifică parola\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parametrii server web"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Rulează la pornire serverul web"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Șablon web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Parolă cu drepturi depline"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Activează utilizatorul cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Parolă cu drepturi scăzute"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Activează înaintarea portului UPnP pe portul serverului web"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Port UPnP TCP server web (facultativ)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Timp reîmprospătare pagină (în secunde)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Activează compresia Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Valoare implicită a sistemului"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Bine"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Apăsați aici pentru a aplica orice modificare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Comentariu :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Director intrare :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Nu modifica"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Selectați culoarea pentru această categorie (selectată curent):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Apăsați acest buton pentru resetarea jurnalului."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Apăsați acest buton pentru a se actualiza lista serverelor din URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Listă server"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Introduceți aici adresa URL pentru un fișier server.met și apăsați butonul din stânga pentru a actualiza lista serverelor. cunoscute."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Adăugare server manual: Nume"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Introduceți aici numele noului server"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Introduceți aici portul serverului."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Adăugați un server manual (completați întâi câmpurile din stânga) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Jurnal aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Informație server"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Informație eD2k"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Apăsați pe acest buton pentru a actualiza lista nodurilor din URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Noduri (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Introduceți aici adresa url către un fișier nodes.dat și apăsați butonul din stânga pentru actualizarea listei nodurilor cunoscute."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Stare noduri"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nod nou"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap de la clienții cunoscuți"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Deconectare Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Utilizează identificarea securizată a utilizatorilor"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Este recomandat să activați această opțiune. Nu veți primii credite dacă SUI nu este activat."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protocol disimulare"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Suport protocol disimulare"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Această opțiune activează Protocolul Disimulare, și determină aMule să accepte conexiuni disimulate de la alți clienți."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Utilizați disimularea pentru conexiunile de ieșire"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Această opțiune determină aMule să utilizeze Protocolul Disimulare când conectează alți clienți/servere."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Acceptă numai conexiuni disimulate"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Această opțiune face aMule să accepte numai conexiuni disimulate. Veți avea mai puține surse, dar tot traficul va fi disimulat"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Fiecare"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nimănui"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Cine poate vedea fișierele mele partajate:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Selectați cine poate solicita să vizualizeze o listă a fișierelor partajate."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtrare-IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtru clienți"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor client cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrare servere"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Activați filtrarea IP-urilor server cum este definit în fișierul ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Reîncarcă lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Reîncarcă lista IP-urilor de filtrat din fișierul ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Actualizează acum"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Nivel de filtrare:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtrează mereu IP-urile LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Manipulare paranoică a IP-urilor care nu se potrivesc"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utilizați în tot sistemul ipfilter.dat dacă este disponibil"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Dacă nu s-a găsit local ipfilter.dat, permite utilizarea unui fișier ipfilter din sistem."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Activare semnătură online"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Activați scrierea fișierului OS, care poate fi utilizat de aplicații exterioare la crearea semnăturilor și aprecierii."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frecvență actualizare (secunde)"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Schimbați frecvența (în secunde) a actualizărilor semnăturii online."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Salvează fișierul semnăturii online în:"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Apăsați aici pentru a selecta directorul care conține fișierele cu semnătura online."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Arată steagul țării pentru clienți"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Rată date :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Surse"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4694,11 +4686,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4708,225 +4700,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Descărcare:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Actualizare automată filtru ip la pornire"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrare mesaje de intrare (cu excepția chat-ului curent):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrează toate mesajele"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrare mesaje de la persoane care nu sunt în lista de prieteni"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrare mesaje de la clienți necunoscuți"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrare mesaje conținând )utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "adăugați aici cuvintele pe care amule trebuie să le filtreze și să blocheze mesajele care le includ"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Arată în jurnal mesajele primite"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Comentarii"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrare comentarii conținând (utilizați ',' ca separator):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Activează autentificarea"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Utilizator:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Parolă:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Parola de utilizat pentru conectarea la proxy"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Activează proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Tip proxy:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Gazdă proxy:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Port proxy:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Portul proxy"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Conectează la:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Nume utilizator"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Utilizează compresia gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Activează jurnalizarea de depanare detaliată."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Numai la fișierul jurnal"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Categorii mesaje:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Așteptați..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Adaugă importurile"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Reîncearcă selectatele"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Elimină selecția"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Tipuri de evenimente"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistici și clienți în coadă pentru fișier(ele) selectate : Sesiune / Tot timpul"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Încărcări active"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Procentul din totalul fișierelor"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Toate fișierele"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Fișierele selectate"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Numai încărcările active"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Reîncarcă:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Reîncărcați fișierele partajate"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Trimite"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Trimite mesajul specificat"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Conectare la orice server și/sau Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Fișiere partajate"
 
@@ -5289,188 +5281,188 @@ msgstr "Descărcat"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Valoare implicită a sistemului"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albaneză"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabă"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturian"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Bască"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgară"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Catalană"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Chineză (Simplificat)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Chinez (tradițional)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Croată"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Cehă"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Daneză"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Olandeză"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Englez (U.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonă"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandeză"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Franceză"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galiciană"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Germană"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grecesc"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Ebraică"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Maghiară"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiană"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japoneză"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreană"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituaniană"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegian"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Poloneză"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugheză"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugheză (Brazilia)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Română"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rusă"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovenă"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spaniolă"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suedeză"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turcă"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ucraineană"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Schimbă limba"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Nu sunt instalate traduceri pentru aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Nu sunt limbi disponibile"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Portul TCP nu poate fi mai mare decât 65532 fiindcă soclul UDP al serverului trebuie să fie TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Va fi folosit portul implicit (%d)"
@@ -8422,6 +8414,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Sortare automată fișiere (consum mare de CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule va sorta automat coloanele în lista descărcărilor"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Respinge pachetele dacă adresa ip a clientului este diferită de adresa ip de unde este primit pachetul. Utilizați cu precauție."

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:08+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -660,8 +660,8 @@ msgstr " Kad: Выключено"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -672,7 +672,7 @@ msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Отключиться"
 
@@ -681,7 +681,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Подключиться"
 
@@ -732,111 +732,111 @@ msgstr "Вы действительно хотите выйти из %s?"
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Сети"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Загрузки"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Публикуемые файлы"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Нет сети"
 
@@ -975,14 +975,14 @@ msgstr "Ссылка неверна или уже в списке."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Не удается создать директорию '%s' для категории '%s', оставляем директорию '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -993,44 +993,44 @@ msgstr "Не удается создать директорию '%s' для ка
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Не удалось получить список доступных файлов от '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Ищем друга для lowid-соединения"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Поддельная версия eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (имитация eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (имитация eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (на основе eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Псевдоним: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Запрошено: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1038,7 +1038,7 @@ msgstr[0] "Статистика для текущего сеанса: приня
 msgstr[1] "Статистика для текущего сеанса: принято %d из %d запросов, %s передано\n"
 msgstr[2] "Статистика для текущего сеанса: принято %d из %d запросов, %s передано\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1046,21 +1046,21 @@ msgstr[0] "Статистика для всех сеансов: принято %
 msgstr[1] "Статистика для всех сеансов: принято %d из %d запросов, %s передано\n"
 msgstr[2] "Статистика для всех сеансов: принято %d из %d запросов, %s передано\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Запрошен неизвестный файл"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Отфильтрованное сообщение от '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Новое сообщение от '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов из несуществующего каталога %s -> Проигнорировано"
@@ -1219,7 +1219,7 @@ msgid "Disconnected"
 msgstr "Отключен"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1375,19 +1375,19 @@ msgstr "Авто [Выс]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1414,7 +1414,7 @@ msgid "Queue Full"
 msgstr "Очередь заполнена"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "В очереди"
 
@@ -1479,7 +1479,7 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1552,7 +1552,7 @@ msgstr "Часть"
 msgid "Size"
 msgstr "Размер"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Передано"
 
@@ -1609,7 +1609,7 @@ msgstr ""
 "Ответ от: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Авто"
@@ -1684,34 +1684,34 @@ msgstr "Присвоить категорию"
 msgid "&Open the file"
 msgstr "&Открыть файл"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Введите новое имя файла:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Переименовать файл"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Загрузки (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1721,11 +1721,11 @@ msgstr ""
 "при каждом предпросмотре, установите предпочитаемый\n"
 "видео проигрыватель в настройках (по умолчанию %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Предварительный просмотр"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ОШИБКА: невозможно запустить видео-проигрыватель. Команда: `%s'"
@@ -2290,7 +2290,7 @@ msgstr "Не удалось открыть список друзей 'emfriends.
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - нет клиентов на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Друзья"
 
@@ -2640,58 +2640,58 @@ msgstr[2] "Записано %d Kad контактов"
 msgid "Kad user"
 msgstr "Сеть Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Имя файла"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Размер файла"
 
 # по крайней мере торренты называют его так
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Рейтинг"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Загружено"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Запрошено"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Разрешено"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Полных источников"
 
@@ -2807,7 +2807,7 @@ msgid "WARNING: "
 msgstr "ПРЕДУПРЕЖДЕНИЕ:"
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Закрыть"
 
@@ -2825,7 +2825,7 @@ msgid "Paste"
 msgstr "Вставить"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистить"
@@ -3250,8 +3250,8 @@ msgstr "Источников:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3396,7 +3396,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Заголовок :"
 
@@ -3507,7 +3507,7 @@ msgstr "Имя пользователя :"
 msgid "Userhash :"
 msgstr "Хеш пользователя :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Добавить"
@@ -3516,15 +3516,15 @@ msgstr "Добавить"
 msgid "Download-Speed"
 msgstr "Скорость приема"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Текущая"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Средняя за все время"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "В среднем за сеанс"
 
@@ -3764,7 +3764,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Введите имя предпочитаемого браузера. Оставьте поле пустым чтобы использовать системный браузер по умолчанию."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3838,7 +3838,7 @@ msgstr "Закрепить локальный адрес за IP (пустой �
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Только для продвинутых пользователей: если у вас несколько сетевых интерфейсов введите адрес того, которым будет пользоваться aMule."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Закрепить локальный адрес за IP (пустой для любого):"
@@ -3859,7 +3859,7 @@ msgstr "Максимум одновременных соединений:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4180,7 +4180,7 @@ msgstr "Узлы Kad (действующие)"
 msgid "Kad-nodes session"
 msgstr "Узлы Kad (сессия)"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Выбрать"
 
@@ -4302,423 +4302,415 @@ msgstr "Плоская"
 msgid "Round"
 msgstr "Круглая"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Авто-сортировка файлов (нагружает процессор)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule будет сортировать файлы в списке загрузок автоматически."
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Параметры внешних соединений"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Принимать внешние соединения"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP прослушиваемого интерфейса:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введите сюда IP в формате a.b.c.d для прослушиваемого интерфейса ВС. Пустое поле или значение 0.0.0.0 означают любой интерфейс."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Включить UPnP для порта ВС"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "порт TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Проверяю пароль\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Параметры веб-сервера"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запускать веб-сервер при старте"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Веб-шаблон"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Пароль для обычного доступа"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Разрешить ограниченный доступ"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Пароль ограниченного доступа"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Разрешить UPnP форвардинг порта веб-сервера"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP порт веб-сервера (не обязательно):"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Период обновления страницы (в секундах)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Включить сжатие Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Системный"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "ОК"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Кликните тут, чтобы сохранить внесенные вами изменения."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Комментарий :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Каталог загрузок:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Установить приоритет для новых файлов:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Не изменять"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Выбрать цвет для этой категории:"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Кликните тут для очистки журнала."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Кликните здесь чтобы обновить список серверов через URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Список серверов"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введите URL к файлу 'server.met' и нажмите кнопку слева для обновления списка известных серверов."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Добавить сервер вручную: Имя"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Введите имя нового сервера"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Введите здесь порт сервера."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Добавить сервер (предварительно заполните поля слева) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Журнал aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Сообщение сервера"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Инфо ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Инфо Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Нажмите на эту кнопку чтобы обновить список узлов из URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Узлы (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кнопку слева чтобы обновить список известных узлов."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Инициализация"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Новый узел"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Порт:"
 
 # Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Инициализация от известных клиентов"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Отключить Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Использовать безопасную идентификацию пользователя"
 
 # интересно, что на самом деле подразумевалось под 'credits'
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендуется включить данную опцию. Вы не будете получать рейтинга если БИП выключена."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Вуалирование протокола"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Поддержка вуалирования протокола"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Включает вуалирование протокола и позволяет aMule принимать завуалированные соединения от других клиентов."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Использовать вуалирование исходящих соединений"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Включает вуалирование протокола при соединении с другими клиентами и серверами."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Принимать только завуалированные соединения"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "aMule будет принимать только завуалированные соединения. У вас будет меньше источников, но зато весь трафик будет завуалирован."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Все"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Никто"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Кто может запрашивать публикуемые файлы:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Выберите, кому показывать список ваших файлов."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Фильтрование IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Фильтровать клиентов."
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP клиентов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Фильтровать сервера"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Включает фильтрацию IP серверов в соответствии с файлом ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Обновить список"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Прочесть список IP адресов, указанных в файле '~/.aMule/ipfilter.dat'."
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Обновить сейчас"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Уровень фильтрации:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Всегда фильтровать IP-адреса LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноидная обработка несовпадающих IP "
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Использовать системный ipfilter.dat если возможно"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Если не найден локальный ipfilter.dat разрешить использовать системный"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Включить Online-подпись"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Включает запись файла OS, который может использоваться другими приложениями для создания подписей."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Частота обновления (в секундах):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Изменить частоту обновления для Online-подписи в секундах."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Сохранять Online-подпись в:"
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Кликните здесь, чтобы выбрать каталок для файлов Online-подписи."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Показывать национальные флаги клиентов"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Скорость передачи:"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Источники"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4726,11 +4718,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4740,227 +4732,227 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Прием: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматически обновлять IP-фильтр при запуске"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фильтровать входящие сообщения (кроме текущего чата):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Фильтровать все сообщения"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Фильтровать сообщения пользователей не из вашего списка друзей"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Фильтровать сообщения от неизвестных клиентов"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фильтровать сообщения по содержанию (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Добавьте сюда ключевые слова, при наличии которых aMule будет отфильтровывать и блокировать входящие сообщения."
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Показывать полученные сообщения в логе"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Комментарии"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фильтровать комментарии содержащие (используйте ',' как разделитель):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Включить идентификацию"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Имя:"
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для подключения к прокси-серверу"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Использовать прокси-сервер"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Тип прокси-сервера:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Прокси-сервер:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Порт прокси-сервера"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Соединиться с:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Войти на удаленный aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Имя пользователя"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Запомнить настройки"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Использовать gzip-сжатие"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Записывать в журнал подробные сообщения отладчика."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Открыть файл"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Категории сообщений:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ожидание..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Добавить файлы"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Перезапустить выбранное"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Удалить выбранное"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Типы Событий"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Статистика и очередь клиентов для выбранных файлов: За сессию / За все время"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Активные загрузки"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Процент от всех файлов"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Все файлы"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Выбранные файлы"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Только активные передачи"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Обновить:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Обновить список публикуемых файлов"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Отправить"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Отправить данное сообщение."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Соединиться с произвольным сервером и/или Kad"
 
 # подпись в главном окне. длинная просто не влезет.
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Файлы"
 
@@ -5326,189 +5318,189 @@ msgstr "Загружено"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Системный"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Албанский"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Арабский"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Астурианский"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Баскский"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Болгарский"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Каталонский"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Китайский (упрощенный)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Китайский (традиционный)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Хорватский"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Чешский"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Датский"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Голландский"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Английский (Великобритания)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Эстонский"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Финский"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Французский"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Гальский"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Немецкий"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Греческий"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Израильский"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Итальянский"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Японский"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Корейский"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Литовский"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвежский (Нюнорск)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Польский"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Португальский (Бразилия)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Румынский"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Русский"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Словакский"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Испанский"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Шведский"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Турецкий"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Изменить язык"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступен"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "нет доступных опций"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускаем"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP порт не может быть выше 65532, так как UDP сокет - TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Используется порт по умолчанию (%d)"
@@ -8474,6 +8466,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Авто-сортировка файлов (нагружает процессор)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule будет сортировать файлы в списке загрузок автоматически."
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Отбрасывает пакеты у которых IP клиента отличается от IP с которого пришел пакет. Используйте осторожно."

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:09+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -655,8 +655,8 @@ msgstr "Kad: izklopljen"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -667,7 +667,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
@@ -676,7 +676,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Poveži se"
 
@@ -726,111 +726,111 @@ msgstr "Ali res želite zapustiti %s?"
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Omrežja"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Prejemanja"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Deljene datoteke"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Sporočila"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistika"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Nastavitve"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Brez omrežja"
 
@@ -969,14 +969,14 @@ msgstr "Neveljavna povezava oz. je že na seznamu."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »%s«."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -987,44 +987,44 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 msgid "Unknown"
 msgstr "Neznano"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Iskanje kolega za povezavo z nizkim ID-jem"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (lažna različica eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (lažni eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (lažni eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (temelji na eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Vzdevek: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Zahtevano: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1033,7 +1033,7 @@ msgstr[1] "Statistika datotek v tej seji: Sprejetih %d od %d zahteve, %s prenese
 msgstr[2] "Statistika datotek v tej seji: Sprejetih %d od %d zahtev, %s prenesenih\n"
 msgstr[3] "Statistika datotek v tej seji: Sprejetih %d od %d zahtev, %s prenesenih\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1042,21 +1042,21 @@ msgstr[1] "Statistika datotek vseh sej: Sprejetih %d od %d zahteve, %s preneseni
 msgstr[2] "Statistika datotek vseh sej: Sprejetih %d od %d zahtev, %s prenesenih\n"
 msgstr[3] "Statistika datotek vseh sej: Sprejetih %d od %d zahtev, %s prenesenih\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Zahtevana neznana datoteka"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Filtrirano sporočilo od »%s« (IP: %s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Novo sporočilo od »%s« (IP: %s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Uporabnik %s (%u) je zahteval seznam deljenih datotek za mapo »%s« → prezrto"
@@ -1217,7 +1217,7 @@ msgid "Disconnected"
 msgstr "Ni povezave"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1373,19 +1373,19 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1412,7 +1412,7 @@ msgid "Queue Full"
 msgstr "Vrsta polna"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "V vrsti"
 
@@ -1477,7 +1477,7 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1549,7 +1549,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Velikost"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Preneseno"
 
@@ -1606,7 +1606,7 @@ msgstr ""
 "Odziv od: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Samod."
@@ -1681,34 +1681,34 @@ msgstr "Dodeli kategoriji"
 msgid "&Open the file"
 msgstr "&Odpri datoteko"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Vnesite novo ime za to datoteko:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Preimenuj datoteko"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MiB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%d.%m.%y %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Prejemanja (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1717,11 +1717,11 @@ msgstr ""
 "Da preprečite to opozorilo ob vsakem ogledu,\n"
 "nastavite svoj priljubljen predvajalnik video posnetkov (privzet je %s)"
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Ogled datoteke"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "NAPAKA: Ni bilo mogoče zagnati zunanjega predvajalnika. Ukaz: »%s«"
@@ -2288,7 +2288,7 @@ msgstr "Datoteke s seznamom prijateljev »emfriends.met« ni bilo moč odpreti z
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITIČNO – ni odjemalca za StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Prijatelji"
 
@@ -2642,57 +2642,57 @@ msgstr[3] "Zapisani %d stiki Kad"
 msgid "Kad user"
 msgstr "Omrežje Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Ime datoteke"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Velikost datoteke"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Delilno razmerje"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Zahtevano"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Sprejeto"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Popolnih virov"
 
@@ -2808,7 +2808,7 @@ msgid "WARNING: "
 msgstr "OPOZORILO: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Zapri"
 
@@ -2826,7 +2826,7 @@ msgid "Paste"
 msgstr "Prilepi"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Počisti"
@@ -3247,8 +3247,8 @@ msgstr "Viri datoteke:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "Ni na voljo"
 
@@ -3393,7 +3393,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Naslov:"
 
@@ -3502,7 +3502,7 @@ msgstr "Uporabniško ime:"
 msgid "Userhash :"
 msgstr "Koda uporabnika:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Dodaj"
@@ -3511,15 +3511,15 @@ msgstr "Dodaj"
 msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Trenutno"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Trenutno povprečje"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Povprečje seje"
 
@@ -3760,7 +3760,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Sem vnesite ime brskalnika. Za uporabo privzetega sistemskega brskalnika pustite prazno."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3834,7 +3834,7 @@ msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Samo za napredne uporabnike: če imate več omrežnih vmesnikov, vnesite naslov vmesnika, s katerim bo povezan aMule."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Krajevni naslov poveži z IP-jem (prazno za poljuben):"
@@ -3855,7 +3855,7 @@ msgstr "Največ istočasnih povezav:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4175,7 +4175,7 @@ msgstr "Vozlišča Kad v teku"
 msgid "Kad-nodes session"
 msgstr "Vozlišča Kad te seje"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Izberi"
 
@@ -4293,423 +4293,415 @@ msgstr "Plosko"
 msgid "Round"
 msgstr "Zaokroženo"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Samodejno razvrščaj datoteke"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule bo samodejno razvrstil datoteke na vašem seznamu pprejemanj, kar potrebuje precej procesorske moči."
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parametri za zunanje povezave"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Sprejmi zunanje povezave"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP vmesnika, ki posluša:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Sem vnesite veljaven IP v formatu a.b.c.d za poslušalen vmesnik. Prazno polje ali 0.0.0.0 pomeni poljuben vmesnik."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata zunanjih povezav"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Geslo"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Vrata TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Preverjanje gesla\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Parametri spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Spletni strežnik zaženi ob zagonu"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Spletna predloga"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Geslo za vse pravice"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Omogoči uporabnika z nizkimi pravicami"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Geslo za nizke pravice"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Vklopi posredovanje vrat UPnP za vrata spletnega strežnika"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Vrata TCP za UPnP za spletni strežnik (neobvezno)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Čas med osvežitvami strani (v sek.)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Omogoči stiskanje gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Sistemsko privzet"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "V redu"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliknite tukaj za uveljavitev sprememb v nastavitvah."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komentar:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Mapa za prejeto:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Spremeni prednost novo dodeljenim datotekam:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Ne spremeni"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Kliknite ta gumb, da ponastavite dnevnik."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama strežnikov iz URL-ja."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Seznam strežnikov"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Vnesite URL do datoteke server.met in kliknite gumb na levi, da posodobite seznam strežnikov."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Ročno dodaj strežnik: ime"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Sem vnesite ime novega strežnika"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Vrata"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Sem vnesite vrata strežnika."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Ročno dodaj strežnik (najprej izpolnite vsa polja) …"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule dnevnik"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Podatki o strežniku"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Podatki o eD2k"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliknite ta gumb za posodobitev seznama vozlišč iz URL-ja."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Vozlišča (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Vnesite URL do datoteke nodes.dat in pritisnite gumb na levi za posodobitev seznama vozlišč."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Začetno nalaganje"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Novo vozlišče"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Vrata:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 "Naloži od znanih \n"
 "odjemalcev"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Prekini povezavo s Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Uporabi varno identifikacijo uporabnikov"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Priporočamo, da omogočite to možnost. Če to ni omogočeno, ne boste prejeli točk za zasluge."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Omogoči maskiranje protokola"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal maskirane povezave od drugih odjemalcev."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Uporabi maskiranje za izhodne povezave"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ob vklopu te možnosti, bo aMule uporabil maskiranje pri povezavi z drugimi odjemalci in na strežnike."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Dovoli samo maskirane povezave"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ob vklopu te možnosti, bo aMule sprejemal samo maskirane povezave. Imeli boste manj virov, vendar bodo vse povezave maskirane."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Vsi"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Nihče"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Kdo lahko vidi moje deljene datoteke:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Izberite, kdo lahko zahteva vaš seznam deljenih datotek."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtriranje IP-jev"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtriraj odjemalce"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje odjemalčevih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtriraj strežnike"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Omogoči filtriranje strežnikovih IP-jev, določenih v datoteki ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Znova naloži seznam"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ponovno naloži seznam IP-jev za filtriranje iz ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Posodobi zdaj"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Stopnja filtriranja:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Vedno filtriraj IP-je krajevnega omrežja"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoično rokovanje z ne-ujemajočimi IP-ji"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Uporabi sistemsko ipfilter.dat, če je na voljo"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Če krajevne datoteke ipfilter.dat ni moč najti, omogoči uporabo sistemske datoteke."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Omogoči spletni podpis"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Omogoči pisanje v datoteko spletnega podpisa, katero lahko uporabljajo zunanji programi za izdelavo podpisov in podobnih stvari."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Pogostost posodobitev (sek.):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Spremeni pogostost (v sekundah) posodobitev spletnega podpisa."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Spletni podpis shrani v datoteko: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Kliknite tukaj, da nastavite mapo, ki vsebuje datoteke za spletni podpis."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Prikaži zastave držav za odjemalce"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Podatkovna hitrost:"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Viri"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4717,11 +4709,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4731,225 +4723,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Prejemanje: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Samodejno posodobi filter IP-jev ob zagonu"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtriraj prejeta sporočila (razen v trenutnem pogovoru):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtriraj vsa sporočila"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtriraj sporočila vseh, ki niso na seznamu prijateljev"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtriraj sporočila neznanih uporabnikov"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtriraj sporočila, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "Sem dodajte besede, ki naj jih aMule filtrira, vključno s sporočili v katerih se nahajajo."
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Prejeta sporočila prikaži v dnevniku"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Komentarji"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtriraj komentarje, ki vsebujejo (uporabi »,« kot ločilnik):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Omogoči overjanje"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Uporabniško ime: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Geslo:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Geslo za povezavo s posrednikom"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Omogoči posrednika"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Vrsta posrednika:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Gostitelj posrednika:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Vrata posrednika:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Vrata posredniškega strežnika"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Poveži se z:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Uporabniško ime"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Uporabi stiskanje gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Omogoči podrobno beleženje za razhroščevanje."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Samo v dnevniško datoteko"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Kategorije sporočil:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Čakanje …"
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Dodaj uvoze"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Ponovno poskusi izbrane"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Odstrani izbrane"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Vrste dogodkov"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistika in odjemalci v vrsti za izbrane datoteke: seja / ves čas"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Odstotek vseh datotek"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Vse datoteke"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Izbrane datoteke"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Samo dejavna pošiljanja"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Znova naloži"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Ponovno naloži deljene datoteke"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Pošlji"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Pošlje navedeno sporočilo."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Deljene datoteke"
 
@@ -5318,188 +5310,188 @@ msgstr "Prejeto"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Sistemsko privzet"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albansko"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabsko"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturijsko"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskovsko"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bolgarsko"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalonsko"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kitajsko (poenostavljeno)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kitajsko (tradicionalno)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Hrvaško"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Češko"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Dansko"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nizozemsko"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Angleško (Z.K.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonsko"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finsko"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Francosko"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galicijsko"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Nemško"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grško"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebrejsko"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Madžarsko"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italijansko"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonsko"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korejsko"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litvansko"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveško (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Poljsko"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugalsko"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugalsko (brazilsko)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Romunsko"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rusko"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovensko"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Špansko"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Švedsko"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turško"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukrajinsko"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Spremeni jezik"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Za aMule ni nameščenega nobenega prevoda"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Na voljo ni nobenega jezika"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Vrata TCP ne smejo biti večja od 65532, ker so vrata UDP TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Uporabljena bodo privzeta vrata (%d)"
@@ -8459,6 +8451,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Samodejno razvrščaj datoteke"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule bo samodejno razvrstil datoteke na vašem seznamu pprejemanj, kar potrebuje precej procesorske moči."
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Zavrne paket, če se odjemalčev IP razlikuje od IP-ja kjer paket izvira. Bodite pazljivi pri uporabi te možnosti."

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:10+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -649,8 +649,8 @@ msgstr "Kad: Fikur"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -661,7 +661,7 @@ msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Shkeputu"
 
@@ -670,7 +670,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Lidhu"
 
@@ -721,112 +721,112 @@ msgstr "Vertet deshironi qe te dilni nga aMule?"
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Rrjetet"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Shkarkime"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Mesazhe"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistikat"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Preferencat"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Nuk ka rrjet"
 
@@ -969,14 +969,14 @@ msgstr "Link i pavlere ose qe eshte ne liste."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -987,72 +987,72 @@ msgstr ""
 msgid "Unknown"
 msgstr "E panjohur"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (eMule e falsifikuar versioni %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (eMule e falsifikuar)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (eMule e falsifikuar)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (e bazuar ne eMule v0 %u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Emri: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Kerkuar: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistikat e failit per kete sesion: U pranua %d nga %d kerkesa, %s te transferuara\n"
 msgstr[1] "Statistikat e failit per kete sesion: U pranuan %d nga %d kerkesat, %s te transferuara\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Statistikat e failit per te gjitha sesionet: U pranua %d nga %d kerkesa, %s te transferuar\n"
 msgstr[1] "Statistikat e faileve per te gjitha sesionet: U pranua %d nga %d kerkesat, %s te transferuara\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Po kerkoni nje faili te panjohur"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Filtrim mesazhi nga '%s' (IP: %s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Mesazh i ri nga '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara per kartelen %s -> nuk u lejua"
@@ -1210,7 +1210,7 @@ msgid "Disconnected"
 msgstr "I shkeputur"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1363,19 +1363,19 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1402,7 +1402,7 @@ msgid "Queue Full"
 msgstr "Radha ne pritje eshte plote"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Ne radhe"
 
@@ -1467,7 +1467,7 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Size"
 msgstr "Madhesia"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Te transferuara"
 
@@ -1594,7 +1594,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Automatike"
@@ -1669,45 +1669,45 @@ msgstr "Vendos tek kategoria"
 msgid "&Open the file"
 msgstr "&Hap failin"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Futni nje emer te ti per kete fail:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Riemertim i failit"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Shkarkimet (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Parashikimi i failit"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "GABIM: Deshtoi te luaj media-player te jashtem! Komanda: `%s'"
@@ -2273,7 +2273,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Shkoket"
 
@@ -2621,57 +2621,57 @@ msgstr[1] "U shkruajten %d kontakte Kadi"
 msgid "Kad user"
 msgstr "Rrjeti Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Emri i failit"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2789,7 +2789,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Mbylle"
 
@@ -2807,7 +2807,7 @@ msgid "Paste"
 msgstr "Ngjit"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Pastro"
@@ -3228,8 +3228,8 @@ msgstr "Burime te gjetura :"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3374,7 +3374,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titulli :"
 
@@ -3481,7 +3481,7 @@ msgstr "Emri i Perdoruesit :"
 msgid "Userhash :"
 msgstr "Userhash :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Shto"
@@ -3490,15 +3490,15 @@ msgstr "Shto"
 msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Aktualisht"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Mesatarja e Punes"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Mesatarja e Sesionit"
 
@@ -3739,7 +3739,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3813,7 +3813,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3833,7 +3833,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4152,7 +4152,7 @@ msgstr "Nyjet e Kad jane duke punuar"
 msgid "Kad-nodes session"
 msgstr "Sesioni i Nyjeve te Kad"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Zgjidh"
 
@@ -4271,423 +4271,415 @@ msgstr "E sheshte"
 msgid "Round"
 msgstr "E rrumbullakosur"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule do te rreshtoje automatikisht kollonat ne listen tuaj te shkarkimeve"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Parametrat e Lidhjeve te Jashtme"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Prano lidhje te jashtme"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Futni ketu nje ip te vlefshem ne formatin a.b.c.d per te degjuar nderfaqesin EC. Nje fushe boshe ose 0.0.0.0 do te nenkuptoje cdo nderfaqe."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivizo port forwarding UPnP tek porta EC"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Fjalekalim"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Duke kerkuar fjalekalimin\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Modeli Web"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Fjalekalim per te drejta komplete"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Aktivizo Perdorues me te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Fjalekalim per te drejta te kufizuara"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Koha e Rifreskimit te Faqes (ne sek)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Aktivizo kompresimin Gzip"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "E vendosur nga sistemi"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Ne rregull"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Kliko ketu per te bere aktive ndryshimet qe u bene tek Preferencat."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Komente :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Direktoria e Hyrjeve :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Nderro perparesine per failet e reja te caktuara :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Mos nderro"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Kliko ne kete buton per te resetuar log-un."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e serverave nga URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Futni url tek nje fail server.met dhe shtypni butonin ne te majte per te azhornuar listen e serverave te njohur."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Futni emrin e serverit te ri ketu"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Porta"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Futni porten e serverit ketu."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Shto ne menyre manuale nje server (mbushni fushen ne te majte me pare) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Log i aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Informacion mbi serverin"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Informacioni i ED2K"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Kliko ne kete buton per te azhornuar listen e nyjeve nga URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Nyjet (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Fut url e nje faili nodes.dat dhe shtyp butonin ne te majte per te azhornuar listen e nyjeve te njohura."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Nyje e re"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Porta:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Bootstrap nga \n"
 "kliente te njohur"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Shkeput Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Perdor Identifikimin e Sigurte te Perdoruesve"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Eshte e rekomandueshme qe ta lejoni kete opsion. Ju nuk mund te merrni kredite nqs SUI nuk eshte i aktivizuar."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Mbeshtet Protokollin e Turbullimit"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ky opsion lejon Protokollin e Turbullimit, dhe ben qe aMule te pranoje lidhje te turbulluara nga kliente te tjere."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Perdor turbullimin per lidhjet ne dalje"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ky opsion lejon aMule-n qe te perdori protokollin e turbullimit kur lidhet me klientet/serverat e tjere."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Prano vetem lidhje te turbulluara"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Ky opsion e ben aMule-n qe te lejoje lidhje te turbulluara. Ju do te keni me pak burime, por i gjithe trafiku juaj do te turbullohet"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Te gjithe"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Zgjidh se kush ka kerkuar te shikoje listene faileve qe ju keni ndare."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "Filtrimi-IP"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtro klientet"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te klientave te percaktuar ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtron Serverat"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Lejo filtrimin e IP-ve te serverave te percaktuara ne failin ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Ringarko listen e IP-ve per te filtruar nga faili ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Azhorno tani"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Niveli i Filtrimit:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Gjithmone filtro IP-te LAN"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Perdorim Paranoik te IP-ve qe nuk korrespondojne"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Perdor ipfilter.dat te sistemit nqs eshte i disponueshem"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Nese nuk eshte gjetur ndonje ipfilter.dat lokal, lejo perdorimin e failit ipfilter te sistemit."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Lejo Firmen-Online"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Lejon shkrimin e faileve OS, qe mund te perdorren nga aplikacione te jashtme per te krijuar firma dhe te ngjashme."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Frekuenca e azhornimeve (sek):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Nderron frekuqncen (ne sekonda) te azhornimit te Firmes Online."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Shtypni ketu per te zgjedhur direktorine qe permban failet e Firmes Online."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Shpejtesia :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Burime"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4695,11 +4687,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4709,232 +4701,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Shkarkim: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Azhornim-Automatik i ipfilter sapo te ndizet"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtron mesazhet ne hyrje (pervec chatit qe po zhvilloni):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtron te gjithe mesazhet"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtron mesazhet nga njerezit qe nuk ndohen ne listen e miqve tuaj"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtron mesazhet nga klienta t èanjohur"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtron mesazhet qe permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "shto ketu fjalet qe aMule do te filtroje duke bllokuar mesazhet qe ato mbajne"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Komente"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Komente e filtrave permbajne (perdor ',' si nje ndarese):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Aktivizo njohjen"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Fjalekalimi:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Fjalekalimi per te perdorur per tu lidhur tek Proksi(Proxy)"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Aktivizo Proksin(Proxy)"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Lloji i Proksit(Proxy):"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Hosti i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Porta e Proksit:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Porta e Proksit(Proxy)"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Lidhu me:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Emri i Perdoruesit"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Perdor kompresimin gzip"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivizon logging-un e detajuar te mesazheve te debug-ut."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "&Hap failin"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Kategorite e Mesazheve:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Ne pritje..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Shton importimet"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Provoji perseri te perzgjedhurit"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Zhvendos te perzgjedhurat"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Fshih failet e ndara"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Zgjidh filtrin e shikimit"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Ngarkime Aktive"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Lista e Ringarkimeve"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Ringarko failet e ndara"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Dergo"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Dergo mesazhin e specifikuar."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Lidhu me ndonje server dhe/ose Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "File te ndara"
 
@@ -5295,192 +5287,192 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "E vendosur nga sistemi"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabe"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baske"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bullgare"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katallanase"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kineze (E thjeshtesuar)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "KIneze (Tradicionale)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroate"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Ceke"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Daneze"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Holandeze"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Anglisht (G.B.)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estoneze"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finlandeze"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Frengjisht"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galiciane"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Gjermanisht"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Greqisht"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Cifut"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Hungarisht"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italiane"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonisht"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreane"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Lituane"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norvegjeze (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polake"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugeze"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugeze (Braziliane)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Shqip"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ruse"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Sllovene"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spanjolle"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Suedeze"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turqisht"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Gjuha"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Porta TCP nuk mund te jene me te medha se 65532  sepse socket i UDP eshte fiksuar ne TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Do te perdoret porta e vendosur (%d)"
@@ -8430,6 +8422,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule do te rreshtoje automatikisht kollonat ne listen tuaj te shkarkimeve"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Refuzo paketat nqs IP e klientit eshte e ndryshme nga IP se ku paketat kane ardhur. Perdore me kujdes."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:11+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -648,8 +648,8 @@ msgstr "Kad: Av"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -660,7 +660,7 @@ msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Koppla från"
 
@@ -669,7 +669,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Anslut"
 
@@ -720,111 +720,111 @@ msgstr "Vill du verkligen avsluta %s?"
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Nätverk"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Hämtningar"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Delade filer"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Meddelanden"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Statistik"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Inget nätverk"
 
@@ -963,14 +963,14 @@ msgstr "Felaktig länk eller redan i listan."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -981,72 +981,72 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 msgid "Unknown"
 msgstr "Okänd"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Misslyckades med att hämta filer från användaren '%s'"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Letar efter en kompis för lowid-anslutning"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Falsk eMule-version %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Falsk eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Falsk eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baserad på eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Smeknamn: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Begärd: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistik för den här gången: Accepterat %d av %d begäran, %s överfört\n"
 msgstr[1] "Filstatistik för den här gången: Accepterat %d av %d begäran, %s överfört\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Filstatistik sedan början: Accepterat %d av %d begäran, %s överfört\n"
 msgstr[1] "Filstatistik sedan början: Accepterat %d av %d begäran, %s överfört\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Begärde okänd fil"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Meddelande filtrerat från '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Nytt meddelande från '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Användare %s (%u) begärde sharedfiles-list för icke exiterade mapp '%s' -> Ignorerad"
@@ -1203,7 +1203,7 @@ msgid "Disconnected"
 msgstr "Frånkopplad"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1357,19 +1357,19 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1396,7 +1396,7 @@ msgid "Queue Full"
 msgstr "Kö full"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "I kö"
 
@@ -1461,7 +1461,7 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "Del"
 msgid "Size"
 msgstr "Storlek"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Överfört"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "Återkoppling från: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Auto"
@@ -1665,34 +1665,34 @@ msgstr "Koppla till kategori"
 msgid "&Open the file"
 msgstr "&Öppna filen"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Ange nytt namn för den här filen:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Byt namn på fil"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H.%M.%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Hämtningar (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1701,11 +1701,11 @@ msgstr ""
 "För att slippa den här varningen i varje förhandsvisning,\n"
 "Ställ in önskad videospelare i inställningar (standard är %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Förhandsvisning av fil"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEL: Kunde inte starta externa mediaspelaren! Kommado: `%s'"
@@ -2267,7 +2267,7 @@ msgstr "Kunde inte öppna vän-list-filen 'emfriends.met' för skrivning!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRITISKT - ingen klient för StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Vänner"
 
@@ -2611,57 +2611,57 @@ msgstr[1] "Skrev %d Kad kontakter"
 msgid "Kad user"
 msgstr "Kad-nätverk"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Filnamn"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Filstorlek"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Dela-förhållande"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Begärda"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Accepterad"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Kompletta källor"
 
@@ -2777,7 +2777,7 @@ msgid "WARNING: "
 msgstr "VARNING: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Stäng"
 
@@ -2795,7 +2795,7 @@ msgid "Paste"
 msgstr "Klistra in"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Töm"
@@ -3216,8 +3216,8 @@ msgstr "Filkällor:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3362,7 +3362,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Titel :"
 
@@ -3471,7 +3471,7 @@ msgstr "Användarnamn :"
 msgid "Userhash :"
 msgstr "Userhash:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Lägg till"
@@ -3480,15 +3480,15 @@ msgstr "Lägg till"
 msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Aktuell"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Löpande medelvärde"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Sessionens genomsnittliga"
 
@@ -3728,7 +3728,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Ange din webbläsares namn här. Lämna detta fält tomt för att använda systemets standardwebbläsare."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3802,7 +3802,7 @@ msgstr "Bind lokal adress till IP (tom för alla):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Endast avancerade användare: Om du har flera nätverksgränssnitt, ange adressen för gränssnittet till vilket aMule ska bindas."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Bind lokal adress till IP (tom för alla):"
@@ -3823,7 +3823,7 @@ msgstr "Max samtidiga anslutningar:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4143,7 +4143,7 @@ msgstr "Kad-noder körs"
 msgid "Kad-nodes session"
 msgstr "Kad-noder session"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Välj"
 
@@ -4261,421 +4261,413 @@ msgstr "Platt"
 msgid "Round"
 msgstr "Rund"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Auto-sortera filer (hög CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule sorterar kolumnerna i din nedladdningslista automatiskt"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Externa Anslutningsparametrar "
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Acceptera externa anslutningar"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP för lyssningsgränssnitt:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Ange här en giltig ip i ABCD format för att lyssna EC-gränssnittet. Ett tomt fält eller 0.0.0.0 kommer att innebära alla gränssnitt."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Aktivera UPnP-portforwarding på EC-port"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Lösenord"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP-port:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Kontrollerar lösenord\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Webbserverparametrar"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Kör webbserver vid start"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web mall"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Fullständiga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Aktivera låga användarrättigheter"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Låga rättigheterslösenord"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Aktivera UPnP-port-forwarding för webbserverport"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Webbserverns UPnP TCP-port (tillval)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Siduppdateringstid (i sek)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Aktivera Gzip-komprimering"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Systemets standard"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Klicka här för att tillämpa eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Kommentar :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Inkommande mapp:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Ändra prioritet för nya tilldelade filer:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Ändra inte"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Välj färg för denna kategori (den valda):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Klicka på den här knappen för att återställa loggen."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Klicka på knappen för att uppdatera servrerlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Serverlista"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Ange URL till en server.met-fil här och tryck på knappen till vänster för att uppdatera listan över kända servrar."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Lägg till server manuellt: Namn"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Skriv in namnet på den nya servern här"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Ange porten på servern här."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Lägg manuellt till en server (fyll fälten till vänster innan) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule-logg"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Serverinformation"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K-info"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Klicka på knappen för att uppdatera nodlistan från URL ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Noder (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Ange URL till en nodes.dat fil här och tryck på knappen till vänster för att uppdatera listan över kända noder."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Nodstatistik"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Bootstrap"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Ny nod"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bootstrap från kända klienter"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Koppla från Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Använd säker användarIdentifiering"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Det rekommenderas att aktivera det här alternativet. Du kommer inte att få poäng om SUI är inte aktiverat."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Stöd protokollfördunkling"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Det här alternativet aktiverat protokollffördunkling och låter aMule acceptera dålda anslutningar från andra klienter."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Använd obfuscation (fördunkling) för utgående anslutningar"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Det här alternativet gör aMule använder protokoll-Obfuscation (fördunkling) vid anslutning till andra klienter/servrar."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Accepterar endast fördunklade anslutningar"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Det här alternativet gör aMule endast acceptera fördunklade anslutningar. Du kommer att ha mindre källor, men all din trafik kommer att döljas"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Alla"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Ingen."
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Vem kan se mina delade filer:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Välj vem som kan begära att få se en lista över dina delade filer."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-filtrering"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Filtrera klienter"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av klient-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Filtrera servrar"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Aktivera filtrering av server-IP:n definierade i filen ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Återladda lista"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Återladda listan över IP-adresser att filtrera bort från filen ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Uppdatera nu"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Filtreringsnivå:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Filtrera alltid LAN-IP-adresser"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Paranoid hantering av icke-matchande IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Använd systemvidd ipfilter.dat om sådan finns"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Om det inte en lokal ipfilter.dat hittas, tillåt användning av systemvidd ipfilterfil."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Aktivera Onlinesignaturer"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Möjliggör skrivning av OS-filen, som kan användas av externa program för att skapa signaturer och liknande."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Uppdateringsfrekvens (Sek):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Ändra frekvensen (i sekunder) av OnlineSignaturuppdateringar."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Spara onlinesignaturfil i: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Klicka här för att välja den katalog som innehåller onlineSignaturFilerna."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "Visa landsflagger för klienter"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Datahastighet :"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Källor"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4683,11 +4675,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4697,225 +4689,225 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Hämta: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Auto-uppdatering av ipfilter vid start"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Filtrera inkommande meddelanden (utom nuvarande chatt):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Filtrera alla meddelanden"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Filtrera meddelanden från folk som inte finns i din kompislista"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Filtrera meddelanden från okända klienter"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Filtrera meddelanden som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "skriv här orden amule ska filtrera och blockera meddelanden med dem"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Visa mottagna meddelanden i loggen"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Filtrera kommentarer som innehåller (använd ',' som separator):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Aktivera autentisering"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Användarnamn: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Lösenordet som ska användas för att ansluta till proxyn"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Aktivera proxy"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Proxytyp:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Proxyserver:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Proxyport:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Proxyporten"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Anslut till:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Användarnamn"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Använd gzip-komprimering"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktivera Utförlig Debug-loggning."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Endast till loggfil"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Meddelandekategorier:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Väntar..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Lägg till importer"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Återförsök den valda"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Ta bort vald"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Händelsetyper"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Statistik och köade klienter för vald fil(er): Session / All tid"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Procent av den totala filer"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Alla filer"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Valda filer"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Endast aktiva uppladdningar"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Återladda:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Återladda dina delade filer"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Skicka"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Skickar det specificerade meddelandet."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Anslut till någon server och/eller Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Utdelade filer"
 
@@ -5274,188 +5266,188 @@ msgstr "Nedladdad"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Systemets standard"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Albansk"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arabiska"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturiska"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskiska"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgariska"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalanska"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Kinesiska (Förenklad)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Kinesiska (Traditionell)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Kroatiska"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Checkiska"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danska"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Nederländska"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Engelska (Storbritannien)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estniska"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Finska"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Franska"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galiciska"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Tyska"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Grekisk"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Hebreiska"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Ungerska"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Italienska"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japanska"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Koreanska"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norska (nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Polska"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portugisiska"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portugisiska (Brasilien)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Romänska"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Ryska"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovenska"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Spanska"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Svenska"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Turkiska"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Byt språk"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "Det finns inga översättningar installerade för aMule"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Inga språk tillgängliga"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP-port kan inte vara högre än 65532 på grund av server UDP-socket är TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Standardporten kommer att användas ( %d )"
@@ -8394,6 +8386,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Auto-sortera filer (hög CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule sorterar kolumnerna i din nedladdningslista automatiskt"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Förkastar paketet om klient-ip skiljer sig från ip där paketet hämtas från. Används med försiktighet."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:17+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -619,8 +619,8 @@ msgstr ""
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -631,7 +631,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr ""
 
@@ -690,111 +690,111 @@ msgstr ""
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr ""
 
@@ -928,14 +928,14 @@ msgstr ""
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -946,72 +946,72 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
@@ -1168,7 +1168,7 @@ msgid "Disconnected"
 msgstr ""
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1321,19 +1321,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1360,7 +1360,7 @@ msgid "Queue Full"
 msgstr ""
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "காட்"
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr ""
@@ -1626,45 +1626,45 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
 "set your preferred video player in preferences (default is %s)."
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr ""
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr ""
 
@@ -2535,57 +2535,57 @@ msgstr[1] ""
 msgid "Kad user"
 msgstr ""
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr ""
 
@@ -2700,7 +2700,7 @@ msgid "WARNING: "
 msgstr ""
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgid "Paste"
 msgstr ""
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr ""
@@ -3130,8 +3130,8 @@ msgstr ""
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr ""
 
@@ -3271,7 +3271,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr ""
@@ -3386,15 +3386,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr ""
 
@@ -3632,7 +3632,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr ""
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3706,7 +3706,7 @@ msgstr ""
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr ""
 
@@ -3726,7 +3726,7 @@ msgstr ""
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr ""
 
@@ -4044,7 +4044,7 @@ msgstr ""
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr ""
 
@@ -4160,413 +4160,405 @@ msgstr ""
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr ""
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4574,11 +4566,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4588,222 +4580,222 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr ""
 
@@ -5161,187 +5153,187 @@ msgstr ""
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr ""
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-25 19:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -652,8 +652,8 @@ msgstr "Kad: Kapalı"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -664,7 +664,7 @@ msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
@@ -673,7 +673,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "Bağlan"
 
@@ -723,111 +723,111 @@ msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Ağlar"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "İndirmeler"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Paylaşılan dosyalar"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Sohbet"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Ayarlar"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Ağ yok"
 
@@ -967,14 +967,14 @@ msgstr "Geçersiz bağlantı veya zaten listede mevcut."
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanılıyor."
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -985,72 +985,72 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "DüşükID bağlantı için bir eş aranıyor"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Sahte eMule sürümü %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Sahte eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (Sahte eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (eMule s.0.%u üzerine kurulu)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Rumuz: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "İstek: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Bu oturum için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 msgstr[1] "Bu oturum için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "Tüm oturumlar için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 msgstr[1] "Tüm oturumlar için dosya durumu: Kabul edilen istek %d, toplam %d, %s aktarıldı\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Bilinmeyen dosya istendi"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "'%s' kullanıcısından gelen ileti engellendi. (IP: %s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "'%s' kullanıcısından yeni ileti geldi (IP: %s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Kullanıcı %s (%u), var olmayan '%s' dizini için paylaşılmış dosya listenizi istedi. -> Görmezden gelindi."
@@ -1207,7 +1207,7 @@ msgid "Disconnected"
 msgstr "Bağlantı kesildi"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1360,19 +1360,19 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1399,7 +1399,7 @@ msgid "Queue Full"
 msgstr "Sıra dolu"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "Sırada"
 
@@ -1464,7 +1464,7 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1535,7 +1535,7 @@ msgstr "Parça"
 msgid "Size"
 msgstr "Boyut"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Aktarıldı"
 
@@ -1592,7 +1592,7 @@ msgstr ""
 "Geri besleme: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Otomatik"
@@ -1667,34 +1667,34 @@ msgstr "Sınıfa Ekle"
 msgid "&Open the file"
 msgstr "Dosyayı &Aç"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Bu dosya için yeni bir isim girin:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Dosya yeniden adlandır"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "İndirmeler (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr "varsayılan Windows kabuk işleyicisi"
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1703,11 +1703,11 @@ msgstr ""
 "Her önizlemede bu uyarının gösterilmesini önlemek için,\n"
 "seçeneklerden tercih ettiğiniz video oynatıcısını ayarlayın (varsayılan %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Dosya ön izlemesi"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "Hata: Ortam oynatıcısını çalıştırma başarısız! Komut : `%s'"
@@ -2267,7 +2267,7 @@ msgstr "Arkadaş listesi 'emfriends.met' dosyasına yazılamıyor!"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "KRİTİK - SohbetOturumunuBaşlat' ta istemci yok"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Arkadaşlar"
 
@@ -2609,57 +2609,57 @@ msgstr[1] "%d Kademlia bağlantısı yazıldı"
 msgid "Kad user"
 msgstr "Kad kullanıcısı"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "'%s' için Kad not araması başlatılmadı: Kad bağlı değil"
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "'%s' için Kad not araması başlatılmadı: bu dosya için bir not araması zaten çalışıyor"
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "'%s' için Kad not araması başlatılmadı: dosya paylaşım listesinde, indirme kuyruğunda veya arama sonuçlarında mevcut değil"
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "'%s' için Kad not araması başlatılmadı: başka bir Kad araması (mesela bir kaynak araması) zaten bu dosyanın karma değeri kullanılarak çalışıyor - kısa bir süre sonra tekrar deneyin"
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "'%s' için Kad not araması başlatılmadı: PrepareLookup başarısız oldu"
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Dosya adı"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Dosya"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Paylaşım oranı"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "İstenen"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Kabul edilen"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Tamamlandı"
 
@@ -2774,7 +2774,7 @@ msgid "WARNING: "
 msgstr "UYARI: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Kapat"
 
@@ -2792,7 +2792,7 @@ msgid "Paste"
 msgstr "Yapıştır"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Temizle"
@@ -3204,8 +3204,8 @@ msgstr "Dosya kaynakları:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3345,7 +3345,7 @@ msgstr "Sanatçı:"
 msgid "Album :"
 msgstr "Albüm:"
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Başlık :"
 
@@ -3453,7 +3453,7 @@ msgstr "Kullanıcı Adı :"
 msgid "Userhash :"
 msgstr "Kullanıcı Adreslemesi :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Ekle"
@@ -3462,15 +3462,15 @@ msgstr "Ekle"
 msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Şimdiki"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Çalışma ortalaması"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Oturum ortalaması"
 
@@ -3708,7 +3708,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Tarayıcı adını buraya giriniz. Sisteminizin ön tanımlı tarayıcısını kullanmak için boş bırakınız."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3782,7 +3782,7 @@ msgstr "Yerel adresi IP' ye bağla (herhangi biri için boş bırakın):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Sadece ileri düzey kullanıcılar: Birden fazla ağ arayüzünüz varsa; aMule'nin izleyeceği arayüz adresini giriniz."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr "Ağ arayüzüne bağla (herhangi biri için boş bırakın):"
 
@@ -3802,7 +3802,7 @@ msgstr "En cazla eş bağlantı sayısı:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4122,7 +4122,7 @@ msgstr "İşlemdeki Kad-düğümleri"
 msgid "Kad-nodes session"
 msgstr "Oturumdaki Kad-düğümleri"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Seçiniz"
 
@@ -4238,413 +4238,405 @@ msgstr "Düz"
 msgid "Round"
 msgstr "Yuvarlatılmış"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Dosyaları otomatik sırala (yüksek CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule aktarım listenizdeki sütunları otomatikman sıralayacaktır."
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Dışarıdan Bağlantı Parametreleri"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Dışarıdan bağlantıları kabul et."
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "Dinlenen arayüzün IP' si:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Dinleme EC arayüzü için a.b.c.d biçiminde geçerli bir ip giriniz. Boş bırakılan alan veya 0.0.0.0 arayüz yok demektir."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP portu:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "EC portuna UPnP port yönlendirmesi etkin."
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Şifre"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr "aMule API sunucusu parametreleri"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr "Başlangıçta amuleapi (REST API) çalıştır"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr "HTTP bağlantı noktası:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi HTTP sunucusunun dinlediği arayüz. 127.0.0.1 (varsayılan) sadece yerel bağlantıları kabul eder; onu başka makinelere açmak için 0.0.0.0 veya belirli bir IP kullanın (aşağıda bir yönetici parolası tanımlayın)."
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr "Yönetici parolası"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Web sunucusu değerleri"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr "Başlangıçta web sunucusunu başlat (eskimiş)"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web şablonu"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Tam hak şifresi"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Düşük hakka sahip kullanıcıyı etkin kıl."
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Düşük hak şifresi"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Web sunucu portunun UPnp port iletimini etkinleştir"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web sunucusu UPnp TCP portu (İsteğe bağlı)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Sayfa yenileme zamanı (sn)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Gzip sıkıştırmayı etkinleştir."
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr "Sayfayı varsayılan değerlere sıfırla"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr "Güncel sayfadaki ayarları varsayılan değerlerine sıfırla."
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Tamam"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişikliklerin uygulanması için buraya tıklayınız."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Yorum:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Gelen Dosyalar Dizini :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "Değiştirme"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Günlük kayıtlarını silmek için bu düğmeye basınız."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Sunucu listesini İnternet'den güncellemek için bu düğmeye basınız…"
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Sunucu"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Adresi server.met dosyasına buradan giriniz. Sonra, bilinen sunucuları güncellemek için soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Sunucuyu elle ekle: İsim"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Yeni sunucunun adını buraya giriniz."
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Sunucunu portunu buraya giriniz."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Sunucuyu elle ekle (önce soldaki alanları doldurunuz) …"
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule Günlüğü"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Sunucu Bilgisi"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K Bilgileri"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kademlia Bilgileri"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Düğüm listesini İnternet'den güncellemek için bu düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Düğümler (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Bilinen düğümleri güncellemek için buraya adresi giriniz ve soldaki düğmeye tıklayınız."
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Yeni düğüm"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Port:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Kad Bağlantısını Kes"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Güvenli Kullanıcı Kimlik Doğrulamasını Kullan"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Bu seçeneği aktifleştirmeniz önerilir. SUI aktif değilse, kredi alamazsınız."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Protokol Gizleme"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Protokol Gizleme etkin"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Bu seçenek Protokol Gizleme'yi etkinleştirir ve aMule'nin gizlenmiş bağlantıları kabul etmesini sağlar."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Giden bağlantılar için gizleme kullan"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Bu seçenek diğer kullanıcı veya sunucularla olan bağlantılarda Protokol Gizleme'yi etkinleştirir."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Sadece gizlenmiş bağlantıları kabul et"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Bu seçenek aMule'nin sadece gizlenmiş bağlantıları kabul etmesini sağlar. Daha az kaynak bulursunuz; ancak tüm trafiğiniz de karartılmış olur."
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Herkes"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Hiç kimse"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Paylaşılan dosyalarımı kim görebilir:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Paylaşılan dosyalarınızı kime göstereceğinizi seçiniz."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP_Süzme"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Kullanıcıları Süz"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan kullanıcı IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Sunucuları süz"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "~/.aMule/ipfilter.dat dosyasında tanımlanan sunucu IP'lerini süzmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Listeyi yeniden yükle"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "~/.aMule/ipfilter.dat dosyasından IP'leri süzgece yeniden yükle."
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "Adres:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Şimdi güncelle"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Ip süzgecini başlangıçta otomatikman güncelle."
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Süzme Seviyesi:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Her zaman LAN IP'lerini süz."
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Uyuşmayan IP'lere şüpheci yaklaşım."
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "İstemcinin sahip olduğunu iddia ettiği IP, kaynak IP'den farklı olduğunda paketi reddeder (sahtekarlık önleyici kontrol). Sadece bağlantı sorunları oluşturuyorsa devre dışı bırakın."
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Varsa, sistem geneli ipfilter.dat kullan"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Yerel bir ipfilter.dat dosyası bulunamazsa, sistem geneli ipfilter kullanımına izin ver."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Çevrimiçi-İmza' yı Etkinleştir"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Diğer uygulamaların imzalar ve benzerlerini oluşturabilmesi için kullanabileceği Çev.İmza dosyasını yazmayı etkinleştirir."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Güncelleme Sıklığı (Sn.):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Çevrim içi İmza güncellemeleri için (saniye bazında) sıklığı değiştirir."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Çevrim içi imza dosyasını buraya sakla: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Çevrim içi İmza dosyalarını içeren dizini seçiniz."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "İstemciler için ülke bayraklarını göster"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "Transferler, kuyruklar ve arama görünümlerinde ülkelerin bayrakları sütununu görüntüle. Geçerli bir MMDB GeoIP veri tabanı gerektirir (aşağıya bakınız)."
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "Veri Tabanı"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "Kaynak:"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP (ücretsiz, hesap gerektirmez)"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2 (ücretsiz, hesap gerektirir)"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "Kişiselleştirilmiş URL"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "Hangi tedarikçinin GeoIP MMDB veri tabanını sağlayacağını seçin. DB-IP varsayılan değerdir - hesap gerektirmez. MaxMind ücretsiz bir hesap + lisans anahtarı gerektirir. Herhangi başka bir MMDB makinesine (mesela yerel bir yansıya) yönlendirme yapmak için kişiselleştirilmiş URL kullanın."
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4656,11 +4648,11 @@ msgstr ""
 "IP-Ülke verileri DB-IP.com tarafından sağlanmaktadır - https://db-ip.com\n"
 "Lisans: Creative Commons Atıf 4.0 - https://creativecommons.org/licenses/by/4.0/deed.tr"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "Lisans anahtarı:"
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4676,11 +4668,11 @@ msgstr ""
 "Lisans: MaxMind GeoLite2 Kullanıcı Lisans Anlaşması - https://www.maxmind.com/en/geolite2/eula\n"
 "Atıf ve hesap oluşturulması gerektirir; en az her 30 günde bir güncelleyin."
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "İndirme Bağlantısı:"
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4690,211 +4682,211 @@ msgstr ""
 "Bağlantı kimlik doğrulama bilgileri içerebilir (https://kullanıcı:parola@makine/…)\n"
 "Lisans ve atıf koşulları kaynak URL tarafından belirlenir - bunlardan siz sorumlu olursunuz."
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "Seçili kaynaktan GeoIP veri tabanını indir."
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "Başlangıçta otomatik olarak güncelle"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "aMule her başladığında, GeoIP veri tabanını seçili kaynaktan tekrar indir."
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Gelen iletileri süz (o anki sohbet dışında):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Hepsini süz."
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Arkadaş listesindekiler dışında herkesi süz."
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Bilinmeyen yazılımlardan gelenleri süz."
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "buraya ekleyeceğiniz sözcükleri içeren iletiler aMule tarafından engellenir."
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Günlükte alınan iletileri göster"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Şu içerikteki iletileri süz (ayraç olarak ',' kullanınız.):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Yetkilendirmeyi etkinleştir."
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Kullanıcı adı: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Şifre:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli şifre"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Vekil sunucuyu Etkinleştir."
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Vekil sunucu Türü:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Vekil sunucu makine:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Vekil sunucu Portu:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Vekil sunucu portu"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "Bağlan:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Kullanıcı adı"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "ZLIB sıkıştırmasını zorla"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Fazladan Hata Çıktısı Kaydını Etkinleştir."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "Sadece Kütük Dosyasına"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "İleti Sınıfları:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Bekliyor…"
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "İçe aktarımları ekle"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Seçileni tekrar dene"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Seçileni çıkar"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Olay Türleri"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "Seçili dosya(lar) için kuyruktaki istemciler ve istatistikler: Oturum / Bütün zamanlar"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "Toplam dosyaların yüzdesi"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "Seçilen dosyalar"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "Sadece aktif Göndermeler"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "Yeniden yükle:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Paylaşılan dosyalarınızı yeniden yükleyin"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Gönder"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Belirlenen iletiyi gönderir."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
 
@@ -5254,187 +5246,187 @@ msgstr "İndirildi"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Sistem öntanımlısı"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Arnavutça"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Arapça"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "Asturyasça"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Baskça"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Bulgarca"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Çince (Basitleştirilmiş)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Çince (Geleneksel)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Hırvatça"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Çekçe"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Danca"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Felemenkçe"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "İngilizce (U.K)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "İngilizce (ABD)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Estonca"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Fince"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Fransızca"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Galce"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Almanca"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Yunanca"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "İbranice"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "İtalyanca"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Japonca"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Korece"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr "Letonca"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Litvanyaca"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Norveççe (Nynorsk)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Lehçe"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Portekizce"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Portekizce (Brezilya)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "Rumence"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Rusça"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Slovence"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "İspanyolca"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "İsveççe"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "Dili Değiştirin"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "aMule tercümeleri kurulu değildir"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "Diller mevcut değil"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP portu numarası, UDP soketi TCP+3 olduğundan 65532' den yüksek olamaz"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Varsayılan port kullanılacak (%d)"
@@ -8375,6 +8367,12 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Dosyaları otomatik sırala (yüksek CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule aktarım listenizdeki sütunları otomatikman sıralayacaktır."
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Paketin alındığı ip ile kullanıcı ip numarası farklıysa paket reddedilir. Dikkatli kullanın."

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:13+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -649,8 +649,8 @@ msgstr "Kad: вимкнена"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -661,7 +661,7 @@ msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
@@ -670,7 +670,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "З'єднатися"
 
@@ -721,112 +721,112 @@ msgstr "Ви справді хочете вийти з aMule?"
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "Мережі"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "Звантаження"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "Спільні файли"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "Немає мережі"
 
@@ -965,14 +965,14 @@ msgstr "Недопустиме посилання або вже в перелі�
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -983,44 +983,44 @@ msgstr ""
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "Неможливо отримати спільні файли користувача %s"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "Шукається друг для lowid-з'єднання"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (Підробна версія eMule %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (Підробний eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (підробний eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (оснований на eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Прізвисько: %s ID: %u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "Запросив: %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
@@ -1028,7 +1028,7 @@ msgstr[0] "Статистика файлів для цієї сесії: доз�
 msgstr[1] "Статистика файлів для цієї сесії: дозволено %d з %d запитаних, %s передано\n"
 msgstr[2] "Статистика файлів для цієї сесії: дозволено %d з %d запитаних, %s передано\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
@@ -1036,21 +1036,21 @@ msgstr[0] "Статистика файлів для всіх сесій: доз�
 msgstr[1] "Статистика файлів для всіх сесій: дозволено %d з %d запитаних, %s передано\n"
 msgstr[2] "Статистика файлів для всіх сесій: дозволено %d з %d запитаних, %s передано\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "Запитаний невідомий файл"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "Повідомлення відфільтроване від '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "Нове повідомлення від '%s' (IP:%s)"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів для теки %s -> відмовлено"
@@ -1210,7 +1210,7 @@ msgid "Disconnected"
 msgstr "Від'єднана"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1368,19 +1368,19 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1407,7 +1407,7 @@ msgid "Queue Full"
 msgstr "Черга заповнена"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "В черзі"
 
@@ -1473,7 +1473,7 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1545,7 +1545,7 @@ msgstr "Частина"
 msgid "Size"
 msgstr "Розмір"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "Переданих"
 
@@ -1602,7 +1602,7 @@ msgstr ""
 "Відгук від: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "Автоматично"
@@ -1677,34 +1677,34 @@ msgstr "Призначити категорію"
 msgid "&Open the file"
 msgstr "Відкрити файл"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "Введіть нову назву для цього файлу:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "Змінити назву файлу"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f кбайт/с"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y.%m.%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Звантаження (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1713,11 +1713,11 @@ msgstr ""
 "Щоб попередити показ цього застереження під час кожного попереднього перегляду,\n"
 "оберіть відеопрогравач в налаштуваннях (за замовчуванням %s)."
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "Попередній перегляд файлу"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ПОМИЛКА: не вдалося виконати зовнішній медіа-програвач! Команда: '%s'"
@@ -2285,7 +2285,7 @@ msgstr "Неможливо відкрити перелік друзів 'emfrien
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "КРИТИЧНО - немає клієнта на StartChatSession"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "Друзі"
 
@@ -2638,57 +2638,57 @@ msgstr[2] "Записано %d контактів Kad"
 msgid "Kad user"
 msgstr "Мережа Kad"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "Назва файлу"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "Розмір файлу"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "Відношення передачі"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "Запитано"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "Дозволено"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "Завершених джерел"
 
@@ -2807,7 +2807,7 @@ msgid "WARNING: "
 msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "Закрити"
 
@@ -2825,7 +2825,7 @@ msgid "Paste"
 msgstr "Вставити"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "Очистити"
@@ -3247,8 +3247,8 @@ msgstr "Завершених джерел"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "недоступні"
 
@@ -3393,7 +3393,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "Назва:"
 
@@ -3502,7 +3502,7 @@ msgstr "Ім'я користувача:"
 msgid "Userhash :"
 msgstr "Хеш користувача:"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "Додати"
@@ -3511,15 +3511,15 @@ msgstr "Додати"
 msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "Поточна"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "Середня"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "Середня за сесію"
 
@@ -3760,7 +3760,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "Введіть тут назву вашого переглядача тенет. Залиште це поле порожнім, щоб використовувати переглядач встановлений за замовчуванням."
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3834,7 +3834,7 @@ msgstr "Використовувати IP-адресу (пусто для буд
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "Тільки досвідченим користувачам: якщо ви маєте багато мережевих інтерфейсів, введіть адресу інтерфейсу до якого слід прив'язатися aMule."
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "Використовувати IP-адресу (пусто для будь-якої):"
@@ -3855,7 +3855,7 @@ msgstr "Найбільше одночасних з'єднань:"
 msgid "Kademlia"
 msgstr "Kademlia"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4175,7 +4175,7 @@ msgstr "Вузлів Kad запущено"
 msgid "Kad-nodes session"
 msgstr "Вузлів Kad за сесію"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "Вибрати"
 
@@ -4294,425 +4294,417 @@ msgstr "Плаский"
 msgid "Round"
 msgstr "Круглий"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "Автоматично впорядковувати файли (багато ресурсів CPU)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule буде автоматично впорядковувати стовпці в переліку звантажень"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "Параметри зовнішніх з'єднань"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "Дозволити зовнішні з'єднання"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "IP-адреса інтерфейса:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "Введіть IP-адресу в вірному форматі a.b.c.d для прослуховування EC-інтерфейсу. Порожнє поле або 0.0.0.0 означатиме всі."
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "Ввімкнути UPnP перенаправлення для EC-порту"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "Пароль"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "Порт TCP:"
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "Перевіряється пароль\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Налаштування веб-сервера"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "Запустити веб-сервер під час запуску"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Веб шаблон"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "Пароль повних прав"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "Ввімкнути користувача з низькими правами"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "Пароль низьких прав"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "Ввімкнути UPnP перенаправлення портів для порту веб-сервера"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "UPnP TCP-порт веб-сервера (не обов'язково)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "Час оновлення сторінки (с)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "Дозволити Gzip-стиснення"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "Мова системи"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "Гаразд"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "Натисніть тут щоб застосувати зміни зроблені в налаштуваннях."
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "Коментар:"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "Вхідна тека:"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "Змінити перевагу для нового призначеного файлу:"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 #, fuzzy
 msgid "Don't change"
 msgstr "Не змінювати"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "Натисніть цю кнопку, щоб очистити часопис."
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "Натисніть на кнопку щоб оновити перелік серверів з адреси..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "Перелік серверів"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "Введіть адресу файлу server.met та натисніть кнопку ліворуч щоб оновити перелік відомих серверів."
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "Додати сервер вручну: Назва"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "Введіть тут назву нового сервера"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Порт"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "Введіть тут порт сервера."
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "Додати сервер вручну (заповніть поля ліворуч)..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "Часопис aMule"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "Інфо сервера"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "Інфо eD2k"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "Натисніть на цю кнопку щоб оновити перелік вузлів з URL..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "Вузли (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "Введіть адресу файлу nodes.dat та натисніть кнопку ліворуч щоб оновити перелік відомих вузлів. "
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "Початковий запуск"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "Новий вузол"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP:"
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "Порт:"
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 #, fuzzy
 msgid "Bootstrap from known clients"
 msgstr ""
 "Початковий запуск\n"
 "відомого клієнта"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "Від'єднатися від Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "Використовувати безпечну ідентифікацію користувача"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "Рекомендовано ввімкнути цю опцію. Ви не отримаєте довіру якщо безпечна ідентифікація вимкнена."
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "Приховування протоколу"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "Підтримка приховування протоколу"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "Ця опція вмикає приховування протоколу та дозволяє aMule приймати приховані з'єднання від інших клієнтів."
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "Використовувати приховування для вихідних з'єднань"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "Ця опція вмикає приховування протоколу під час з'єдання з іншими клієнтами/серверами."
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "Приймати тільки приховані з'єднання"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "Приймати приховані з'єднання. Будете мати менше джерел, але весь ваш трафік буде приховано"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "Кожен"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "Жоден"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "Хто може бачити мої спільні файли:"
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "Оберіть тих, хто може запитати перелік ваших спільних файлів."
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP-фільтрування"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "Фільтрувати клієнтів"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес клієнтів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "Фільтрувати сервери"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "Ввімкнено фільтрування IP-адрес серверів, що визначені в файлі ~/.aMule/ipfilter.dat."
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "Перезавантажити перелік IP-адрес для фільтрування з файлу ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "URL:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "Оновити зараз"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "Рівень фільтра:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "Завжди відфільтровувати IP-адреси локальних мереж"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "Параноїдальна обробка IP-адрес, що не співпали"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "Використовувати системний ipfilter.dat якщо наявний"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "Якщо не знайдено місцевий ipfilter.dat, дозволити використання системного."
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "Ввімкнути онлайн-підпис"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "Ввімкнути запис файлу ОС, який може бути використано зовнішніми програмами для створення підписів та подібного."
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "Частота оновлення (с)"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "Змінити частоту (в секундах) оновлень онлайн-підписів."
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "Зберегти файл онлайн-підпису в: "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "Натисніть тут, щоб вибрати теку, що містить файли з онлайн-підписами."
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "Швидкість передачі:"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "Джерела"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4720,11 +4712,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4734,232 +4726,232 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "Звантаження: "
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "Автоматичне оновлення IP-фільтру після запуску"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "Фільтрувати вхідні повідомлення (окрім поточної розмови):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "Фільтрувати всі повідомлення"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "Фільтрувати повідомлення від людей, що не в вашому переліку друзів"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "Фільтрувати повідомлення від невідомих клієнтів"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "Фільтрувати повідомлення, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "додати слова, які aMule буде фільтрувати, та забороняти повідомлення, що їх містять"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "Показувати отримані повідомлення в часописі"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "Коментарі"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "Фільтрувати коментарі, що містять (використовуйте ',' для переліку):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "Включити авторизацію"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "Ім'я користувача: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "Пароль:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "Пароль для з'єднання з проксі"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "Ввімкнути проксі"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "Тип проксі:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "Хост проксі:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "Порт проксі:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "Порт проксі"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "З'єднатись з:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "Ім'я користувача"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "Використовувати gzip-стиснення"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "Ввімкнути докладне ведення часопису."
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "Відкрити файл"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "Категорія повідомлення:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "Очікується..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "Додати зовнішні внесення"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "Повторити вибрані"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "Вилучити вибрані"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "Типи подій"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 #, fuzzy
 msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 #, fuzzy
 msgid "All files"
 msgstr "Сховати спільні файли"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 #, fuzzy
 msgid "Selected files"
 msgstr "Вибрати фільтр перегляду"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 #, fuzzy
 msgid "Active uploads only"
 msgstr "Чинні вивантаження"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 #, fuzzy
 msgid "Reload:"
 msgstr "Перезавантажити перелік"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "Перезавантажити ваші спільні файли"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "Надіслати"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "Надіслати вказане повідомлення."
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "Спільні файли"
 
@@ -5323,192 +5315,192 @@ msgstr "Звантажені"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "Мова системи"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "Арабська"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 #, fuzzy
 msgid "Asturian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "Баскська"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "Болгарська"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "Каталонська"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "Китайська (спрощена)"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "Китайська (традиційна)"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "Хорватська"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "Чеська"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "Данська"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "Нідерландська"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "Англійська (Великобританія)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "Естонська"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "Фінська"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "Французька"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "Галісійська"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "Німецька"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "Грецька"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "Іврит"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "Угорська"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "Італійська"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "Японська"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "Корейська"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "Литовська"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "Норвезька (Нюнорск)"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "Польська"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "Португальська"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "Португальська (Бразилія)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 #, fuzzy
 msgid "Romanian"
 msgstr "Албанська"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "Російська"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "Словенська"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "Іспанська"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "Шведська"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "Турецька"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "Українська"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 #, fuzzy
 msgid "Change Language"
 msgstr "Мова: "
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 #, fuzzy
 msgid "No languages available"
 msgstr "Недоступний"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "немає наявних опцій"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "Порт TCP не може бути більшим ніж 65532, оскільки UDP-порт сервера є TCP+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "Буде використовуватися порт за замовчуванням (%d)"
@@ -8493,6 +8485,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "Автоматично впорядковувати файли (багато ресурсів CPU)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule буде автоматично впорядковувати стовпці в переліку звантажень"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "Відкинути пакет якщо IP-адреса клієнта відрізняється від IP-адреси з якої прийшов пакет. Використовуйте обережно."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-25 19:02+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -656,8 +656,8 @@ msgstr "Kad: 关闭"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -668,7 +668,7 @@ msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "断开连接"
 
@@ -677,7 +677,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "连接"
 
@@ -727,111 +727,111 @@ msgstr "您确定要退出 %s 吗？"
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "网络"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "下载"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "共享文件"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "消息"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "统计"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "设置"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "无网络"
 
@@ -971,14 +971,14 @@ msgstr "非法链接或已经存在列表中。"
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目录。"
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -989,72 +989,72 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 msgid "Unknown"
 msgstr "未知"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "无法获取用户 %s 的共享文件"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "正在搜索好友进行 Low ID 连接"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (假冒 eMule 版本 %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (假冒 eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (假冒 eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (基于 eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "昵称：%s ID：%u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "已请求： %s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "本次会话运行文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 msgstr[1] "本次会话运行文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "所有会话文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 msgstr[1] "所有会话文件统计：接受了 %d 个请求（总请求数 %d），已传输 %s\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "请求了未知文件"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "来自 %s（IP：%s）的消息被过滤掉了"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "新消息来自于 %s（IP：%s）"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "用户 %s（%u）请求目录 %s 的共享文件列表 -> 已忽略"
@@ -1211,7 +1211,7 @@ msgid "Disconnected"
 msgstr "断开连接"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1364,19 +1364,19 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1403,7 +1403,7 @@ msgid "Queue Full"
 msgstr "队列已满"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "正在排队"
 
@@ -1468,7 +1468,7 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1539,7 +1539,7 @@ msgstr "块"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "已传输"
 
@@ -1596,7 +1596,7 @@ msgstr ""
 "报告来自: %s (%s)\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "自动"
@@ -1671,34 +1671,34 @@ msgstr "指定到分类"
 msgid "&Open the file"
 msgstr "打开文件 (&O)"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "请输入新文件名:"
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "重命名文件"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下载 (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr "默认的 Windows 外壳处理器"
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1707,11 +1707,11 @@ msgstr ""
 "为了不让此提示在每次预览时都出现，\n"
 "请在设置中预设您喜欢的播放器（默认为%s）。"
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "文件预览"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "错误: 无法运行外部媒体播放器！ 命令: `%s'"
@@ -2271,7 +2271,7 @@ msgstr "写好友列表文件emfriends.met失败！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "严重错误 - 开始聊天进程没有客户端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "好友"
 
@@ -2611,57 +2611,57 @@ msgstr[1] "已写入%d个Kad联系人"
 msgid "Kad user"
 msgstr "Kad 用户"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr "“%s” 的 Kad 笔记搜索未启动：Kad 未连接"
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr "“%s” 的 Kad 笔记搜索未启动：已经有一个该文件的笔记查询在运行"
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr "“%s” 的 Kad 笔记搜索未启动：文件不在共享列表、下载队列或搜索结果中"
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr "“%s” 的 Kad 笔记搜索未启动：另一个 Kad 搜索（比如来源搜索）已经在使用此文件的哈希值 —— 请稍后重试"
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr "“%s” 的 Kad 笔记搜索未启动：PrepareLookup 失败"
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "文件名"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "文件大小"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "共享率"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "已请求"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "已接受"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "完成的源"
 
@@ -2776,7 +2776,7 @@ msgid "WARNING: "
 msgstr "警告: "
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "关闭"
 
@@ -2794,7 +2794,7 @@ msgid "Paste"
 msgstr "粘贴"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3206,8 +3206,8 @@ msgstr "文件源:"
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3347,7 +3347,7 @@ msgstr "艺术家："
 msgid "Album :"
 msgstr "专辑："
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "标题 :"
 
@@ -3455,7 +3455,7 @@ msgstr "用户名 :"
 msgid "Userhash :"
 msgstr "用户哈希 :"
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "添加"
@@ -3464,15 +3464,15 @@ msgstr "添加"
 msgid "Download-Speed"
 msgstr "下载速度"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "当前"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "动态平均值"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "本次运行平均值"
 
@@ -3710,7 +3710,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "在此处输入您的浏览器名称，如要使用系统默认浏览器则请留空。"
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3784,7 +3784,7 @@ msgstr "为本地地址绑定 IP (全部绑定则留空):"
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "只限高级用户：如果您有多个网络接口，请输入 aMule 将要绑定接口的地址。"
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 msgid "Bind to network interface (empty for any):"
 msgstr "绑定网络接口（留空绑定全部）："
 
@@ -3804,7 +3804,7 @@ msgstr "最大同时连接数:"
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4124,7 +4124,7 @@ msgstr "运行的 Kad 节点"
 msgid "Kad-nodes session"
 msgstr "本次运行的 Kad 节点"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "选择"
 
@@ -4240,413 +4240,405 @@ msgstr "扁平"
 msgid "Round"
 msgstr "圆柱"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "自动排序文件 (高 CPU 占用)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule 会自动将下载列表按列排序"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "远程连接参数"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "接受远程连接"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "监听接口的 IP:"
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "在此输入正确的 IP(格式：a.b.c.d)用于监听远程连接接口。空着不填或者 0.0.0.0 表示任何接口。"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP 端口："
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "为远程连接端口启用 UPnP"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密码"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 msgid "aMule API server parameters"
 msgstr "aMule API 服务器参数"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr "启动时运行 amuleapi (REST API)"
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 msgid "HTTP port:"
 msgstr "HTTP 端口："
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr "amuleapi 接口的 HTTP 服务器监听默认地址为 127.0.0.1，该地址仅接受本地连接；使用 0.0.0.0 或特定 IP 地址可将其暴露给其他主机（请在下方设置管理密码）。"
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 msgid "Admin password"
 msgstr "管理密码"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "Web 服务参数"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 msgid "Run webserver on startup (deprecated)"
 msgstr "启动时运行 web 服务器（已废弃）"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "Web 模板"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "最高权限密码"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "启用低权限用户"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "低权限密码"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "为 Web 服务端口启用 UPn P端口转发"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "Web 服务器 UPnP 的 TCP 端口(可选)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "页面刷新周期(秒)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "启用 Gzip 压缩"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 msgid "Reset page to defaults"
 msgstr "重置页面为默认"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr "重置当前页面设置为默认值。"
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "确定"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "点击这里立即使用新的设置。"
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有设置改动。"
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "注释 :"
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "下载目录 :"
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "设置新加入的文件优先级为 :"
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "不要改变"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "选择该分类颜色 (当前选择) :"
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "按此按钮清空日志。"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "按此按钮从该网址更新服务器列表 ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "服务器列表"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "输入 server.met 文件的地址，再按此按钮更新服务器列表。"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "手动添加服务器：名称"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "在此输入新服务器的名称"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP 地址:端口"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "在此请输入服务器端口。"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "添加新服务器 (先填写左侧的内容) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule 日志"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "服务器信息"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "ED2K 信息"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad 信息"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "按此更新节点列表自网址..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "节点 (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "输入 nodes.dat 文件的地址并按左边的按钮以更新已知节点列表"
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "节点状态"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "启动"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "新节点"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "端口："
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "从已知用户启动"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "断开 Kad"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "使用安全用户认证"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建议使用此选项，如果安全用户认证没有启用，将不会接收信用证明。"
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "模糊协议"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "支持模糊协议"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "此选项启用了模糊协议，可让aMule接受其他用户用迷糊协议的连接"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "为传出连接使用模糊协议"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "此选项使aMule在连接其他用户或服务器时使用模糊协议。"
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "仅接受模糊协议连接"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "此选项让aMule只接受模糊协议连接，源相对来说会更少，但全部数据包都将进行迷惑处理"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "没有人"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "谁可查看我的共享文件："
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "选择可以浏览共享文件列表的用户。"
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP 过滤"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "过滤用户"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的用户IP"
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "过滤服务器"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "过滤在文件~/.aMule/ipfilter.dat中定义的服务器IP"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "刷新列表"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "更新 IP 地址过滤列表自文件 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "地址:"
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "启动后自动更新IP 地址过滤列表"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "过滤级别:"
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "始终过滤局域网 IP"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "处理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr "当数据包的源 IP 地址与客户端声称的 IP 地址不同时，拒绝该数据包（防欺骗检查）。仅在导致连接问题时才禁用此功能。"
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "在可用的情况下使用系统级别的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果没有找到本地 ipfilter.dat 文件，则允许使用系统级的IP过滤文件。"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "启用在线统计"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "输出该文件以用于在线统计等等。"
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "更新频率 (秒):"
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "更改在线统计文件的更新频率 (秒) 。"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "保存在线签名位置： "
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "单击此处选择包含在线签名文件的目录。"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "为客户端显示国旗"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr "在传输、队列和搜索视图中渲染地区旗帜列。需要有效的 MMDB GeoIP 数据库（见下文）。"
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 msgid "Database"
 msgstr "数据库"
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 msgid "Source:"
 msgstr "源："
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr "DB-IP（免费，无需账户）"
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr "MaxMind GeoLite2（免费，需注册账户）"
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr "自定义 URL"
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr "选择哪个提供商提供 GeoIP MMDB 数据库。DB-IP 是默认选项，无需账户。MaxMind 需要一个免费账户和许可证密钥。使用自定义 URL 指向任何其他 MMDB 主机（例如本地镜像）。"
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4658,11 +4650,11 @@ msgstr ""
 "IP-to-Country 数据由 DB-IP.com 提供 - https://db-ip.com\n"
 "许可证：知识共享署名 4.0 国际版 - https://creativecommons.org/licenses/by/4.0/"
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr "许可证密钥："
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4678,11 +4670,11 @@ msgstr ""
 "许可证：MaxMind GeoLite2 最终用户许可协议 - https://www.maxmind.com/en/geolite2/eula\n"
 "需要注明出处并注册账户；至少每 30 天刷新一次。"
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 msgid "Download URL:"
 msgstr "下载地址："
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
@@ -4692,211 +4684,211 @@ msgstr ""
 "URL 可包含凭据（例如 https://user:pass@host/...）。\n"
 "许可和署名条款由上游 URL 决定——你需自行负责。"
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr "从所选源下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 msgid "Auto-update on startup"
 msgstr "启动后自动更新"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr "每次启动 aMule 时，从所选源重新下载 GeoIP 数据库。"
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "过滤收到的消息 (不包括当前对话):"
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "过滤所有消息"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "过滤来自好友列表外的消息"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "过滤来自未知用户的消息"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "过滤包含以下内容的消息 (用半角逗号分隔):"
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "输入需过滤的词组"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "在日志中显示接收的消息"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "备注"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "过滤包含以下内容的备注 (使用“,”作为分隔符):"
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "启用验证："
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "用户名: "
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "密码:"
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "连接代理服务器的密码"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "启用代理"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "代理类型:"
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "代理服务器:"
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "代理端口:"
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "代理端口"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "连接到:"
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "用户名"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 msgid "Force ZLIB compression"
 msgstr "强制使用 ZLIB 压缩"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "启用详细调试日志。"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 msgid "Only to Logfile"
 msgstr "只记录到日志文件"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "消息分类:"
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等待中..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "添加导入文件"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "重试所选"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "删除所选"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "事件类型"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "所选文件的统计和队列用户：会话/全部时间"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "活跃上传"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "全部文件的百分比"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "显示客户端"
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "所有文件"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "选择的文件"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "仅活跃上传"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "重新载入:"
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "刷新共享文件"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "发送"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "发送指定消息。"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "连接至任何服务器和/或 Kad"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "共享文件"
 
@@ -5256,187 +5248,187 @@ msgstr "已下载"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "系统默认"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "澳大利亚"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "简体中文"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "繁体中文"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "克罗的亚语"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "捷克语"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "丹麦语"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "英语（英国）"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 msgid "English (U.S.)"
 msgstr "英语（美国）"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "爱斯托尼亚语"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "法语"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "德语"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "希腊语"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "意大利语"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "日语"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "韩语"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威语"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "芬兰语"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙语（巴西）"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "俄语"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "乌克兰"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "更改语言"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "没有为 aMule 安装语言文件"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "语言文件不可用"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "选项不可用"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP端口不可高于65532，因为服务器UDP端口值为TCP端口值+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "缺省端口将被使用（%d）"
@@ -8374,6 +8366,12 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "自动排序文件 (高 CPU 占用)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule 会自动将下载列表按列排序"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "如果客户端 ip 和发送数据包的 ip 不同则拒绝数据包。请谨慎使用。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-24 17:10+0200\n"
+"POT-Creation-Date: 2026-07-26 10:41+0200\n"
 "PO-Revision-Date: 2026-07-24 18:15+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -653,8 +653,8 @@ msgstr "Kad：關閉"
 #: src/amuleDlg.cpp:963 src/DownloadListCtrl.cpp:465
 #: src/DownloadListCtrl.cpp:704 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:727 src/muuli_wdr.cpp:778 src/muuli_wdr.cpp:842
-#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2202 src/muuli_wdr.cpp:2287
-#: src/muuli_wdr.cpp:3033 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
+#: src/muuli_wdr.cpp:894 src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2283
+#: src/muuli_wdr.cpp:3029 src/ServerListCtrl.cpp:162 src/ServerListCtrl.cpp:585
 #: src/ServerListCtrl.cpp:606 src/TransferWnd.cpp:376
 #: src/utils/wxCas/src/wxcasprefs.cpp:235
 msgid "Cancel"
@@ -665,7 +665,7 @@ msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
 #: src/amuleDlg.cpp:969 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
-#: src/muuli_wdr.cpp:2425
+#: src/muuli_wdr.cpp:2421
 msgid "Disconnect"
 msgstr "中斷連線"
 
@@ -674,7 +674,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
 #: src/amuleDlg.cpp:975 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
-#: src/muuli_wdr.cpp:2580 src/muuli_wdr.cpp:3030 src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:2576 src/muuli_wdr.cpp:3026 src/muuli_wdr.cpp:3365
 msgid "Connect"
 msgstr "連線"
 
@@ -725,111 +725,111 @@ msgstr "您確定要離開 %s 嗎？"
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1529
+#: src/amuleDlg.cpp:1524
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1548 src/muuli_wdr.cpp:1950 src/Preferences.cpp:952
+#: src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1950 src/Preferences.cpp:950
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1576
+#: src/amuleDlg.cpp:1571
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1579
+#: src/amuleDlg.cpp:1574
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1703 src/amuleDlg.cpp:1949 src/muuli_wdr.cpp:1474
-#: src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1698 src/amuleDlg.cpp:1944 src/muuli_wdr.cpp:1474
+#: src/muuli_wdr.cpp:3367
 msgid "Networks"
 msgstr "網路"
 
-#: src/amuleDlg.cpp:1707 src/muuli_wdr.cpp:3371
+#: src/amuleDlg.cpp:1702 src/muuli_wdr.cpp:3367
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1709 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1704 src/muuli_wdr.cpp:3368
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp:1713 src/muuli_wdr.cpp:3372
+#: src/amuleDlg.cpp:1708 src/muuli_wdr.cpp:3368
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1715 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3373 src/Statistics.cpp:829
+#: src/amuleDlg.cpp:1710 src/DownloadListCtrl.cpp:695 src/muuli_wdr.cpp:392
+#: src/muuli_wdr.cpp:1576 src/muuli_wdr.cpp:3369 src/Statistics.cpp:829
 msgid "Downloads"
 msgstr "下載"
 
-#: src/amuleDlg.cpp:1719 src/muuli_wdr.cpp:3373
+#: src/amuleDlg.cpp:1714 src/muuli_wdr.cpp:3369
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1721 src/muuli_wdr.cpp:3257
+#: src/amuleDlg.cpp:1716 src/muuli_wdr.cpp:3253
 msgid "Shared files"
 msgstr "檔案分享"
 
-#: src/amuleDlg.cpp:1725 src/muuli_wdr.cpp:3375
+#: src/amuleDlg.cpp:1720 src/muuli_wdr.cpp:3371
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1727 src/muuli_wdr.cpp:2897 src/muuli_wdr.cpp:3329
-#: src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1722 src/muuli_wdr.cpp:2893 src/muuli_wdr.cpp:3325
+#: src/muuli_wdr.cpp:3372
 msgid "Messages"
 msgstr "訊息"
 
-#: src/amuleDlg.cpp:1731 src/muuli_wdr.cpp:3376
+#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3372
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1733 src/muuli_wdr.cpp:3377 src/PrefsUnifiedDlg.cpp:311
+#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3373 src/PrefsUnifiedDlg.cpp:311
 #: src/Statistics.cpp:779 src/Statistics.cpp:1235
 msgid "Statistics"
 msgstr "統計"
 
-#: src/amuleDlg.cpp:1737 src/muuli_wdr.cpp:3377
+#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3373
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3379 src/PrefsUnifiedDlg.cpp:327
+#: src/amuleDlg.cpp:1735 src/muuli_wdr.cpp:3375 src/PrefsUnifiedDlg.cpp:327
 #: src/utils/wxCas/src/wxcasprefs.cpp:39
 msgid "Preferences"
 msgstr "偏好設定"
 
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3379
+#: src/amuleDlg.cpp:1739 src/muuli_wdr.cpp:3375
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1747 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1742 src/muuli_wdr.cpp:3376
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1751 src/muuli_wdr.cpp:3380
+#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:3376
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1754 src/muuli_wdr.cpp:3381
+#: src/amuleDlg.cpp:1749 src/muuli_wdr.cpp:3377
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:1952
+#: src/amuleDlg.cpp:1947
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:1955
+#: src/amuleDlg.cpp:1950
 msgid "No network"
 msgstr "無網路"
 
@@ -968,14 +968,14 @@ msgstr "無效連結或已在清單中。"
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 
-#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1839
-#: src/BaseClient.cpp:2443 src/BaseClient.cpp:2454 src/BaseClient.cpp:2727
+#: src/amule-remote-gui.cpp:2279 src/BaseClient.cpp:1830
+#: src/BaseClient.cpp:2434 src/BaseClient.cpp:2445 src/BaseClient.cpp:2718
 #: src/ClientDetailDialog.cpp:72 src/ClientDetailDialog.cpp:73
 #: src/ClientDetailDialog.cpp:103 src/ClientDetailDialog.cpp:104
 #: src/ClientDetailDialog.cpp:123 src/DataToText.cpp:61 src/DataToText.cpp:86
 #: src/DataToText.cpp:101 src/DataToText.cpp:136 src/DataToText.cpp:165
-#: src/DownloadListCtrl.cpp:1131 src/DownloadListCtrl.cpp:1144
-#: src/DownloadListCtrl.cpp:1155 src/ExternalConn.cpp:608
+#: src/DownloadListCtrl.cpp:1127 src/DownloadListCtrl.cpp:1140
+#: src/DownloadListCtrl.cpp:1151 src/ExternalConn.cpp:608
 #: src/FileDetailDialog.cpp:203 src/FileDetailDialog.cpp:235
 #: src/FileDetailDialog.cpp:242 src/GenericClientListCtrl.cpp:1171
 #: src/GenericClientListCtrl.cpp:1182 src/GenericClientListCtrl.cpp:1192
@@ -986,70 +986,70 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 msgid "Unknown"
 msgstr "不明"
 
-#: src/BaseClient.cpp:1384
+#: src/BaseClient.cpp:1375
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr "無法從使用者 %s 取得分享檔案清單"
 
-#: src/BaseClient.cpp:1636
+#: src/BaseClient.cpp:1627
 msgid "Searching buddy for lowid connection"
 msgstr "搜尋 LowID 連線好友"
 
-#: src/BaseClient.cpp:1856
+#: src/BaseClient.cpp:1847
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr " (假 eMule 版本 %#x)"
 
-#: src/BaseClient.cpp:1864
+#: src/BaseClient.cpp:1855
 msgid " (Fake eMule)"
 msgstr " (假 eMule)"
 
-#: src/BaseClient.cpp:1867
+#: src/BaseClient.cpp:1858
 msgid "xMule (Fake eMule)"
 msgstr "xMule (假 eMule)"
 
-#: src/BaseClient.cpp:1912
+#: src/BaseClient.cpp:1903
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (源自 eMule v0.%u)"
 
-#: src/BaseClient.cpp:2136
+#: src/BaseClient.cpp:2127
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr "暱稱：%s ID：%u"
 
-#: src/BaseClient.cpp:2138
+#: src/BaseClient.cpp:2129
 #, c-format
 msgid "Requested: %s\n"
 msgstr "已要求：%s\n"
 
-#: src/BaseClient.cpp:2140
+#: src/BaseClient.cpp:2131
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for this session: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "本次：共接受 %d/%d 個要求，已傳送 %s\n"
 
-#: src/BaseClient.cpp:2146
+#: src/BaseClient.cpp:2137
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural "Filestats for all sessions: Accepted %d of %d requests, %s transferred\n"
 msgstr[0] "總計：共接受 %d/%d 個要求，已傳送 %s\n"
 
-#: src/BaseClient.cpp:2152
+#: src/BaseClient.cpp:2143
 msgid "Requested unknown file"
 msgstr "已要求不明檔案"
 
-#: src/BaseClient.cpp:2829
+#: src/BaseClient.cpp:2820
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr "來自 %s (IP：%s) 的訊息被過濾掉了"
 
-#: src/BaseClient.cpp:2977
+#: src/BaseClient.cpp:2968
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr "來自 %s (IP:%s) 的新訊息"
 
-#: src/BaseClient.cpp:3069
+#: src/BaseClient.cpp:3060
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "使用者 %s (%u) 要求不存在的目錄 %s 的分享檔案清單 -> 已忽略"
@@ -1204,7 +1204,7 @@ msgid "Disconnected"
 msgstr "已中斷連線"
 
 #: src/ClientDetailDialog.cpp:151 src/ClientDetailDialog.cpp:155
-#: src/DownloadListCtrl.cpp:1008 src/GenericClientListCtrl.cpp:980
+#: src/DownloadListCtrl.cpp:1004 src/GenericClientListCtrl.cpp:980
 #: src/GenericClientListCtrl.cpp:991 src/SharedFilesCtrl.cpp:764
 #, c-format
 msgid "%.1f kB/s"
@@ -1357,19 +1357,19 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2253
+#: src/DataToText.cpp:47 src/DownloadListCtrl.cpp:698 src/muuli_wdr.cpp:2249
 #: src/ServerListCtrl.cpp:263 src/ServerListCtrl.cpp:456
 #: src/SharedFilesCtrl.cpp:144
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2254
+#: src/DataToText.cpp:49 src/DownloadListCtrl.cpp:699 src/muuli_wdr.cpp:2250
 #: src/ServerListCtrl.cpp:266 src/ServerListCtrl.cpp:457
 #: src/SharedFilesCtrl.cpp:145
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2255
+#: src/DataToText.cpp:51 src/DownloadListCtrl.cpp:700 src/muuli_wdr.cpp:2251
 #: src/ServerListCtrl.cpp:269 src/ServerListCtrl.cpp:458
 #: src/SharedFilesCtrl.cpp:146
 msgid "High"
@@ -1396,7 +1396,7 @@ msgid "Queue Full"
 msgstr "等候區已滿"
 
 #: src/DataToText.cpp:74 src/GenericClientListCtrl.cpp:1119
-#: src/KnownFile.cpp:1897 src/muuli_wdr.cpp:623
+#: src/KnownFile.cpp:1889 src/muuli_wdr.cpp:623
 msgid "On Queue"
 msgstr "等候中"
 
@@ -1461,7 +1461,7 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3150
+#: src/DataToText.cpp:152 src/muuli_wdr.cpp:217 src/muuli_wdr.cpp:3146
 #: src/SearchDlg.cpp:109 src/TextClient.cpp:911
 msgid "Kad"
 msgstr "Kad"
@@ -1533,7 +1533,7 @@ msgstr "部份"
 msgid "Size"
 msgstr "大小"
 
-#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3217
+#: src/DownloadListCtrl.cpp:160 src/muuli_wdr.cpp:3213
 msgid "Transferred"
 msgstr "已傳輸"
 
@@ -1590,7 +1590,7 @@ msgstr ""
 "%s (%s) 回覆訊息\n"
 "\n"
 
-#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2256
+#: src/DownloadListCtrl.cpp:701 src/muuli_wdr.cpp:2252
 #: src/SharedFilesCtrl.cpp:149
 msgid "Auto"
 msgstr "自動"
@@ -1665,34 +1665,34 @@ msgstr "分類"
 msgid "&Open the file"
 msgstr "開啟檔案(&O)"
 
-#: src/DownloadListCtrl.cpp:851 src/SharedFilesCtrl.cpp:872
+#: src/DownloadListCtrl.cpp:847 src/SharedFilesCtrl.cpp:872
 msgid "Enter new name for this file:"
 msgstr "請輸入新檔案名稱："
 
-#: src/DownloadListCtrl.cpp:852 src/SharedFilesCtrl.cpp:873
+#: src/DownloadListCtrl.cpp:848 src/SharedFilesCtrl.cpp:873
 msgid "File rename"
 msgstr "更改檔名"
 
-#: src/DownloadListCtrl.cpp:1006 src/GenericClientListCtrl.cpp:978
+#: src/DownloadListCtrl.cpp:1002 src/GenericClientListCtrl.cpp:978
 #: src/GenericClientListCtrl.cpp:989 src/SharedFilesCtrl.cpp:761
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f KB/s"
 
-#: src/DownloadListCtrl.cpp:1142 src/DownloadListCtrl.cpp:1153
+#: src/DownloadListCtrl.cpp:1138 src/DownloadListCtrl.cpp:1149
 msgid "%y/%m/%d %H:%M:%S"
 msgstr "%y/%m/%d %H:%M:%S"
 
-#: src/DownloadListCtrl.cpp:1295
+#: src/DownloadListCtrl.cpp:1291
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下載 (%i)"
 
-#: src/DownloadListCtrl.cpp:1460
+#: src/DownloadListCtrl.cpp:1456
 msgid "the default Windows shell handler"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:1466
+#: src/DownloadListCtrl.cpp:1462
 #, c-format
 msgid ""
 "To prevent this warning to show up in every preview,\n"
@@ -1701,11 +1701,11 @@ msgstr ""
 "請在偏好設定中設定影片播放器 (預設為 %s)，\n"
 "以避免這個警告訊息繼續出現。"
 
-#: src/DownloadListCtrl.cpp:1469
+#: src/DownloadListCtrl.cpp:1465
 msgid "File preview"
 msgstr "檔案預覽"
 
-#: src/DownloadListCtrl.cpp:1524
+#: src/DownloadListCtrl.cpp:1520
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "錯誤：無法執行媒體播放器！指令：「 %s 」"
@@ -2265,7 +2265,7 @@ msgstr "無法開啟好友清單檔案 emfriends.met 供寫入！"
 msgid "CRITICAL - no client on StartChatSession"
 msgstr "重大錯誤 - 開始交談時沒有客戶端"
 
-#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2646 src/muuli_wdr.cpp:3305
+#: src/FriendListCtrl.cpp:128 src/muuli_wdr.cpp:2642 src/muuli_wdr.cpp:3301
 msgid "Friends"
 msgstr "好友"
 
@@ -2602,57 +2602,57 @@ msgstr[0] "已寫入 %d 個 Kad 聯絡人"
 msgid "Kad user"
 msgstr "kad 網路"
 
-#: src/KnownFile.cpp:1542
+#: src/KnownFile.cpp:1534
 #, c-format
 msgid "Kad note search for '%s' not started: Kad is not connected"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1542
 #, c-format
 msgid "Kad note search for '%s' not started: a note lookup is already running for this file"
 msgstr ""
 
-#: src/KnownFile.cpp:1563
+#: src/KnownFile.cpp:1555
 #, c-format
 msgid "Kad note search for '%s' not started: file is not in the shared list, download queue or search results"
 msgstr ""
 
-#: src/KnownFile.cpp:1577
+#: src/KnownFile.cpp:1569
 #, c-format
 msgid "Kad note search for '%s' not started: another Kad search (e.g. a source search) is already using this file's hash - try again shortly"
 msgstr ""
 
-#: src/KnownFile.cpp:1586
+#: src/KnownFile.cpp:1578
 #, c-format
 msgid "Kad note search for '%s' not started: PrepareLookup failed"
 msgstr ""
 
-#: src/KnownFile.cpp:1888 src/PartFileConvertDlg.cpp:96
+#: src/KnownFile.cpp:1880 src/PartFileConvertDlg.cpp:96
 msgid "File name"
 msgstr "檔案名稱"
 
-#: src/KnownFile.cpp:1888
+#: src/KnownFile.cpp:1880
 msgid "File size"
 msgstr "檔案大小"
 
-#: src/KnownFile.cpp:1889
+#: src/KnownFile.cpp:1881
 msgid "Share ratio"
 msgstr "分享率"
 
-#: src/KnownFile.cpp:1892 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1884 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/KnownFile.cpp:1893 src/muuli_wdr.cpp:3201
+#: src/KnownFile.cpp:1885 src/muuli_wdr.cpp:3197
 msgid "Requested"
 msgstr "已要求"
 
-#: src/KnownFile.cpp:1895
+#: src/KnownFile.cpp:1887
 msgid "Accepted"
 msgstr "已接受"
 
-#: src/KnownFile.cpp:1897
+#: src/KnownFile.cpp:1889
 msgid "Complete sources"
 msgstr "完整來源"
 
@@ -2768,7 +2768,7 @@ msgid "WARNING: "
 msgstr "警告："
 
 #: src/MuleNotebook.cpp:179 src/muuli_wdr.cpp:813 src/muuli_wdr.cpp:1225
-#: src/muuli_wdr.cpp:3105 src/muuli_wdr.cpp:3345
+#: src/muuli_wdr.cpp:3101 src/muuli_wdr.cpp:3341
 msgid "Close"
 msgstr "關閉"
 
@@ -2786,7 +2786,7 @@ msgid "Paste"
 msgstr "貼上"
 
 #: src/MuleTextCtrl.cpp:89 src/muuli_wdr.cpp:358 src/muuli_wdr.cpp:753
-#: src/muuli_wdr.cpp:2330 src/muuli_wdr.cpp:2349 src/muuli_wdr.cpp:2371
+#: src/muuli_wdr.cpp:2326 src/muuli_wdr.cpp:2345 src/muuli_wdr.cpp:2367
 #: src/utils/aLinkCreator/src/alcframe.cpp:142
 msgid "Clear"
 msgstr "清除"
@@ -3207,8 +3207,8 @@ msgstr "檔案來源："
 #: src/muuli_wdr.cpp:1156 src/muuli_wdr.cpp:1163 src/muuli_wdr.cpp:1168
 #: src/muuli_wdr.cpp:1175 src/muuli_wdr.cpp:1180 src/muuli_wdr.cpp:1187
 #: src/muuli_wdr.cpp:1201 src/muuli_wdr.cpp:1208 src/muuli_wdr.cpp:1213
-#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3203 src/muuli_wdr.cpp:3211
-#: src/muuli_wdr.cpp:3219
+#: src/muuli_wdr.cpp:1220 src/muuli_wdr.cpp:3199 src/muuli_wdr.cpp:3207
+#: src/muuli_wdr.cpp:3215
 msgid "N/A"
 msgstr "N/A"
 
@@ -3353,7 +3353,7 @@ msgstr ""
 msgid "Album :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2225
+#: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:2221
 msgid "Title :"
 msgstr "標題："
 
@@ -3462,7 +3462,7 @@ msgstr "使用者名稱︰"
 msgid "Userhash :"
 msgstr "使用者 hash 值："
 
-#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2420
+#: src/muuli_wdr.cpp:891 src/muuli_wdr.cpp:1720 src/muuli_wdr.cpp:2416
 #: src/utils/aLinkCreator/src/alcframe.cpp:137
 msgid "Add"
 msgstr "加入"
@@ -3471,15 +3471,15 @@ msgstr "加入"
 msgid "Download-Speed"
 msgstr "下載速度"
 
-#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2524
+#: src/muuli_wdr.cpp:950 src/muuli_wdr.cpp:985 src/muuli_wdr.cpp:2520
 msgid "Current"
 msgstr "目前"
 
-#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:958 src/muuli_wdr.cpp:993 src/muuli_wdr.cpp:2528
 msgid "Running average"
 msgstr "執行中平均值"
 
-#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2540
+#: src/muuli_wdr.cpp:966 src/muuli_wdr.cpp:1001 src/muuli_wdr.cpp:2536
 msgid "Session average"
 msgstr "本次平均值"
 
@@ -3719,7 +3719,7 @@ msgid "Enter your browser name here. Leave this field empty to use the system de
 msgstr "請輸入瀏覽器的名稱，空白則使用系統預設。"
 
 #: src/muuli_wdr.cpp:1331 src/muuli_wdr.cpp:1348 src/muuli_wdr.cpp:1655
-#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:1686 src/muuli_wdr.cpp:1698 src/muuli_wdr.cpp:2736
 #: src/utils/aLinkCreator/src/alcframe.cpp:135
 #: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
 msgid "Browse"
@@ -3793,7 +3793,7 @@ msgstr "選定本機使用 IP (留白或輸入)："
 msgid "Advanced users only: If you have multiple network interfaces, enter the address of the interface to which aMule should be bound."
 msgstr "進階使用者用：如果您有多網路介面，請輸入要給 aMule 使用的的網路位址。"
 
-#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2037
+#: src/muuli_wdr.cpp:1444 src/muuli_wdr.cpp:2033
 #, fuzzy
 msgid "Bind to network interface (empty for any):"
 msgstr "選定本機使用 IP (留白或輸入)："
@@ -3814,7 +3814,7 @@ msgstr "最大同時連線數："
 msgid "Kademlia"
 msgstr "Kad"
 
-#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3145
+#: src/muuli_wdr.cpp:1480 src/muuli_wdr.cpp:3141
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4134,7 +4134,7 @@ msgstr "執行中 Kad 節點"
 msgid "Kad-nodes session"
 msgstr "本次 Kad 節點"
 
-#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2274
+#: src/muuli_wdr.cpp:1848 src/muuli_wdr.cpp:2270
 msgid "Select"
 msgstr "選取"
 
@@ -4252,421 +4252,413 @@ msgstr "扁平"
 msgid "Round"
 msgstr "圓弧"
 
-#: src/muuli_wdr.cpp:2002
-msgid "Auto-sort files (high CPU)"
-msgstr "自動排序檔案 (耗系統資源)"
-
-#: src/muuli_wdr.cpp:2004
-msgid "aMule will sort the columns in your download list automatically"
-msgstr "aMule 將自動對下載清單進行排序"
-
-#: src/muuli_wdr.cpp:2021
+#: src/muuli_wdr.cpp:2017
 msgid "External Connection Parameters"
 msgstr "外部連線參數"
 
-#: src/muuli_wdr.cpp:2024
+#: src/muuli_wdr.cpp:2020
 msgid "Accept external connections"
 msgstr "接受外部連線"
 
-#: src/muuli_wdr.cpp:2031 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2027 src/muuli_wdr.cpp:2086
 msgid "IP of the listening interface:"
 msgstr "監聽 IP："
 
-#: src/muuli_wdr.cpp:2034
+#: src/muuli_wdr.cpp:2030
 msgid "Enter here a valid ip in the a.b.c.d format for the listening EC interface. An empty field or 0.0.0.0 will mean any interface."
 msgstr "輸入要監聽外部連線的的 IP (格式：a.b.c.d)，空白或 0.0.0.0 表示全部。"
 
-#: src/muuli_wdr.cpp:2055 src/muuli_wdr.cpp:2134
+#: src/muuli_wdr.cpp:2051 src/muuli_wdr.cpp:2130
 msgid "TCP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2061
+#: src/muuli_wdr.cpp:2057
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr "外部連線通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2065 src/muuli_wdr.cpp:3017
+#: src/muuli_wdr.cpp:2061 src/muuli_wdr.cpp:3013
 #: src/utils/wxCas/src/wxcasprefs.cpp:167
 msgid "Password"
 msgstr "密碼"
 
-#: src/muuli_wdr.cpp:2071
+#: src/muuli_wdr.cpp:2067
 #, fuzzy
 msgid "aMule API server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2074
+#: src/muuli_wdr.cpp:2070
 msgid "Run amuleapi (REST API) on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2079
+#: src/muuli_wdr.cpp:2075
 #, fuzzy
 msgid "HTTP port:"
 msgstr "TCP 埠："
 
-#: src/muuli_wdr.cpp:2093
+#: src/muuli_wdr.cpp:2089
 msgid "The interface amuleapi's HTTP server listens on. 127.0.0.1 (default) accepts only local connections; use 0.0.0.0 or a specific IP to expose it to other hosts (set an admin password below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2096
+#: src/muuli_wdr.cpp:2092
 #, fuzzy
 msgid "Admin password"
 msgstr "正在檢查密碼\n"
 
-#: src/muuli_wdr.cpp:2104
+#: src/muuli_wdr.cpp:2100
 msgid "Web server parameters"
 msgstr "網站伺服器參數"
 
-#: src/muuli_wdr.cpp:2107
+#: src/muuli_wdr.cpp:2103
 #, fuzzy
 msgid "Run webserver on startup (deprecated)"
 msgstr "啟動時執行網站伺服器"
 
-#: src/muuli_wdr.cpp:2113
+#: src/muuli_wdr.cpp:2109
 msgid "Web template"
 msgstr "網頁模板"
 
-#: src/muuli_wdr.cpp:2118
+#: src/muuli_wdr.cpp:2114
 msgid "Full rights password"
 msgstr "絕對權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2122
+#: src/muuli_wdr.cpp:2118
 msgid "Enable Low rights User"
 msgstr "啟用低權限使用者"
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2123
 msgid "Low rights password"
 msgstr "低權限使用者密碼"
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2137
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr "網站伺服器的通訊埠啟用 UPnP 通訊埠轉向"
 
-#: src/muuli_wdr.cpp:2146
+#: src/muuli_wdr.cpp:2142
 msgid "Web server UPnP TCP port (Optional)"
 msgstr "網站伺服器的 UPnP TCP 埠 (選用)"
 
-#: src/muuli_wdr.cpp:2154
+#: src/muuli_wdr.cpp:2150
 msgid "Page Refresh Time (in secs)"
 msgstr "頁面更新時間 (秒)"
 
-#: src/muuli_wdr.cpp:2161
+#: src/muuli_wdr.cpp:2157
 msgid "Enable Gzip compression"
 msgstr "啟用 Gzip 壓縮"
 
-#: src/muuli_wdr.cpp:2195
+#: src/muuli_wdr.cpp:2191
 #, fuzzy
 msgid "Reset page to defaults"
 msgstr "系統預設"
 
-#: src/muuli_wdr.cpp:2196
+#: src/muuli_wdr.cpp:2192
 msgid "Reset the settings on the current page to their default values."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2198 src/muuli_wdr.cpp:2284 src/ServerWnd.cpp:259
+#: src/muuli_wdr.cpp:2194 src/muuli_wdr.cpp:2280 src/ServerWnd.cpp:259
 #: src/ServerWnd.cpp:267
 msgid "OK"
 msgstr "OK"
 
-#: src/muuli_wdr.cpp:2200
+#: src/muuli_wdr.cpp:2196
 msgid "Click here to apply any changes made to the preferences."
 msgstr "點選這裏立即套用已變更的偏好設定。"
 
-#: src/muuli_wdr.cpp:2203
+#: src/muuli_wdr.cpp:2199
 msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
-#: src/muuli_wdr.cpp:2232
+#: src/muuli_wdr.cpp:2228
 msgid "Comment :"
 msgstr "註解："
 
-#: src/muuli_wdr.cpp:2239
+#: src/muuli_wdr.cpp:2235
 msgid "Incoming Dir :"
 msgstr "新進檔目錄："
 
-#: src/muuli_wdr.cpp:2248
+#: src/muuli_wdr.cpp:2244
 msgid "Change priority for new assigned files :"
 msgstr "設定新加入的檔案優先等級為："
 
-#: src/muuli_wdr.cpp:2252
+#: src/muuli_wdr.cpp:2248
 msgid "Don't change"
 msgstr "不要變更"
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2260
 msgid "Select color for this Category (currently selected) :"
 msgstr "選取該分類的顏色 (目前選擇)："
 
-#: src/muuli_wdr.cpp:2331 src/muuli_wdr.cpp:2350 src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2327 src/muuli_wdr.cpp:2346 src/muuli_wdr.cpp:2368
 msgid "Click this button to reset the log."
 msgstr "點選這個按鈕來清除記錄。"
 
-#: src/muuli_wdr.cpp:2391
+#: src/muuli_wdr.cpp:2387
 msgid "Click on this button to update the servers list from URL ..."
 msgstr "點選這個按鈕從該網址更新伺服器清單 ..."
 
-#: src/muuli_wdr.cpp:2395
+#: src/muuli_wdr.cpp:2391
 msgid "Server list"
 msgstr "伺服器清單"
 
-#: src/muuli_wdr.cpp:2399
+#: src/muuli_wdr.cpp:2395
 msgid "Enter the url to a server.met file here and press the button to the left to update the list of known servers."
 msgstr "輸入 server.met 檔案的網址並按下左邊的按鈕以更新已知伺服器清單。"
 
-#: src/muuli_wdr.cpp:2404
+#: src/muuli_wdr.cpp:2400
 msgid "Add server manually: Name"
 msgstr "手動加入伺服器：名稱"
 
-#: src/muuli_wdr.cpp:2407
+#: src/muuli_wdr.cpp:2403
 msgid "Enter the name of the new server here"
 msgstr "輸入新伺服器的名稱"
 
-#: src/muuli_wdr.cpp:2409 src/ServerWnd.cpp:206
+#: src/muuli_wdr.cpp:2405 src/ServerWnd.cpp:206
 msgid "IP:Port"
 msgstr "IP:Port"
 
-#: src/muuli_wdr.cpp:2412
+#: src/muuli_wdr.cpp:2408
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
-#: src/muuli_wdr.cpp:2418
+#: src/muuli_wdr.cpp:2414
 msgid "Enter the port of the server here."
 msgstr "輸入伺服器的通訊埠。"
 
-#: src/muuli_wdr.cpp:2421
+#: src/muuli_wdr.cpp:2417
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr "手動加入伺服器 (填入左側空格中) ..."
 
-#: src/muuli_wdr.cpp:2450
+#: src/muuli_wdr.cpp:2446
 msgid "aMule Log"
 msgstr "aMule 記錄"
 
-#: src/muuli_wdr.cpp:2458
+#: src/muuli_wdr.cpp:2454
 msgid "Server Info"
 msgstr "伺服器資訊"
 
-#: src/muuli_wdr.cpp:2462
+#: src/muuli_wdr.cpp:2458
 msgid "ED2K Info"
 msgstr "eD2k 資訊"
 
-#: src/muuli_wdr.cpp:2466
+#: src/muuli_wdr.cpp:2462
 msgid "Kad Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp:2494
+#: src/muuli_wdr.cpp:2490
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr "點選這個按鈕來從該網址更新節點清單 ..."
 
-#: src/muuli_wdr.cpp:2498
+#: src/muuli_wdr.cpp:2494
 msgid "Nodes (0)"
 msgstr "節點 (0)"
 
-#: src/muuli_wdr.cpp:2502
+#: src/muuli_wdr.cpp:2498
 msgid "Enter the url to a nodes.dat file here and press the button to the left to update the list of known nodes."
 msgstr "輸入 nodes.dat 檔案的網址，並按下左邊的按鈕以更新已知節點清單。"
 
-#: src/muuli_wdr.cpp:2505
+#: src/muuli_wdr.cpp:2501
 msgid "Nodes stats"
 msgstr "節點狀態"
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2543
 msgid "Bootstrap"
 msgstr "啓動"
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2546
 msgid "New node"
 msgstr "新節點"
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2551
 msgid "IP:"
 msgstr "IP："
 
-#: src/muuli_wdr.cpp:2575
+#: src/muuli_wdr.cpp:2571
 msgid "Port:"
 msgstr "埠："
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2584
 msgid "Bootstrap from known clients"
 msgstr "從已知客戶端啓動"
 
-#: src/muuli_wdr.cpp:2590
+#: src/muuli_wdr.cpp:2586
 msgid "Disconnect Kad"
 msgstr "中斷 Kad 連線"
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2620
 msgid "Use Secure User Identification"
 msgstr "啟用使用者安全認證"
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2622
 msgid "It is recommended to enable this option. You will not receive credits if SUI is not enabled."
 msgstr "建議啟用此選項。如果使用者安全認證未啟用，將會得不到積分。"
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2624
 msgid "Protocol Obfuscation"
 msgstr "模糊協定"
 
-#: src/muuli_wdr.cpp:2631
+#: src/muuli_wdr.cpp:2627
 msgid "Support Protocol Obfuscation"
 msgstr "支援模糊協定"
 
-#: src/muuli_wdr.cpp:2633
+#: src/muuli_wdr.cpp:2629
 msgid "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated connections from other clients."
 msgstr "啓用模糊協定，可讓 aMule 接受來自其他客戶端的模糊連線。"
 
-#: src/muuli_wdr.cpp:2635
+#: src/muuli_wdr.cpp:2631
 msgid "Use obfuscation for outgoing connections"
 msgstr "對外的連線使用模糊協定"
 
-#: src/muuli_wdr.cpp:2637
+#: src/muuli_wdr.cpp:2633
 msgid "This option makes aMule use Protocol Obfuscation when connecting other clients/servers."
 msgstr "使 aMule 在與其他客戶端或伺服器連線時使用模糊協定。"
 
-#: src/muuli_wdr.cpp:2639
+#: src/muuli_wdr.cpp:2635
 msgid "Accept only obfuscated connections"
 msgstr "只接受模糊連線"
 
-#: src/muuli_wdr.cpp:2640
+#: src/muuli_wdr.cpp:2636
 msgid "This option makes aMule only accept obfuscated connections. You will have less sources, but all your traffic will be obfuscated"
 msgstr "讓 aMule 只接受模糊協定，檔案來源會比較少，但所有傳輸都將是模糊連線"
 
-#: src/muuli_wdr.cpp:2645
+#: src/muuli_wdr.cpp:2641
 msgid "Everybody"
 msgstr "任何人"
 
-#: src/muuli_wdr.cpp:2647
+#: src/muuli_wdr.cpp:2643
 msgid "No one"
 msgstr "無"
 
-#: src/muuli_wdr.cpp:2649
+#: src/muuli_wdr.cpp:2645
 msgid "Who can see my shared files:"
 msgstr "誰可以看我的分享檔案："
 
-#: src/muuli_wdr.cpp:2650
+#: src/muuli_wdr.cpp:2646
 msgid "Select who can request to view a list of your shared files."
 msgstr "選取可以瀏覽分享檔案清單的使用者。"
 
-#: src/muuli_wdr.cpp:2652
+#: src/muuli_wdr.cpp:2648
 msgid "IP-Filtering"
 msgstr "IP 過濾"
 
-#: src/muuli_wdr.cpp:2659
+#: src/muuli_wdr.cpp:2655
 msgid "Filter clients"
 msgstr "過濾客戶端"
 
-#: src/muuli_wdr.cpp:2661
+#: src/muuli_wdr.cpp:2657
 msgid "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的客戶端 IP"
 
-#: src/muuli_wdr.cpp:2663
+#: src/muuli_wdr.cpp:2659
 msgid "Filter servers"
 msgstr "過濾伺服器"
 
-#: src/muuli_wdr.cpp:2665
+#: src/muuli_wdr.cpp:2661
 msgid "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr "過濾列在 ~/.aMule/ipfilter.dat 檔案中的伺服器 IP 。"
 
-#: src/muuli_wdr.cpp:2669
+#: src/muuli_wdr.cpp:2665
 msgid "Reload List"
 msgstr "重載入清單"
 
-#: src/muuli_wdr.cpp:2670
+#: src/muuli_wdr.cpp:2666
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr "重新載入 IP 過濾清單 ~/.aMule/ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2676
+#: src/muuli_wdr.cpp:2672
 msgid "URL:"
 msgstr "網址："
 
-#: src/muuli_wdr.cpp:2680 src/muuli_wdr.cpp:2873
+#: src/muuli_wdr.cpp:2676 src/muuli_wdr.cpp:2869
 msgid "Update now"
 msgstr "立即更新"
 
-#: src/muuli_wdr.cpp:2683
+#: src/muuli_wdr.cpp:2679
 msgid "Auto-update ipfilter at startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2687
+#: src/muuli_wdr.cpp:2683
 msgid "Filtering Level:"
 msgstr "過濾等級："
 
-#: src/muuli_wdr.cpp:2693
+#: src/muuli_wdr.cpp:2689
 msgid "Always filter LAN IPs"
 msgstr "永遠過濾區域網路 IP"
 
-#: src/muuli_wdr.cpp:2696
+#: src/muuli_wdr.cpp:2692
 msgid "Paranoid handling of non-matching IPs"
 msgstr "處理不匹配的 IP"
 
-#: src/muuli_wdr.cpp:2698
+#: src/muuli_wdr.cpp:2694
 msgid "Rejects a packet when its source IP differs from the IP the client claims (an anti-spoofing check). Disable only if it causes connection problems."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2700
+#: src/muuli_wdr.cpp:2696
 msgid "Use system-wide ipfilter.dat if available"
 msgstr "如果可以則使用系統級的 ipfilter.dat"
 
-#: src/muuli_wdr.cpp:2701
+#: src/muuli_wdr.cpp:2697
 #, fuzzy
 msgid "If there's no local ipfilter.dat found, allow usage of a system-wide ipfilter file."
 msgstr "如果找不到本機 ipfilter.dat 檔案，則允許使用系統級的 IP 過濾檔。"
 
-#: src/muuli_wdr.cpp:2718
+#: src/muuli_wdr.cpp:2714
 msgid "Enable Online-Signature"
 msgstr "啟用線上簽名識別"
 
-#: src/muuli_wdr.cpp:2720
+#: src/muuli_wdr.cpp:2716
 msgid "Enables the writing of the OS file, which can be used by external apps to create signatures and the like."
 msgstr "啟用寫入到作業系統檔案，以讓外部程式用來建立簽名識別等等。"
 
-#: src/muuli_wdr.cpp:2724
+#: src/muuli_wdr.cpp:2720
 msgid "Update Frequency (Secs):"
 msgstr "更新頻率(秒)："
 
-#: src/muuli_wdr.cpp:2727
+#: src/muuli_wdr.cpp:2723
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr "變更線上簽名識別檔的更新頻率 (單位為 秒)。"
 
-#: src/muuli_wdr.cpp:2735
+#: src/muuli_wdr.cpp:2731
 msgid "Save online signature file in: "
 msgstr "儲存線上簽名識別檔："
 
-#: src/muuli_wdr.cpp:2741
+#: src/muuli_wdr.cpp:2737
 msgid "Click here to select the directory containing the the Online Signature files."
 msgstr "點擊選取線上簽識別名檔案所在的目錄。"
 
-#: src/muuli_wdr.cpp:2774
+#: src/muuli_wdr.cpp:2770
 msgid "Show country flags for clients"
 msgstr "顯示客戶端的國旗"
 
-#: src/muuli_wdr.cpp:2775
+#: src/muuli_wdr.cpp:2771
 msgid "Render the country flag column in the transfers, queue and search views. Requires a valid MMDB GeoIP database (see below)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2780
+#: src/muuli_wdr.cpp:2776
 #, fuzzy
 msgid "Database"
 msgstr "速度："
 
-#: src/muuli_wdr.cpp:2796
+#: src/muuli_wdr.cpp:2792
 #, fuzzy
 msgid "Source:"
 msgstr "來源"
 
-#: src/muuli_wdr.cpp:2799
+#: src/muuli_wdr.cpp:2795
 msgid "DB-IP (free, no account)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2800
+#: src/muuli_wdr.cpp:2796
 msgid "MaxMind GeoLite2 (free, account required)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2801
+#: src/muuli_wdr.cpp:2797
 msgid "Custom URL"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2804
+#: src/muuli_wdr.cpp:2800
 msgid "Choose which provider supplies the GeoIP MMDB database. DB-IP is the default - no account required. MaxMind requires a free account + license key. Use Custom URL to point at any other MMDB host (e.g. a local mirror)."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2821
+#: src/muuli_wdr.cpp:2817
 msgid ""
 "No configuration required.\n"
 "\n"
@@ -4674,11 +4666,11 @@ msgid ""
 "License: Creative Commons BY 4.0 - https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2834
+#: src/muuli_wdr.cpp:2830
 msgid "License key:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2836
 msgid ""
 "Sign up for a free MaxMind account, then generate a License Key:\n"
 "https://www.maxmind.com/en/geolite2/signup\n"
@@ -4688,226 +4680,226 @@ msgid ""
 "Requires attribution and account registration; refresh at least every 30 days."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2855
+#: src/muuli_wdr.cpp:2851
 #, fuzzy
 msgid "Download URL:"
 msgstr "下載："
 
-#: src/muuli_wdr.cpp:2861
+#: src/muuli_wdr.cpp:2857
 msgid ""
 "Must point to an .mmdb file or a .gz / .tar.gz containing one.\n"
 "URL may include credentials (https://user:pass@host/...).\n"
 "License and attribution terms are set by the upstream URL - you are responsible."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2874
+#: src/muuli_wdr.cpp:2870
 msgid "Download the GeoIP database from the selected source."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2876
+#: src/muuli_wdr.cpp:2872
 #, fuzzy
 msgid "Auto-update on startup"
 msgstr "啓動後自動更新 IP 過濾清單"
 
-#: src/muuli_wdr.cpp:2877
+#: src/muuli_wdr.cpp:2873
 msgid "Re-download the GeoIP database from the selected source every time aMule starts."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2900
+#: src/muuli_wdr.cpp:2896
 msgid "Filter incoming messages (except current chat):"
 msgstr "過濾收到的訊息 (不包含目前交談)："
 
-#: src/muuli_wdr.cpp:2902
+#: src/muuli_wdr.cpp:2898
 msgid "Filter all messages"
 msgstr "過濾所有訊息"
 
-#: src/muuli_wdr.cpp:2904
+#: src/muuli_wdr.cpp:2900
 msgid "Filter messages from people not on your friend list"
 msgstr "過濾來自好友以外的訊息"
 
-#: src/muuli_wdr.cpp:2906
+#: src/muuli_wdr.cpp:2902
 msgid "Filter messages from unknown clients"
 msgstr "過濾來自不明客戶端的訊息"
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2904
 msgid "Filter messages containing (use ',' as separator):"
 msgstr "過濾含以下內容的訊息 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2911 src/muuli_wdr.cpp:2922
+#: src/muuli_wdr.cpp:2907 src/muuli_wdr.cpp:2918
 msgid "add here the words amule should filter and block messages including it"
 msgstr "輸入要過濾的詞句"
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2909
 msgid "Show received messages in the log"
 msgstr "記錄收到的訊息"
 
-#: src/muuli_wdr.cpp:2916
+#: src/muuli_wdr.cpp:2912
 msgid "Comments"
 msgstr "註解"
 
-#: src/muuli_wdr.cpp:2919
+#: src/muuli_wdr.cpp:2915
 msgid "Filter comments containing (use ',' as separator):"
 msgstr "過濾含以下內容的註解 (用逗號 ',' 隔開)："
 
-#: src/muuli_wdr.cpp:2942
+#: src/muuli_wdr.cpp:2938
 msgid "Enable authentication"
 msgstr "啓用登入驗證"
 
-#: src/muuli_wdr.cpp:2943
+#: src/muuli_wdr.cpp:2939
 msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
-#: src/muuli_wdr.cpp:2946
+#: src/muuli_wdr.cpp:2942
 msgid "Username: "
 msgstr "使用者名稱："
 
-#: src/muuli_wdr.cpp:2949
+#: src/muuli_wdr.cpp:2945
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
 
-#: src/muuli_wdr.cpp:2951
+#: src/muuli_wdr.cpp:2947
 msgid "Password:"
 msgstr "密碼："
 
-#: src/muuli_wdr.cpp:2954
+#: src/muuli_wdr.cpp:2950
 msgid "The password to use to connect to the proxy"
 msgstr "登入代理伺服器的密碼"
 
-#: src/muuli_wdr.cpp:2956
+#: src/muuli_wdr.cpp:2952
 msgid "Enable Proxy"
 msgstr "啓用代理伺服器"
 
-#: src/muuli_wdr.cpp:2957
+#: src/muuli_wdr.cpp:2953
 msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
-#: src/muuli_wdr.cpp:2960
+#: src/muuli_wdr.cpp:2956
 msgid "Proxy type:"
 msgstr "類型："
 
-#: src/muuli_wdr.cpp:2971
+#: src/muuli_wdr.cpp:2967
 msgid "Proxy host:"
 msgstr "主機："
 
-#: src/muuli_wdr.cpp:2974
+#: src/muuli_wdr.cpp:2970
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
-#: src/muuli_wdr.cpp:2976
+#: src/muuli_wdr.cpp:2972
 msgid "Proxy port:"
 msgstr "連接埠："
 
-#: src/muuli_wdr.cpp:2979
+#: src/muuli_wdr.cpp:2975
 msgid "The proxy port"
 msgstr "代理伺服器連接埠"
 
-#: src/muuli_wdr.cpp:2998
+#: src/muuli_wdr.cpp:2994
 msgid "Connect to:"
 msgstr "連線到："
 
-#: src/muuli_wdr.cpp:3007
+#: src/muuli_wdr.cpp:3003
 msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
-#: src/muuli_wdr.cpp:3012
+#: src/muuli_wdr.cpp:3008
 msgid "User name"
 msgstr "使用者名稱"
 
-#: src/muuli_wdr.cpp:3023
+#: src/muuli_wdr.cpp:3019
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
-#: src/muuli_wdr.cpp:3026
+#: src/muuli_wdr.cpp:3022
 #, fuzzy
 msgid "Force ZLIB compression"
 msgstr "使用 gzip 壓縮"
 
-#: src/muuli_wdr.cpp:3050
+#: src/muuli_wdr.cpp:3046
 msgid "Enable Verbose Debug-Logging."
 msgstr "啓用記錄詳細除錯訊息。"
 
-#: src/muuli_wdr.cpp:3052
+#: src/muuli_wdr.cpp:3048
 #, fuzzy
 msgid "Only to Logfile"
 msgstr "開啟檔案(&O)"
 
-#: src/muuli_wdr.cpp:3054
+#: src/muuli_wdr.cpp:3050
 msgid "Message Categories:"
 msgstr "訊息分類："
 
-#: src/muuli_wdr.cpp:3078 src/PartFileConvertDlg.cpp:160
+#: src/muuli_wdr.cpp:3074 src/PartFileConvertDlg.cpp:160
 msgid "Waiting..."
 msgstr "等候中..."
 
-#: src/muuli_wdr.cpp:3098
+#: src/muuli_wdr.cpp:3094
 msgid "Add imports"
 msgstr "加入"
 
-#: src/muuli_wdr.cpp:3101
+#: src/muuli_wdr.cpp:3097
 msgid "Retry selected"
 msgstr "重試"
 
-#: src/muuli_wdr.cpp:3103
+#: src/muuli_wdr.cpp:3099
 msgid "Remove selected"
 msgstr "移除"
 
-#: src/muuli_wdr.cpp:3166
+#: src/muuli_wdr.cpp:3162
 msgid "Event Types"
 msgstr "事件種類"
 
-#: src/muuli_wdr.cpp:3185
+#: src/muuli_wdr.cpp:3181
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr "已選取的檔案的統計資料與等候區客戶端數：本次 / 總計"
 
-#: src/muuli_wdr.cpp:3209
+#: src/muuli_wdr.cpp:3205
 msgid "Active Uploads"
 msgstr "目前上傳數"
 
-#: src/muuli_wdr.cpp:3223
+#: src/muuli_wdr.cpp:3219
 msgid "Percent of total files"
 msgstr "% (所有檔案中)"
 
-#: src/muuli_wdr.cpp:3263
+#: src/muuli_wdr.cpp:3259
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
-#: src/muuli_wdr.cpp:3265
+#: src/muuli_wdr.cpp:3261
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/muuli_wdr.cpp:3268
+#: src/muuli_wdr.cpp:3264
 msgid "Selected files"
 msgstr "選取的檔案"
 
-#: src/muuli_wdr.cpp:3271
+#: src/muuli_wdr.cpp:3267
 msgid "Active uploads only"
 msgstr "僅限目前上傳中"
 
-#: src/muuli_wdr.cpp:3275
+#: src/muuli_wdr.cpp:3271
 msgid "Reload:"
 msgstr "重新載入："
 
-#: src/muuli_wdr.cpp:3279
+#: src/muuli_wdr.cpp:3275
 msgid "Reload your shared files"
 msgstr "重新載入分享的檔案"
 
-#: src/muuli_wdr.cpp:3341
+#: src/muuli_wdr.cpp:3337
 msgid "Send"
 msgstr "傳送"
 
-#: src/muuli_wdr.cpp:3342
+#: src/muuli_wdr.cpp:3338
 msgid "Sends the specified message."
 msgstr "傳送訊息。"
 
-#: src/muuli_wdr.cpp:3346
+#: src/muuli_wdr.cpp:3342
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp:3369
+#: src/muuli_wdr.cpp:3365
 msgid "Connect to any server and/or Kad"
 msgstr "連線到任何伺服器 和/或 Kad 網路"
 
-#: src/muuli_wdr.cpp:3375 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
+#: src/muuli_wdr.cpp:3371 src/SharedFilesCtrl.cpp:141 src/Statistics.cpp:941
 msgid "Shared Files"
 msgstr "分享檔案"
 
@@ -5262,188 +5254,188 @@ msgstr "已下載"
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
-#: src/Preferences.cpp:674
+#: src/Preferences.cpp:672
 msgid "System default"
 msgstr "系統預設"
 
-#: src/Preferences.cpp:675
+#: src/Preferences.cpp:673
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
-#: src/Preferences.cpp:676
+#: src/Preferences.cpp:674
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: src/Preferences.cpp:677
+#: src/Preferences.cpp:675
 msgid "Asturian"
 msgstr "奧地利語"
 
-#: src/Preferences.cpp:678
+#: src/Preferences.cpp:676
 msgid "Basque"
 msgstr "巴斯克語"
 
-#: src/Preferences.cpp:679
+#: src/Preferences.cpp:677
 msgid "Bulgarian"
 msgstr "保加利亞語"
 
-#: src/Preferences.cpp:680
+#: src/Preferences.cpp:678
 msgid "Catalan"
 msgstr "加泰隆尼亞語"
 
-#: src/Preferences.cpp:681
+#: src/Preferences.cpp:679
 msgid "Chinese (Simplified)"
 msgstr "簡體中文"
 
-#: src/Preferences.cpp:682
+#: src/Preferences.cpp:680
 msgid "Chinese (Traditional)"
 msgstr "正體中文"
 
-#: src/Preferences.cpp:683
+#: src/Preferences.cpp:681
 msgid "Croatian"
 msgstr "克羅埃西亞語"
 
-#: src/Preferences.cpp:684
+#: src/Preferences.cpp:682
 msgid "Czech"
 msgstr "捷克語"
 
-#: src/Preferences.cpp:685
+#: src/Preferences.cpp:683
 msgid "Danish"
 msgstr "丹麥語"
 
-#: src/Preferences.cpp:686
+#: src/Preferences.cpp:684
 msgid "Dutch"
 msgstr "荷蘭語"
 
-#: src/Preferences.cpp:687
+#: src/Preferences.cpp:685
 msgid "English (U.K.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:688
+#: src/Preferences.cpp:686
 #, fuzzy
 msgid "English (U.S.)"
 msgstr "英語 (英國)"
 
-#: src/Preferences.cpp:689
+#: src/Preferences.cpp:687
 msgid "Estonian"
 msgstr "愛沙尼亞語"
 
-#: src/Preferences.cpp:690
+#: src/Preferences.cpp:688
 msgid "Finnish"
 msgstr "芬蘭語"
 
-#: src/Preferences.cpp:691
+#: src/Preferences.cpp:689
 msgid "French"
 msgstr "法語"
 
-#: src/Preferences.cpp:692
+#: src/Preferences.cpp:690
 msgid "Galician"
 msgstr "加利西亞語"
 
-#: src/Preferences.cpp:693
+#: src/Preferences.cpp:691
 msgid "German"
 msgstr "德語"
 
-#: src/Preferences.cpp:694
+#: src/Preferences.cpp:692
 msgid "Greek"
 msgstr "希臘語"
 
-#: src/Preferences.cpp:695
+#: src/Preferences.cpp:693
 msgid "Hebrew"
 msgstr "希伯來語"
 
-#: src/Preferences.cpp:696
+#: src/Preferences.cpp:694
 msgid "Hungarian"
 msgstr "匈牙利語"
 
-#: src/Preferences.cpp:697
+#: src/Preferences.cpp:695
 msgid "Italian"
 msgstr "義大利語"
 
-#: src/Preferences.cpp:698
+#: src/Preferences.cpp:696
 msgid "Japanese"
 msgstr "日語"
 
-#: src/Preferences.cpp:699
+#: src/Preferences.cpp:697
 msgid "Korean"
 msgstr "韓語"
 
-#: src/Preferences.cpp:700
+#: src/Preferences.cpp:698
 msgid "Latvian"
 msgstr ""
 
-#: src/Preferences.cpp:701
+#: src/Preferences.cpp:699
 msgid "Lithuanian"
 msgstr "立陶宛語"
 
-#: src/Preferences.cpp:702
+#: src/Preferences.cpp:700
 msgid "Norwegian (Nynorsk)"
 msgstr "新挪威語"
 
-#: src/Preferences.cpp:703
+#: src/Preferences.cpp:701
 msgid "Polish"
 msgstr "波蘭語"
 
-#: src/Preferences.cpp:704
+#: src/Preferences.cpp:702
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: src/Preferences.cpp:705
+#: src/Preferences.cpp:703
 msgid "Portuguese (Brazilian)"
 msgstr "葡萄牙語 (巴西)"
 
-#: src/Preferences.cpp:706
+#: src/Preferences.cpp:704
 msgid "Romanian"
 msgstr "羅馬尼亞語"
 
-#: src/Preferences.cpp:707
+#: src/Preferences.cpp:705
 msgid "Russian"
 msgstr "俄語"
 
-#: src/Preferences.cpp:708
+#: src/Preferences.cpp:706
 msgid "Slovenian"
 msgstr "斯洛維尼亞語"
 
-#: src/Preferences.cpp:709
+#: src/Preferences.cpp:707
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: src/Preferences.cpp:710
+#: src/Preferences.cpp:708
 msgid "Swedish"
 msgstr "瑞典語"
 
-#: src/Preferences.cpp:711
+#: src/Preferences.cpp:709
 msgid "Turkish"
 msgstr "土耳其語"
 
-#: src/Preferences.cpp:712
+#: src/Preferences.cpp:710
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: src/Preferences.cpp:815
+#: src/Preferences.cpp:813
 msgid "Change Language"
 msgstr "變更語言"
 
-#: src/Preferences.cpp:879
+#: src/Preferences.cpp:877
 msgid "There are no translations installed for aMule"
 msgstr "沒有已安裝的 aMule 翻譯"
 
-#: src/Preferences.cpp:880
+#: src/Preferences.cpp:878
 msgid "No languages available"
 msgstr "沒有可用的語言"
 
-#: src/Preferences.cpp:1011
+#: src/Preferences.cpp:1009
 msgid "no options available"
 msgstr "沒有選項"
 
-#: src/Preferences.cpp:2182
+#: src/Preferences.cpp:2175
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
-#: src/Preferences.cpp:2351
+#: src/Preferences.cpp:2344
 msgid "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr "TCP 埠不可大於 65532，因爲伺服器 UDP 連接端點值爲 TCP 埠值+3"
 
-#: src/Preferences.cpp:2352
+#: src/Preferences.cpp:2345
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr "使用預設通訊埠 (%d)"
@@ -8369,6 +8361,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c:58
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Auto-sort files (high CPU)"
+#~ msgstr "自動排序檔案 (耗系統資源)"
+
+#~ msgid "aMule will sort the columns in your download list automatically"
+#~ msgstr "aMule 將自動對下載清單進行排序"
 
 #~ msgid "Rejects packet if the client ip is different from the ip where the packet is received from. Use with caution."
 #~ msgstr "拒絕客戶端 IP 與接收封包中的 IP 不同的封包。(請小心使用)"

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -799,9 +799,7 @@ void CDownloadListCtrl::OnMouseRightClick(wxListEvent &evt)
 
 	m_menu->Enable(MP_MENU_EXTD, canPause);
 
-	bool autosort = thePrefs::AutoSortDownload(false);
 	PopupMenu(m_menu, evt.GetPoint());
-	thePrefs::AutoSortDownload(autosort);
 
 	delete m_menu;
 	m_menu = NULL;
@@ -826,9 +824,7 @@ void CDownloadListCtrl::ShowFileDetailDialog(long index)
 	for (int i = 0; i < nrItems; i++) {
 		files.push_back(reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(i))->GetFile());
 	}
-	bool autosort = thePrefs::AutoSortDownload(false);
 	CFileDetailDialog(this, files, index).ShowModal();
-	thePrefs::AutoSortDownload(autosort);
 }
 
 void CDownloadListCtrl::OnKeyPressed(wxKeyEvent &event)

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -235,7 +235,6 @@ bool CPreferences::s_FollowSymlinksInShares;
 wxString CPreferences::s_ExcludeSharePatterns;
 bool CPreferences::s_ExcludeSharePatternsUseRegex;
 CShareExcludeFilter CPreferences::s_ShareExcludeFilter;
-bool CPreferences::s_AutoSortDownload;
 bool CPreferences::s_NewVersionCheck;
 // Default true so the monolithic app (which never receives the capability tag
 // over EC and doesn't consult this flag) is unaffected; the remote GUI
@@ -1566,11 +1565,6 @@ void CPreferences::BuildItemList(const wxString &appdir)
 			"Thumbs.db|ehthumbs.db|desktop.ini|.directory")));
 	NewCfgItem(IDC_EXCLUDE_SHARE_REGEX,
 		(new Cfg_Bool("/eMule/ExcludeSharePatternsUseRegex", s_ExcludeSharePatternsUseRegex, false)));
-
-	/**
-	 * Auto-Sorting of downloads
-	 **/
-	NewCfgItem(IDC_AUTOSORT, (new Cfg_Bool("/eMule/AutoSortDownloads", s_AutoSortDownload, false)));
 
 #if defined(ENABLE_VERSION_CHECK) || defined(CLIENT_GUI)
 	/**

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -740,14 +740,6 @@ public:
 	static int PreviewExcludeCount(
 		const wxString &patterns, bool useRegex, const wxArrayString &fileNames);
 
-	static bool AutoSortDownload() { return s_AutoSortDownload; }
-	static bool AutoSortDownload(bool val)
-	{
-		bool tmp = s_AutoSortDownload;
-		s_AutoSortDownload = val;
-		return tmp;
-	}
-
 	// Version check
 
 	static bool GetCheckNewVersion() { return s_NewVersionCheck; }
@@ -1129,8 +1121,6 @@ protected:
 	static wxString s_ExcludeSharePatterns;
 	static bool s_ExcludeSharePatternsUseRegex;
 	static CShareExcludeFilter s_ShareExcludeFilter;
-
-	static bool s_AutoSortDownload;
 
 	// Version check
 	static bool s_NewVersionCheck;

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1452,11 +1452,6 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 			theApp->amuledlg->m_activewnd == theApp->amuledlg->m_transferwnd) {
 			m_transferwnd->UpdateCatTabTitles();
 		}
-		if (thePrefs::AutoSortDownload()) {
-			m_transferwnd->downloadlistctrl->SortList();
-			m_transferwnd->clientlistctrl->SortList();
-			m_sharedfileswnd->peerslistctrl->SortList();
-		}
 		m_kademliawnd->UpdateNodeCount(CStatistics::GetKadNodes());
 
 #if defined(ENABLE_VERSION_CHECK) && defined(CLIENT_GUI)

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1999,10 +1999,6 @@ wxSizer *PreferencesGuiTweaksTab( wxWindow *parent, bool call_fit, bool set_size
     wxStaticText *item20 = new wxStaticText( parent, -1, _("Round"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add( item20, wxSizerFlags().CenterVertical().Right().Border(wxRIGHT, 5) );
     item13->Add( item16, wxSizerFlags(1).Expand().CenterVertical() );
-    wxCheckBox *item21 = new wxCheckBox( parent, IDC_AUTOSORT, _("Auto-sort files (high CPU)"), wxDefaultPosition, wxDefaultSize, 0 );
-    item21->SetValue( TRUE );
-    item21->SetToolTip( _("aMule will sort the columns in your download list automatically") );
-    item13->Add( item21, wxSizerFlags().Expand().CenterVertical() );
     item0->Add( item13, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 0) );
     if (set_sizer)
     {

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -414,7 +414,6 @@ wxSizer *PreferencesaMuleTweaksTab(wxWindow *parent, bool call_fit = TRUE, bool 
 #define IDC_PERCENT 10209
 #define IDC_PROGBAR 10210
 #define IDC_3DDEPTH 10211
-#define IDC_AUTOSORT 10212
 wxSizer *PreferencesGuiTweaksTab(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 
 #define IDC_EXT_CONN_ACCEPT 10213


### PR DESCRIPTION
Follow-up to #540: removes the now-superseded **"Auto-sort files (high CPU)"** preference.

**Why.** #540 added the virtual-list model with **"Live column sorting"**, which keeps the Downloads, Clients and Shared-peers lists sorted *incrementally* — repositioning individual rows as their values change, and only for dynamic sort columns (speed, progress, transferred, sources, …). The old "Auto-sort files" did the same job by brute force: a 5 s timer re-sorting each *entire* list (O(N log N) per list, up to 5 s stale) — hence its "(high CPU)" label. The three lists it re-sorted are now all `CMuleVirtualListCtrl`, so live-sort fully covers them. `LiveListSort` defaults on; `AutoSortDownloads` defaulted off.

**What's removed.** The checkbox + `IDC_AUTOSORT`, the `AutoSortDownload` preference (getter/setter/member/definition + `Cfg_Bool` registration), the 5 s `SortList()` block in `CamuleDlg`, and the two `AutoSortDownload(false)` save/restore wrappers that suppressed the old timer while a context menu / file-detail dialog was modal (the new model handles the menu-repaint case via #540's fix). `SortList()` itself is unchanged (27 other callers, e.g. clicking a column header). Catalogs regenerated.
