### PR TITLE
fix(ec): encode directory bool prefs like every other boolean pref

### DIFF
--- a/src/ECSpecialMuleTags.cpp
+++ b/src/ECSpecialMuleTags.cpp
@@ -368,10 +368,15 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 			dirtag.AddTag(CECTag(EC_TAG_STRING, theApp->glob_prefs->shareddir_list[i].GetRaw()));
 		}
 		dirPrefs.AddTag(dirtag);
-		dirPrefs.AddTag(CECTag(EC_TAG_DIRECTORIES_SHARE_HIDDEN, thePrefs::ShareHiddenFiles()));
-		dirPrefs.AddTag(CECTag(EC_TAG_DIRECTORIES_AUTO_RESCAN, thePrefs::AutoRescanSharedDirs()));
-		dirPrefs.AddTag(
-			CECTag(EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS, thePrefs::FollowSymlinksInShares()));
+		if (thePrefs::ShareHiddenFiles()) {
+			dirPrefs.AddTag(CECEmptyTag(EC_TAG_DIRECTORIES_SHARE_HIDDEN));
+		}
+		if (thePrefs::AutoRescanSharedDirs()) {
+			dirPrefs.AddTag(CECEmptyTag(EC_TAG_DIRECTORIES_AUTO_RESCAN));
+		}
+		if (thePrefs::FollowSymlinksInShares()) {
+			dirPrefs.AddTag(CECEmptyTag(EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS));
+		}
 		dirPrefs.AddTag(
 			CECTag(EC_TAG_DIRECTORIES_EXCLUDE_PATTERNS, thePrefs::GetExcludeSharePatterns()));
 		dirPrefs.AddTag(

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2182,12 +2182,9 @@ void ParseDirectoriesPrefs(const CECTag *d, PreferencesSnapshot &out)
 				out.directories.shared.emplace_back(child.GetStringData().utf8_str());
 		}
 	}
-	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_SHARE_HIDDEN))
-		out.directories.share_hidden = t->GetInt() != 0;
-	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_AUTO_RESCAN))
-		out.directories.auto_rescan = t->GetInt() != 0;
-	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS))
-		out.directories.follow_symlinks = t->GetInt() != 0;
+	out.directories.share_hidden = d->GetTagByName(EC_TAG_DIRECTORIES_SHARE_HIDDEN) != nullptr;
+	out.directories.auto_rescan = d->GetTagByName(EC_TAG_DIRECTORIES_AUTO_RESCAN) != nullptr;
+	out.directories.follow_symlinks = d->GetTagByName(EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS) != nullptr;
 	if (const CECTag *t = d->GetTagByName(EC_TAG_DIRECTORIES_EXCLUDE_PATTERNS)) {
 		out.directories.exclude_patterns = std::string(t->GetStringData().utf8_str());
 	}


### PR DESCRIPTION
Fixes the Directories preferences **Share hidden files**, **Follow symbolic links in shared folders** (and the related **auto-rescan** flag) not sticking when changed from the remote GUI: disabling them lasted only the session, and the daemon re-enabled them on the next prefs push.

**Root cause.** Every boolean preference is packed as an empty tag *only when true* and decoded by tag presence (`ApplyBoolean`). These three were the exception — packed as always-present value tags (`CECTag(tag, 0/1)`). The remote GUI does both its `GET` and its `SET` at `EC_DETAIL_UPDATE`, where `ApplyBoolean` decodes a bool by *presence*; since these tags were always present, every one of them was forced to `true` and the user's choice was dropped — in both directions (the daemon applying the GUI's change, and the GUI reading the daemon's state). `auto_rescan` was silently affected too; it just went unnoticed because its default is on.

**Fix.** Pack the three the same way as the other 43 boolean prefs — `CECEmptyTag` when true — so the existing `ApplyBoolean` decode is already correct, and read them by presence in the amuleapi refresher to match. No special-casing left.

**amuleapi is unaffected.** Its PATCH path already sends value tags at `EC_DETAIL_FULL`, which `ApplyBoolean` decodes by value (partial updates still express "set to false" via an explicit `0` tag). The REST JSON contract is unchanged — `share_hidden` / `auto_rescan` / `follow_symlinks` are still booleans — so no doc or test change. The refresher's read is now presence-based, matching how it already reads every other boolean pref.

Defaults are unchanged: **Share hidden files** off, **Follow symbolic links** on. Monolithic aMule never round-trips preferences through EC and is unaffected. Verified by building `amuled`, `amulegui`, and `amuleapi`.
