### PR TITLE
fix(gui): persist search type + save column widths on close

### DIFF
--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -120,6 +120,14 @@ public:
 	virtual void SaveSettings();
 
 	/**
+	 * Returns true if a persistence name was set via SetTableName(), i.e.
+	 * SaveSettings()/LoadSettings() will actually store/restore this list.
+	 * Lets callers persist a list's layout without tripping the unnamed-list
+	 * assertion inside SaveSettings().
+	 */
+	bool HasStoredTableName() const { return !m_name.IsEmpty(); }
+
+	/**
 	 * Loads column settings.
 	 *
 	 * Currently loads the width of all columns, hidden columns, the column

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -24,6 +24,7 @@
 //
 
 #include <wx/app.h>
+#include <wx/config.h> // Needed to persist the default search type
 
 #include <wx/gauge.h> // Do_not_auto_remove (win32)
 
@@ -49,6 +50,7 @@ static wxCommandEvent nullEvent;
 wxBEGIN_EVENT_TABLE(CSearchDlg, wxPanel)
 	EVT_BUTTON(IDC_STARTS, CSearchDlg::OnBnClickedStart)
 	EVT_TEXT_ENTER(IDC_SEARCHNAME, CSearchDlg::OnBnClickedStart)
+	EVT_CHOICE(ID_SEARCHTYPE, CSearchDlg::OnSearchTypeChanged)
 
 	EVT_BUTTON(IDC_CANCELS, CSearchDlg::OnBnClickedStop)
 	EVT_BUTTON(IDC_SEARCHMORE, CSearchDlg::OnBnClickedSearchMore)
@@ -146,7 +148,52 @@ void CSearchDlg::FixSearchTypes()
 		searchchoice->Insert(m_searchchoices[2], pos++);
 	}
 
-	searchchoice->SetSelection(0);
+	// Restore the last-used search type (persisted in OnSearchTypeChanged)
+	// instead of always defaulting to Local. The stored value is the stable
+	// canonical code (0 = Local, 1 = Global, 2 = Kad); map it back onto
+	// whichever entries are present now, falling back to the first entry when
+	// the saved type's network is disabled (amule-org/amule#608).
+	long savedType = 0;
+	wxConfigBase::Get()->Read("/eMule/DefaultSearchType", &savedType, 0);
+	int selection = 0;
+	if (thePrefs::GetNetworkED2K()) {
+		if (savedType == 1) { // Global
+			selection = 1;
+		} else if (savedType == 2 && thePrefs::GetNetworkKademlia()) { // Kad
+			selection = 2;
+		}
+		// else Local (0), or the saved network is gone -> first entry
+	}
+	// With ED2K disabled the only entry is Kad at index 0, so 0 is correct.
+	if (searchchoice->GetCount()) {
+		if (selection >= (int)searchchoice->GetCount()) {
+			selection = 0;
+		}
+		searchchoice->SetSelection(selection);
+	}
+}
+
+int CSearchDlg::GetSelectedSearchTypeCanonical()
+{
+	int selection = CastChild(ID_SEARCHTYPE, wxChoice)->GetSelection();
+	if (selection == wxNOT_FOUND) {
+		return wxNOT_FOUND;
+	}
+	// FixSearchTypes() inserts choices as Local, Global, Kad, but drops the
+	// ED2K pair when ED2K is disabled -- then the only entry (Kad) sits at 0,
+	// so shift it onto the canonical Kad code (2).
+	if (!thePrefs::GetNetworkED2K()) {
+		selection += 2;
+	}
+	return selection;
+}
+
+void CSearchDlg::OnSearchTypeChanged(wxCommandEvent &WXUNUSED(evt))
+{
+	const int canonical = GetSelectedSearchTypeCanonical();
+	if (canonical != wxNOT_FOUND) {
+		wxConfigBase::Get()->Write("/eMule/DefaultSearchType", (long)canonical);
+	}
 }
 
 CSearchListCtrl *CSearchDlg::GetSearchList(wxUIntPtr id)
@@ -564,14 +611,9 @@ void CSearchDlg::StartNewSearch()
 
 	SearchType search_type = KadSearch;
 
-	int selection = CastChild(ID_SEARCHTYPE, wxChoice)->GetSelection();
-
-	// In muuli_wdr.cpp, Search Choices are inserted in this order: Local, Global, Kad.
-	// If ED2K is disabled, the only choice in the menu is Kad,
-	// but the starting value is 0 and we need a 2 for the switch
-	if (!thePrefs::GetNetworkED2K()) {
-		selection += 2;
-	}
+	// Canonical order (0 = Local, 1 = Global, 2 = Kad), normalised for the
+	// disabled-ED2K case inside the helper.
+	int selection = GetSelectedSearchTypeCanonical();
 
 	switch (selection) {
 	case 0: // Local Search

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -131,9 +131,18 @@ public:
 
 	void FixSearchTypes();
 
+	// Current ID_SEARCHTYPE selection normalised to a stable code
+	// (0 = Local, 1 = Global, 2 = Kad) independent of which networks are
+	// enabled, so it can be persisted and restored across restarts.
+	// Returns wxNOT_FOUND if nothing is selected.
+	int GetSelectedSearchTypeCanonical();
+
 private:
 	// Event handlers
 	void OnFieldChanged(wxEvent &evt);
+
+	// Persists the chosen search type so it survives a restart (amule-org/amule#608).
+	void OnSearchTypeChanged(wxCommandEvent &evt);
 
 	void OnListItemSelected(wxListEvent &ev);
 	void OnBnClickedReset(wxCommandEvent &ev);

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -57,6 +57,7 @@
 #include "DownloadQueue.h"    // Needed for CDownloadQueue
 #include "KadDlg.h"           // Needed for CKadDlg
 #include "Logger.h"
+#include "MuleListCtrl.h" // Needed for CMuleListCtrl (synchronous column-save)
 #include "MuleTextCtrl.h" // Needed for CMuleTextCtrl (fast-links placeholder)
 #include "MuleTrayIcon.h"
 #include "muuli_wdr.h"   // Needed for ID_BUTTON*
@@ -1224,6 +1225,25 @@ bool CamuleDlg::LoadGUIPrefs(bool override_pos, bool override_size)
 	return true;
 }
 
+// Persist every named CMuleListCtrl's column layout synchronously by walking
+// the widget tree. Each ~CMuleListCtrl already does this, but the main window
+// is torn down via the lazy wxPendingDelete of amuledlg->Destroy(); on the
+// tray-Exit / HideOnClose path the app can leave the loop before that pending
+// delete runs, so the column widths never reach disk (amule-org/amule#608).
+// Calling it here, from SaveGUIPrefs() (which runs and Flush()es on every
+// close path), makes the save deterministic regardless of teardown order.
+static void SaveListControlSettings(wxWindow *parent)
+{
+	for (wxWindow *child : parent->GetChildren()) {
+		if (CMuleListCtrl *list = dynamic_cast<CMuleListCtrl *>(child)) {
+			if (list->HasStoredTableName()) {
+				list->SaveSettings();
+			}
+		}
+		SaveListControlSettings(child);
+	}
+}
+
 bool CamuleDlg::SaveGUIPrefs()
 {
 	/* Razor 1a - Modif by MikaelB
@@ -1267,6 +1287,10 @@ bool CamuleDlg::SaveGUIPrefs()
 
 	// Saving sash position of splitter in server window
 	config->Write(section + "SRV_SPLITTER_POS", (long)m_srv_split_pos);
+
+	// Persist list column layouts here (synchronously, before the Flush)
+	// rather than relying solely on the lazy ~CMuleListCtrl (amule-org/amule#608).
+	SaveListControlSettings(this);
 
 	config->Flush(true);
 


### PR DESCRIPTION
Addresses two of the three issues in #608.

**Search type reverts to "Local".** The Local/Global/Kad dropdown was hard-reset to the first entry on every launch (`FixSearchTypes()`), with nothing persisting the choice. It's now stored in `wxConfig` as a stable canonical code (0=Local, 1=Global, 2=Kad) whenever it changes and restored on startup, mapped back onto whichever networks are currently enabled (falling back to the first entry when the saved type's network is disabled).

**Column widths not saved when "hide window when close button is pressed" is enabled.** Column layouts are written in `~CMuleListCtrl`, which runs via the lazy `wxPendingDelete` of `amuledlg->Destroy()`. On the tray-Exit / hide-on-close path the app can leave the main loop before that pending delete runs, so widths never reach disk — they persist only on a normal window close. The fix walks the widget tree from `SaveGUIPrefs()` (which runs synchronously and `Flush()`es on every close path) and saves each named list's settings there, independent of teardown order.

Both are cross-platform: the search-type reset happened on all platforms, and the column-width save path now runs on every platform (a harmless redundant save where the lazy delete already ran, an actual fix where it didn't).

The third item (status icon shows disconnected) is not included here — it should already be resolved by the recent art (SVG) switch; the reporter is being asked to retest a current build.

Addresses #608 (search type + column widths).
