### PR TITLE
fix(core): coalesce known.met saves after media probes (#616)

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1808,6 +1808,16 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 		msPrevKnownMet = msCur;
 	}
 
+	// Coalesced flush of media-probe tag updates (#616): OnMediaProbeFinished
+	// bumps m_mediaTagsDirtiedMs on every probe instead of saving inline; save
+	// once here when probing has been idle for 30 s. Resets the periodic timer
+	// above so we don't rewrite known.met twice in quick succession.
+	if (m_mediaTagsDirtiedMs && msCur - m_mediaTagsDirtiedMs >= 30000) {
+		knownfiles->Save();
+		m_mediaTagsDirtiedMs = 0;
+		msPrevKnownMet = msCur;
+	}
+
 	// Recommended by lugdunummaster himself - from emule 0.30c
 	serverconnect->KeepConnectionAlive();
 
@@ -1959,11 +1969,15 @@ void CamuleApp::OnMediaProbeFinished(CMediaProbeEvent &evt)
 	// EC exports the tag list; the remote GUI + web UI need to see
 	// the new values on next refresher tick.
 	file->MarkECChanged();
-	// Persist immediately so the tags survive a crash before the
-	// next scheduled known.met flush. CKnownFileList::Save is cheap
-	// (append-only over a memory buffer) and this only fires when a
-	// probe actually succeeded, so overhead is bounded.
-	theApp->knownfiles->Save();
+	// Coalesce the known.met save instead of rewriting the whole file per
+	// probe. CKnownFileList::Save rewrites every known file, so a per-probe
+	// save is O(files) each time -- O(N^2) when the whole library is probed at
+	// startup, which pegged a core and could re-enter Save mid-write (#616).
+	// Bump the last-change stamp on every probe; OnCoreTimer flushes a single
+	// Save once probing has been idle for 30 s, collapsing a startup burst
+	// into one write. The 30-min periodic save is the backstop if probes
+	// trickle in without ever pausing, and shutdown always flushes.
+	m_mediaTagsDirtiedMs = theStats::GetUptimeMillis();
 }
 
 void CamuleApp::OnFinishedCompletion(CCompletionEvent &evt)

--- a/src/amule.h
+++ b/src/amule.h
@@ -426,6 +426,13 @@ protected:
 
 	APPState m_app_state;
 
+	// Media-probe tag writes coalesce into one known.met save: every
+	// OnMediaProbeFinished stamps this (uptime ms), and OnCoreTimer flushes a
+	// single Save() once probing has been idle for 30 s -- avoids the O(N^2)
+	// full-file rewrite when the whole library is probed at startup (#616).
+	// 0 = nothing pending.
+	uint64 m_mediaTagsDirtiedMs = 0;
+
 	// Headless GeoIP resolver, owned by the core (created in OnInit under
 	// ENABLE_IP2COUNTRY). NULL when GeoIP is disabled/unsupported.
 	CIP2Country *m_IP2Country;


### PR DESCRIPTION
Reproducible CPU-core peg (apparent hang) at startup and an occasional crash, both from the media-probe feature.

**Root cause** — `OnMediaProbeFinished` called `CKnownFileList::Save()` after **every** ffprobe result. `Save()` rewrites the *entire* known.met (all known files), so probing a full library at startup is O(files × probes):

- **CPU spin:** the reported ~98% one-core "hang" is aMule re-serializing the whole known.met per probe (not ffprobe — the reporter correctly ruled that out).
- **Crash:** the backtrace shows `Save()` at two frames — a slow O(N) save yields to the event loop, the next queued probe-finished event fires mid-save, and the nested `Save()`/`WriteToFile` corrupts the tag iteration (crash in the `CTagString`/`wxString` destructor). `MediaProbeThread` itself is clean (results posted by value via a cloned event); the old `CTag::operator=` double-free is unrelated / already fixed.

The inline comment calling `Save()` "cheap (append-only over a memory buffer)" was inaccurate — it's a full rewrite.

**Fix** — stamp a dirty time on each probe and flush a single `Save()` from `OnCoreTimer` once probing has been idle for 30 s (a startup burst collapses to one write; the window extends while results keep arriving). The existing 30-minute periodic save is the backstop for a never-pausing trickle, and shutdown always flushes. Media tags lost on a hard crash are cheaply re-derived by re-probing.

Closes #616
