### PR TITLE
fix(remote-gui): batch the download list on every poll, not just after a reconnect

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -256,10 +256,14 @@ void CDownloadListCtrl::BeginBatchUpdate()
 	m_batchUpdate = true;
 }
 
-void CDownloadListCtrl::EndBatchUpdate()
+void CDownloadListCtrl::EndBatchUpdate(bool doSort)
 {
 	m_batchUpdate = false;
-	SortList();
+	// A poll that only updated rows in place (no new files) leaves the sort
+	// order untouched, so skip the O(n log n) SortList entirely (issue #615).
+	if (doSort) {
+		SortList();
+	}
 	Thaw();
 }
 

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -96,12 +96,14 @@ public:
 
 	/**
 	 * Bracket a burst of AddFile()/UpdateItem() calls (a reconnect resync —
-	 * issue #444) so the list repaints once (Freeze) and sorts once, instead
-	 * of per-item. Existing rows are updated in place; new rows are appended
-	 * without a per-item sort. EndBatchUpdate() does the single SortList().
+	 * issue #444, or any poll that adds a batch of downloads — issue #615) so
+	 * the list repaints once (Freeze) and sorts once, instead of per-item.
+	 * Existing rows are updated in place; new rows are appended without a
+	 * per-item sort. EndBatchUpdate() does the single SortList(), unless
+	 * doSort is false (a pure in-place update needs no re-sort).
 	 */
 	void BeginBatchUpdate();
-	void EndBatchUpdate();
+	void EndBatchUpdate(bool doSort = true);
 
 	/**
 	 * Removes the specified file from the list.

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1895,15 +1895,30 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 	accepted = 0;
 
 	// The first poll after a reconnect re-processes the whole (potentially
-	// 10k+) library in one go (update-in-place + add + prune). Batch both
-	// list ctrls so that stays one repaint + one sort instead of per row
-	// (issue #444). Captured now because ProcessItemUpdate/AddFile below,
-	// and the final prune, all touch the ctrls; the flag itself is cleared
-	// at the end. The cold-boot m_initialUpdate path has its own batching
-	// (ShowFileList) and never overlaps — m_initialUpdate is false here.
+	// 10k+) library in one go (update-in-place + add + prune) — that is the
+	// reconcile case, and it also batches the shared-files ctrl below (issue
+	// #444). The cold-boot m_initialUpdate path has its own batching
+	// (ShowFileList) and never overlaps — m_initialUpdate is false whenever
+	// reconcile is true.
 	const bool reconcile = m_reconnectReconcile;
-	if (reconcile) {
+
+	// Batch the download list on every steady-state poll, not just a reconnect
+	// resync: an ordinary poll can surface a whole burst of freshly-added
+	// downloads at once (e.g. a hundred search results dropped into a large
+	// queue), and CDownloadListCtrl::AddFile() re-sorts the entire list on
+	// every insert. On a 10k queue that is O(n^2 log n) and freezes the GUI for
+	// seconds (issue #615). BeginBatchUpdate() suppresses the per-item sort;
+	// the single SortList() runs once at the end, and only if we actually added
+	// a file (downloadListGrew) — a pure in-place stat poll stays sort-free.
+	// The cold-boot m_initialUpdate path has its own batching (ShowFileList),
+	// so leave it alone to avoid a redundant second sort. Captured now because
+	// ProcessItemUpdate/AddFile below and the final prune all touch the ctrl.
+	const bool batchDownloadList = !m_initialUpdate;
+	bool downloadListGrew = false;
+	if (batchDownloadList) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->BeginBatchUpdate();
+	}
+	if (reconcile) {
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->BeginBatchUpdate();
 	}
 	// Set below if the reconnect reconcile reply is too empty to trust as a
@@ -2016,6 +2031,7 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 					// via ShowFileList() (issue #414 — O(n^2) otherwise).
 					theApp->amuledlg->m_transferwnd->downloadlistctrl->AddFile(
 						file, /*deferView=*/m_initialUpdate);
+					downloadListGrew = true;
 					newFile = file;
 				} else {
 					newFile = new CKnownFile(tag);
@@ -2073,8 +2089,14 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 			}
 		}
 	}
+	if (batchDownloadList) {
+		// Sort once if the poll added a file (or on a reconnect resync, where
+		// the whole list was reconciled); otherwise the order is unchanged and
+		// EndBatchUpdate() just Thaws without a needless re-sort.
+		theApp->amuledlg->m_transferwnd->downloadlistctrl->EndBatchUpdate(
+			reconcile || downloadListGrew);
+	}
 	if (reconcile) {
-		theApp->amuledlg->m_transferwnd->downloadlistctrl->EndBatchUpdate();
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->EndBatchUpdate();
 	}
 	// One-shot: consumed by the first post-reconnect poll above, unless the


### PR DESCRIPTION
Fixes #615.

### Symptom
Adding a batch of downloads to a large queue over the **remote GUI** freezes the GUI for seconds and the download counter rises at only a few files per second. @ghysler's repro: select ~100 search results → Download, against a ~10k download queue.

### Cause
`CKnownFilesRem::ProcessUpdate()` (the remote GUI's download-queue poll handler) only wrapped the list controls in `BeginBatchUpdate()`/`EndBatchUpdate()` for the post-reconnect *reconcile* (#444). On an ordinary steady-state poll the batch was never engaged, so every freshly-arrived partfile ran through `CDownloadListCtrl::AddFile()` with the per-item `SortList()` active — a full re-sort of the whole list on **every insert**.

On a 10k queue that is O(n²·log n) and blocks the GUI event loop. The frozen loop then drains the outbound download requests slowly, which is why the queue fills at only ~4/sec. @ghysler correctly guessed this was the same *re-sort-on-every-insert* class as #415/#444 — just on a different, un-batched path.

### Fix
Batch the download list on every non-initial poll:
- `BeginBatchUpdate()` suppresses the per-item sort during the loop.
- The single `SortList()` runs once at the end, and **only if the poll actually added a file** (`downloadListGrew`) — a pure in-place stat poll stays sort-free, so the common case pays nothing. `EndBatchUpdate()` gains a `doSort` parameter (default `true`) for this.
- The cold-boot `m_initialUpdate` path keeps its own `ShowFileList()` batching, untouched.
- Shared-files ctrl batching is unchanged (reconnect-only).

Result on the repro: one sort + one repaint per poll instead of ~100.
