### PR TITLE
fix(gui): batch the download list when downloading many search results

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -37,9 +37,13 @@
 #include "CommentDialogLst.h" // Needed for CCommentDialogLst (Kad comments/ratings)
 #include "SearchDlg.h"        // Needed for CSearchDlg
 #include "amuleDlg.h"         // Needed for CamuleDlg
-#include "muuli_wdr.h"        // Needed for clientImages
-#include "Preferences.h"      // Needed for thePrefs
-#include "GuiEvents.h"        // Needed for CoreNotify_Search_Add_Download
+#ifndef CLIENT_GUI
+#include "TransferWnd.h"      // Needed for CTransferWnd (download-list batching)
+#include "DownloadListCtrl.h" // Needed for CDownloadListCtrl (download-list batching)
+#endif
+#include "muuli_wdr.h"   // Needed for clientImages
+#include "Preferences.h" // Needed for thePrefs
+#include "GuiEvents.h"   // Needed for CoreNotify_Search_Add_Download
 #include "MuleColour.h"
 
 wxBEGIN_EVENT_TABLE(CSearchListCtrl, CMuleListCtrl)
@@ -879,6 +883,16 @@ void CSearchListCtrl::DownloadSelected(int category)
 		}
 	}
 
+#ifndef CLIENT_GUI
+	// Monolithic: Search_Add_Download runs synchronously on this thread, so
+	// each selected file's Notify_DownloadCtrlAddFile -> AddFile fires a
+	// per-item SortList() inline. Batch the whole selection into a single sort
+	// + repaint (issue #615). The remote GUI's adds arrive later via the
+	// download-queue poll, which already batches, so this is monolithic-only.
+	CDownloadListCtrl *downloadlist = theApp->amuledlg->m_transferwnd->downloadlistctrl;
+	downloadlist->BeginBatchUpdate();
+#endif
+
 	// Process all selections
 	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	while (index > -1) {
@@ -886,6 +900,10 @@ void CSearchListCtrl::DownloadSelected(int category)
 		CoreNotify_Search_Add_Download(file, category);
 		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	}
+
+#ifndef CLIENT_GUI
+	downloadlist->EndBatchUpdate();
+#endif
 	// Listcontrol gets updated by notification when download is started
 }
 


### PR DESCRIPTION
Follow-up to #620, which fixed the same slow-bulk-download freeze on the **remote GUI**. The monolithic GUI has the identical problem on a different, un-batched path.

### Cause
`CSearchListCtrl::DownloadSelected()` loops over the selected results calling `Search_Add_Download` per file. In the monolithic build that notification runs **synchronously on the main thread** (`HandleNotification` calls the functor directly when `wxThread::IsMain()`), so each file's `Notify_DownloadCtrlAddFile` → `CDownloadListCtrl::AddFile()` fires a per-item `SortList()` inline — a full re-sort of the whole download list on every insert. Downloading ~100 selected results into a ~10k queue is O(n²·log n) and freezes the GUI, exactly the class of #415 / #444 / #615.

The batching added in #620 lives only in the remote GUI's poll handler, so it doesn't help the monolithic path.

### Fix
Wrap the selection loop in the download list's `BeginBatchUpdate()` / `EndBatchUpdate()` — the per-item sort is suppressed during the loop and a single `SortList()` + repaint runs at the end.

Gated behind `#ifndef CLIENT_GUI`: in the remote GUI the adds arrive later via the download-queue poll (already batched by #620), so there is nothing to batch synchronously there — wrapping it would only cost a redundant sort/repaint of the download list on every download click.

Covers all `DownloadSelected` entry points (button, menu, double-click/enter, category-assign). Verified by building both `amule` and `amulegui`.
