### PR TITLE
fix(remote-gui): batch the shared-files list on every poll, not just reconnect

### DIFF
--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -96,6 +96,7 @@ enum SharedFilesListColumns
 CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos, wxSize size, int flags)
 : CMuleVirtualListCtrl(parent, id, pos, size, flags | wxLC_OWNERDRAW)
 , m_inBulkUpdate(false)
+, m_batchUpdate(false)
 {
 	// Setting the sorter function.
 	SetSortFunc(SortProc);
@@ -317,14 +318,22 @@ void CSharedFilesCtrl::ShowFileList()
 
 void CSharedFilesCtrl::BeginBatchUpdate()
 {
-	// ShowFile() appends without sorting, so a reconnect resync only needs
-	// the repaints coalesced (Freeze) and one final sort in EndBatchUpdate.
+	// During the batch ShowFile() appends the row (O(1)) instead of doing a
+	// sorted AddItemData() (which rebuilds the whole row index per insert --
+	// O(n), i.e. O(n^2) for a burst on a large share). Coalesce the repaints
+	// (Freeze) and defer the single sort to EndBatchUpdate().
 	Freeze();
+	m_batchUpdate = true;
 }
 
-void CSharedFilesCtrl::EndBatchUpdate()
+void CSharedFilesCtrl::EndBatchUpdate(bool doSort)
 {
-	SortList();
+	m_batchUpdate = false;
+	// A poll that only updated rows in place (no new files) leaves the sort
+	// order untouched, so skip the O(n log n) SortList entirely.
+	if (doSort) {
+		SortList();
+	}
 	Thaw();
 }
 
@@ -344,6 +353,21 @@ void CSharedFilesCtrl::ClearList()
 
 void CSharedFilesCtrl::ShowFile(CKnownFile *file)
 {
+	if (m_batchUpdate) {
+		// Batched poll (remote GUI): append at the end (O(1)) and let
+		// EndBatchUpdate() sort once. AddItemData()'s sorted insert rebuilds
+		// the whole row index on every call (O(n)), which turns a burst of
+		// freshly-shared files into an O(n^2) freeze on a large share.
+		// Mirrors CDownloadListCtrl::ShowFile(). AppendItemDataNow() keeps the
+		// row index and item count live, so the interleaved reconcile prune
+		// and in-place UpdateItem() during the same poll stay correct.
+		const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(file);
+		if (RowOfData(data) == -1) {
+			AppendItemDataNow(data);
+			ShowFilesCount();
+		}
+		return;
+	}
 	DoShowFile(file, false);
 }
 

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -59,7 +59,7 @@ public:
 	// Bracket a reconnect resync (issue #444) so the list repaints once
 	// (Freeze) and sorts once at the end rather than per updated/added row.
 	void BeginBatchUpdate();
-	void EndBatchUpdate();
+	void EndBatchUpdate(bool doSort = true);
 
 	/**
 	 * Adds the specified file to the list, updating filecount and more.
@@ -238,6 +238,10 @@ private:
 	//! When true, UpdateItem() short-circuits and the bulk caller is
 	//! responsible for issuing a single Refresh() at end-of-bulk.
 	bool m_inBulkUpdate;
+
+	//! True between BeginBatchUpdate()/EndBatchUpdate(): ShowFile() appends
+	//! the row without sorting; EndBatchUpdate() does the single SortList().
+	bool m_batchUpdate;
 
 	// The virtual-list model, sorting, live auto-sort and selection
 	// preservation all live in CMuleVirtualListCtrl now.

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1896,8 +1896,8 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 
 	// The first poll after a reconnect re-processes the whole (potentially
 	// 10k+) library in one go (update-in-place + add + prune) — that is the
-	// reconcile case, and it also batches the shared-files ctrl below (issue
-	// #444). The cold-boot m_initialUpdate path has its own batching
+	// reconcile case (issue #444), which drives the one-shot absence-prune
+	// below. The cold-boot m_initialUpdate path has its own batching
 	// (ShowFileList) and never overlaps — m_initialUpdate is false whenever
 	// reconcile is true.
 	const bool reconcile = m_reconnectReconcile;
@@ -1918,7 +1918,17 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 	if (batchDownloadList) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->BeginBatchUpdate();
 	}
-	if (reconcile) {
+
+	// Same reasoning for the shared-files list: a steady-state poll can surface
+	// a burst of freshly-shared files (many downloads completing, or a shared
+	// folder added/rescanned daemon-side), and ShowFile() -> AddItemData()
+	// rebuilds the whole virtual-list row index on every insert -- O(n) each,
+	// O(n^2) on a large share. Batch every non-initial poll and sort once at the
+	// end, only if the poll actually added a file (sharedListGrew). Reconnect
+	// reconcile is one such non-initial poll, so it is covered too.
+	const bool batchSharedList = !m_initialUpdate;
+	bool sharedListGrew = false;
+	if (batchSharedList) {
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->BeginBatchUpdate();
 	}
 	// Set below if the reconnect reconcile reply is too empty to trust as a
@@ -2040,6 +2050,7 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 					if (!m_initialUpdate) {
 						theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->ShowFile(
 							newFile);
+						sharedListGrew = true;
 					}
 				}
 				AddItem(newFile);
@@ -2096,8 +2107,12 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->EndBatchUpdate(
 			reconcile || downloadListGrew);
 	}
-	if (reconcile) {
-		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->EndBatchUpdate();
+	if (batchSharedList) {
+		// Sort once if the poll added a shared file (or on a reconnect resync,
+		// where the whole list was reconciled); otherwise the order is
+		// unchanged and EndBatchUpdate() just Thaws without a needless re-sort.
+		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->EndBatchUpdate(
+			reconcile || sharedListGrew);
 	}
 	// One-shot: consumed by the first post-reconnect poll above, unless the
 	// reply was too empty to trust and we left the flag armed for the next.


### PR DESCRIPTION
Companion to #620/#621, which fixed the slow-bulk-*download* freeze. The shared-files list has the same class of problem in the **remote GUI**, and #620 deliberately left it out (its shared-ctrl batching stayed reconnect-only). A steady-state poll that surfaces a burst of freshly-shared files — many downloads completing daemon-side, or a shared folder added/rescanned on the daemon — freezes the GUI on a large share.

### Cause
`CKnownFilesRem::ProcessUpdate()` adds each newly-shared file via `CSharedFilesCtrl::ShowFile()` → `AddItemData()`. On this virtual list `AddItemData()` does a sorted insert **and rebuilds the entire row index** (`RebuildRowIndex()`) on every call — O(n) per insert, so a burst of k new files against an n-file share is O(k·n). The shared-files ctrl was only wrapped in `BeginBatchUpdate`/`EndBatchUpdate` on a reconnect reconcile, and — unlike the download list — a plain Freeze/deferred-sort batch wouldn't even help here, because the per-insert cost is the row-index rebuild, not a sort.

### Fix
Give the shared-files ctrl the same append-path batching the download list already uses:
- **`CSharedFilesCtrl`**: during a batch, `ShowFile()` appends with `AppendItemDataNow()` — O(1), and it keeps the row index and item count live, so the interleaved reconcile prune (`RemoveItemData`) and in-place `UpdateItem()` in the same poll stay correct. The single `SortList()` is deferred to `EndBatchUpdate(doSort)`. The non-batch single-add path (a lone completed download, monolithic) is unchanged — still the sorted `AddItemData()`.
- **`CKnownFilesRem::ProcessUpdate`**: batch the shared list on every non-initial poll (not just reconnect), mirroring the download list, and sort once at the end only if the poll actually added a file (`sharedListGrew`). A pure in-place stat poll stays sort-free.

Net: a bulk shared-file poll is one sort + one repaint instead of one row-index rebuild per file — and the reconnect resync of a large share gets the same speed-up.

Monolithic is unaffected: its bulk shared paths already funnel through the batched `Reload()` → `ShowFileList()`, and the dir-watcher coalesces bursts into a single `Reload()`.

Verified by building `amule` and `amulegui`.
