### PR TITLE
fix(gui): stop the virtual lists asserting on click over their image list

### DIFF
--- a/src/MuleVirtualListCtrl.h
+++ b/src/MuleVirtualListCtrl.h
@@ -128,6 +128,15 @@ protected:
 	/** Virtual-list text callback -> GetItemColumnText(). */
 	virtual wxString OnGetItemText(long item, long column) const;
 
+	/** Virtual-list image callback. These lists own-draw their icons in
+	 *  OnDrawItem(); the small image list attached by CMuleListCtrl exists
+	 *  only for that drawing. A wxLC_VIRTUAL control still queries the per-item
+	 *  image whenever an image list is present, and the generic wxListCtrl
+	 *  asserts if OnGetItemColumnImage/OnGetItemImage is not overridden (a
+	 *  debug-build assert on click -- issue #625). Report "no image". */
+	virtual int OnGetItemColumnImage(long WXUNUSED(item), long WXUNUSED(column)) const { return -1; }
+	virtual int OnGetItemImage(long WXUNUSED(item)) const { return -1; }
+
 private:
 	// The sorted view (row i -> m_items[i]) and a data->row index kept in
 	// lockstep for O(1) update/remove (rebuilt after any insert/erase/sort).


### PR DESCRIPTION
Fixes #625.

Clicking a row on the download tab tripped a debug-build assert:

```
assert "!GetImageList(wxIMAGE_LIST_SMALL)" failed in OnGetItemImage():
List control has an image list, OnGetItemImage or OnGetItemColumnImage should be overridden.
```

**Cause.** The download, shared-files and clients lists own-draw their rows (`OnDrawItem`) but inherit a small image list from `CMuleListCtrl`. Once they moved to `wxLC_VIRTUAL`, wx began querying the per-item image while caching a line (on hit-test / click), and the generic `wxListCtrl` asserts when neither `OnGetItemColumnImage` nor `OnGetItemImage` is overridden. Release builds compile the assert out but still pay the pointless per-item query.

**Fix.** Override both in the base `CMuleVirtualListCtrl` to report "no image" (`-1`) — the icons are painted in `OnDrawItem`, not by wx. One change fixes all three virtual lists (download, shared files, clients); the reporter hit it on the download tab but the shared-files and clients lists share the same base and the same latent assert.

Verified by building `amule` and `amulegui`.
