### PR TITLE
feat(gui): open file details on double-click of a still-downloading file

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -652,8 +652,13 @@ void CDownloadListCtrl::OnItemActivated(wxListEvent &evt)
 {
 	CPartFile *file = reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(evt.GetIndex()))->GetFile();
 
+	// A completed previewable media file plays on double-click, as before.
+	// Anything else (a still-downloading file, or a non-previewable one) opens
+	// the file-details modal, matching the shared-files table's double-click.
 	if ((!file->IsPartFile() || file->IsCompleted()) && file->PreviewAvailable()) {
 		PreviewFile(file);
+	} else {
+		ShowFileDetailDialog(evt.GetIndex());
 	}
 }
 


### PR DESCRIPTION
Double-clicking a download only did something for a **completed previewable** media file (it played it); double-clicking a still-downloading file did nothing. The shared-files table opens the file-details modal on double-click, so this brings the download list in line.

- A completed previewable media file still **plays** on double-click (unchanged).
- Everything else — a file still downloading, or a completed non-previewable one — now opens the **file-details modal**, the same one already reachable from the right-click "Show file details" entry.
- Preview stays on the right-click menu, including partial preview while downloading (available once the first 256 KB is in), so nothing is lost.

Verified by building `amule` and `amulegui`.
