### PR TITLE
packaging: fully static amuled/amulecmd/amuleapi (musl) Linux track

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -36,7 +36,7 @@ on:
           Comma-separated list of platform tracks to run.
           Default empty = run all. Useful during iteration to focus
           on the failing tracks without paying for the green ones.
-          Valid: appimage, flatpak, macos, windows.
+          Valid: appimage, flatpak, macos, windows, linux-static.
         required: false
         type: string
         default: ''
@@ -118,6 +118,49 @@ jobs:
         with:
           name: appimage-${{ matrix.arch }}
           path: dist/aMule-*-Linux-*.AppImage
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------
+  # Linux — fully static amuled/amulecmd/amuleapi (musl/Alpine) on
+  # x86_64 + aarch64 native runners. Self-contained binaries with no
+  # runtime shared-library deps, for containers / minimal / musl hosts.
+  # See packaging/docker/Dockerfile.static-daemon.
+  # ------------------------------------------------------------------
+  linux-static:
+    name: Linux static (${{ matrix.arch }})
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'linux-static')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x86_64,  runs-on: ubuntu-22.04 }
+          - { arch: aarch64, runs-on: ubuntu-22.04-arm }
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # git describe for the version string
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # STATIC_CACHE_SCOPE turns on buildx's gha layer cache (the ccache
+      # analogue for this track): the dep layers (Crypto++ / wxWidgets /
+      # pupnp / apk) persist across runs, so only the aMule compile re-runs
+      # on a src change. Empty on workflow_call (release.yml tag builds) so
+      # the shipped binaries always come from a cold compile.
+      - name: Build static tarball
+        env:
+          STATIC_CACHE_SCOPE: ${{ github.event_name != 'workflow_call' && format('linux-static-{0}', matrix.arch) || '' }}
+        run: packaging/linux/build.sh static
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: linux-static-${{ matrix.arch }}
+          path: dist/aMule-*-Linux-*-static.tar.gz
           if-no-files-found: error
 
   # ------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,12 @@ jobs:
           pattern: windows-*
           path: dist/
           merge-multiple: true
+      - name: Download Linux static daemon tarballs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: linux-static-*
+          path: dist/
+          merge-multiple: true
       - name: Download source bundle
         uses: actions/download-artifact@v8
         with:
@@ -254,12 +260,13 @@ jobs:
           check "macOS Universal2 .dmg"             1 'aMule-*-macOS-universal2.dmg'
           check "Windows portable .zip (x64 + arm64)" 2 'aMule-*-Windows-*.zip'
           check "Windows installer .exe (x64 + arm64)" 2 'aMule-*-Windows-Setup-*.exe'
+          check "Linux static daemon (x86_64 + aarch64)" 2 'aMule-*-Linux-*-static.tar.gz'
           check "Source bundle"                     1 'aMule-*-src.tar.gz'
           if [ "$fail" -ne 0 ]; then
             echo "::error::Artifact manifest incomplete — refusing to assemble the draft Release."
             exit 1
           fi
-          echo "All 10 expected release artifacts present."
+          echo "All 12 expected release artifacts present."
 
       - name: Create draft Release
         env:

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,8 +2,10 @@
 
 This tree builds aMule into the four user-facing distribution formats:
 **AppImage**, **Flatpak**, **macOS Universal2 .dmg**, and **Windows
-portable .zip**. All four are produced from a single `git` checkout
-plus per-platform tooling (Docker / Homebrew / MSYS2).
+portable .zip**, plus a headless **fully static Linux daemon** tarball
+(amuled + amulecmd + amuleapi, no runtime shared-library deps). All are
+produced from a single `git` checkout plus per-platform tooling (Docker /
+Homebrew / MSYS2).
 
 The recipes are driven by [`.github/workflows/packaging.yml`](../.github/workflows/packaging.yml)
 on GitHub Actions, but every script also runs locally — useful for
@@ -17,8 +19,9 @@ packaging/
 ├── linux/
 │   ├── appimage/         AppImage recipe (Docker-driven)
 │   ├── flatpak/          Flatpak manifest (template + generated yaml)
-│   ├── build.sh          dispatcher — picks appimage or flatpak
-│   └── versions.env      pinned tarball URLs + SHA256s for both
+│   ├── static/           Fully static musl daemon recipe (Alpine Docker)
+│   ├── build.sh          dispatcher — picks appimage, flatpak or static
+│   └── versions.env      pinned tarball URLs + SHA256s for all three
 ├── macos/                macOS Universal2 .dmg recipe
 └── windows/              Windows portable .zip recipe (MSYS2)
 ```
@@ -30,6 +33,7 @@ build instructions and design notes:
 | -------- | --------------------------------------------------------------------- | --------------------- |
 | Linux    | [`linux/appimage/README.md`](linux/appimage/README.md)                | `.AppImage` (single file, glibc ≥ 2.35) |
 | Linux    | [`linux/flatpak/README.md`](linux/flatpak/README.md)                  | `.flatpak` (sandboxed, GNOME 49 runtime) |
+| Linux    | [`linux/static/README.md`](linux/static/README.md)                    | `.tar.gz` (static musl daemon: amuled + amulecmd + amuleapi) |
 | macOS    | [`macos/README.md`](macos/README.md)                                  | `.dmg` (Universal2, arm64 + x86_64) |
 | Windows  | [`windows/README.md`](windows/README.md)                              | `.zip` (portable, MSYS2 runtime bundled) |
 
@@ -44,6 +48,9 @@ packaging/linux/build.sh appimage
 
 # Linux Flatpak (host arch — needs flatpak-builder + GNOME runtime)
 packaging/linux/build.sh flatpak
+
+# Linux fully static musl daemon tarball (host arch — needs Docker)
+packaging/linux/build.sh static
 
 # macOS Universal2 .dmg (needs Homebrew with deps installed)
 packaging/macos/build.sh
@@ -66,6 +73,7 @@ in parallel on its native runner — no QEMU emulation. Matrix:
 | -------------- | ----------------------- | ----- |
 | AppImage x86_64 / aarch64 | `ubuntu-22.04` / `ubuntu-22.04-arm` | glibc 2.35 baseline for compat |
 | Flatpak x86_64 / aarch64  | `ubuntu-24.04` / `ubuntu-24.04-arm` | needs `appstream-compose` 1.0+ from 24.04 |
+| Linux static x86_64 / aarch64 | `ubuntu-22.04` / `ubuntu-22.04-arm` | musl/Alpine Docker build; buildx gha layer cache |
 | macOS arm64 / x86_64      | both on `macos-15`                  | x86_64 builds via Rosetta-emulated Homebrew at `/usr/local`; the legacy `macos-13` Intel runner is being retired by GitHub |
 | macOS Universal2 .dmg     | `macos-15`                          | depends on the two macOS jobs; lipo-merges + ad-hoc-codesigns the result |
 | Windows x64 / arm64       | `windows-latest`                    | MSYS2 MINGW64 / CLANGARM64 |
@@ -75,7 +83,7 @@ Triggers:
 * **Push to `master`** (or any `packaging**` branch) when packaging /
   source / cmake files change — keeps master always-shippable.
 * **Manual `workflow_dispatch`** — with an `only=appimage,flatpak,
-  macos,windows` input for iterating on a single track.
+  macos,windows,linux-static` input for iterating on a single track.
 
 Pull-request triggers are deliberately omitted to halve CI cost; if
 you want to inspect a PR's artifacts before merging, dispatch the

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -18,6 +18,9 @@ commands:
                              arch: host (default) | x86_64 | aarch64
   flatpak [arch]             produce .flatpak bundle in dist/
                              arch: host (default) | x86_64 | aarch64
+  static [arch]              produce a fully static musl daemon tarball
+                             (amuled + amulecmd + amuleapi) in dist/
+                             arch: host (default) | x86_64 | aarch64
   validate [arch]            run amuled --version inside a fixed matrix
                              of distro Docker images to catch lib-load
                              regressions. arch: host (default) only —
@@ -219,6 +222,87 @@ build_flatpak() {
     echo "==> Done: ${bundle}"
 }
 
+build_static() {
+    # Fully static amuled/amulecmd/amuleapi (musl/Alpine). Unlike the
+    # AppImage track (toolchain image + docker run over a repo mount), this
+    # COPYs the checkout into the build and exports the binaries from a
+    # scratch stage via buildx --output. Versions come from versions.env.
+    local arch_in="${1:-host}"
+    local target_arch
+    case "${arch_in}" in
+        host)    target_arch="$(uname -m)" ;;
+        x86_64)  target_arch=x86_64 ;;
+        aarch64) target_arch=aarch64 ;;
+        *)       echo "fatal: unsupported arch '${arch_in}' (choose host|x86_64|aarch64)" >&2; exit 1 ;;
+    esac
+
+    local docker_platform arch_label
+    case "${target_arch}" in
+        x86_64)  docker_platform=linux/amd64; arch_label=x64   ;;
+        aarch64) docker_platform=linux/arm64; arch_label=arm64 ;;
+    esac
+
+    # Pre-flight: cross-arch builds need tonistiigi/binfmt registered.
+    if [ "${target_arch}" != "$(uname -m)" ]; then
+        if ! docker run --rm --platform "${docker_platform}" alpine:latest /bin/true 2>/dev/null; then
+            echo "fatal: cross-arch build requested (target=${target_arch}, host=$(uname -m)) but binfmt not registered." >&2
+            echo "       run once on this host: $0 setup-cross-arch" >&2
+            exit 1
+        fi
+    fi
+
+    local artifact_dir="${REPO_ROOT}/dist"
+    mkdir -p "${artifact_dir}"
+    local outdir
+    outdir="$(mktemp -d)"
+
+    # Optional buildx layer cache — the ccache analogue for this track.
+    # CI sets STATIC_CACHE_SCOPE for non-release runs so the dep layers
+    # (Crypto++ / wxWidgets / pupnp / apk) persist via the gha backend;
+    # unset = plain build, so release (workflow_call) builds cold-compile.
+    local -a cache_args=()
+    if [[ -n "${STATIC_CACHE_SCOPE:-}" ]]; then
+        cache_args+=(--cache-from "type=gha,scope=${STATIC_CACHE_SCOPE}")
+        cache_args+=(--cache-to "type=gha,mode=max,scope=${STATIC_CACHE_SCOPE}")
+    fi
+
+    echo "==> Building static binaries (${target_arch}, platform=${docker_platform})"
+    docker buildx build \
+        --platform "${docker_platform}" \
+        -f "${SCRIPT_DIR}/static/Dockerfile" \
+        --build-arg "ALPINE_STATIC_BASE=${ALPINE_STATIC_BASE}" \
+        --build-arg "WX_VERSION=${WX_VERSION}" \
+        --build-arg "WX_TARBALL_URL=${WX_TARBALL_URL}" \
+        --build-arg "WX_SHA256=${WX_SHA256}" \
+        --build-arg "CRYPTOPP_TAG_SUFFIX=${CRYPTOPP_TAG_SUFFIX}" \
+        --build-arg "LIBUPNP_VERSION=${LIBUPNP_VERSION}" \
+        --build-arg "LIBUPNP_TARBALL_URL=${LIBUPNP_TARBALL_URL}" \
+        --build-arg "LIBUPNP_SHA256=${LIBUPNP_SHA256}" \
+        "${cache_args[@]}" \
+        --output "type=local,dest=${outdir}" \
+        "${REPO_ROOT}"
+
+    # Belt-and-suspenders: the Dockerfile already gates on this, re-check here.
+    local b
+    for b in amuled amulecmd amuleapi; do
+        file "${outdir}/${b}" | grep -q "statically linked" \
+            || { echo "fatal: ${b} is not statically linked" >&2; exit 1; }
+    done
+
+    # Filename mirrors the AppImage / Flatpak layout: one tarball per
+    # (arch, version) using the x64 / arm64 label (#764).
+    local version
+    version=$(cd "${REPO_ROOT}" && git describe --tags --always --dirty 2>/dev/null || echo "snapshot")
+    local stem="aMule-${version}-Linux-${arch_label}-static"
+    mkdir -p "${outdir}/${stem}"
+    cp "${outdir}/amuled" "${outdir}/amulecmd" "${outdir}/amuleapi" "${outdir}/${stem}/"
+    local tarball="${artifact_dir}/${stem}.tar.gz"
+    echo "==> Bundling ${tarball}"
+    tar -czf "${tarball}" -C "${outdir}" "${stem}"
+    rm -rf "${outdir}"
+    echo "==> Done: ${tarball}"
+}
+
 setup_cross_arch() {
     # tonistiigi/binfmt registers QEMU emulators in the host kernel's
     # binfmt_misc so docker can run / build images for non-native
@@ -383,6 +467,7 @@ validate_appimage() {
 case "${target}" in
     appimage)                build_appimage "${1:-}" ;;
     flatpak)                 build_flatpak "${1:-}" ;;
+    static)                  build_static "${1:-}" ;;
     render-flatpak-manifest) render_flatpak_manifest ;;
     validate)                validate_appimage "${1:-}" ;;
     all)                     build_all ;;

--- a/packaging/linux/static/Dockerfile
+++ b/packaging/linux/static/Dockerfile
@@ -1,0 +1,143 @@
+# syntax=docker/dockerfile:1
+#
+# Fully static aMule daemon (musl/Alpine) — self-contained amuled, amulecmd
+# and amuleapi binaries with no runtime shared-library dependencies. Feature
+# set: UPnP, IP2Country (GeoIP), BFD backtraces, NLS, and wxWebRequest
+# downloads. The monolithic GUI is intentionally excluded: wxGTK dlopen()s
+# loader/theme/input-method modules, so it cannot be meaningfully static.
+#
+# Driven by packaging/linux/build.sh, which feeds the ARGs below from
+# packaging/linux/versions.env (the single source of truth for pinned
+# versions). Build from the repository root:
+#
+#   packaging/linux/build.sh static            # host arch, tarball in dist/
+#
+# or directly (context is the checkout):
+#
+#   docker build -f packaging/linux/static/Dockerfile \
+#     --build-arg ALPINE_STATIC_BASE=3.20 --build-arg WX_VERSION=... \
+#     --output type=local,dest=out .
+#
+# Build args have no defaults so a missing pin fails loud — the caller must
+# source versions.env.
+
+ARG ALPINE_STATIC_BASE
+
+FROM alpine:${ALPINE_STATIC_BASE} AS builder
+
+ARG WX_VERSION
+ARG WX_TARBALL_URL
+ARG WX_SHA256
+ARG CRYPTOPP_TAG_SUFFIX
+ARG LIBUPNP_VERSION
+ARG LIBUPNP_TARBALL_URL
+ARG LIBUPNP_SHA256
+
+RUN apk add --no-cache \
+        build-base cmake git python3 pkgconf wget \
+        autoconf automake libtool \
+        linux-headers \
+        boost-dev \
+        zlib-dev zlib-static \
+        expat-dev expat-static \
+        curl-dev curl-static \
+        openssl-dev openssl-libs-static \
+        nghttp2-dev nghttp2-static \
+        brotli-dev brotli-static \
+        c-ares-dev c-ares-static \
+        zstd-dev zstd-static \
+        libidn2-dev libidn2-static \
+        libunistring-dev libunistring-static \
+        libpsl-dev libpsl-static \
+        binutils-dev \
+        libmaxminddb-dev libmaxminddb-static \
+        gettext gettext-dev gettext-static
+
+# --- Crypto++ (static libcryptopp.a) ---
+RUN git clone --depth 1 --branch "CRYPTOPP_${CRYPTOPP_TAG_SUFFIX}" \
+        https://github.com/weidai11/cryptopp.git /tmp/cryptopp \
+ && make -C /tmp/cryptopp -j"$(nproc)" libcryptopp.a \
+ && make -C /tmp/cryptopp PREFIX=/usr/local install
+
+# --- wxWidgets (static, base + net, no GUI) ---
+RUN wget -qO /tmp/wx.tar.bz2 "${WX_TARBALL_URL}" \
+ && echo "${WX_SHA256}  /tmp/wx.tar.bz2" | sha256sum -c - \
+ && mkdir -p /tmp/wx && tar -xf /tmp/wx.tar.bz2 -C /tmp/wx --strip-components=1 \
+ && cd /tmp/wx && ./configure \
+        --disable-shared \
+        --disable-gui \
+        --with-zlib=builtin \
+        --with-expat=builtin \
+        --prefix=/usr/local \
+ && make -j"$(nproc)" && make install
+
+# --- libupnp / pupnp (static; no static Alpine package, build from source) ---
+# versions.env pins the GitHub source archive (autotools not pre-generated),
+# so bootstrap with autoreconf first. The autotools build installs no CMake
+# config, letting aMule's find_package(UPNP CONFIG) cleanly fall back to
+# pkg-config and pick up the static libupnp.a / libixml.a.
+# CFLAGS="-include stddef.h": pupnp 1.14.x's threadutil sources use NULL
+# without pulling in <stddef.h> transitively, which fails on musl (glibc /
+# the GNOME SDK happen to include it via other headers, so the Flatpak
+# build of the same archive is unaffected).
+RUN wget -qO /tmp/libupnp.tar.gz "${LIBUPNP_TARBALL_URL}" \
+ && echo "${LIBUPNP_SHA256}  /tmp/libupnp.tar.gz" | sha256sum -c - \
+ && mkdir -p /tmp/libupnp && tar -xf /tmp/libupnp.tar.gz -C /tmp/libupnp --strip-components=1 \
+ && cd /tmp/libupnp && ./bootstrap \
+ && ./configure --disable-shared --enable-static --disable-samples --prefix=/usr/local \
+        CFLAGS="-include stddef.h" \
+ && make -j"$(nproc)" && make install
+
+# Force static resolution for deps that ship BOTH .so and .a. CMake's
+# find_library prefers the .so dev symlink and hands its ABSOLUTE path to the
+# linker, which -static then rejects ("attempted static link of dynamic
+# object"). -DCMAKE_FIND_LIBRARY_SUFFIXES=.a doesn't stick (the platform module
+# resets it during project()). Dropping just the libX.so dev symlinks — while
+# keeping libX.so.N for dynamic build tools like msgfmt — makes find_library
+# resolve to the static archive. Every lib below has a .a present.
+RUN for l in bfd opcodes ctf sframe zstd z maxminddb intl; do \
+        rm -f "/usr/lib/lib$l.so" "/lib/lib$l.so"; \
+    done
+
+# --- aMule (static daemon, full feature set: UPnP + IP2Country + BFD + NLS) ---
+# Built from the repository checkout (the build context), so CI validates the
+# code under review. The only feature dropped is the optional
+# CHTTPDownloadThread CURLOPT tuning (CMAKE_DISABLE_FIND_PACKAGE_CURL) — its
+# config-mode target drags in libcurl.so; downloads still work via wx's own
+# (static) libcurl webrequest backend.
+COPY . /src
+WORKDIR /src
+RUN export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig \
+ && cmake -S . -B build-static \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_MONOLITHIC=OFF \
+        -DBUILD_DAEMON=ON \
+        -DBUILD_AMULECMD=ON \
+        -DBUILD_AMULEAPI=ON \
+        -DENABLE_UPNP=ON \
+        -DENABLE_IP2COUNTRY=ON \
+        -DENABLE_BFD=ON \
+        -DENABLE_NLS=ON \
+        -DENABLE_VERSION_CHECK=OFF \
+        -DwxWidgets_USE_STATIC=ON \
+        -DwxWidgets_CONFIG_EXECUTABLE=/usr/local/bin/wx-config \
+        -DZLIB_USE_STATIC_LIBS=ON \
+        -DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON \
+        -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++" \
+        -DCMAKE_CXX_STANDARD_LIBRARIES="$(pkg-config --static --libs libcurl)" \
+ && cmake --build build-static -j"$(nproc)" \
+ && mkdir -p /out \
+ && for b in amuled amulecmd amuleapi; do \
+        cp "$(find build-static -type f -name "$b" | head -1)" /out/; \
+    done \
+ && strip /out/amuled /out/amulecmd /out/amuleapi
+
+# Sanity gate: fail the build unless each binary is a static executable.
+RUN for b in amuled amulecmd amuleapi; do \
+        file "/out/$b"; \
+        ldd "/out/$b" 2>&1 | grep -qE "Not a valid dynamic program|not a dynamic executable" \
+          || { echo "FAIL: $b is dynamically linked"; ldd "/out/$b"; exit 1; }; \
+    done
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/packaging/linux/static/Dockerfile.dockerignore
+++ b/packaging/linux/static/Dockerfile.dockerignore
@@ -1,0 +1,14 @@
+# Build-context excludes for the static-daemon image (BuildKit resolves this
+# per-Dockerfile ignore file). .git is intentionally kept so aMule's CMake can
+# derive the version via `git describe`.
+build
+build-*
+out
+out-*
+_build
+dist
+CMakeCache.txt
+CMakeFiles
+**/*.o
+**/*.a
+.DS_Store

--- a/packaging/linux/static/README.md
+++ b/packaging/linux/static/README.md
@@ -1,0 +1,59 @@
+# Fully static aMule daemon (musl/Alpine)
+
+Produces `amuled`, `amulecmd` and `amuleapi` as **fully static** binaries —
+one self-contained file each, with no runtime shared-library dependencies.
+`scp` them to any Linux host of the right architecture and run; nothing to
+install.
+
+```sh
+packaging/linux/build.sh static            # host arch → tarball in dist/
+packaging/linux/build.sh static x86_64     # cross-arch (needs setup-cross-arch)
+packaging/linux/build.sh static aarch64
+```
+
+Output: `dist/aMule-<version>-Linux-<x64|arm64>-static.tar.gz`.
+
+## What's included
+
+Feature set is complete for a headless node: **UPnP**, **IP2Country**
+(GeoIP; supply your own `GeoLite2`/`dbip` `.mmdb`), **BFD** crash
+backtraces, **NLS**, and **wxWebRequest** HTTP downloads.
+
+The monolithic **GUI is intentionally excluded** — wxGTK `dlopen()`s
+pixbuf/theme/input-method modules at runtime, so it cannot be meaningfully
+static-linked. This track is daemon-only.
+
+## Why musl (Alpine), not glibc
+
+glibc's NSS `dlopen()`s `libnss_*` even inside a `-static` binary, so
+hostname resolution would still need those `.so`s on the target — not
+self-contained. musl builds NSS into libc, so `-static` is genuinely
+standalone. (macOS static linking isn't possible at all: Apple ships no
+static `libSystem`.)
+
+## How it's built
+
+[`Dockerfile`](Dockerfile) on an Alpine base (`ALPINE_STATIC_BASE`),
+driven by `build.sh` which feeds versions from
+[`../versions.env`](../versions.env):
+
+- **wxWidgets** built static, `--disable-gui`, with the libcurl backend
+  (`WX_*` pins, SHA256-verified).
+- **Crypto++** built static (`CRYPTOPP_TAG_SUFFIX`).
+- **pupnp/libupnp** built static from the pinned source archive
+  (`LIBUPNP_*`, SHA256-verified; autotools bootstrapped in-tree).
+- `libmaxminddb` / `binutils` (BFD) / `gettext` (libintl) from Alpine's
+  static packages.
+- Final `-static` link pulls the `libcurl → openssl → nghttp2/brotli/…`
+  closure via `pkg-config --static`.
+
+The build gates on a `file`/`ldd` static-linking check, so a regression
+fails the build rather than shipping a dynamically-linked binary.
+
+## Runtime notes
+
+Neither affects the static property:
+
+- **HTTPS needs a CA bundle** present on the host (`/etc/ssl/certs`) for
+  certificate verification — that's data, not a library.
+- These are **daemon binaries only**; there is no GUI.

--- a/packaging/linux/versions.env
+++ b/packaging/linux/versions.env
@@ -17,6 +17,12 @@
 # openSUSE Leap 15.5/Tumbleweed, Arch, Mint, Pop!_OS, Steam Deck, Pi OS).
 UBUNTU_BASE=22.04
 
+# Alpine base for the fully static musl daemon image (static/). musl (not
+# glibc) because glibc's NSS dlopen()s libnss_* even in a -static binary,
+# so hostname resolution wouldn't be self-contained; musl builds NSS into
+# libc, making -static genuinely standalone.
+ALPINE_STATIC_BASE=3.20
+
 # --------------------------------------------------------------------
 # wxWidgets (built from source for AppImage; consumed as a Flatpak module)
 # --------------------------------------------------------------------


### PR DESCRIPTION
Adds a fully static musl/Alpine build producing self-contained `amuled`, `amulecmd` and `amuleapi` binaries with no runtime shared-library dependencies, wired into the existing Linux packaging pipeline as a new track.

The motivation is a drop-in daemon that runs on any Linux of the right architecture without pulling in wxWidgets, Boost, Crypto++, libupnp, and the rest — one binary you can `scp` and run. Handy for containers, minimal/musl hosts, and NAS boxes.

## Scope

Daemon and CLI only (`amuled` + `amulecmd` + `amuleapi`). The monolithic GUI is intentionally excluded: wxGTK `dlopen()`s pixbuf/theme/input-method modules at runtime, so it can't be meaningfully static-linked. macOS static linking isn't possible either (Apple ships no static `libSystem`), and glibc's NSS `dlopen()`s `libnss_*` even in a `-static` binary — hence musl, where NSS is built into libc and `-static` is genuinely standalone.

Feature set is complete for a headless node: UPnP, IP2Country (GeoIP), BFD backtraces, NLS, and wxWebRequest downloads. The only thing dropped is the optional `CHTTPDownloadThread` CURLOPT tuning (its config-mode CMake target drags in `libcurl.so`); downloads still work via wx's own static libcurl webrequest backend.

## Integration

Follows the existing `packaging/linux/` conventions rather than adding a parallel pipeline:

- `packaging/linux/static/` holds the recipe (Dockerfile + README), a sibling of `appimage/` and `flatpak/`.
- Versions come from `packaging/linux/versions.env` (wx / Crypto++ / libupnp, SHA256-verified) — nothing pinned in the Dockerfile; adds `ALPINE_STATIC_BASE`.
- `packaging/linux/build.sh` gains a `static` target mirroring the other tracks.
- `packaging.yml` gains a `linux-static` matrix job (x86_64 + aarch64 native runners) that calls `build.sh static`, with a buildx `type=gha` layer cache — the ccache analogue for this track — disabled on `workflow_call` so release builds cold-compile.
- `release.yml` downloads the `linux-static-*` artifacts into the draft, with a manifest check like the other platforms.

Ships one tarball per arch: `aMule-<ver>-Linux-<x64|arm64>-static.tar.gz`.

## Verification

`file` reports *statically linked*, `ldd` reports *not a dynamic executable*, and the binaries run in a bare `busybox`/`scratch` container with no libraries present. Both the Dockerfile and `build.sh` gate on the static-linking check, so a regression fails the build rather than shipping a dynamically-linked binary.

Beyond `--version`, a manual run of the aarch64 artifact brings the daemon up (binds the eD2k + EC ports), connects with `amulecmd` over EC, and shuts down cleanly — so the static daemon works end to end, not just at startup.

Two runtime notes, neither affecting the static property: HTTPS needs a CA bundle present on the host (`/etc/ssl`), and there is no GUI in these binaries.
