### PR TITLE
gui: live text filter for the downloads and shared-files tables

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -228,8 +228,9 @@ void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 			return;
 		}
 
-		// Check if the new file is visible in the current category
-		if (file->CheckShowItemInGivenCat(m_category)) {
+		// Check if the new file is visible in the current category (and
+		// passes the active text filter).
+		if (IsVisibleInCat(file, m_category)) {
 			ShowFile(file, true);
 			if (file->IsCompleted()) {
 				CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(true);
@@ -281,7 +282,7 @@ void CDownloadListCtrl::ShowFileList()
 
 	for (const auto &entry : m_ListItems) {
 		CPartFile *file = entry.second->GetFile();
-		if (file->CheckShowItemInGivenCat(m_category)) {
+		if (IsVisibleInCat(file, m_category)) {
 			ShowFile(file, true);
 			if (file->IsCompleted()) {
 				hasCompletedDownloads = true;
@@ -327,7 +328,7 @@ void CDownloadListCtrl::UpdateItem(const void *toupdate)
 
 		CPartFile *file = item->GetFile();
 
-		bool show = file->CheckShowItemInGivenCat(m_category);
+		bool show = IsVisibleInCat(file, m_category);
 
 		if (index != -1) {
 			if (show) {
@@ -392,8 +393,8 @@ void CDownloadListCtrl::ChangeCategory(int newCategory)
 
 		CPartFile *file = it->second->GetFile();
 
-		bool curVisibility = file->CheckShowItemInGivenCat(m_category);
-		bool newVisibility = file->CheckShowItemInGivenCat(newCategory);
+		bool curVisibility = IsVisibleInCat(file, m_category);
+		bool newVisibility = IsVisibleInCat(file, newCategory);
 
 		if (newVisibility && file->IsCompleted()) {
 			hasCompletedDownloads = true;
@@ -418,6 +419,41 @@ void CDownloadListCtrl::ChangeCategory(int newCategory)
 uint8 CDownloadListCtrl::GetCategory() const
 {
 	return m_category;
+}
+
+bool CDownloadListCtrl::PassesTextFilter(const CPartFile *file) const
+{
+	if (m_filterText.IsEmpty()) {
+		return true;
+	}
+	// Case-insensitive substring match on the file name (m_filterText is
+	// already lower-cased by SetFilterText()).
+	return file->GetFileName().GetPrintable().Lower().Contains(m_filterText);
+}
+
+bool CDownloadListCtrl::IsVisibleInCat(CPartFile *file, int category) const
+{
+	return file->CheckShowItemInGivenCat(category) && PassesTextFilter(file);
+}
+
+void CDownloadListCtrl::SetFilterText(const wxString &text)
+{
+	const wxString lower = text.Lower();
+	if (lower == m_filterText) {
+		return;
+	}
+	m_filterText = lower;
+
+	// Re-evaluate visibility of every model item against the new filter,
+	// mirroring ChangeCategory(): the model in m_ListItems always holds every
+	// file, so we just add/remove rows to match. One repaint, one sort.
+	Freeze();
+	for (const auto &entry : m_ListItems) {
+		CPartFile *file = entry.second->GetFile();
+		ShowFile(file, IsVisibleInCat(file, m_category));
+	}
+	SortList();
+	Thaw();
 }
 
 /**

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -95,6 +95,14 @@ public:
 	void ShowFileList();
 
 	/**
+	 * Sets the live text filter. Only files whose name contains @a text
+	 * (case-insensitive) are shown, AND-ed with the current category. An
+	 * empty string clears the filter. Purely GUI-side, so it works the same
+	 * in the monolithic app and the remote GUI (amulegui).
+	 */
+	void SetFilterText(const wxString &text);
+
+	/**
 	 * Bracket a burst of AddFile()/UpdateItem() calls (a reconnect resync —
 	 * issue #444, or any poll that adds a batch of downloads — issue #615) so
 	 * the list repaints once (Freeze) and sorts once, instead of per-item.
@@ -252,6 +260,17 @@ private:
 
 	//! The currently displayed category
 	uint8 m_category;
+
+	//! Live text filter (lower-cased), empty when inactive. See SetFilterText().
+	wxString m_filterText;
+
+	//! True if @a file passes the current text filter (name substring match).
+	bool PassesTextFilter(const CPartFile *file) const;
+
+	//! Whether @a file should be displayed in @a category: the category
+	//! predicate AND-ed with the text filter. Takes a non-const file because
+	//! CPartFile::CheckShowItemInGivenCat() is not const.
+	bool IsVisibleInCat(CPartFile *file, int category) const;
 
 	//! Flag if change of item selection is pending
 	bool m_ItemSelectionChangePending;

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -308,12 +308,35 @@ void CSharedFilesCtrl::ShowFileList()
 	std::vector<CKnownFile *> files;
 	theApp->sharedfiles->CopyFileList(files);
 	for (CKnownFile *file : files) {
-		AppendItemData(reinterpret_cast<wxUIntPtr>(file));
+		if (PassesTextFilter(file)) {
+			AppendItemData(reinterpret_cast<wxUIntPtr>(file));
+		}
 	}
 	FinishBulkLoad();
 	ShowFilesCount();
 
 	Thaw();
+}
+
+bool CSharedFilesCtrl::PassesTextFilter(const CKnownFile *file) const
+{
+	if (m_filterText.IsEmpty()) {
+		return true;
+	}
+	// Case-insensitive substring match on the file name (m_filterText is
+	// already lower-cased by SetFilterText()).
+	return file->GetFileName().GetPrintable().Lower().Contains(m_filterText);
+}
+
+void CSharedFilesCtrl::SetFilterText(const wxString &text)
+{
+	const wxString lower = text.Lower();
+	if (lower == m_filterText) {
+		return;
+	}
+	m_filterText = lower;
+	// Rebuild the model from the master share, applying the new filter.
+	ShowFileList();
 }
 
 void CSharedFilesCtrl::BeginBatchUpdate()
@@ -353,6 +376,12 @@ void CSharedFilesCtrl::ClearList()
 
 void CSharedFilesCtrl::ShowFile(CKnownFile *file)
 {
+	// A newly-shared file that doesn't match the active filter stays hidden;
+	// it'll appear if the filter is cleared/changed (which rebuilds the model).
+	if (!PassesTextFilter(file)) {
+		return;
+	}
+
 	if (m_batchUpdate) {
 		// Batched poll (remote GUI): append at the end (O(1)) and let
 		// EndBatchUpdate() sort once. AddItemData()'s sorted insert rebuilds

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -53,6 +53,13 @@ public:
 	/** Reloads the list of shared files. */
 	void ShowFileList();
 
+	/**
+	 * Sets the live text filter. Only files whose name contains @a text
+	 * (case-insensitive) are shown; an empty string clears the filter. Purely
+	 * GUI-side, so it works the same in the monolithic app and amulegui.
+	 */
+	void SetFilterText(const wxString &text);
+
 	/** Empties the list (virtual-mode: clears the model + row index). */
 	void ClearList();
 
@@ -234,6 +241,12 @@ private:
 
 	//! Pointer used to ensure that the menu isn't displayed twice.
 	wxMenu *m_menu;
+
+	//! Live text filter (lower-cased), empty when inactive. See SetFilterText().
+	wxString m_filterText;
+
+	//! True if @a file passes the current text filter (name substring match).
+	bool PassesTextFilter(const CKnownFile *file) const;
 
 	//! When true, UpdateItem() short-circuits and the bulk caller is
 	//! responsible for issuing a single Refresh() at end-of-bulk.

--- a/src/SharedFilesWnd.cpp
+++ b/src/SharedFilesWnd.cpp
@@ -41,6 +41,7 @@ wxBEGIN_EVENT_TABLE(CSharedFilesWnd, wxPanel)
 	EVT_LIST_ITEM_SELECTED(ID_SHFILELIST, CSharedFilesWnd::OnItemSelectionChanged)
 	EVT_LIST_ITEM_DESELECTED(ID_SHFILELIST, CSharedFilesWnd::OnItemSelectionChanged)
 	EVT_BUTTON(ID_BTNRELSHARED, CSharedFilesWnd::OnBtnReloadShared)
+	EVT_TEXT(IDC_SHARED_FILTER, CSharedFilesWnd::OnFilterChanged)
 	EVT_BUTTON(ID_SHAREDCLIENTTOGGLE, CSharedFilesWnd::OnToggleClientList)
 	// The "show clients for" radio buttons are bound dynamically in the ctor.
 
@@ -263,6 +264,11 @@ void CSharedFilesWnd::OnBtnReloadShared(wxCommandEvent &WXUNUSED(evt))
 	// remote gui will update display when data is back
 	SelectionUpdated();
 #endif
+}
+
+void CSharedFilesWnd::OnFilterChanged(wxCommandEvent &WXUNUSED(evt))
+{
+	sharedfilesctrl->SetFilterText(CastChild(IDC_SHARED_FILTER, wxTextCtrl)->GetValue());
 }
 
 void CSharedFilesWnd::OnItemSelectionChanged(wxListEvent &evt)

--- a/src/SharedFilesWnd.h
+++ b/src/SharedFilesWnd.h
@@ -96,6 +96,9 @@ private:
 	 */
 	void OnBtnReloadShared(wxCommandEvent &evt);
 
+	/** Live text-filter box changed: push the new text to the shared list. */
+	void OnFilterChanged(wxCommandEvent &evt);
+
 	/**
 	 * Event-handler for showing details about a shared file(s).
 	 */

--- a/src/TransferWnd.cpp
+++ b/src/TransferWnd.cpp
@@ -59,6 +59,8 @@ wxBEGIN_EVENT_TABLE(CTransferWnd, wxPanel)
 	EVT_BUTTON(ID_BTNCLRCOMPL, CTransferWnd::OnBtnClearDownloads)
 	EVT_BUTTON(ID_CLIENTTOGGLE, CTransferWnd::OnToggleClientList)
 
+	EVT_TEXT(IDC_TRANSFER_FILTER, CTransferWnd::OnFilterChanged)
+
 	EVT_MENU_RANGE(MP_CAT_SET0, MP_CAT_SET0 + 15, CTransferWnd::OnSetDefaultCat)
 	EVT_MENU(MP_CAT_ADD, CTransferWnd::OnAddCategory)
 	EVT_MENU(MP_CAT_EDIT, CTransferWnd::OnEditCategory)
@@ -390,6 +392,11 @@ void CTransferWnd::OnBtnClearDownloads(wxCommandEvent &WXUNUSED(evt))
 	downloadlistctrl->Freeze();
 	downloadlistctrl->ClearCompleted();
 	downloadlistctrl->Thaw();
+}
+
+void CTransferWnd::OnFilterChanged(wxCommandEvent &WXUNUSED(evt))
+{
+	downloadlistctrl->SetFilterText(CastChild(IDC_TRANSFER_FILTER, wxTextCtrl)->GetValue());
 }
 
 void CTransferWnd::Prepare()

--- a/src/TransferWnd.h
+++ b/src/TransferWnd.h
@@ -142,6 +142,9 @@ private:
 	 */
 	void OnBtnClearDownloads(wxCommandEvent &evt);
 
+	/** Live text-filter box changed: push the new text to the download list. */
+	void OnFilterChanged(wxCommandEvent &evt);
+
 	/**
 	 * Event-handler for changing categories.
 	 */

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -395,6 +395,10 @@ wxSizer *transferTopPane( wxWindow *parent, bool call_fit, bool set_sizer )
     CMuleNotebook *item4 = new CMuleNotebook( parent, ID_CATEGORIES, wxDefaultPosition, wxSize(15,MULE_NOTEBOOK_TAB_HEIGHT), 0 );
     wxASSERT( item4 );
     item1->Add( item4, wxSizerFlags(1).FixedMinSize().Center() );
+    wxStaticText *itemDlFilterLabel = new wxStaticText( parent, -1, _("Filter:"), wxDefaultPosition, wxDefaultSize, 0 );
+    item1->Add( itemDlFilterLabel, wxSizerFlags().Center().Border(wxLEFT, 5) );
+    wxTextCtrl *itemDlFilter = new wxTextCtrl( parent, IDC_TRANSFER_FILTER, "", wxDefaultPosition, wxSize(150,-1), 0 );
+    item1->Add( itemDlFilter, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
     CDownloadListCtrl *item5 = new CDownloadListCtrl( parent, ID_DLOADLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
     item5->SetName( "downloadList" );
@@ -3248,12 +3252,24 @@ wxSizer *sharedfilesTopDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    wxFlexGridSizer *item1 = new wxFlexGridSizer( 4, 0, 0 );
-    item1->AddGrowableCol( 1 );
+    // Header row: [Shared files] [Filter: ___] ... [Show Clients ...] ... [Reload].
+    // The left and right regions each take proportion 1, so they are equal width
+    // and the radio group in the middle (proportion 0) stays centered in the
+    // window regardless of how wide the left/right content is (the filter box
+    // widened the left region, which knocked the radios off-centre under the
+    // old growable-column layout).
+    wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
 
+    wxBoxSizer *itemShLeft = new wxBoxSizer( wxHORIZONTAL );
     wxStaticText *item2 = new wxStaticText( parent, -1, _("Shared files"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->SetName( "sharedFilesLabel" );
-    item1->Add( item2, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
+    itemShLeft->Add( item2, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
+    wxStaticText *itemShFilterLabel = new wxStaticText( parent, -1, _("Filter:"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemShLeft->Add( itemShFilterLabel, wxSizerFlags().CenterVertical().Border(wxLEFT, 10) );
+    wxTextCtrl *itemShFilter = new wxTextCtrl( parent, IDC_SHARED_FILTER, "", wxDefaultPosition, wxSize(150,-1), 0 );
+    itemShLeft->Add( itemShFilter, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
+    item1->Add( itemShLeft, wxSizerFlags(1).CenterVertical() );
+
     // "Show Clients for" as a label + inline radio buttons. This replaces a
     // wxRadioBox whose title row wasted vertical space in the header.
     wxBoxSizer *item3 = new wxBoxSizer( wxHORIZONTAL );
@@ -3269,12 +3285,16 @@ wxSizer *sharedfilesTopDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     itemShowUploading->SetName( "showClientsUploading" );
     item3->Add( itemShowUploading, wxSizerFlags().CenterVertical() );
     item1->Add( item3, wxSizerFlags().Center().Border(wxALL, 5) );
+
+    wxBoxSizer *itemShRight = new wxBoxSizer( wxHORIZONTAL );
+    itemShRight->AddStretchSpacer( 1 );
     wxStaticText *item4 = new wxStaticText( parent, -1, _("Reload:"), wxDefaultPosition, wxDefaultSize, 0 );
     item4->SetName( "sharedFilesLabel" );
-    item1->Add( item4, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
+    itemShRight->Add( item4, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     wxBitmapButton *item5 = new wxBitmapButton( parent, ID_BTNRELSHARED, amuleDlgImages( 18 ), wxDefaultPosition, wxSize(32,32) );
     item5->SetToolTip( _("Reload your shared files") );
-    item1->Add( item5, 0, wxALIGN_CENTER_VERTICAL, 0 );
+    itemShRight->Add( item5, wxSizerFlags().CenterVertical().Border(wxRIGHT, 5) );
+    item1->Add( itemShRight, wxSizerFlags(1).CenterVertical() );
 
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
     CSharedFilesCtrl *item6 = new CSharedFilesCtrl( parent, ID_SHFILELIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -94,6 +94,9 @@ wxSizer *searchDlg(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE
 #define ID_BTNCLRCOMPL 10026
 #define ID_CATEGORIES 10027
 #define ID_DLOADLIST 10028
+// Live text-filter box in the downloads header. Picked above the existing
+// wxDesigner-generated range so a future regeneration doesn't reuse the ID.
+#define IDC_TRANSFER_FILTER 10485
 wxSizer *transferTopPane(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 
 extern wxSizer *s_clientlistHeader;
@@ -595,6 +598,9 @@ wxSizer *sharedfilesBottomDlg(wxWindow *parent, bool call_fit = TRUE, bool set_s
 #define ID_SHOW_CLIENTS_MODE 10325
 #define ID_BTNRELSHARED 10326
 #define ID_SHFILELIST 10327
+// Live text-filter box in the shared-files header. Picked above the existing
+// wxDesigner-generated range so a future regeneration doesn't reuse the ID.
+#define IDC_SHARED_FILTER 10486
 wxSizer *sharedfilesTopDlg(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 
 #define ID_FRIENDLIST 10328


### PR DESCRIPTION
Closes #589.

Adds a **Filter** box to the header of both the **Downloads** and **Shared Files** tables. Type text and the list shows only files whose name contains it (case-insensitive); clearing the box restores the full list. This brings the GUI in line with the new WebUI, which already has it.

## Design

Purely GUI-side — the filter operates on the local list model, so it works identically in the monolithic app and the remote GUI (`amulegui`) with **no EC protocol change**. Both tables are virtual lists (`CMuleVirtualListCtrl`), so filtering just changes which items are in the model; `SortList()` and the `OnGetItem*` path handle re-render and sorting.

- **Downloads** (`CDownloadListCtrl`): the model already holds every file independent of what's displayed, and the category tabs already gate visibility through a predicate. The filter adds `PassesTextFilter()` AND-ed into that predicate via `IsVisibleInCat()`, and changing the text re-runs the same repopulate loop `ChangeCategory()` uses.
- **Shared files** (`CSharedFilesCtrl`): `SetFilterText()` rebuilds the model from the master share applying the filter; per-file adds respect it too.

Modeled on the existing search-results filter (`CSearchListCtrl`).

## Notes

- Reuses the existing `_("Filter:")` string — no new translations.
- The shared-files header was relaid out (equal-proportion side regions) so the "Show Clients for" radio group stays window-centered next to the new filter box.
- New control IDs picked above the wxDesigner-generated range, per the `muuli_wdr` convention.

Built clean on macOS and Linux for both the monolithic app and `amulegui`; interactive testing in both tables underway.
