### PR TITLE
fix(gui): cap the search-result colour gradient below full saturation

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -395,7 +395,11 @@ void CSearchListCtrl::UpdateItemColor(long index)
 			break;
 		default: {
 			// New result -- blue-tinted gradient by source count.
-			const int shift = std::min((int)file->GetSourceCount() * 5, 255);
+			// Capped below 255: a fully saturated blue text on white
+			// (or white-ish on dark) is hard to read, so the gradient
+			// tops out at a legible mid-blue instead of collapsing
+			// every popular result to the same illegible extreme.
+			const int shift = std::min((int)file->GetSourceCount() * 5, 180);
 			colour = isDark ? wxColour(255 - shift, 255 - shift, 255) : wxColour(0, 0, shift);
 			break;
 		}


### PR DESCRIPTION
## Summary
Search results with many sources (51+) collapsed to a fully saturated
`RGB(0,0,255)` text colour, which is hard to read on both light and
dark backgrounds — ironically making the most popular results the
least legible.

## Fix
Cap the colour shift at 180 instead of 255, so the gradient still
conveys source count but never reaches full saturation.

## Test plan
- [x] Built locally on macOS (arm64) with CMake/wxWidgets 3.3.3
- [x] Visually verify search results with 51+ sources render legibly on both light and dark themes

Fixes #630