### PR TITLE
fix(macos): register and handle .emulecollection files as an openable document type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -415,6 +415,21 @@ if (BUILD_MONOLITHIC)
 			VERBATIM
 		)
 
+		# Declare aMule as a handler for .emulecollection files so
+		# Finder offers it in "Open With" and delivers the file path
+		# via the standard macOS Open Document apple-event, which
+		# CamuleGuiApp::MacOpenFiles() picks up. Without this key,
+		# LaunchServices has no record that aMule understands the
+		# extension, so double-clicking (or forcing it via "Get
+		# Info" -> Open with) does nothing.
+		add_custom_command (TARGET amule POST_BUILD
+			COMMAND /usr/bin/plutil -replace CFBundleDocumentTypes
+				-json "[{\"CFBundleTypeName\": \"eMule Collection\", \"CFBundleTypeExtensions\": [\"emulecollection\"], \"CFBundleTypeRole\": \"Editor\"}]"
+				"$<TARGET_BUNDLE_CONTENT_DIR:amule>/Info.plist"
+			COMMENT "Declaring aMule.app as a .emulecollection file handler"
+			VERBATIM
+		)
+
 		# Copy translation catalogs into the .app bundle so the in-tree
 		# build picks them up.  wxLocale's lookup prefix on macOS is
 		# wxStandardPaths::GetDataDir() + "/locale", which resolves to

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -49,8 +49,8 @@
 #include "ThreadTasks.h"
 #include "MuleCollection.h" // Needed for CMuleCollection
 #include "DownloadQueue.h"  // Needed for CDownloadQueue::AddLinks
-#include "Logger.h"    // Needed for EVT_MULE_LOGGING
-#include "GuiEvents.h" // Needed for EVT_MULE_NOTIFY
+#include "Logger.h"         // Needed for EVT_MULE_LOGGING
+#include "GuiEvents.h"      // Needed for EVT_MULE_NOTIFY
 
 #ifdef __WXMAC__
 #include <CoreFoundation/CFBundle.h>                 // Do_not_auto_remove

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -47,6 +47,8 @@
 #endif
 #include "PartFileConvert.h"
 #include "ThreadTasks.h"
+#include "MuleCollection.h" // Needed for CMuleCollection
+#include "DownloadQueue.h"  // Needed for CDownloadQueue::AddLinks
 #include "Logger.h"    // Needed for EVT_MULE_LOGGING
 #include "GuiEvents.h" // Needed for EVT_MULE_NOTIFY
 
@@ -344,6 +346,25 @@ void CamuleGuiApp::MacReopenApp()
 		amuledlg->Show(true);
 		amuledlg->Iconize(false);
 		amuledlg->Raise();
+	}
+}
+
+void CamuleGuiApp::MacOpenFiles(const wxArrayString &fileNames)
+{
+	for (size_t i = 0; i < fileNames.GetCount(); ++i) {
+		const wxString &fileName = fileNames[i];
+		if (!fileName.Lower().EndsWith(wxT(".emulecollection"))) {
+			continue;
+		}
+
+		CMuleCollection collection;
+		if (collection.Open((std::string)fileName.mb_str())) {
+			wxArrayString links;
+			for (size_t e = 0; e < collection.size(); ++e) {
+				links.Add(wxString(collection[e].c_str(), wxConvUTF8));
+			}
+			downloadqueue->AddLinks(links);
+		}
 	}
 }
 #endif

--- a/src/amule.h
+++ b/src/amule.h
@@ -555,6 +555,15 @@ class CamuleGuiApp : public CamuleApp, public CamuleGuiBase
 	// window hidden via the close button (HideOnClose pref) stays
 	// permanently hidden - the app appears stuck.
 	virtual void MacReopenApp();
+
+	// Handles files macOS hands us via the Open Document apple-event
+	// (Finder double-click / "Open With", or a Dock drop) — currently
+	// just .emulecollection files, declared as a supported document
+	// type in the bundle's Info.plist (see src/CMakeLists.txt). Without
+	// this override wxApp's default implementation silently drops the
+	// paths, so nothing happens even once LaunchServices routes the
+	// file to us.
+	virtual void MacOpenFiles(const wxArrayString &fileNames);
 #endif
 
 public:


### PR DESCRIPTION
## Summary
aMule.app's Info.plist only declared `CFBundleURLTypes` (ed2k://,
magnet:), so LaunchServices had no record that aMule understands
`.emulecollection` files. Finder's "Open With" (or setting aMule as
the default handler via Get Info) would launch the app but nothing
happened, since no `MacOpenFiles` override existed to receive the
file path either.

## Fix
- Inject a `CFBundleDocumentTypes` entry for the `emulecollection`
  extension into the generated Info.plist (same `plutil` pattern
  already used for `CFBundleURLTypes`).
- Override `CamuleGuiApp::MacOpenFiles()` to parse the incoming
  file(s) with `CMuleCollection` and queue their links, reusing the
  same logic `CSharedFilesCtrl::OnAddCollection()` already uses for
  the "Add files in collection to transfer list" context-menu action.

## Test plan
- [x] Built locally on macOS (arm64) with CMake/wxWidgets 3.3.3
- [x] Verified `Info.plist` now contains `CFBundleDocumentTypes` for `emulecollection`
- [x] Simulated a real Finder "Open With" via `open -a aMule.app test.emulecollection` (delivers the file through the standard Open Document Apple Event, same path as a real double-click)
- [x] Confirmed via logging that `MacOpenFiles` fires, the collection is parsed, and the link is queued in `CDownloadQueue` (second run correctly reported the file as already queued)

Fixes #631