### PR TITLE
i18n: extract FirstRunWizard.cpp strings

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -28,6 +28,7 @@ src/ExternalConn.cpp
 src/ExternalConnector.cpp
 src/FileDetailDialog.cpp
 src/FileDetailListCtrl.cpp
+src/FirstRunWizard.cpp
 src/FriendList.cpp
 src/FriendListCtrl.cpp
 src/GenericClientListCtrl.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -305,11 +305,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr ""
 
@@ -1476,7 +1476,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr ""
 
@@ -2187,6 +2187,198 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+msgid "Connection & bandwidth"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+msgid "Connection speed:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+msgid "Your peer lists are already in place - nothing to download."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -2981,7 +3173,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3101,7 +3293,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3549,24 +3741,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3633,13 +3813,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3668,10 +3841,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3684,16 +3853,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3724,10 +3885,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3750,10 +3907,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3888,10 +4041,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3900,14 +4049,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5149,7 +5290,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5796,7 +5937,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
@@ -5808,7 +5949,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5848,36 +5989,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6900,10 +7041,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:13+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -311,12 +311,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i خادمات وجدت في server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "صنف"
 
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1625,7 +1625,7 @@ msgid "Show file &details"
 msgstr "اعرض الملف &تفاصيل"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "اعرض كل التعليقات"
 
@@ -2212,6 +2212,201 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "يتم الإتصال"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "اتصال"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "تصفح"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -3019,7 +3214,7 @@ msgstr ""
 msgid "Type"
 msgstr "نوع"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3139,7 +3334,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "التحميل"
 
@@ -3592,24 +3787,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3676,13 +3859,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "تصفح"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3711,10 +3887,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3727,16 +3899,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3767,10 +3931,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3794,10 +3954,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "أعد المحاولة"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr ""
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3931,10 +4087,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3943,14 +4095,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5213,7 +5357,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5877,7 +6021,7 @@ msgstr "ملفات مشاركة"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "بحث"
@@ -5890,7 +6034,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5931,37 +6075,37 @@ msgstr "غير مقيم"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "طلب ملف اخر"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "إلغاء"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7006,10 +7150,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:14+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -322,12 +322,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i sirvidor alcontráu en server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Enter Captcha"
 msgstr "Inxertar Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoría"
 
@@ -1515,7 +1515,7 @@ msgstr "ERROR: Error d'entrada/salida!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: Falló!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "En cola"
 
@@ -1641,7 +1641,7 @@ msgid "Show file &details"
 msgstr "Amosar detalles fi&cheru"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Amosar tolos comentarios"
 
@@ -2261,6 +2261,204 @@ msgstr "%.2f%% fináu."
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "¡Bienllegáu!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Coneutando a collaciu"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Estáu de conexón:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Redes"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Puertu TCP estándar "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Puertu UDP estándar (Kad / gueta global) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Habilitar UPnP pal reunvíu de puertu del router"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Coneutar"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Yá tas descargando el ficheru %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Auto-actualizar la llista de sirvidores al aniciu"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Carpeta de destín pa les descargues"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Desaminar"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Carpeta pa los ficheros temporales de descargues"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3076,7 +3274,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Triba"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Llocal"
 
@@ -3196,7 +3394,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Encaboxar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarga"
 
@@ -3656,24 +3854,12 @@ msgstr "Comprobar nueva versión al entamu"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Habilitando esto, fadrá que aMule compruebe si esiste una nueva versión al entamu."
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3740,13 +3926,6 @@ msgstr "Seleición del restolador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduz el nome del to restolador. Déxalo ermo si quies usar el que hai por defeutu."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Desaminar"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Abrir en nueva llingüeta si ye dable"
@@ -3775,10 +3954,6 @@ msgstr "Asignación de puestu reserváu"
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Puertu TCP estándar "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Esti ye'l puertu eD2k estándar y nun pue deshabilitase"
@@ -3791,17 +3966,9 @@ msgstr "Puertu UDP pa peticiones del sirvidor (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Puertu UDP estándar (Kad / gueta global) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Esti puertu UDP úsase pa peticiones estendíes de eD2k y la rede Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Habilitar UPnP pal reunvíu de puertu del router"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3832,10 +3999,6 @@ msgstr "Max. fontes descargando un ficheru:"
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3859,10 +4022,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "reintentos"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Auto-actualizar la llista de sirvidores al aniciu"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3996,10 +4155,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Carpeta de destín pa les descargues"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4009,14 +4164,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Carpeta pa los ficheros temporales de descargues"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5286,7 +5433,7 @@ msgstr "Asignando"
 msgid "Insufficient disk space"
 msgstr "Espaciu en discu insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargáu"
@@ -5977,7 +6124,7 @@ msgstr "Carpetes compartíes"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Guetar"
@@ -5990,7 +6137,7 @@ msgstr "El tamañu mínimu tien de ser menor al tamañu máximu. Tamañu máximu
 msgid "Search warning"
 msgstr "Alerta de gueta"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -6032,38 +6179,38 @@ msgstr "Non evaluada"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Descargar na categoría"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Amestar URLs opcionales pa esti ficheru"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Guetar ficheros rellacionaos (eD2k, gueta llocal)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Conseñar como ficheru conocíu"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar l'enllaz eD2k al cartafueyos"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Tas coneutáu al sirvidor, que tentes desaniciar. Por favor desconéutate primero."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Encaboxar"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7106,10 +7253,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -311,12 +311,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сървъра бяха намерени в server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Категория"
 
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1620,7 +1620,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr ""
 
@@ -2209,6 +2209,202 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Добре дошли!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Свързва"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Връзка"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Вие вече опитвате да свалите файла %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Избери"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -3011,7 +3207,7 @@ msgstr "Име:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3131,7 +3327,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Изтегляне"
 
@@ -3583,24 +3779,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3667,13 +3851,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Избери"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3702,10 +3879,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3718,16 +3891,8 @@ msgstr ""
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3758,10 +3923,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3784,10 +3945,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3922,10 +4079,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3934,14 +4087,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5195,7 +5340,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5849,7 +5994,7 @@ msgstr "Споделени файлове (%i)"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Търсене"
@@ -5862,7 +6007,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5903,37 +6048,37 @@ msgstr "Няма оценки"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Поискан му е друг файл"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Отказ"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6976,10 +7121,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -304,11 +304,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr ""
 
@@ -1475,7 +1475,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr ""
 
@@ -2186,6 +2186,198 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+msgid "Connection & bandwidth"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+msgid "Connection speed:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+msgid "Your peer lists are already in place - nothing to download."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -2980,7 +3172,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3100,7 +3292,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3548,24 +3740,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3632,13 +3812,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3667,10 +3840,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3683,16 +3852,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3723,10 +3884,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3749,10 +3906,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3887,10 +4040,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3899,14 +4048,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5148,7 +5289,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5795,7 +5936,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
@@ -5807,7 +5948,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5847,36 +5988,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6899,10 +7040,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -322,12 +322,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S'ha trobat %i servidor al server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgid "Enter Captcha"
 msgstr "Introdueix el Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoria"
 
@@ -1512,7 +1512,7 @@ msgstr "ERROR: error d'E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: Ha fallat!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "En cua"
 
@@ -1638,7 +1638,7 @@ msgid "Show file &details"
 msgstr "Mostra els &detalls del fitxer"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Mostra els comentaris"
 
@@ -2255,6 +2255,204 @@ msgstr "%.1f%% fet"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Benvinguts!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Connectant amb un amic"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Estat de la connexió:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Xarxes"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Port TCP per defecte:"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Port UDP extès (Kad / cerca global) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Activa UPnP per redirecció de ports"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Arrancada"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Ja esteu intentant baixar el fitxer %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Actualitza automàticament la llista de servidors a l'inici"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Carpeta on desar les descàrregues"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Explora"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Carpeta on desar les descàrregues temporals"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3066,7 +3264,7 @@ msgstr "Nom:"
 msgid "Type"
 msgstr "Tipus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3186,7 +3384,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Atura"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Baixada"
 
@@ -3644,24 +3842,12 @@ msgstr "Comprova si hi ha noves versions a l'inici"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "L'aMule comprovarà si hi ha noves versions durant l'inici"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3728,13 +3914,6 @@ msgstr "Selecció del navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introdueix el nom del teu navegador. Deixa el camp buit per usar el navegador per defecte del sistema."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Explora"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Obre en una nova pestanya si és possible"
@@ -3763,10 +3942,6 @@ msgstr "Per posició (slot)"
 msgid "Ports"
 msgstr "Ports "
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Port TCP per defecte:"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Aquest és el port eD2k estàndard i no es pot inhabilitar."
@@ -3779,17 +3954,9 @@ msgstr "Port UDP per sol·licituds del servidor (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Port UDP extès (Kad / cerca global) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Aquest port UDP és utilitzat per sol·licituds eD2k i Kad exteses"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Activa UPnP per redirecció de ports"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3820,10 +3987,6 @@ msgstr "Nombre màxim de fonts per descàrrega:"
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3847,10 +4010,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "intents"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Actualitza automàticament la llista de servidors a l'inici"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3984,10 +4143,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Carpeta on desar les descàrregues"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3997,14 +4152,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Carpeta on desar les descàrregues temporals"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5263,7 +5410,7 @@ msgstr "Assignant"
 msgid "Insufficient disk space"
 msgstr "Espai en disc insuficient"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Baixat"
@@ -5950,7 +6097,7 @@ msgstr "Carpetes compartides"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Error en la cerca"
 
@@ -5962,7 +6109,7 @@ msgstr "La mida mínima ha de ser menor que la màxima. S'ignorarà la mida màx
 msgid "Search warning"
 msgstr "Avís de cerca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -6003,37 +6150,37 @@ msgstr "Sense Valorar"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Baixa a la categoria"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obté %s per aquest fitxer"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca fitxers relacionats (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marca com a fitxer conegut"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia l'enllaç eD2k al porta-retalls"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Esteu connectat al servidor què intenteu eliminar. Si us plau, primer desconnecteu-vos."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Cancel·lat"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nou"
 
@@ -7069,10 +7216,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:16+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -321,11 +321,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1072,7 +1072,7 @@ msgid "Enter Captcha"
 msgstr "Vložte captchu"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1512,7 +1512,7 @@ msgstr "CHYBA: I/O chyba!"
 msgid "ERROR: Failed!"
 msgstr "CHYBA: Selhání!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Ve frontě"
 
@@ -1638,7 +1638,7 @@ msgid "Show file &details"
 msgstr "Zobrazit &podrobnosti souboru"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Zobrazit všechny komentáře"
 
@@ -2240,6 +2240,204 @@ msgstr "%.2f%% dokončeno"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Vítejte!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Připojuji se ke kamarádovi"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Stav připojení:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Sítě"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standardní TCP port"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Rozšířený UDP port (Kad / globální vyhledávání)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Povolit UPnP port forwarding"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Soubor %s se již pokoušíte stáhnout"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Automaticky aktualizovat seznam serverů po spuštění"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Cílový adresář pro stahování"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Procházet"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3059,7 +3257,7 @@ msgstr "Název:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokální"
 
@@ -3179,7 +3377,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zastavit"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Stahování"
 
@@ -3636,24 +3834,12 @@ msgstr "Kontrola nové verze po spuštění"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "aMule po spuštění zkontroluje, zda nevyšla nová verze"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3720,13 +3906,6 @@ msgstr "Výběr prohlížeče"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Procházet"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Otevřít pokud možno v novém tabu"
@@ -3755,10 +3934,6 @@ msgstr "Přidělování slotů"
 msgid "Ports"
 msgstr "Porty"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standardní TCP port"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tohle je standardní eD2k port a nelze jej zakázat."
@@ -3771,17 +3946,9 @@ msgstr "UDP port pro požadavky serveru (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Rozšířený UDP port (Kad / globální vyhledávání)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tento UDP port je použit pro rozšířené požadavky eD2k a pro síť Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Povolit UPnP port forwarding"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3811,10 +3978,6 @@ msgstr "Max. zdrojů na stahovaný soubor:"
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3838,10 +4001,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "pokusech"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Automaticky aktualizovat seznam serverů po spuštění"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3975,10 +4134,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Cílový adresář pro stahování"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3987,14 +4142,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5263,7 +5410,7 @@ msgstr "Alokuji"
 msgid "Insufficient disk space"
 msgstr "Nedostatek místa na disku"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Staženo"
@@ -5949,7 +6096,7 @@ msgstr "Sdílené adresáře"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Vyhledávání"
@@ -5962,7 +6109,7 @@ msgstr "Min. velikost musí být menší než max. velikost. Ignoruji max. velik
 msgid "Search warning"
 msgstr "Varování při vyhledávání"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hlavní"
 
@@ -6003,37 +6150,37 @@ msgstr "Nehodnocené"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Přidat volitelné URL pro tento soubor"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Vyhledat související soubory (eD2k, lokální server)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Označit jako známý soubor"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Zkopírovat eD2k odkaz do schránky"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Snažíte se smazat server, na který jste právě připojen(a). Nejprve se prosím odpojte."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Zrušeno"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nový"
 
@@ -7081,10 +7228,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:17+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -312,12 +312,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i Serverer fundet i server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1066,7 +1066,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategori"
 
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1628,7 +1628,7 @@ msgid "Show file &details"
 msgstr "Vis fil &detaljer"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Vis alle kommentarer"
 
@@ -2218,6 +2218,202 @@ msgstr ""
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Velkommen"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Forbundet til %s"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Forbindelse"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Du prøver allerede at downloade denne fil %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Gennemse"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3028,7 +3224,7 @@ msgstr ""
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3148,7 +3344,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3603,24 +3799,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3687,13 +3871,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Gennemse"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3722,10 +3899,6 @@ msgstr "Slot Tildeling"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3738,16 +3911,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3778,10 +3943,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3805,10 +3966,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "forsøg"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr ""
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3942,10 +4099,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3954,14 +4107,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5224,7 +5369,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5889,7 +6034,7 @@ msgstr "Delte Filer"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Søg"
@@ -5902,7 +6047,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5943,37 +6088,37 @@ msgstr "Ikke anslået"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Indtast nyt navn for denne fil:"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Afbryd"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7019,10 +7164,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:18+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -332,11 +332,11 @@ msgstr ""
 "aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
 "Wählen Sie aus, welche heruntergeladen werden sollen:"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "eD2k-Serverliste (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
@@ -1084,7 +1084,7 @@ msgid "Enter Captcha"
 msgstr "Captcha eingeben"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1520,7 +1520,7 @@ msgstr "FEHLER: IO-Fehler!"
 msgid "ERROR: Failed!"
 msgstr "FEHLER: Fehlgeschlagen!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "In Warteschlange"
 
@@ -1646,7 +1646,7 @@ msgid "Show file &details"
 msgstr "Zeige &Dateieigenschaften"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Zeige alle Kommentare"
 
@@ -2261,6 +2261,204 @@ msgstr "%.1f%% erledigt"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Willkommen!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Verbinde zu Kumpel"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Verbindungstyp:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Netzwerke"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standard-TCP-Port"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Erweiterter UDP-Port (Kad / globale Suche)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Aktiviere UPnP für Router-Port-Weiterleitung"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Die Datei %s wird bereits heruntergeladen"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Serverliste beim Programmstart aktualisieren"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "aMule automatisch starten wenn ich mich einlogge"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Zielverzeichnis für Downloads."
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Durchsuchen"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Verzeichnis für temporäre Downloaddateien"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3064,7 +3262,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Suchtyp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3184,7 +3382,7 @@ msgstr "Bittet Kad-Peers, die bereits geantwortet haben, die Suche zu erweitern.
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3642,24 +3840,12 @@ msgstr "Beim Start auf neue Version prüfen"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Wenn dies aktiviert ist, wird aMule beim Start überprüfen, ob eine neue Version vorliegt"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "aMule automatisch starten wenn ich mich einlogge"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registriert einen Autostart pro Nutzer. Wenn du das Programm verschiebst musst du aMule manuell starten um den Eintrag zu aktualisieren."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3726,13 +3912,6 @@ msgstr "Browser-Wahl"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Gib den Namen des gewünschten Browsers hier ein. Bei einem leeren Feld wird der voreingestellte Systembrowser benutzt."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Durchsuchen"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Öffne in neuem Reiter, wenn möglich"
@@ -3761,10 +3940,6 @@ msgstr "Slotzuteilung"
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standard-TCP-Port"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dies ist der Standard-eD2k-Port. Er kann nicht deaktiviert werden."
@@ -3777,17 +3952,9 @@ msgstr "UDP-Port für Serveranfragen (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Erweiterter UDP-Port (Kad / globale Suche)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Dieser UDP-Port wird für erweiterte ED2k-Anfragen und das Kad-Netzwerk benutzt."
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Aktiviere UPnP für Router-Port-Weiterleitung"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3818,10 +3985,6 @@ msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "eD2k"
@@ -3845,10 +4008,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "Versuchen"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Serverliste beim Programmstart aktualisieren"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3982,10 +4141,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Zielverzeichnis für Downloads."
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3997,14 +4152,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Wähle einen Ordner in dem vollständige Downloads gepeichert werden sollen. Dieser Ordner wird automatisch geteilt."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Alle Dateien in diesem Ordner werden mit anderen Nutzern geteilt)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Verzeichnis für temporäre Downloaddateien"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5258,7 +5405,7 @@ msgstr "Reserviere"
 msgid "Insufficient disk space"
 msgstr "Zu wenig Festplattenplatz"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Heruntergeladen"
@@ -5945,7 +6092,7 @@ msgstr "Freigegebene Ordner"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deaktiviert sind."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Suchfehler"
 
@@ -5957,7 +6104,7 @@ msgstr "Mindestgröße muss kleiner sein, als die Höchstgröße: Höchstgröße
 msgid "Search warning"
 msgstr "Suchwarnung"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hauptkategorie"
 
@@ -5998,37 +6145,37 @@ msgstr "Nicht bewertet"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Herunterladen in Kategorie"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "%s für diese Datei erhalten"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Suche verwandte Dateien (eD2k, lokale Server)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Als bekannte Datei kennzeichnen"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du bist zu einem Server verbunden, den du zu löschen versuchst. Bitte zuerst trennen."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Abgebrochen"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Neu"
 
@@ -7061,10 +7208,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:19+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -326,12 +326,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "βρέθηκε %i διακομιστής στο server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Κατηγορία"
 
@@ -1523,7 +1523,7 @@ msgstr "ΣΦΑΛΜΑ: σφάλμα εισόδου/εξόδου!"
 msgid "ERROR: Failed!"
 msgstr "ΣΦΑΛΜΑ: Απέτυχε!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Εν αναμονή"
 
@@ -1649,7 +1649,7 @@ msgid "Show file &details"
 msgstr "Εμφάνιση &λεπτομερειών για το αρχείο"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Εμφάνιση όλων των σχολίων"
 
@@ -2270,6 +2270,204 @@ msgstr "%.2f%% ολοκληρώθηκαν"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Καλώς ήρθατε (Καλώς σας βρήκαμε)"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Συνδεδεμένος στον φιλαράκο"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Κατάσταση σύνδεσης:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Δίκτυα"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Πρότυπη θύρα TCP"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Εκτεταμένη θύρα UDP (Kad / καθολική αναζήτηση)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Ενεργοποίηση UPnP για προώθηση της θύρας του δρομολογητή"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Εκκινητήρας"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Ήδη προσπαθείτε να κατεβάσετε το αρχείο %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Κατάλογος για τα εισερχόμενα"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Επιλογή"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Κατάλογος για τα προσωρινά αρχεία"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3087,7 +3285,7 @@ msgstr "Όνομα:"
 msgid "Type"
 msgstr "Τύπος"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Τοπικό"
 
@@ -3207,7 +3405,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Σταμάτημα"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Κατέβασμα"
 
@@ -3667,24 +3865,12 @@ msgstr "Έλεγχος για νέα έκδοση κατά την εκκίνησ
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Αν ενεργοποιηθεί, το aMule θα ελέγχει αν υπάρχει νέα έκδοση κατά την εκκίνηση"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3751,13 +3937,6 @@ msgstr "Επιλογή περιηγητή ιστοσελίδων"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Εισάγετε το όνομα το περιηγητή ιστολελίδων. Αφήστε αυτό το πεδίο κενό για τον προεπιλεγμένο περιηγητή."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Επιλογή"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Αν είναι δυνατόν, άνοιξε τη σελίδα σε καινούρια καρτέλα"
@@ -3786,10 +3965,6 @@ msgstr "Ανάθεση θυρίδας"
 msgid "Ports"
 msgstr "Θύρες"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Πρότυπη θύρα TCP"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Αυτή είναι η βασική θύρα eD2k και δεν μπορεί να απενεργοποιηθεί."
@@ -3802,17 +3977,9 @@ msgstr "Θύρα UDP για αιτήσεις εξυπηρετητή (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Εκτεταμένη θύρα UDP (Kad / καθολική αναζήτηση)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Αυτή η θύρα UDP χρησιμοποιήται για εκτεταμένες αιτήσεις eD2k και για το δίκτυο Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Ενεργοποίηση UPnP για προώθηση της θύρας του δρομολογητή"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3843,10 +4010,6 @@ msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3870,10 +4033,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "προσπάθειες"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Αυτόματη ενημέρωση λίστας διακομιστών κατά την εκκίνηση"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4007,10 +4166,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Κατάλογος για τα εισερχόμενα"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4020,14 +4175,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5298,7 +5445,7 @@ msgstr "Κατανέμει"
 msgid "Insufficient disk space"
 msgstr "Ανεπαρκής χώρος στο δίσκο"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Έχει κατεβεί"
@@ -5991,7 +6138,7 @@ msgstr "Κοινόχρηστα αρχεία"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Αναζητήσεις"
@@ -6004,7 +6151,7 @@ msgstr "Το ελάχιστο μέγεθος πρέπει να είναι μικ
 msgid "Search warning"
 msgstr "Προειδοποίηση ψαξίματος"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Κύρια"
 
@@ -6045,38 +6192,38 @@ msgstr "Μη αποτιμημένο"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Κατέβασμα στην κατηγορία"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Προσθήκη προαιρετικών URL για αυτό το αρχείο"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Αναζήτηση παρόμοιων αρχείων (στο eD2k, τοπικός διακομιστής)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Σημείωση αρχείου ως γνωστού"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Είστε συνδεδεμένος στον διακομιστή που προσπαθείτε να σβήσετε. Παρακαλείστε να αποσυνδεθείτε πρώτα"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Ακύρωση"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7123,10 +7270,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -305,11 +305,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr ""
 
@@ -1476,7 +1476,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr ""
 
@@ -2187,6 +2187,198 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+msgid "Connection & bandwidth"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+msgid "Connection speed:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+msgid "Your peer lists are already in place - nothing to download."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -2981,7 +3173,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3101,7 +3293,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3549,24 +3741,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3633,13 +3813,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3668,10 +3841,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3684,16 +3853,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3724,10 +3885,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3750,10 +3907,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3888,10 +4041,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3900,14 +4049,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5149,7 +5290,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5796,7 +5937,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
@@ -5808,7 +5949,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5848,36 +5989,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6900,10 +7041,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:19+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -334,11 +334,11 @@ msgstr ""
 "aMule ha detectado archivos de bootstrap de red faltantes.\n"
 "Seleccione cuáles descargar:"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
@@ -1088,7 +1088,7 @@ msgid "Enter Captcha"
 msgstr "Introduzca el \"captcha\""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoría"
 
@@ -1523,7 +1523,7 @@ msgstr "ERROR: ¡error de E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: ¡no se ha podido realizar la acción!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "En la cola"
 
@@ -1649,7 +1649,7 @@ msgid "Show file &details"
 msgstr "Mostrar los detalles del archivo"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Mostrar todos los comentarios"
 
@@ -2264,6 +2264,204 @@ msgstr "%.1f%% terminado"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "¡Bienvenido!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Conectando a amigo"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Tipo de conexión:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Redes"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Puerto TCP estándar "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Puerto UDP adicional (Kad / búsqueda global) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Habilitar UPnP para el reenvío del puerto del \"router\""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Inicialización"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Ya está intentando descargar el archivo %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Autoactualizar la lista de servidores al inicio"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "Iniciar aMule automáticamente al iniciar sesión"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr "Registrar aMule para los enlaces ed2k://"
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr "Registrar aMule para los enlaces magnet:"
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Carpeta de destino para las descargas"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Examinar"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Carpeta para los archivos temporales de las descargas"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3063,7 +3261,7 @@ msgstr "Nombre:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3183,7 +3381,7 @@ msgstr "Pide a los pares Kad que ya han respondido que amplíen la búsqueda. Ca
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarga"
 
@@ -3633,25 +3831,13 @@ msgstr "Comprobar periódicamente si hay una versión nueva"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Habilitando esto hará que aMule compruebe si existe una versión nueva al inicio, y una vez al día mientras se ejecuta"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "Iniciar aMule automáticamente al iniciar sesión"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registra una entrada en el SO por usuario para arrancar automáticamente aMule al iniciar sesión. Si se mueve el binario de aMule, tras ello deberá lanzarse una vez manualmente para actualizar esa entrada."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr "Registrar aMule para los enlaces ed2k://"
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Hace que aMule sea el manejador predeterminado de los enlaces ed2k://, de modo que al hacer clic en uno desde el navegador o el gestor de archivos se abra aquí."
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
-msgstr "Registrar aMule para los enlaces magnet:"
 
 #: src/muuli_wdr.cpp:1286
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
@@ -3717,13 +3903,6 @@ msgstr "Selección del navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduzca el nombre de su navegador. Déjelo en blanco si quiere usar el predefinido del sistema."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Examinar"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Abrir en una pestaña nueva si es posible"
@@ -3752,10 +3931,6 @@ msgstr "Asignación de puesto reservado"
 msgid "Ports"
 msgstr "Puertos"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Puerto TCP estándar "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este es el puerto eD2k estándar y no puede ser deshabilitado."
@@ -3768,17 +3943,9 @@ msgstr "Puerto UDP para peticiones del servidor (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Puerto UDP adicional (Kad / búsqueda global) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este puerto UDP se usa para peticiones adicionales de eD2k y la red Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Habilitar UPnP para el reenvío del puerto del \"router\""
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3808,10 +3975,6 @@ msgstr "Número máximo de fuentes descargando un archivo:"
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3835,10 +3998,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "reintentos"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Autoactualizar la lista de servidores al inicio"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3972,10 +4131,6 @@ msgstr "Detectar"
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Buscar los lugares de instalación estándar para un binario ffprobe y rellenar el campo de la ruta."
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Carpeta de destino para las descargas"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3987,14 +4142,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Elija la carpeta donde se guardarán las descargas terminadas. Todos los archivos de esa carpeta se compartirán con otros usuarios."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Todos los archivos de esta carpeta se comparten con otros usuarios)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Carpeta para los archivos temporales de las descargas"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5254,7 +5401,7 @@ msgstr "Asignando"
 msgid "Insufficient disk space"
 msgstr "Espacio en disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargado"
@@ -5930,7 +6077,7 @@ msgstr "Carpeta compartida"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Error de búsqueda"
 
@@ -5942,7 +6089,7 @@ msgstr "El tamaño mínimo debe ser menor que el tamaño máximo. Tamaño máxim
 msgid "Search warning"
 msgstr "Aviso de búsqueda"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -5982,36 +6129,36 @@ msgstr "Tasa de bits"
 msgid "Codec"
 msgstr "Códec"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Descargar en la categoría"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtener %s para este archivo"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Buscar archivos relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marcar como archivo conocido"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar el enlace eD2k al portapapeles"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Actualmente no estás conectado a un servidor que admita la función de búsqueda de 'Archivos Relacionados'"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Cancelada"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nuevo"
 
@@ -7043,10 +7190,6 @@ msgstr "La rotación de fuentes del modo endgame es %s.\n"
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Búsqueda iniciada (id %u).\n"
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -322,12 +322,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Failis server.met on %i serverit"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgid "Enter Captcha"
 msgstr "Sisesta inimtesti kontrollkood"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategooria"
 
@@ -1513,7 +1513,7 @@ msgstr "VIGA: IO viga!"
 msgid "ERROR: Failed!"
 msgstr "VIGA: Ebaõnnestus!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Järjekorras"
 
@@ -1639,7 +1639,7 @@ msgid "Show file &details"
 msgstr "Näita &detaile"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Näita kõiki kommentaare"
 
@@ -2256,6 +2256,204 @@ msgstr "%.2f%% tehtud"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Ohoo, rõõm sind näha!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Ühendun semuga"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Ühenduse olek:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Võrgud"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Vaikimisi TCP Port "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Laiendatud UDP port (Kad / globaalne otsing) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Luba UPnP ruuteri portide suunamiseks"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Sa juba proovid '%s' faili tõmmata"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Käivitamisel värskenda automaatselt serverite nimekirja"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Tõmmatavate failide kataloog"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Lehitse"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Ajutiste tõmmatavate failide kataloog"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3067,7 +3265,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tüüp"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Kohalik"
 
@@ -3187,7 +3385,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Seiska"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Tõmbamine"
 
@@ -3645,24 +3843,12 @@ msgstr "Kontrolli käivitumisel uue versiooni olemasolu"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Valituna kontrollib aMule käivitumisel värskema versiooni olemasolu"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3729,13 +3915,6 @@ msgstr "Lehitseja valik"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sisesta siia lehitsejaprogrammi nimi. Jättes välja tühjaks, kasutab süsteem vaikimisi määratud lehitsejat."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Lehitse"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Võimalusel ava uus sakk"
@@ -3764,10 +3943,6 @@ msgstr "Määratud pesa"
 msgid "Ports"
 msgstr "Pordid"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Vaikimisi TCP Port "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "See on eD2k standard port ja seda ei saa välja lülitada."
@@ -3780,17 +3955,9 @@ msgstr "UDP port serveri päringute jaoks (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Laiendatud UDP port (Kad / globaalne otsing) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Seda UDP porti kasutatkse laiendatud omadustega eD2k ja Kad võrgu puhul"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Luba UPnP ruuteri portide suunamiseks"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3821,10 +3988,6 @@ msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3848,10 +4011,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "katset"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Käivitamisel värskenda automaatselt serverite nimekirja"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3985,10 +4144,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Tõmmatavate failide kataloog"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3998,14 +4153,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Ajutiste tõmmatavate failide kataloog"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5264,7 +5411,7 @@ msgstr "Eraldamine"
 msgid "Insufficient disk space"
 msgstr "Ebapiisav kettaruum"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Allalaetud"
@@ -5953,7 +6100,7 @@ msgstr "Jagatud kataloogid"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Otsingud"
@@ -5966,7 +6113,7 @@ msgstr "Min suurus peab olema väiksem kui max suurus. Ignoreerin Max suurust."
 msgid "Search warning"
 msgstr "Otsingu hoiatus"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Peamine"
 
@@ -6008,37 +6155,37 @@ msgstr "Pole hinnatud"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Tõmba kataloogi"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Lisa selle faili alternatiivsed URL'id"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Otsi seotud faile (eD2k, kohalik server)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Märgi fail tuntuks"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopeeri eD2k link lõikepuhvrisse"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sa oled serveriga, mida soovid kustutada, ühenduses. Palun katkesta ühendus. Serverit ei kustutatud."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Loobutud"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Uus"
 
@@ -7074,10 +7221,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:20+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -323,12 +323,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "zerbitzari %i aurkiturik server.met fitxategian"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgid "Enter Captcha"
 msgstr "Idatzi kaptxa"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1514,7 +1514,7 @@ msgstr "ERROREA: SI errorea!"
 msgid "ERROR: Failed!"
 msgstr "ERROREA: Huts egin du!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Ilaran"
 
@@ -1640,7 +1640,7 @@ msgid "Show file &details"
 msgstr "Erakutsi &xehetasunak"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Erakutsi iruzkin guztiak"
 
@@ -2257,6 +2257,204 @@ msgstr "%.1f%% egina"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Ongietorria!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Lagunera konektatzen"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Konexio egoera:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Sareak"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "TCP ataka estandarra "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Hedatutako UDP ataka (Kad / bilaketa orokorra) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Gaitu UPnP router ataka berbideraketarako"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Autoabioa"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Dagoeneko %s fitxategia deskargatzen ari zara"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Auto-eguneratu zerbitzari zerrenda abioan"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Deskargentzat helburu karpeta"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Arakatu"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Aldiroko deskarga fitxategientzat karpeta"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3068,7 +3266,7 @@ msgstr "Izena:"
 msgid "Type"
 msgstr "Mota"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokala"
 
@@ -3188,7 +3386,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Gelditu"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Deskargatu"
 
@@ -3646,24 +3844,12 @@ msgstr "Arakatu bertsio berrien bila abiaraztean"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Hau gaitzean Amulek abiaraztean bertsio berririk dagoen arakatzea egingo du"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3730,13 +3916,6 @@ msgstr "Nabigatzaile hautaketa"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Idatzi zure nabigatzaile izena hemen. Zurian utzi sisteman lehenetsitako nabigatzailea erabiltzeko."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Arakatu"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Ireki fitxa berrian aukera dagoenenean"
@@ -3765,10 +3944,6 @@ msgstr "Ataka ezarpena"
 msgid "Ports"
 msgstr "Atakak"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "TCP ataka estandarra "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Hau eD2k ataka estandarra da eta ezin da ezgaitu."
@@ -3781,17 +3956,9 @@ msgstr "UDP ataka zerbitzari eskakizunetarako (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Hedatutako UDP ataka (Kad / bilaketa orokorra) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "UDP ataka hau hedaturiko eD2k eskakizun eta Kad sarerako erabiltzen da"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Gaitu UPnP router ataka berbideraketarako"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3822,10 +3989,6 @@ msgstr "Jatorri muga deskarga bakoitzerako:"
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3849,10 +4012,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "saiakerak"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Auto-eguneratu zerbitzari zerrenda abioan"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3986,10 +4145,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Deskargentzat helburu karpeta"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3999,14 +4154,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5264,7 +5411,7 @@ msgstr "Esleitzen"
 msgid "Insufficient disk space"
 msgstr "Disko leku askieza"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Deskargatua"
@@ -5952,7 +6099,7 @@ msgstr "Partekatutako karpetak"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Bilaketak"
@@ -5965,7 +6112,7 @@ msgstr "Gutxienezko tamaina gehienezkoa baino txikiagoa izan behar da. Gehienezk
 msgid "Search warning"
 msgstr "Bilaketa oharra"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Nagusia"
 
@@ -6007,37 +6154,37 @@ msgstr "Kalifikatu gabea"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Kategori honetan deskargatu"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Eskuratu %s fitxategi honentzat"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Bilatu erlazionatutako fitxategiak (eD2k, zerbitzari lokala)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Markatu fitxategia ezaguna bezala"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiatu ed2k lotura arbelera"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Konektaturik zauden zerbitzaria ezabatu nahi duzu. Mesedez deskonektatu lehenik."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Utzia"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Berria"
 
@@ -7070,10 +7217,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:21+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -323,12 +323,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i palvelin tiedostossa server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgid "Enter Captcha"
 msgstr "Syötä kuvavarmennus"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Luokittelu"
 
@@ -1514,7 +1514,7 @@ msgstr "VIRHE: IO-virhe!"
 msgid "ERROR: Failed!"
 msgstr "VIRHE: Epäonnistui!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Jonossa"
 
@@ -1640,7 +1640,7 @@ msgid "Show file &details"
 msgstr "Näytä tie&doston tiedot"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Näytä kaikki kommentit"
 
@@ -2257,6 +2257,204 @@ msgstr "%.1f%% valmiina"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f KB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Tervetuloa!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Yhdistetään kaveriin"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Yhteyden tila:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Verkot"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Vakio TCP-portti"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Laajennettu UDP-portti (Kad / haku kaikkialta)."
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Käytä UPnP:tä reitittimen portinohjauksessa"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Yhdistämisapu"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Lataat jo tiedostoa %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Päivitä palvelinlista käynnistettäessä"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Kansio ladatuille tiedostoille"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Selaa"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Kansio latauksen väliaikaisille tiedostoille"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3068,7 +3266,7 @@ msgstr "Nimi:"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Paikallinen"
 
@@ -3188,7 +3386,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Pysäytä"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Lataa"
 
@@ -3646,24 +3844,12 @@ msgstr "Tarkista uuden version saatavuus käynnistettäessä"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "aMule tarkistaa käynnistyessään uuden version olemassaolon kun tämä on päällä."
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3730,13 +3916,6 @@ msgstr "Selaimen valinta"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Syötä tähän selaimesi nimi. Jätä tyhjäksi jos haluat käyttää järjestelmän oletusselainta."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Selaa"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Avaa uuteen välilehteen mikäli mahdollista"
@@ -3765,10 +3944,6 @@ msgstr "Paikkavaraus"
 msgid "Ports"
 msgstr "Portit"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Vakio TCP-portti"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tämä on vakio eD2k-portti eikä sitä voi kytkeä pois päältä."
@@ -3781,17 +3956,9 @@ msgstr "UDP-portti palvelinpyyntöihin (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Laajennettu UDP-portti (Kad / haku kaikkialta)."
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Tätä UDP-porttia käytetään laajennettuihin eD2k-hakuihin sekä Kad-verkossa"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Käytä UPnP:tä reitittimen portinohjauksessa"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3822,10 +3989,6 @@ msgstr "Lähteitä enintään tiedostoa kohden:"
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3849,10 +4012,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "yrityksen jälkeen"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Päivitä palvelinlista käynnistettäessä"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3986,10 +4145,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Kansio ladatuille tiedostoille"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3999,14 +4154,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5264,7 +5411,7 @@ msgstr "Allokoidaan"
 msgid "Insufficient disk space"
 msgstr "Riittämätön levytila"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Ladattu"
@@ -5952,7 +6099,7 @@ msgstr "Jaetut kansiot"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Haut"
@@ -5965,7 +6112,7 @@ msgstr "Vähimmäiskoon pitää olla pienempi kuin enimmäiskoon. Enimmäiskokoa
 msgid "Search warning"
 msgstr "Hakuvaroitus"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Kaikki"
 
@@ -6007,37 +6154,37 @@ msgstr "Ei luokitusta"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Lataa luokassa"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Hanki %s tälle tiedostolle"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Hae tähän liittyviä tiedostoja (eD2k, paikallinen palvelin)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Merkitse tunnetuksi tiedostoksi"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopioi eD2k-linkki leikepöydälle"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Olet yhdistettynä palvelimeen jota yrität poistaa, katkaise yhteys ensin."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Peruutettu"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Uusi"
 
@@ -7070,10 +7217,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:22+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -332,11 +332,11 @@ msgstr ""
 "aMule a détecté des fichiers d'amorçage de réseau manquants.\n"
 "Sélectionnez ceux à télécharger :"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "Liste de serveurs eD2k (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nœuds d'amorçage Kad (nodes.dat)"
 
@@ -1086,7 +1086,7 @@ msgid "Enter Captcha"
 msgstr "Entrer le Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Catégorie"
 
@@ -1521,7 +1521,7 @@ msgstr "ERREUR : Erreur E/S !"
 msgid "ERROR: Failed!"
 msgstr "ERREUR : Échec !"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Mis en file d'attente"
 
@@ -1647,7 +1647,7 @@ msgid "Show file &details"
 msgstr "Afficher les &Détails"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Afficher tous les commentaires"
 
@@ -2262,6 +2262,204 @@ msgstr "%.1f%% effectué"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f Ko/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Bienvenue !"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Connexion au pote"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Type de la connexion :"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Réseaux"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Port TCP standard "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Port UDP étendu (recherche Kad / globale) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Activer UPnP pour la redirection de port du routeur"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Amorçage"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Vous êtes déjà en train de télécharger le fichier %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Mise à jour automatique de la liste des serveurs au démarrage"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "Lancer aMule automatiquement lorsque j'ouvre une session"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr "Enregistrer aMule pour les liens ed2k://"
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr "Enregistrer aMule pour les liens magnet:"
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Dossier de destination des téléchargements"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Parcourir"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Dossier des fichiers de téléchargements temporaires"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3061,7 +3259,7 @@ msgstr "Nom :"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3181,7 +3379,7 @@ msgstr "Demande aux pairs Kad ayant déjà répondu d'élargir la recherche. Cha
 msgid "Stop"
 msgstr "Arrêter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Réception"
 
@@ -3631,25 +3829,13 @@ msgstr "Vérifier les nouvelles versions périodiquement"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Si vous activer ceci, aMule vérifiera si de nouvelles versions sont disponibles au démarrage et une fois par jour pendant son exécution"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "Lancer aMule automatiquement lorsque j'ouvre une session"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Enregistre une entrée de lancement automatique auprès du système d'exploitation pour qu'aMule se lance à l'ouverture d'une session. Si vous déplacez le binaire d'aMule, lancez-le par la suite une fois manuellement pour que l'entrée soit actualisée."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr "Enregistrer aMule pour les liens ed2k://"
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Fait d'aMule le gestionnaire par défaut des liens ed2k:// pour qu'un clic sur un tel lien sur votre navigateur ou gestionnaire de fichiers l'ouvre ici."
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
-msgstr "Enregistrer aMule pour les liens magnet:"
 
 #: src/muuli_wdr.cpp:1286
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
@@ -3715,13 +3901,6 @@ msgstr "Sélection du navigateur"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indiquez le nom de votre navigateur ici. Laissez ce champ vide pour utiliser le navigateur par défaut du système."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Parcourir"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Ouvrir si possible dans un nouvel onglet"
@@ -3750,10 +3929,6 @@ msgstr "Attribution de slot"
 msgid "Ports"
 msgstr "Ports"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Port TCP standard "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ceci est le port eD2k standard et ne peut pas être activé."
@@ -3766,17 +3941,9 @@ msgstr "Port UDP pour les requêtes des serveurs (TCP+3) :"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Port UDP étendu (recherche Kad / globale) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ce port UDP est utilisé pour les requêtes eD2k étendues et pour le réseau Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Activer UPnP pour la redirection de port du routeur"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3806,10 +3973,6 @@ msgstr "Sources maximales par fichier téléchargé :"
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3833,10 +3996,6 @@ msgstr "Les serveurs statiques ne sont jamais enlevés, même lorsqu'ils sont in
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "essais"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Mise à jour automatique de la liste des serveurs au démarrage"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3970,10 +4129,6 @@ msgstr "Détecter"
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Rechercher les binaires de ffprobe aux emplacements par défaut et compléter le champ emplacement."
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Dossier de destination des téléchargements"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3985,14 +4140,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Choisissez le répertoire où les téléchargements terminés seront enregistrés. Tous les fichiers de ce répertoire seront partagés avec les autres pairs."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Tous les fichiers de ce répertoire sont partagés avec les autres pairs)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Dossier des fichiers de téléchargements temporaires"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5248,7 +5395,7 @@ msgstr "En cours d'allocation"
 msgid "Insufficient disk space"
 msgstr "Espace disque insuffisant"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Téléchargé"
@@ -5924,7 +6071,7 @@ msgstr "Dossier partagé"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossible d'effectuer une recherche."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erreur de recherche"
 
@@ -5936,7 +6083,7 @@ msgstr "La taille minimum doit être inférieur à la taille maximum. Taille max
 msgid "Search warning"
 msgstr "Avertissement dans la recherche"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -5976,36 +6123,36 @@ msgstr "Débit binaire"
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Télécharger dans la catégorie"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtenir %s pour ce fichier"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Chercher les fichiers liés (eD2k, serveur local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marquer comme fichier connu"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copier le lien eD2k dans le presse-papiers"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Vous n'êtes actuellement pas connecté à un serveur prenant en charge la fonction de recherche de fichiers associés"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Annulé"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nouveau"
 
@@ -7035,10 +7182,6 @@ msgstr "La rotation de sources pour « endgame » est %s.\n"
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Recherche démarrée (id %u).\n"
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:22+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -344,11 +344,11 @@ msgstr ""
 "aMule detectou que faltan ficheiros necesarios para arrancar a rede.\n"
 "Escolla os que queira descargar:"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodos de inicio de Kad (nodes.dat)"
 
@@ -1097,7 +1097,7 @@ msgid "Enter Captcha"
 msgstr "Introduza o Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoría"
 
@@ -1533,7 +1533,7 @@ msgstr "ERRO: Erro de E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERRO: Non se puido realizar a acción!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "En cola"
 
@@ -1659,7 +1659,7 @@ msgid "Show file &details"
 msgstr "Amosar &detalles do ficheiro"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Ver todos os comentarios"
 
@@ -2274,6 +2274,204 @@ msgstr "%.1f%% feito"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Benvido!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Conectado a colega"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Estado de conexión:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Redes"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Porto TCP normativizado "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Porto UDP ampliado (Kad / busca global) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Activar UPnP para configurar os portos no encamiñador"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Arranque autónomo (dende cero)"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "O ficheiro %s xa se está descargando"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Actualizar automáticamente a lista de servidores no arranque"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "Arrancar aMule automaticamente ao iniciar sesión"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Cartafol de destino para descargas"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Navegador"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Cartafol para ficheiros de descarga temporais"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3077,7 +3275,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3197,7 +3395,7 @@ msgstr "Solicitar que os clientes Kad contactados estendan a busca. Cada pulsaci
 msgid "Stop"
 msgstr "Deter"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descargar"
 
@@ -3655,24 +3853,12 @@ msgstr "Comprobar se hai unha nova versión ao iniciar"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Activar isto fará que aMule comprobe se hai unha nova versión ao iniciarse"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "Arrancar aMule automaticamente ao iniciar sesión"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Crea unha configuración de usuario para que o sistema operativo inicie aMule ao entrar. Se polo que sexa móvese o programa aMule, execúteo unha primeira vez a man para actualizar a configuración."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3739,13 +3925,6 @@ msgstr "Selección de navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduza o nome do seu navegador aquí. Deixe o campo baleiro para empregar o navegador predeterminado do sistema."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Navegador"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Abrir nunha nova lapela se é posible"
@@ -3774,10 +3953,6 @@ msgstr "Asignación de ocos"
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Porto TCP normativizado "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto eD2k normativizado e non se pode desactivar."
@@ -3790,17 +3965,9 @@ msgstr "Porto UDP para peticións do servidor (TCP+3)"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Porto UDP ampliado (Kad / busca global) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP úsase para peticións eD2k ampliadas e para a rede Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Activar UPnP para configurar os portos no encamiñador"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3831,10 +3998,6 @@ msgstr "Límite de fontes por ficheiro descargado:"
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3858,10 +4021,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "intentos"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Actualizar automáticamente a lista de servidores no arranque"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3995,10 +4154,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Cartafol de destino para descargas"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4010,14 +4165,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolla o cartafol onde gardar as descargas completas. Compartiranse todos os ficheiros do cartafol co resto de parceiros."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Compartiranse todos os ficheiros do cartafol co resto de parceiros)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Cartafol para ficheiros de descarga temporais"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5272,7 +5419,7 @@ msgstr "Reservando"
 msgid "Insufficient disk space"
 msgstr "Espazo no disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descargado"
@@ -5959,7 +6106,7 @@ msgstr "Cartafoles compartidos"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erro na busca"
 
@@ -5971,7 +6118,7 @@ msgstr "O tamaño mínimo debe ser máis pequeno que o máximo. Tamaño máximo 
 msgid "Search warning"
 msgstr "Aviso na busca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -6012,37 +6159,37 @@ msgstr "Non evaluada"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Descargar na categoría"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obter %s para este ficheiro"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurar ficheiros relacionados (eD2k, busca local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marcar o ficheiro como coñecido"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar a ligazón eD2k ó portapapeis"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Está conectado ao servidor que tenta borrar. Por favor desconéctese primeiro."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Novo"
 
@@ -7076,10 +7223,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:23+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -319,11 +319,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1068,7 +1068,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "קטיגוריה"
 
@@ -1504,7 +1504,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "נכנס לתור"
 
@@ -1628,7 +1628,7 @@ msgid "Show file &details"
 msgstr "הראה &פרטי קבצים"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "הראה את כל ההערות"
 
@@ -2223,6 +2223,204 @@ msgstr "%.2f%% הושלם"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f ק\"ב/ש"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "ברוכים הבאים!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "מחובר לחבר"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "מצב חיבור:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "רשתות"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "קבצים זמניים"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "אתה כבר מנסה להוריד את הקובץ %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "דפדף"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3037,7 +3235,7 @@ msgstr "שם:"
 msgid "Type"
 msgstr "סוג/טיפוס"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "מקומי"
 
@@ -3157,7 +3355,7 @@ msgstr ""
 msgid "Stop"
 msgstr "עצור"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "הורדה"
 
@@ -3612,24 +3810,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3696,13 +3882,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "דפדף"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3731,10 +3910,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3747,16 +3922,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3787,10 +3954,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3813,10 +3976,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3951,10 +4110,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3963,14 +4118,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5233,7 +5380,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5916,7 +6063,7 @@ msgstr "קבצים משותפים"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "חיפושים"
@@ -5929,7 +6076,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "ראשי"
 
@@ -5970,37 +6117,37 @@ msgstr "לא מדורג"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "הורדה בקטיגוריה"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "הוסף כתובות URL אופתינליות לקובץ זה"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "סמן בתור קובץ מוכר"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "ביטול"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7044,10 +7191,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:24+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -316,12 +316,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i servera pronadjeno u server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgid "Enter Captcha"
 msgstr "Pisati captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgid "Show file &details"
 msgstr "Pokazi &detalje fajla"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Pokazi sve kommentare"
 
@@ -2226,6 +2226,202 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Spajanje"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Veza"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Privremene datoteke"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Vec pokusavate downloadovati fajl %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Pretrazi :"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -3039,7 +3235,7 @@ msgstr "Naziv:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3159,7 +3355,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3612,24 +3808,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3696,13 +3880,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Pretrazi :"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3731,10 +3908,6 @@ msgstr "Alokacija slota"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3747,16 +3920,8 @@ msgstr ""
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3787,10 +3952,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3814,10 +3975,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "pokusaja"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr ""
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3951,10 +4108,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3963,14 +4116,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5240,7 +5385,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5913,7 +6058,7 @@ msgstr "Dijeljeni fajlovi"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Pretrage"
@@ -5926,7 +6071,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5967,37 +6112,37 @@ msgstr "Bez ocjene"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Upitao za drugi fajl"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Otkaz"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Novo"
 
@@ -7050,10 +7195,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:25+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -326,11 +326,11 @@ msgstr ""
 "aMule hiányzó hálózati bootstrap fájlokat észlelt.\n"
 "Válassza ki a letölteni kivántakat:"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "eD2k szerver lista (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad bootstrap csomópontok (nodes.dat)"
 
@@ -1076,7 +1076,7 @@ msgid "Enter Captcha"
 msgstr "Captcha megadása"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategória"
 
@@ -1509,7 +1509,7 @@ msgstr "HIBA: IO hiba!"
 msgid "ERROR: Failed!"
 msgstr "HIBA: Sikertelen!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Várólistán"
 
@@ -1635,7 +1635,7 @@ msgid "Show file &details"
 msgstr "Fájl &részleteinek megjelenítése"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Összes megjegyzés megjelenítése"
 
@@ -2248,6 +2248,204 @@ msgstr "%.1f%% kész"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Üdvözöljük!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Kapcsolódás a pajtáshoz"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Kapcsolat állapota:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Hálózatok"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Szabvány TCP port "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Bővített UDP port (Kad / globális keresés) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "UPnP engedélyezése a router port továbbításhoz"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Rendszerbetöltés"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Már próbálod letölteni a(z) '%s' fájlt."
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Kiszolgáló lista automatikus frissítése indításkor"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "aMule automatikus indítása bejelentkezéskor"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Célkönyvtár a letöltéseknek"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Tallóz"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Könyvtár az ideiglenes letöltési fájloknak"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3046,7 +3244,7 @@ msgstr "Név:"
 msgid "Type"
 msgstr "Típus"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Helyi"
 
@@ -3166,7 +3364,7 @@ msgstr "Kérje meg a már válaszolt Kad partnereket, hogy szélesítsék a kere
 msgid "Stop"
 msgstr "Leállít"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Letöltés"
 
@@ -3624,24 +3822,12 @@ msgstr "Indításkor új verzió keresése"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Engedélyezve indításnál az aMule új verziót fog keresni."
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "aMule automatikus indítása bejelentkezéskor"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Felhasználónkénti automatikus indítási bejegyzést regisztrál, hogy az aMule bejelentkezéskor elinduljon. Ha áthelyezi az aMule bináris fájlt, indítsa el az aMule-t manuálisan a bejegyzés frissítéséhez."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3708,13 +3894,6 @@ msgstr "Böngésző kiválasztása"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Írd ide a böngésződ nevét. Hagyd üresen, hogy a rendszer alapértelmezett böngészőjéhez."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Tallóz"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Megnyitás új fülön, ha lehetséges"
@@ -3743,10 +3922,6 @@ msgstr "Slot kiosztás"
 msgid "Ports"
 msgstr "Portok"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Szabvány TCP port "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Ez a szabvány eD2k port és nem lehet letiltani."
@@ -3759,17 +3934,9 @@ msgstr "UDP port a kiszolgáló kérésekhez (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Bővített UDP port (Kad / globális keresés) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ezt az UDP portot a bővített eD2k kérések és a Kad hálózat használja"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "UPnP engedélyezése a router port továbbításhoz"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3800,10 +3967,6 @@ msgstr "Max források letöltési fájlonként:"
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3827,10 +3990,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "próbálkozás után"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Kiszolgáló lista automatikus frissítése indításkor"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3964,10 +4123,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Célkönyvtár a letöltéseknek"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3979,14 +4134,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Válassza ki a könyvtárat az elvégzett letöltéseknek. A könyvtár minden fájlja másokkal megosztásra kerül."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Minden fájl ebben a könyvtárban másokkal megosztásra kerül)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Könyvtár az ideiglenes letöltési fájloknak"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5245,7 +5392,7 @@ msgstr "Helyfoglalás"
 msgid "Insufficient disk space"
 msgstr "Elégtelen lemezterület"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Letöltve"
@@ -5926,7 +6073,7 @@ msgstr "Megosztott mappák"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Keresési hiba"
 
@@ -5938,7 +6085,7 @@ msgstr "A minimum méretnek kisebbnek kell lennie a maximum méretnél. Maximum 
 msgid "Search warning"
 msgstr "Keresési figyelmeztetés"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Alap"
 
@@ -5979,37 +6126,37 @@ msgstr "Nincs értékelve"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Letöltés kategóriába"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "%s lekérése ehez a fájlhoz"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Kapcsolódó fájlok keresése (eD2k, helyi kiszolgáló)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Ismertként megjelölés"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k hivatkozás másolása a vágólapra"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Olyan kiszolgálót próbál törölni, amelyikhez csatlakozva van. Kérém először válassza le."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Megszakítva"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Új"
 
@@ -7038,10 +7185,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:25+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -336,12 +336,12 @@ msgstr ""
 "Selezionare quali scaricare:"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "Lista server eD2k (server.met)"
 
 # AI-GENERATED — please review.
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
@@ -1091,7 +1091,7 @@ msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoria"
 
@@ -1526,7 +1526,7 @@ msgstr "ERRORE: Errore di input/output!"
 msgid "ERROR: Failed!"
 msgstr "ERRORE: Fallito!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "In coda"
 
@@ -1652,7 +1652,7 @@ msgid "Show file &details"
 msgstr "Mostra &dettagli file"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Mostra tutti i commenti"
 
@@ -2267,6 +2267,204 @@ msgstr "%.1f%% completato"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Benvenuto!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Connessione in corso all'amico"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Tipo di connessione:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Reti"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Porta TCP standard "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Porta UDP estesa (Kad / ricerca globale) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Abilita UPnP per il port forwarding del router"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Stai già cercando di scaricare il file %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Aggiorna lista server all'avvio"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "Avvia aMule automaticamente all'accesso"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr "Registra aMule per i link ed2k://"
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr "Registra aMule per i link magnet:"
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Cartella di destinazione per i file scaricati"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Sfoglia"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Cartella per i file temporanei"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3066,7 +3264,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Locale"
 
@@ -3186,7 +3384,7 @@ msgstr "Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni 
 msgid "Stop"
 msgstr "Ferma"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3636,25 +3834,13 @@ msgstr "Controlla periodicamente la disponibilità di una nuova versione"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Abilitare questa opzione farà sì che aMule verifichi la disponibilità di nuove versioni all'avvio e una volta al giorno durante l'esecuzione"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "Avvia aMule automaticamente all'accesso"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registra una voce di avvio automatico per l'utente nel sistema operativo affinché aMule venga avviato all'accesso. Se sposti l'eseguibile di aMule, avvialo manualmente una volta per aggiornare la voce."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr "Registra aMule per i link ed2k://"
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Imposta aMule come gestore predefinito per i link ed2k://, cliccandone uno nel browser o nel file manager verrà aperto qui."
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
-msgstr "Registra aMule per i link magnet:"
 
 #: src/muuli_wdr.cpp:1286
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
@@ -3720,13 +3906,6 @@ msgstr "Selezione browser"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Inserisci qui il nome del tuo browser. Lascia vuoto questo campo per utilizzare il browser di sistema predefinito."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Sfoglia"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Apri in una nuova scheda se possibile"
@@ -3755,10 +3934,6 @@ msgstr "Allocazione slot"
 msgid "Ports"
 msgstr "Porte"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Porta TCP standard "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Questa è la porta standard di eD2k e non può essere disabilitata."
@@ -3771,17 +3946,9 @@ msgstr "Porta UDP per le richieste al server (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Porta UDP estesa (Kad / ricerca globale) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Questa porta UDP è utilizzata per le richieste estese eD2k e per la rete Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Abilita UPnP per il port forwarding del router"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3811,10 +3978,6 @@ msgstr "Fonti massime per file in scaricamento:"
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3838,10 +4001,6 @@ msgstr "I server statici non vengono mai rimossi, nemmeno quando risultano irrag
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "tentativi"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Aggiorna lista server all'avvio"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3975,10 +4134,6 @@ msgstr "Rileva"
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Cerca nei percorsi di installazione standard un binario ffprobe e compila il campo del percorso."
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Cartella di destinazione per i file scaricati"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3990,14 +4145,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Scegli la cartella in cui salvare i download completati. Tutti i file in quella cartella saranno condivisi con gli altri peer."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Tutti i file in questa cartella sono condivisi con gli altri peer)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Cartella per i file temporanei"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5253,7 +5400,7 @@ msgstr "Allocazione in corso"
 msgid "Insufficient disk space"
 msgstr "Spazio su disco insufficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Scaricato"
@@ -5928,7 +6075,7 @@ msgstr "Cartella condivisa"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Errore di ricerca"
 
@@ -5940,7 +6087,7 @@ msgstr "Min size deve essere più piccola di max size. Ignoro max size."
 msgid "Search warning"
 msgstr "Avviso di ricerca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principale"
 
@@ -5980,36 +6127,36 @@ msgstr "Bitrate"
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Download nella categoria"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Ottieni %s per questo file"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Cerca file correlati (eD2k, server locale)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Segna come file conosciuto"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia il collegamento eD2k negli appunti"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Al momento non sei connesso ad un server che supporta la Ricerca di File Correlati"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Annullata"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nuovo"
 
@@ -7039,10 +7186,6 @@ msgstr "La rotazione delle fonti in modalità endgame è %s.\n"
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Ricerca iniziata (id %u).\n"
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -322,12 +322,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.metに%i個のサーバが見つかりました"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "カテゴリ"
 
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "キューに追加しました"
 
@@ -1639,7 +1639,7 @@ msgid "Show file &details"
 msgstr "ファイルの詳細(&D)"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "全てのコメントを表示"
 
@@ -2257,6 +2257,204 @@ msgstr "%.2f%%終わりました"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "ようこそ！"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "仲間と接続しています"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "接続状況："
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "ネットワーク"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "ブートストラップ"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "閲覧"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3064,7 +3262,7 @@ msgstr "名前："
 msgid "Type"
 msgstr "タイプ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "ローカル"
 
@@ -3184,7 +3382,7 @@ msgstr ""
 msgid "Stop"
 msgstr "中止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -3642,24 +3840,12 @@ msgstr "起動時に新バージョンを確認する"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "これを有効にするとaMuleはスタートアップの時に新バージョンをチェックする"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3726,13 +3912,6 @@ msgstr "ブラウザ選択"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "閲覧"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "可能ならば新しいタブで開く"
@@ -3761,10 +3940,6 @@ msgstr "スロット割り当て"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3777,16 +3952,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3817,10 +3984,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3844,10 +4007,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "回"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr ""
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3981,10 +4140,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3993,14 +4148,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5265,7 +5412,7 @@ msgstr "領域確保中"
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "ダウンロード済み"
@@ -5947,7 +6094,7 @@ msgstr "共有ファイル"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "検索"
@@ -5960,7 +6107,7 @@ msgstr "最小サイズは最大サイズより小さくなければなりませ
 msgid "Search warning"
 msgstr "検索の注意"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "メイン"
 
@@ -6001,38 +6148,38 @@ msgstr "評価されていません"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "カテゴリにダウンロードする"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "このファイルにオプショナルURLを追加する"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "既知ファイルとしてマークする"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "削除しようとするサーバには現在接続しています。先に切断を行ってください。"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "キャンセル"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7071,10 +7218,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:27+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -321,12 +321,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met에서 %i개의 서버가 발견됨"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1089,7 +1089,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "분류"
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "대기열에 있음"
 
@@ -1650,7 +1650,7 @@ msgid "Show file &details"
 msgstr "파일 상세 보기(&d)"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "모든 의견 보기"
 
@@ -2270,6 +2270,204 @@ msgstr "%.2f%% 완료"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "환영합니다!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "친구에게 접속함"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "연결 상태:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "통신망"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "카뎀리아"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "초기적재"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "이미 %s 파일을 내려받으려고 하고있음"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "탐색"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3088,7 +3286,7 @@ msgstr "이름:"
 msgid "Type"
 msgstr "종류"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "지역"
 
@@ -3208,7 +3406,7 @@ msgstr ""
 msgid "Stop"
 msgstr "멈춤"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "내려받기"
 
@@ -3666,24 +3864,12 @@ msgstr "시작할때 새 버젼이 있는지 확인"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "이것을 활성화하면 어뮬은 시작할때마다 새로운 버젼이 있는지 확인할것 입니다."
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3750,13 +3936,6 @@ msgstr "브라우저 선택"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "탐색"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "가능하면 새로운 탭을 생성함"
@@ -3785,10 +3964,6 @@ msgstr "칸 배분"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3801,16 +3976,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3841,10 +4008,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "카뎀리아"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2k"
@@ -3868,10 +4031,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "재시도"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr ""
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4005,10 +4164,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4017,14 +4172,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5294,7 +5441,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5984,7 +6131,7 @@ msgstr "공유 파일"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "검색"
@@ -5997,7 +6144,7 @@ msgstr "최소 크기가 최대 크기보다 작아야 합니다. 최대 크기�
 msgid "Search warning"
 msgstr "검색 경고"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "주"
 
@@ -6038,38 +6185,38 @@ msgstr "선택되지 않은"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "분류내 내려받기"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "이 파일의 추가주소를 더합니다."
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "삭제하려고하는 서버에 접속되어있습니다. 부디 먼저 연결을 끊으세요."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "취소"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7126,10 +7273,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:28+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -325,12 +325,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "server.met faile rastas %i serveris"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1089,7 +1089,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1528,7 +1528,7 @@ msgstr "ERROR: IO klaida!"
 msgid "ERROR: Failed!"
 msgstr "ERROR: nepavyko!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Eilėje"
 
@@ -1654,7 +1654,7 @@ msgid "Show file &details"
 msgstr "&Rodyti failo savybes"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Rodyti komentarus"
 
@@ -2278,6 +2278,204 @@ msgstr "%.2f%% baigta"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Sveikiname!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Prisijungta prie draugo"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Ryšio būklė:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Tinklas"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Inicializavimas"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Automatiškai atnaujinti serverių sąrašą paleidus programą"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Naršyti"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3100,7 +3298,7 @@ msgstr "Pavadinimas:"
 msgid "Type"
 msgstr "Tipas"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Vietinis"
 
@@ -3220,7 +3418,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Sustabdyti"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Atsiųsti"
 
@@ -3678,24 +3876,12 @@ msgstr "Paleidus programą ieškoti naujesnės versijos"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Įjungus šią parinktį aMule kiekieną kartą paleidus programą patikrins ar nėra naujesnės programos versijos"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3762,13 +3948,6 @@ msgstr "Naršyklės parintys"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Naršyti"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Jei įmanoma, atverti naują kortelę"
@@ -3797,10 +3976,6 @@ msgstr "Vieno ryšio sparta"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Tai standartinis eD2k prievadas. Jis negali būti išjungtas."
@@ -3813,16 +3988,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3853,10 +4020,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3880,10 +4043,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "bandymų"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Automatiškai atnaujinti serverių sąrašą paleidus programą"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4017,10 +4176,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4029,14 +4184,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5310,7 +5457,7 @@ msgstr "Paskiriama vieta"
 msgid "Insufficient disk space"
 msgstr "Nepakanka laisvos vietos"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Atsiųsta"
@@ -6007,7 +6154,7 @@ msgstr "Dalinami failai"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Paieška"
@@ -6020,7 +6167,7 @@ msgstr "Apatinė dydžio riba turi būti mažesnė už viršutinę dydžio ribą
 msgid "Search warning"
 msgstr "Dėmesio"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Pagrindinė"
 
@@ -6061,38 +6208,38 @@ msgstr "Nevertinta"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Atsiunčiamą failą įdėti į kategoriją"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Šiam failui įdėti papildomus URL"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Ieškoti panašių failų (eD2k, vietiniame serveryje)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Pažymėti failą kaip jau žinomą"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Prie serverio, kurį norite pašalinti, esate šiuo metu prisijungę. Norėdami pašalinti serverį, iš pradžių turite atsijungti."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Atšaukti"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7146,10 +7293,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:39+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -308,11 +308,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "eD2k serveru saraksts (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1051,7 +1051,7 @@ msgid "Enter Captcha"
 msgstr "Ievadiet Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1487,7 +1487,7 @@ msgstr "KĻŪDA: ievadizvades (I/O) kļūda!"
 msgid "ERROR: Failed!"
 msgstr "KĻŪDA: Neizdevās!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Rindā"
 
@@ -1611,7 +1611,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Rādīt visus komentārus"
 
@@ -2198,6 +2198,201 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Pieslēdzas draugam"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Savienojumi"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Tīkli"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Iespējot UPnP maršrutētāja portu pāradresāciju"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+msgid "Your peer lists are already in place - nothing to download."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Kad palaiž, automātiski atjaunināt serveru sarakstu"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -2993,7 +3188,7 @@ msgstr "Nosaukums:"
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3113,7 +3308,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Apturēt"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3565,24 +3760,12 @@ msgstr "Regulāri pārbaudīt atjauninājumus"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Iespējojot šo, tiks veikta aMule jaunākās versijas pārbaude, kad palaiž programmu"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3649,13 +3832,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ievadiet šeit sava pārlūka nosaukumu. Atstājiet šo lauku tukšu, ja vēlaties izmantot sistēmas noklusējuma pārlūku."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3684,10 +3860,6 @@ msgstr "Katram klientam (vienam savienojumam) izdalītais spraugas"
 msgid "Ports"
 msgstr "Porti"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3700,17 +3872,9 @@ msgstr ""
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Iespējot UPnP maršrutētāja portu pāradresāciju"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3740,10 +3904,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3767,10 +3927,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "mēģinājumiem"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Kad palaiž, automātiski atjaunināt serveru sarakstu"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3904,10 +4060,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3916,14 +4068,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5170,7 +5314,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Lejupielādēta"
@@ -5823,7 +5967,7 @@ msgstr "Kopīgotās datnes"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
@@ -5835,7 +5979,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5875,36 +6019,36 @@ msgstr "Bitu pārraides ātrums"
 msgid "Codec"
 msgstr "Kodeks"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopēt eD2k saiti starpliktuvē"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jūs pašlaik neesiet pieslēgts serverim, kas atbalsta saistīto datņu meklēšanas funkciju"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6933,10 +7077,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:28+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -324,12 +324,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server in server.met gevonden"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgid "Enter Captcha"
 msgstr "Voer captcha in"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categorie"
 
@@ -1514,7 +1514,7 @@ msgstr "FOUT: IO-fout!"
 msgid "ERROR: Failed!"
 msgstr "FOUT: Mislukt!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "In wachtrij"
 
@@ -1640,7 +1640,7 @@ msgid "Show file &details"
 msgstr "Bekijk bestand &details"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Bekijk alle commentaren"
 
@@ -2259,6 +2259,204 @@ msgstr "%.1f%% voltooid"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Welkom!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Aan het verbinden met buddy"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Verbindingsstatus:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Netwerken"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standaard TCP-poort "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Uitgebreide UDP-poort (Kad / globaal zoeken) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Schakel UPnP voor router portforwarding in"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "U probeert het bestand %s al te downloaden"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Auto-update serverlijst bij het opstarten"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Doelmap voor downloads"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Bladeren"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Map voor tijdelijke downloadbestanden"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3071,7 +3269,7 @@ msgstr "Naam:"
 msgid "Type"
 msgstr "Type"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokaal"
 
@@ -3191,7 +3389,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stop"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3649,24 +3847,12 @@ msgstr "Controleer op nieuwe versie bij het starten"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ingeschakeld zorgt dit ervoor dat aMule bij het starten controleert op een nieuwe versie"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3733,13 +3919,6 @@ msgstr "Browserselectie"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Voer hier uw browsernaam in. Laat dit veld leeg om de standaardbrowser van uw systeem te gebruiken."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Bladeren"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Open in nieuw tabblad indien mogelijk"
@@ -3768,10 +3947,6 @@ msgstr "Slot-toewijzing"
 msgid "Ports"
 msgstr "Poorten"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standaard TCP-poort "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dit is de standaard eD2k-poort en kan niet uitgeschakeld worden."
@@ -3784,17 +3959,9 @@ msgstr "UDP-poort voor server aanvragen (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Uitgebreide UDP-poort (Kad / globaal zoeken) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Deze UDP-poort wordt gebruikt voor uitgebreide eD2k-aanvragen en het Kad-netwerk"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Schakel UPnP voor router portforwarding in"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3825,10 +3992,6 @@ msgstr "Max bronnen per bestand aan het downloaden:"
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3852,10 +4015,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "pogingen"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Auto-update serverlijst bij het opstarten"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3989,10 +4148,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Doelmap voor downloads"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4002,14 +4157,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Map voor tijdelijke downloadbestanden"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5268,7 +5415,7 @@ msgstr "Toewijzen"
 msgid "Insufficient disk space"
 msgstr "Onvoldoende schijfruimte"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Gedownload"
@@ -5955,7 +6102,7 @@ msgstr "Gedeelde mappen"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Fout tijdens zoeken"
 
@@ -5967,7 +6114,7 @@ msgstr "Min grootte moet kleiner zijn dan max grootte. Max grootte wordt genegee
 msgid "Search warning"
 msgstr "Zoekwaarschuwing"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Standaard"
 
@@ -6008,37 +6155,37 @@ msgstr "Niet beoordeeld"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Download in categorie"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Verkrijg %s voor dit bestand"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Zoek gelijkwaardige bestanden (eD2k, lokale server)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Markeer als bekend bestand"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopieer eD2k-link naar klembord"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "U bent verbonden met de server die u probeert te verwijderen. Vebreek eerst de verbinding."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Geannuleerd"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nieuw"
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:29+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -324,12 +324,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i tenar funne i server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategori"
 
@@ -1521,7 +1521,7 @@ msgstr "FEIL: Mislukka IO!"
 msgid "ERROR: Failed!"
 msgstr "FEIL: Mislukka!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "I kø"
 
@@ -1647,7 +1647,7 @@ msgid "Show file &details"
 msgstr "Syn fil&detaljar"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Syn alle kommentarar"
 
@@ -2267,6 +2267,204 @@ msgstr "%.2f%%·ferdig"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f·kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Velkomen!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Tilkopla kamerat"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Tilkoplingsstatus:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Nettverk"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Eigenoppstart"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Du freistar allereie nedlasting av fila %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Automatisk oppdatering av tenarlista ved oppstart"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Bla"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3084,7 +3282,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Sort"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3204,7 +3402,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Nedlasting"
 
@@ -3662,24 +3860,12 @@ msgstr "Sjå etter ny utgåve ved oppstart"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Aktivering av denne vil få aMule til å sjå etter ei ny utgåve ved oppstart."
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3746,13 +3932,6 @@ msgstr "Nettlesarval"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Bla"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Opne nytt faneblad dersom mogleg"
@@ -3781,10 +3960,6 @@ msgstr "Opningsdistribusjon"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Dette er standardporten for eD2k og kan ikkje deaktiverast"
@@ -3797,16 +3972,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3837,10 +4004,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2k"
@@ -3864,10 +4027,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "freistnader"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Automatisk oppdatering av tenarlista ved oppstart"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4001,10 +4160,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4013,14 +4168,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5290,7 +5437,7 @@ msgstr "Hentar plass"
 msgid "Insufficient disk space"
 msgstr "Ikkje nok diskplass"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Lasta ned"
@@ -5982,7 +6129,7 @@ msgstr "Delte filer"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Søk"
@@ -5995,7 +6142,7 @@ msgstr "Min storleik må vere mindre enn maks storleik. Maks storleik ignorert."
 msgid "Search warning"
 msgstr "Søkeåtvaring"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Hovud"
 
@@ -6036,38 +6183,38 @@ msgstr "Ikkje gitt verdi"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Nedlasting i kategori"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Legg til valfrie URL`ar for denne fila"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Søk beslekta filer (eD2k, lokal tenar)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Merk som kjend fil"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopier eD2k lenkje til skrivebordet"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du er tilkopla tenaren du freistar å slette. Vér god å kople frå først."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Avbryt"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7114,10 +7261,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:30+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -325,12 +325,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i serwer znaleziono w server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1081,7 +1081,7 @@ msgid "Enter Captcha"
 msgstr "Wpisz Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1521,7 +1521,7 @@ msgstr "BŁĄD: Błąd IO!"
 msgid "ERROR: Failed!"
 msgstr "BŁĄD: Niepowodzenie!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "W kolejce"
 
@@ -1647,7 +1647,7 @@ msgid "Show file &details"
 msgstr "Pokaż &szczegóły pliku"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Pokaż wszystkie komentarze"
 
@@ -2266,6 +2266,204 @@ msgstr "%.2f%% skończone"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Witamy!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Łączenie do kolegi"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Stan połączenia:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Sieci"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standardowy port TCP "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Rozszerzony port UDP (KAD / globalne wyszukiwanie)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Włącz UPnP dla przekierowania portów routera"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Starasz się już pobierać plik %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Autoaktualizacja listy serwerów przy starcie"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Folder docelowy dla pobrań"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Przeglądaj"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Folder dla pobranych plików tymczasowych"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3082,7 +3280,7 @@ msgstr "Nazwa:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokalne"
 
@@ -3202,7 +3400,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Pobieranie"
 
@@ -3660,24 +3858,12 @@ msgstr "Sprawdź podczas startu czy jest nowa wersja"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Włączenie tego spowoduje, że aMule będzie sprawdzał, czy jest nowa wersja podczas startu"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3744,13 +3930,6 @@ msgstr "Wybór przeglądarki"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Podaj tutaj nazwę swojej przeglądarki. Pozostaw to pole puste, aby korzystać z domyślnej przeglądarki systemu."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Przeglądaj"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Otwórz w nowej karcie jeśli to możliwe"
@@ -3779,10 +3958,6 @@ msgstr "Przydział slotów"
 msgid "Ports"
 msgstr "Pporty"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standardowy port TCP "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To jest standardowy port eD2k i nie może być wyłączony."
@@ -3795,17 +3970,9 @@ msgstr "Port UDP dla żądań serwera (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Rozszerzony port UDP (KAD / globalne wyszukiwanie)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ten port UDP jest używany do rozszerzonych żądań ed2k i sieci KAD"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Włącz UPnP dla przekierowania portów routera"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3836,10 +4003,6 @@ msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3863,10 +4026,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "próbach"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Autoaktualizacja listy serwerów przy starcie"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4000,10 +4159,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Folder docelowy dla pobrań"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4013,14 +4168,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Folder dla pobranych plików tymczasowych"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5290,7 +5437,7 @@ msgstr "Alokuję"
 msgid "Insufficient disk space"
 msgstr "Niewystarczająca ilość przestrzeni dyskowej"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Pobrano"
@@ -5986,7 +6133,7 @@ msgstr "Udostępnione foldery"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Szukaj"
@@ -5999,7 +6146,7 @@ msgstr "Min. rozmiar musi być mniejszy od maks. Zignorowano maks. rozmiar."
 msgid "Search warning"
 msgstr "Ostrzeżenie wyszukiwania"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Główne"
 
@@ -6041,37 +6188,37 @@ msgstr "Nieoceniony"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Pobieranie w kategorii"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Dodaj opcjonalny URL dla tego pliku"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Szukaj powiązanych plików (eD2k, serwer lokalny)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Oznacz jako znany plik"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiuj link eD2k do schowka"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jesteś połączony do serwera który chcesz usunąć. Proszę rozłącz się najpierw."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Anulowane"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nowy"
 
@@ -7116,10 +7263,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:31+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -332,11 +332,11 @@ msgstr ""
 "O aMule detectou que faltam arquivos de inicialização da rede.\n"
 "Selecione quais baixar:"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "Lista de servidores eD2k (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Nós de inicialização de Kad"
 
@@ -1087,7 +1087,7 @@ msgid "Enter Captcha"
 msgstr "Insira o Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoria"
 
@@ -1522,7 +1522,7 @@ msgstr "ERRO: erro de E/S!"
 msgid "ERROR: Failed!"
 msgstr "ERRO: Falhou!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Na fila de espera"
 
@@ -1648,7 +1648,7 @@ msgid "Show file &details"
 msgstr "Exibir &detalhes do arquivo"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Exibir todos os comentários"
 
@@ -2263,6 +2263,204 @@ msgstr "%.1f%% concluído"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Bem-vindo!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Conectando ao amigo"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Tipo de Conexão:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Redes"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Porta TCP Padrão "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Porta UDP estendida (Kad / pesquisa global) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Habilitar UPnP para redirecionamento de porta do roteador"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Inicialização"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Ops! Você já está tentando baixar o arquivo %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Lista de servidores auto-atualizáveis na iniciação"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "Iniciar o aMule automaticamente quando eu logar no sistema"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr "Registrar aMule para links ed2k://"
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr "Registra o aMule para links \"magnet:\""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Pasta de destino para baixados"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Procurar"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Pasta para arquivos temporários baixados"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3062,7 +3260,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3182,7 +3380,7 @@ msgstr "Pedir para pares Kad que já responderam para alargar a busca. Cada cliq
 msgid "Stop"
 msgstr "Pare"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3632,25 +3830,13 @@ msgstr "Conferir a existência de uma versão nova periodicamente"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ativar isto faz com que o aMule verifique por nova versão ao iniciar e uma vez por dia enquanto roda"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "Iniciar o aMule automaticamente quando eu logar no sistema"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Registra no sistema operacional uma entrada de início automático por usuário com de modo a iniciar o aMule no login. Se você mover o arquivo binário, rode o aMule uma vez manualmente depois para atualizar a entrada."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr "Registrar aMule para links ed2k://"
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "Torna o aMule o padrão para lidar com links ed2k:// de modo que ao clicar em um em seu navegador ou gerenciador de arquivos o fará abrir aqui."
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
-msgstr "Registra o aMule para links \"magnet:\""
 
 #: src/muuli_wdr.cpp:1286
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
@@ -3716,13 +3902,6 @@ msgstr "Browser Padrão"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Insira o nome do seu navegador aqui. Deixe vazio para usar o navegador padrão do sistema."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Procurar"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Abrir em nova aba se possível"
@@ -3751,10 +3930,6 @@ msgstr "Alocação de Slots"
 msgid "Ports"
 msgstr "Portas"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Porta TCP Padrão "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Essa é a porta eD2k padrão e não pode ser desabilitada."
@@ -3767,17 +3942,9 @@ msgstr "Porta UDP para requisições do servidor (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Porta UDP estendida (Kad / pesquisa global) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Essa porta UDP é usada para requisições eD2k estendidas e rede Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Habilitar UPnP para redirecionamento de porta do roteador"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3807,10 +3974,6 @@ msgstr "Máximo de fontes para arquivos baixando:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3834,10 +3997,6 @@ msgstr "Servidores estáticos nunca são removidos, mesmo que inalcançáveis."
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "tentativas"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Lista de servidores auto-atualizáveis na iniciação"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3971,10 +4130,6 @@ msgstr "Detectar"
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Procura nos locais de instalação padrão por um binário do ffprobe e preenche o campo de caminho."
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Pasta de destino para baixados"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3986,14 +4141,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Escolha a pasta onde os downloads terminados serão guardados. Todos os arquivos nesta pasta serão compartilhados com outros pares."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Todos os arquivos nesta pasta são compartilhados com outros pares)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Pasta para arquivos temporários baixados"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5249,7 +5396,7 @@ msgstr "Alocando"
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Baixado"
@@ -5925,7 +6072,7 @@ msgstr "Pasta compartilhada"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabilitadas."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Erro na busca"
 
@@ -5937,7 +6084,7 @@ msgstr "Tamanho min deve ser menor que tamanho max. Tamanho max ignorado."
 msgid "Search warning"
 msgstr "Alerta da busca"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -5977,36 +6124,36 @@ msgstr "Taxa de Bits"
 msgid "Codec"
 msgstr "Codec"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Baixar na categoria"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obtendo %s para este arquivo"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurando arquivos relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marcar como arquivo conhecido"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para área de transferência"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Você não está atualmente conectado a um servidor que suporta a função \"Arquivos Relacionados\""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Novo"
 
@@ -7036,10 +7183,6 @@ msgstr "Rotação de fontes \"Endgame\" é %s.\n"
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Busca iniciada (id %u).\n"
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:31+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -329,12 +329,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "Foi encontrado %i servidor no server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1083,7 +1083,7 @@ msgid "Enter Captcha"
 msgstr "Escrever 'Captcha'"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categoria"
 
@@ -1520,7 +1520,7 @@ msgstr "ERRO: erro de entrada/saída!"
 msgid "ERROR: Failed!"
 msgstr "ERRO: Falhou!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Em Fila"
 
@@ -1646,7 +1646,7 @@ msgid "Show file &details"
 msgstr "Mostrar &detalhes do ficheiro"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Mostrar todos os comentários"
 
@@ -2263,6 +2263,204 @@ msgstr "%.2f%% terminado"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Bem-vindo!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "A ligar a um parceiro"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Estado da Ligação:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Redes"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Porto TCP Padrão "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Porto UDP estendido (Kad / pesquisa global) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Activar UPnP para encaminhamento de portos no router"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Inicialização"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Já está a tentar transferir o ficheiro %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Auto-actualizar lista de servidores no arranque"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Pasta de destino para downloads"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Procurar"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Pasta para ficheiros temporários"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3074,7 +3272,7 @@ msgstr "Nome:"
 msgid "Type"
 msgstr "Tipo"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3194,7 +3392,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Parar"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Download"
 
@@ -3652,24 +3850,12 @@ msgstr "Verificar nova versão no arranque"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ao activar, fará o aMule procurar por uma nova versão no arranque"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3736,13 +3922,6 @@ msgstr "Selecção de Navegador"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Indique aqui o nome do seu browser. Deixe este campo em branco para utilizar o browser por omissão do sistema."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Procurar"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Abrir num novo separador se possível"
@@ -3771,10 +3950,6 @@ msgstr "Atribuição de Ligações"
 msgid "Ports"
 msgstr "Portos"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Porto TCP Padrão "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Este é o porto da eD2k por omissão e não pode ser desactivado."
@@ -3787,17 +3962,9 @@ msgstr "Porto UDP para pedidos ao servidor (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Porto UDP estendido (Kad / pesquisa global) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Este porto UDP é usado para pedidos eD2k estendidos e para a rede Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Activar UPnP para encaminhamento de portos no router"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3828,10 +3995,6 @@ msgstr "Máximo de fontes por ficheiro:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3855,10 +4018,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "tentativas"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Auto-actualizar lista de servidores no arranque"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3992,10 +4151,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Pasta de destino para downloads"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4005,14 +4160,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Pasta para ficheiros temporários"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5271,7 +5418,7 @@ msgstr "A atribuir"
 msgid "Insufficient disk space"
 msgstr "Espaço em disco insuficiente"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Transferido"
@@ -5960,7 +6107,7 @@ msgstr "Pastas partilhadas"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Pesquisas"
@@ -5973,7 +6120,7 @@ msgstr "O Tamanho mínimo tem de ser menor que o tamanho máximo. Tamanho máxim
 msgid "Search warning"
 msgstr "Aviso de pesquisa"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -6015,37 +6162,37 @@ msgstr "Não avaliado"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Transferir para a categoria"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obter %s para este ficheiro"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Procurar ficheiros relacionados (eD2k, servidor local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marcar como ficheiro conhecido"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para a área de transferência"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Está ligado ao servidor que está a tentar remover. Por favor, desligue-se primeiro."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Cancelado"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Novo"
 
@@ -7078,10 +7225,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:32+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -322,12 +322,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "S-a găsit %i server în server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Enter Captcha"
 msgstr "Introduceți Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Categorie"
 
@@ -1518,7 +1518,7 @@ msgstr "EROARE: Eroare IO!"
 msgid "ERROR: Failed!"
 msgstr "EROARE: Eșuare!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "În coadă"
 
@@ -1644,7 +1644,7 @@ msgid "Show file &details"
 msgstr "Arată fișierele & detaliile"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Arată toate comentariile"
 
@@ -2261,6 +2261,204 @@ msgstr "%.1f%% realizat"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Bine ați venit!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Se conectează la persoane"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Stare conexiune:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Rețele"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Port TCP standard"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Port UDP extins (Kad / căutare globală)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Activează UPnP pentru înaintare port ruter"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Deja încercați să descărcați fișierul %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Actualizează automat lista serverelor la pornire"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Dosar destinație pentru descărcări"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Navigare"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Dosar pentru fișiere descărcate temporar"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3077,7 +3275,7 @@ msgstr "Name:"
 msgid "Type"
 msgstr "Tip"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Local"
 
@@ -3197,7 +3395,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Oprește"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Descarcă"
 
@@ -3655,24 +3853,12 @@ msgstr "Verifică la pornire dacă au apărut versiuni noi"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Activând aceasta va face aMule să verifice după noi versiuni la pornire"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3739,13 +3925,6 @@ msgstr "Selecție navigator"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Introduceți aici numele navigatorului. Lăsați acest câmp necompletat pentru utilizarea navigatorului implicit de sistem."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Navigare"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Deschide într-o fereastră nouă dacă este posibil"
@@ -3774,10 +3953,6 @@ msgstr "Alocare slot"
 msgid "Ports"
 msgstr "Porturi"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Port TCP standard"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Acesta este portul standard eD2k și nu poate fi dezactivat."
@@ -3790,17 +3965,9 @@ msgstr "Port UDP pentru cererile serverului (TCP+3)"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Port UDP extins (Kad / căutare globală)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Acest port UDP este utilizat pentru solicitări extinse eD2k și rețeaua Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Activează UPnP pentru înaintare port ruter"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3831,10 +3998,6 @@ msgstr "Număr maxim de surse pe fișier descărcat:"
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3858,10 +4021,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "încercări"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Actualizează automat lista serverelor la pornire"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3995,10 +4154,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Dosar destinație pentru descărcări"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4008,14 +4163,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Dosar pentru fișiere descărcate temporar"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5276,7 +5423,7 @@ msgstr "Se alocă"
 msgid "Insufficient disk space"
 msgstr "Spațiu pe disc insuficient"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Descărcat"
@@ -5968,7 +6115,7 @@ msgstr "Dosare partajate"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Căutări"
@@ -5981,7 +6128,7 @@ msgstr "Dimensiunea mică trebuie să fie mai mică decât dimensiunea mare. Dim
 msgid "Search warning"
 msgstr "Atenționare căutare"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Principal"
 
@@ -6023,37 +6170,37 @@ msgstr "Nu este apreciat"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Descarcă în categoria"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Obține %s pentru acest fișier"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Caută fișiere asociate (eD2k, server local)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Marchează ca fișier cunoscut"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiază link-ul eD2k în memoria temporară"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Sunteți conectat la serverul pe care încercați să-l ștergeți, deconectați-vă întâi."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Anulat"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Nou"
 
@@ -7097,10 +7244,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:33+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -329,12 +329,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "В файле 'server.met' найден %i сервер"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1089,7 +1089,7 @@ msgid "Enter Captcha"
 msgstr "Введите код"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Категория"
 
@@ -1531,7 +1531,7 @@ msgstr "ОШИБКА: Ошибка ввода/вывода!"
 msgid "ERROR: Failed!"
 msgstr "ОШИБКА: Неудачно!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "В очереди"
 
@@ -1657,7 +1657,7 @@ msgid "Show file &details"
 msgstr "По&казать подробности"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Показать все комментарии"
 
@@ -2278,6 +2278,204 @@ msgstr "%.2f%% готово"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/сек"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Добро пожаловать!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Соединяем с другом"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Состояние соединения:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Сети"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Стандартный порт TCP"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Дополнительный порт UDP (Kad / Глобальный поиск)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Разрешить UPnP форвардинг портов роутера"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Инициализация"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Вы уже пытаетесь загрузить файл %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Автоматически обновлять список серверов при запуске"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Папка для загружаемых файлов"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Открыть"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Папка для временных файлов"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3100,7 +3298,7 @@ msgstr "Имя:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Локальный"
 
@@ -3220,7 +3418,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Остановить"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Загрузка"
 
@@ -3680,24 +3878,12 @@ msgstr "Проверка наличия новой версии при запу�
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "При запуске aMule будет проверено наличие новой версии"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3764,13 +3950,6 @@ msgstr "Выбор браузера"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введите имя предпочитаемого браузера. Оставьте поле пустым чтобы использовать системный браузер по умолчанию."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Открыть"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Открывать в новой вкладке"
@@ -3799,10 +3978,6 @@ msgstr "Слот"
 msgid "Ports"
 msgstr "Порты"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Стандартный порт TCP"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Это стандартный порт eD2k, он не может быть отключен."
@@ -3815,17 +3990,9 @@ msgstr "Порт UDP для запросов сервера (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Дополнительный порт UDP (Kad / Глобальный поиск)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Этот порт UDP используется для дополнительных eD2k запросов и Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Разрешить UPnP форвардинг портов роутера"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3856,10 +4023,6 @@ msgstr "Максимум источников на файл:"
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3883,10 +4046,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "попыток"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Автоматически обновлять список серверов при запуске"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4021,10 +4180,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Папка для загружаемых файлов"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4034,14 +4189,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Папка для временных файлов"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5313,7 +5460,7 @@ msgstr "Выделяется место"
 msgid "Insufficient disk space"
 msgstr "Недостаточно места на диске"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Загружено"
@@ -6009,7 +6156,7 @@ msgstr "Публикуемые папки"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Поиск"
@@ -6023,7 +6170,7 @@ msgid "Search warning"
 msgstr "Предупреждение поиска"
 
 # It's about default category to download to.
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Общая"
 
@@ -6065,37 +6212,37 @@ msgstr "Без оценки"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Загрузить в категории"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Получить %s для этого файла"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Искать связанные файлы (eD2k, локально)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Отметить как известный"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Копировать eD2k ссылку в буфер"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Вы соединены с сервером, который вы пытаетесь удалить. Отключитесь от него."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Отменено"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Новый"
 
@@ -7143,10 +7290,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:33+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -325,12 +325,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i najdenih strežnikov v server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgid "Enter Captcha"
 msgstr "Vnesite besedilo s slike"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1528,7 +1528,7 @@ msgstr "NAPAKA: vhodno/izhodna napaka"
 msgid "ERROR: Failed!"
 msgstr "NAPAKA: neuspeh"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "V vrsti"
 
@@ -1654,7 +1654,7 @@ msgid "Show file &details"
 msgstr "Prikaži po&drobnosti datoteke"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Prikaži vse komentarje"
 
@@ -2276,6 +2276,204 @@ msgstr "%.1f %% zaključeno"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Dobrodošli!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Povezovanje s kolegom"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Stanje povezave:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Omrežja"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standardna vrata TCP "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Dodatna vrata UDP (globalno/Kad iskanje) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Omogoči posredovanje vrat na usmerjevalniku"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Začetno nalaganje"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Datoteko %s že poskušate prejemati"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Ob zagonu samodejno posodobi seznam strežnikov"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Ciljna mapa za prejeto"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Brskanje"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Mapa za začasne datoteke prejemanj"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3097,7 +3295,7 @@ msgstr "Ime:"
 msgid "Type"
 msgstr "Vrsta"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Krajevno"
 
@@ -3217,7 +3415,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ustavi"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Pridobi"
 
@@ -3676,24 +3874,12 @@ msgstr "Ob zagonu preveri za novo različico"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Ob vklopu te možnosti, bo aMule ob vsakem zagonu preveril za novo različico programa."
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3760,13 +3946,6 @@ msgstr "Izbira brskalnika"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Sem vnesite ime brskalnika. Za uporabo privzetega sistemskega brskalnika pustite prazno."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Brskanje"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Odpri v novem zavihku, če je mogoče"
@@ -3795,10 +3974,6 @@ msgstr "Hitrost za eno mesto"
 msgid "Ports"
 msgstr "Vrata"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standardna vrata TCP "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "To so standardna vrata za eD2k in jih ni moč onemogočiti."
@@ -3811,17 +3986,9 @@ msgstr "Vrata UDP za zahtevke strežnika (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Dodatna vrata UDP (globalno/Kad iskanje) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Ta vrata UDP se uporabljajo za dodatne zahtevke eD2k in omrežje Kad."
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Omogoči posredovanje vrat na usmerjevalniku"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3852,10 +4019,6 @@ msgstr "Največ virov na prejemanje:"
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "eD2k"
@@ -3879,10 +4042,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "poskusih"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Ob zagonu samodejno posodobi seznam strežnikov"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4016,10 +4175,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Ciljna mapa za prejeto"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4029,14 +4184,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Mapa za začasne datoteke prejemanj"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5305,7 +5452,7 @@ msgstr "Dodeljevanje"
 msgid "Insufficient disk space"
 msgstr "Premalo prostora na disku"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Prejeto"
@@ -6004,7 +6151,7 @@ msgstr "Deljene mape"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Napaka iskanja"
 
@@ -6016,7 +6163,7 @@ msgstr "Min. velikost mora biti manjša kot maks. velikost. Maks. velikost ni up
 msgid "Search warning"
 msgstr "Opozorilo iskanja"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Glavna"
 
@@ -6057,37 +6204,37 @@ msgstr "Ni ocenjena"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Prejemaj v kategoriji"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Dobi %s za to datoteko"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Poišči sorodne datoteke (eD2k, krajevni strežnik)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Označi kot znano datoteko"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiraj povezavo eD2k na odložišče"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Povezani ste na strežnik, ki ga poskušate izbrisati. Prosimo, najprej prekinite povezavo."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Preklicano"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Novo"
 
@@ -7138,10 +7285,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:34+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -323,12 +323,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i u gjet server ne server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategori"
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Ne radhe"
 
@@ -1642,7 +1642,7 @@ msgid "Show file &details"
 msgstr "Trego &detajet e faileve"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Trego te gjithe komentet"
 
@@ -2261,6 +2261,204 @@ msgstr "%.2f%% te mbaruara"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Miresevini!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "I lidhur me shokun"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Gjendja e lidhjes"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Rrjetet"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Shfleto"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3077,7 +3275,7 @@ msgstr "Emri:"
 msgid "Type"
 msgstr "Tipi"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokale"
 
@@ -3197,7 +3395,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Ndalo"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Shkarkime"
 
@@ -3655,24 +3853,12 @@ msgstr "Kerko per versione te reja sapo te filloje"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Duke aktivizuar kete beni qe aMule te kerkoje per versione te reja sapo te filloje"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3739,13 +3925,6 @@ msgstr "Zgjedhesi i shfletuesit"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Shfleto"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Hape ne nje faqe te re nqs eshte e mundur"
@@ -3774,10 +3953,6 @@ msgstr "Vendndodhja e slotit"
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3790,16 +3965,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3830,10 +3997,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3857,10 +4020,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "tentativa"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr ""
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3994,10 +4153,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4006,14 +4161,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5282,7 +5429,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5972,7 +6119,7 @@ msgstr "File te ndara"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Kerkimet"
@@ -5985,7 +6132,7 @@ msgstr "Masa minimale duhet te jete me e vogel se masa maksimale.Po injoroj Mase
 msgid "Search warning"
 msgstr "PoParalajmerim per kerkim"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Kryesore"
 
@@ -6026,38 +6173,38 @@ msgstr "E pavotuar"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Shkarko ne kategori"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Shtoni URLs opsionale per kete fail"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Shenoje si fail te njohur"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Ju jeni i lidhur tek serveri qe deshironi te fshini. ju lutem ne fillim shkeputuni prej tij."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Fshij"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7103,10 +7250,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:35+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -321,12 +321,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i server hittad i server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgid "Enter Captcha"
 msgstr "Ange Captcha"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Kategori"
 
@@ -1512,7 +1512,7 @@ msgstr "FEL: IO-fel"
 msgid "ERROR: Failed!"
 msgstr "FEL: Mysslyckades!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Lagd i kö"
 
@@ -1638,7 +1638,7 @@ msgid "Show file &details"
 msgstr "Visa fil &details"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Visa alla kommentarer"
 
@@ -2255,6 +2255,204 @@ msgstr "%.1f%% färdig"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Välkommen!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Ansluter till vän"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Anslutningstillstånd:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Nätverk"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standard TCP-port "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Utökad UDP-port (Kad / global sökning) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Aktivera UPnP för vidarebefordring av routerport"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Bootstrap"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Du försöker redan hämta filen %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Auto-uppdatera serverlistan vid start"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Målmapp för hämtningar"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Bläddra"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Mapp för temporära nerladdningsfiler"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3066,7 +3264,7 @@ msgstr "Namn:"
 msgid "Type"
 msgstr "Typ"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Lokal"
 
@@ -3186,7 +3384,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Stoppa"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Hämta"
 
@@ -3644,24 +3842,12 @@ msgstr "Sök efter ny version vid start"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Aktivering av detta kommer att få aMule att leta efter en ny version vid start"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3728,13 +3914,6 @@ msgstr "Webbläsarval"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Ange din webbläsares namn här. Lämna detta fält tomt för att använda systemets standardwebbläsare."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Bläddra"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Öppna i ny flik om möjligt"
@@ -3763,10 +3942,6 @@ msgstr "Spårallokering"
 msgid "Ports"
 msgstr "Portar"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standard TCP-port "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Detta är standard ed2k-port och kan inte avaktiveras."
@@ -3779,17 +3954,9 @@ msgstr "UDP-port för serverförfrågningar (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Utökad UDP-port (Kad / global sökning) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Denna UDP-port används under utökade ed2k-förfrågningar och Kadnätverk"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Aktivera UPnP för vidarebefordring av routerport"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3820,10 +3987,6 @@ msgstr "Max källor per hämtad fil:"
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3847,10 +4010,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "försök"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Auto-uppdatera serverlistan vid start"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3984,10 +4143,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Målmapp för hämtningar"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3997,14 +4152,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Mapp för temporära nerladdningsfiler"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5261,7 +5408,7 @@ msgstr "Allokera"
 msgid "Insufficient disk space"
 msgstr "Otillräckligt diskutrymme"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Nedladdad"
@@ -5948,7 +6095,7 @@ msgstr "Delade mappar"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Sökningar"
@@ -5961,7 +6108,7 @@ msgstr "Min storlek måste vara mindre än max storlek. Max storlek ignoreras."
 msgid "Search warning"
 msgstr "Sökvarning"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Huvud"
 
@@ -6003,37 +6150,37 @@ msgstr "Inte betygsatt"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Nedladdning i kategori"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Hämta %s för den här filen:"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Sök relaterade filer (eD2k, lokal server)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Markera som känd fil"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiera eD2k-länken till urklipp"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Du är ansluten till den server som du försöker ta bort. Vänligen koppla ifrån först."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "Avbryten"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Ny"
 
@@ -7069,10 +7216,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:40+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -304,11 +304,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr ""
 
@@ -1475,7 +1475,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr ""
 
@@ -2186,6 +2186,198 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+msgid "Connection & bandwidth"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+msgid "Connection speed:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+msgid "Your peer lists are already in place - nothing to download."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -2980,7 +3172,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3100,7 +3292,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3548,24 +3740,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3632,13 +3812,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3667,10 +3840,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3683,16 +3852,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3723,10 +3884,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3749,10 +3906,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3887,10 +4040,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3899,14 +4048,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5148,7 +5289,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5795,7 +5936,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
@@ -5807,7 +5948,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5847,36 +5988,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6899,10 +7040,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -325,11 +325,11 @@ msgstr ""
 "aMule, eksik ağ başlatma dosyaları olduğunu tespit etti.\n"
 "Hangilerinin indirileceklerini seçin:"
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "eD2k sunucu listesi (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad başlangıç düğümleri (nodes.dat)"
 
@@ -1079,7 +1079,7 @@ msgid "Enter Captcha"
 msgstr "Captcha Gir"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Sınıf"
 
@@ -1514,7 +1514,7 @@ msgstr "HATA: Girdi-çıktı hatası!"
 msgid "ERROR: Failed!"
 msgstr "HATA: Başarısız!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "Sıraya girdi"
 
@@ -1640,7 +1640,7 @@ msgid "Show file &details"
 msgstr "Dosya &ayrıntılarını göster"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Tüm yorumları göster"
 
@@ -2255,6 +2255,204 @@ msgstr "%.1f%% tamamlandı"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Hoş geldiniz!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "Eşe Bağlanıyor"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Bağlantı Türü:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Ağlar"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Standart TCP Portu "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Genişletilmiş UDP portu (Kad / Genel arama) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Yönlendirici port iletimi için UPnP'yi etkinleştir"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Ön Yükleme"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "%s dosyasını indirmeyi zaten deniyorsunuz"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Otomatik başlangıç"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "aMule'ü oturum açtığımda otomatik olarak başlat"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr "aMule'ü ed2k:// bağlantıları için kaydet"
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr "aMule'ü magnet: bağlantıları için kaydet"
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "İndirmeler için hedef dizin"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Göz at"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Geçici dosyalar için dizin"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3054,7 +3252,7 @@ msgstr "Ad:"
 msgid "Type"
 msgstr "Tür"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Sunucu"
 
@@ -3174,7 +3372,7 @@ msgstr "Zaten cevap vermiş Kad eşlerinden aramayı genişletmelerini iste. Ara
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "İndir"
 
@@ -3624,25 +3822,13 @@ msgstr "Yeni sürümü düzenli olarak denetle"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Bunu etkinleştirmek, aMule'nin yeni sürümleri başlangıçta ve çalıştığı sürece günde bir defa aramasını sağlar"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "aMule'ü oturum açtığımda otomatik olarak başlat"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "Oturum açıldığında aMule'ün çalıştırılması için işletim sistemine kullanıcı başı bir otomatik başlatma unsuru kaydeder. Eğer aMule ikilisini taşırsanız, sonrasında onu bir kere el ile başlatın ki bu unsur güncellensin."
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr "aMule'ü ed2k:// bağlantıları için kaydet"
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "aMule'ü ed2k:// bağlantıları için varsayılan yönetici yapar, yani böyle bir bağlantıya tarayıcınızda veya dosya yöneticinizde tıklamanız onu burada açar."
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
-msgstr "aMule'ü magnet: bağlantıları için kaydet"
 
 #: src/muuli_wdr.cpp:1286
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
@@ -3708,13 +3894,6 @@ msgstr "Tarayıcı Seçimi"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Tarayıcı adını buraya giriniz. Sisteminizin ön tanımlı tarayıcısını kullanmak için boş bırakınız."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Göz at"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Mümkünse yeni sekmede aç"
@@ -3743,10 +3922,6 @@ msgstr "Slot Tahsis Boyutu"
 msgid "Ports"
 msgstr "Portlar"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Standart TCP Portu "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Bu, standart eD2k bağlantı noktasıdır ve devre dışı bırakılamaz."
@@ -3759,17 +3934,9 @@ msgstr "Sunucu istemleri için UDP Portu (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Genişletilmiş UDP portu (Kad / Genel arama) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Bu UDP portu genişletilmiş eD2k istemleri ve Kad ağı için kullanılır"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Yönlendirici port iletimi için UPnP'yi etkinleştir"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3799,10 +3966,6 @@ msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3826,10 +3989,6 @@ msgstr "Statik sunucular hiçbir zaman kaldırılmazlar, ulaşılamaz oldukları
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "denemeden sonra kaldır"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Otomatik başlangıç"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3963,10 +4122,6 @@ msgstr "Tespit et"
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "Bir ffprobe ikilisi için standart kurulum konumlarını ara ve yol alanını doldur."
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "İndirmeler için hedef dizin"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3978,14 +4133,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "Tamamlanmış indirmelerin muhafaza edilecekleri dizini seçin. Bu dizindeki tüm dosyalar diğer eşler ile paylaşılacaktır."
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "(Bu dizindeki tüm dosyalar diğer eşler ile paylaşılmaktadır)"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Geçici dosyalar için dizin"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5241,7 +5388,7 @@ msgstr "Ayrılıyor"
 msgid "Insufficient disk space"
 msgstr "Yetersiz disk alanı"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "İndirildi"
@@ -5917,7 +6064,7 @@ msgstr "Paylaşılan dizin"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak mümkün değildir."
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "Arama hatası"
 
@@ -5929,7 +6076,7 @@ msgstr "En küçük boyut, en büyük boyuttan küçük olmalıdır. En büyük 
 msgid "Search warning"
 msgstr "Arama uyarısı."
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Ana"
 
@@ -5969,36 +6116,36 @@ msgstr "Akış hızı"
 msgid "Codec"
 msgstr "Kodlama"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Sınıfa göre indir"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "Bu dosya için %s iste"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "İlgili dosyaları ara (eD2k, yerel sunucu)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Bilinen dosya olarak işaretle"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k bağlantısını panoya kopyala"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Şu anda İlgili Dosyalar arama işlevini destekleyen bir sunucuya bağlı değilsiniz"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "İptal edildi"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "Yeni"
 
@@ -7028,10 +7175,6 @@ msgstr "\"Endgame\" kaynak değişimi şu durumdadır: %s.\n"
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "Arama başlatıldı (id %u).\n"
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:36+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -322,12 +322,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "%i сервер знайдено в server.met"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "Категорія"
 
@@ -1524,7 +1524,7 @@ msgstr "ПОМИЛКА: помилка введення-виведення!"
 msgid "ERROR: Failed!"
 msgstr "ПОМИЛКА: невдача!"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "В черзі"
 
@@ -1650,7 +1650,7 @@ msgid "Show file &details"
 msgstr "Показати подробиці файлу"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "Показати всі коментарі"
 
@@ -2273,6 +2273,204 @@ msgstr "%.2f%% виконано"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f кбайт/с"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "Ласкаво просимо!"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "З'єднання з другом"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "Стан з'єднання:"
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "Мережі"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kademlia"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "Зразковий TCP-порт "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "Розширений порт UDP (Kad / глобальний пошук) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "Ввімкнути UPnP для перенаправлення портів"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "Початковий запуск"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "Ви вже спробували звантажити файл %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "Автоматичне оновлення переліку серверів після запуску"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "Тека призначення для звантажень"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "Переглянути"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "Тека для тимчасових звантажуваних файлів"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3096,7 +3294,7 @@ msgstr "Назва:"
 msgid "Type"
 msgstr "Тип"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "Місцевий"
 
@@ -3216,7 +3414,7 @@ msgstr ""
 msgid "Stop"
 msgstr "Зупинити"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "Звантаження"
 
@@ -3676,24 +3874,12 @@ msgstr "Перевірити наявність нової версії під �
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "Перевірка нової версії після запуску"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3760,13 +3946,6 @@ msgstr "Обрати переглядач тенет"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "Введіть тут назву вашого переглядача тенет. Залиште це поле порожнім, щоб використовувати переглядач встановлений за замовчуванням."
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "Переглянути"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "Відкрити в новій вкладці, якщо можливо"
@@ -3795,10 +3974,6 @@ msgstr "Виділення шматків"
 msgid "Ports"
 msgstr "Порти"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "Зразковий TCP-порт "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "Це звичайний порт eD2k і не може бути вимкненим."
@@ -3811,17 +3986,9 @@ msgstr "Порт UDP для запитів сервера (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "Розширений порт UDP (Kad / глобальний пошук) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "Цей порт використовується для зовнішній запитів eD2k та для мережі Kad"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "Ввімкнути UPnP для перенаправлення портів"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3852,10 +4019,6 @@ msgstr "Найбільше джерел на звантажуваний файл
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kademlia"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "eD2k"
@@ -3879,10 +4042,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "спроб"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "Автоматичне оновлення переліку серверів після запуску"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -4016,10 +4175,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "Тека призначення для звантажень"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -4029,14 +4184,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "Тека для тимчасових звантажуваних файлів"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5310,7 +5457,7 @@ msgstr "Виділяється"
 msgid "Insufficient disk space"
 msgstr "Не вистачає місця на диску"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "Звантажені"
@@ -6009,7 +6156,7 @@ msgstr "Спільні теки"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "Пошук"
@@ -6022,7 +6169,7 @@ msgstr "Найменший розмір має бути меншим ніж на
 msgid "Search warning"
 msgstr "Очікування пошуку"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "Головна"
 
@@ -6064,38 +6211,38 @@ msgstr "Без рейтингу"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "Звантажити в категорію"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, fuzzy, c-format
 msgid "Get %s for this file"
 msgstr "Додати додаткові URL-адреси для цього файлу"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "Пошук схожих файлів (eD2k, місцевий сервер)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "Позначити як відомий файл"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "Скопіювати eD2k посилання до буферу обміну"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Ви з'єднані з сервером, який хочете видалити, будь ласка, роз'єднайтесь спочатку."
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 #, fuzzy
 msgid "Canceled"
 msgstr "Скасувати"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -7146,10 +7293,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -304,11 +304,11 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgid "Enter Captcha"
 msgstr ""
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr ""
 
@@ -1475,7 +1475,7 @@ msgstr ""
 msgid "ERROR: Failed!"
 msgstr ""
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgid "Show file &details"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr ""
 
@@ -2186,6 +2186,198 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasframe.cpp:1072
 #, c-format
 msgid "%.2f kB/s"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+msgid "Welcome to aMule!"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+msgid "Connection & bandwidth"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+msgid "Connection speed:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+msgid "Networks & ports"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr ""
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+msgid "Bootstrap files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+msgid "Your peer lists are already in place - nothing to download."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
 msgstr ""
 
 #: src/FriendList.cpp:120
@@ -2980,7 +3172,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr ""
 
@@ -3100,7 +3292,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr ""
 
@@ -3548,24 +3740,12 @@ msgstr ""
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3632,13 +3812,6 @@ msgstr ""
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr ""
@@ -3667,10 +3840,6 @@ msgstr ""
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
@@ -3683,16 +3852,8 @@ msgstr ""
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr ""
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1432
@@ -3723,10 +3884,6 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr ""
@@ -3749,10 +3906,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1529
@@ -3887,10 +4040,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3899,14 +4048,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1709
@@ -5148,7 +5289,7 @@ msgstr ""
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
@@ -5795,7 +5936,7 @@ msgstr ""
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr ""
 
@@ -5807,7 +5948,7 @@ msgstr ""
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr ""
 
@@ -5847,36 +5988,36 @@ msgstr ""
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr ""
 
@@ -6899,10 +7040,6 @@ msgstr ""
 #: src/TextClient.cpp:884
 #, c-format
 msgid "Search started (id %u).\n"
-msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
 msgstr ""
 
 #: src/TextClient.cpp:900

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:37+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -329,11 +329,11 @@ msgstr ""
 "aMule 检测到缺少网络引导文件。\n"
 "请选择需要下载的文件："
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 msgid "eD2k server list (server.met)"
 msgstr "eD2k 服务器列表 (server.met)"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr "Kad 引导节点 (nodes.dat)"
 
@@ -1083,7 +1083,7 @@ msgid "Enter Captcha"
 msgstr "输入验证码"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "分类"
 
@@ -1518,7 +1518,7 @@ msgstr "错误：IO 错误！"
 msgid "ERROR: Failed!"
 msgstr "错误：失败！"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "已加入队列"
 
@@ -1644,7 +1644,7 @@ msgid "Show file &details"
 msgstr "显示文件信息 (&D)"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "显示所有评论"
 
@@ -2259,6 +2259,204 @@ msgstr "%.1f%% 已完成"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "欢迎！"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "已连接至好友"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "连接类型："
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "网络"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kad"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "标准 TCP 端口 "
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "扩展 UDP 端口 (Kad/全局搜索) "
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "启用 UPnP 以用于路由器端口转发"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "启动"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "您已经尝试下载文件 %s"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "启动时自动更新服务器列表"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr "登录时自动启动 aMule"
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr "将 aMule 注册为打开 ed2k:// 链接的应用"
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr "将 aMule 注册为打开 magnet: 链接的应用"
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "存放下载文件的文件夹"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "浏览"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr "（此文件夹中的所有文件均与其他对等方共享）"
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "存放临时下载文件的文件夹"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3056,7 +3254,7 @@ msgstr "名称:"
 msgid "Type"
 msgstr "类型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "本地"
 
@@ -3176,7 +3374,7 @@ msgstr "向已响应的 Kad 节点请求扩大搜索范围。每次点击都会�
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "下载"
 
@@ -3626,25 +3824,13 @@ msgstr "定期检查新版本"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "启用此选项将让 aMule 检查新版本（开启时检查及运行时每天检查一次）"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr "登录时自动启动 aMule"
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr "在操作系统中注册一个按用户自动启动的条目，以便在登录时启动 aMule。如果移动了 aMule 的可执行文件，之后请手动启动一次 aMule 以刷新该条目。"
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr "将 aMule 注册为打开 ed2k:// 链接的应用"
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
 msgstr "让 aMule 成为 ed2k:// 链接的默认处理程序，因而在浏览器或文件管理器中点击一个该类型链接时可以在本应用打开。"
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
-msgstr "将 aMule 注册为打开 magnet: 链接的应用"
 
 #: src/muuli_wdr.cpp:1286
 msgid "aMule only handles eD2k-compatible magnets (containing xt=urn:ed2k:). BitTorrent magnets are NOT supported and clicking them will silently fail. If you use a BitTorrent client (Transmission, qBittorrent, etc.), leave this off."
@@ -3710,13 +3896,6 @@ msgstr "浏览器"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "在此处输入您的浏览器名称，如要使用系统默认浏览器则请留空。"
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "浏览"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "如果可能的话，在新标签页中打开"
@@ -3745,10 +3924,6 @@ msgstr "槽速度"
 msgid "Ports"
 msgstr "端口"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "标准 TCP 端口 "
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "这是标准的 eD2k 端口，不能被禁用。"
@@ -3761,17 +3936,9 @@ msgstr "用户服务器请求的 UDP 端口 (TCP+3):"
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "扩展 UDP 端口 (Kad/全局搜索) "
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "此 UDP 端口用于扩展 eD2k 请求和 Kad 网络"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "启用 UPnP 以用于路由器端口转发"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3801,10 +3968,6 @@ msgstr "每个下载文件的最大的源数量:"
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kad"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3828,10 +3991,6 @@ msgstr "即使静态服务器连不上也永远不删除。"
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "次连接失败，则删除该服务器"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "启动时自动更新服务器列表"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3965,10 +4124,6 @@ msgstr "检测"
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr "搜索标准的 ffprobe 二进制文件安装路径，并填写路径字段。"
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "存放下载文件的文件夹"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3980,14 +4135,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr "选择完成下载文件的存储文件夹。该文件夹中的所有文件都将与其他对等节点共享。"
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr "（此文件夹中的所有文件均与其他对等方共享）"
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "存放临时下载文件的文件夹"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5243,7 +5390,7 @@ msgstr "正在分配"
 msgid "Insufficient disk space"
 msgstr "磁盘空间不足"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "已下载"
@@ -5919,7 +6066,7 @@ msgstr "共享的文件夹"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 msgid "Search error"
 msgstr "搜索错误"
 
@@ -5931,7 +6078,7 @@ msgstr "最小值必须小于最大值，最大值已被忽略。"
 msgid "Search warning"
 msgstr "搜索警告"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "主要"
 
@@ -5971,36 +6118,36 @@ msgstr "比特率"
 msgid "Codec"
 msgstr "编解码器"
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "下载分类"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "获取此文件的 %s"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "搜索相关文件（eD2k，本地服务器）"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "标记为已知文件"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "复制eD2k链接至剪贴板"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "当前未连接到支持“相关文件”搜索功能的服务器"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "已取消"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "新建"
 
@@ -7030,10 +7177,6 @@ msgstr "Endgame 源轮替状态为 %s。\n"
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr "已启动搜索（id %u）。\n"
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 11:33+0200\n"
+"POT-Creation-Date: 2026-07-27 13:15+0200\n"
 "PO-Revision-Date: 2026-07-27 10:37+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -326,12 +326,12 @@ msgid ""
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:1005
+#: src/amule.cpp:1005 src/FirstRunWizard.cpp:410
 #, fuzzy
 msgid "eD2k server list (server.met)"
 msgstr "在 server.met 中找到 %i 個伺服器"
 
-#: src/amule.cpp:1012
+#: src/amule.cpp:1012 src/FirstRunWizard.cpp:415
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgid "Enter Captcha"
 msgstr "輸入圖形驗證碼"
 
 #: src/CatDialog.cpp:58 src/DownloadListCtrl.cpp:783 src/muuli_wdr.cpp:253
-#: src/SearchListCtrl.cpp:730 src/TransferWnd.cpp:338
+#: src/SearchListCtrl.cpp:734 src/TransferWnd.cpp:338
 msgid "Category"
 msgstr "分類"
 
@@ -1512,7 +1512,7 @@ msgstr "錯誤：IO 錯誤！"
 msgid "ERROR: Failed!"
 msgstr "錯誤：失敗！"
 
-#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1156
+#: src/DataToText.cpp:185 src/SearchListCtrl.cpp:1160
 msgid "Queued"
 msgstr "待處理"
 
@@ -1638,7 +1638,7 @@ msgid "Show file &details"
 msgstr "顯示檔案詳細資訊(&D)"
 
 #: src/DownloadListCtrl.cpp:772 src/muuli_wdr.cpp:706
-#: src/SearchListCtrl.cpp:746
+#: src/SearchListCtrl.cpp:750
 msgid "Show all comments"
 msgstr "顯示所有註解"
 
@@ -2253,6 +2253,204 @@ msgstr "完成 %.1f%%"
 #, c-format
 msgid "%.2f kB/s"
 msgstr "%.2f KB/s"
+
+#: src/FirstRunWizard.cpp:91
+msgid "Mobile / 4G-5G (20 / 5 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:92
+msgid "ADSL (24 / 1 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:93
+msgid "VDSL (50 / 10 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:94
+msgid "Cable (200 / 20 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:95
+msgid "Fibre 300 (300 / 100 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:96
+msgid "Fibre Gigabit (1000 / 1000 Mbit)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:223
+msgid "aMule first-run setup"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:251
+#, fuzzy
+msgid "Welcome to aMule!"
+msgstr "歡迎！"
+
+#: src/FirstRunWizard.cpp:254
+msgid ""
+"This short setup will get you connected. You can change\n"
+"any of these settings later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:260
+msgid "Choose a nickname other peers will see:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:276
+#, fuzzy
+msgid "Connection & bandwidth"
+msgstr "正在與好友連線"
+
+#: src/FirstRunWizard.cpp:279
+msgid ""
+"Pick the option that best matches your Internet connection,\n"
+"or set the upload and download limits directly below."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:285
+#, fuzzy
+msgid "Connection speed:"
+msgstr "連線狀態："
+
+#: src/FirstRunWizard.cpp:290
+msgid "Other / set manually"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:297
+msgid "Upload limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:305
+msgid "Download limit (kB/s, 0 = unlimited):"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:331
+#, fuzzy
+msgid "Networks & ports"
+msgstr "網路"
+
+#: src/FirstRunWizard.cpp:334
+msgid "aMule can use two networks. We recommend keeping both enabled."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:344 src/TextClient.cpp:894
+msgid "eD2k"
+msgstr "eD2k"
+
+#: src/FirstRunWizard.cpp:348 src/muuli_wdr.cpp:1481
+msgid "Kademlia"
+msgstr "Kad"
+
+#: src/FirstRunWizard.cpp:358 src/muuli_wdr.cpp:1409
+msgid "Standard TCP Port "
+msgstr "標準 TCP 埠"
+
+#: src/FirstRunWizard.cpp:364 src/muuli_wdr.cpp:1421
+msgid "Extended UDP port (Kad / global search) "
+msgstr "擴充 UDP 埠 (Kad / 全球搜尋)"
+
+#: src/FirstRunWizard.cpp:376 src/muuli_wdr.cpp:1428
+msgid "Enable UPnP for router port forwarding"
+msgstr "啟用 UPnP 的路由通訊埠轉向"
+
+#: src/FirstRunWizard.cpp:381
+msgid ""
+"Lets aMule ask your router to forward the ports above so other\n"
+"peers can reach you (a \"HighID\"). Turn off if your router\n"
+"doesn't support UPnP or you forward ports manually."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:398
+#, fuzzy
+msgid "Bootstrap files"
+msgstr "啓動"
+
+#: src/FirstRunWizard.cpp:403
+msgid ""
+"To get started, aMule needs to know about some peers.\n"
+"Select which lists to download now:"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:422
+#, fuzzy
+msgid "Your peer lists are already in place - nothing to download."
+msgstr "您已經在下載檔案 %s 了"
+
+#: src/FirstRunWizard.cpp:433 src/muuli_wdr.cpp:1526
+msgid "Auto-update server list at startup"
+msgstr "啟動時自動更新伺服器清單"
+
+#: src/FirstRunWizard.cpp:446
+msgid "Integrations (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:449
+msgid ""
+"Choose how aMule integrates with your system. You can\n"
+"change any of these later in Preferences."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:459 src/muuli_wdr.cpp:1273
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:479 src/muuli_wdr.cpp:1281
+msgid "Register aMule for ed2k:// links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:487 src/muuli_wdr.cpp:1285
+msgid "Register aMule for magnet: links"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:496
+msgid "Only eD2k-compatible magnets. Leave off if you use a BitTorrent client."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:512
+msgid "Folders (optional)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:515
+msgid ""
+"The defaults are fine for most people. Change them if you\n"
+"want downloads on a different (e.g. larger) disk."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:523 src/FirstRunWizard.cpp:585 src/muuli_wdr.cpp:1688
+msgid "Destination folder for downloads"
+msgstr "下載資料夾"
+
+#: src/FirstRunWizard.cpp:527 src/FirstRunWizard.cpp:543 src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663 src/muuli_wdr.cpp:1694
+#: src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
+#: src/utils/aLinkCreator/src/alcframe.cpp:135
+#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
+msgid "Browse"
+msgstr "瀏覽"
+
+#: src/FirstRunWizard.cpp:533 src/muuli_wdr.cpp:1699
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:539 src/FirstRunWizard.cpp:598 src/muuli_wdr.cpp:1701
+msgid "Folder for temporary download files"
+msgstr "暫存資料夾"
+
+#: src/FirstRunWizard.cpp:560
+#, c-format
+msgid ""
+"Based on this, aMule will allow up to %i sources per file\n"
+"and %i client connections."
+msgstr ""
+
+#: src/FirstRunWizard.cpp:738
+msgid "Show this setup wizard again the next time you start aMule?"
+msgstr ""
+
+#: src/FirstRunWizard.cpp:739
+msgid "Setup not finished"
+msgstr ""
 
 #: src/FriendList.cpp:120
 msgid "Failed to open friend list file 'emfriends.met' for reading!"
@@ -3057,7 +3255,7 @@ msgstr "名稱："
 msgid "Type"
 msgstr "類型"
 
-#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:849
+#: src/muuli_wdr.cpp:215 src/SearchDlg.cpp:110 src/SearchListCtrl.cpp:853
 msgid "Local"
 msgstr "本地"
 
@@ -3177,7 +3375,7 @@ msgstr ""
 msgid "Stop"
 msgstr "停止"
 
-#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:728
+#: src/muuli_wdr.cpp:348 src/muuli_wdr.cpp:1378 src/SearchListCtrl.cpp:732
 msgid "Download"
 msgstr "下載"
 
@@ -3635,24 +3833,12 @@ msgstr "啓動時檢查新版本"
 msgid "Enabling this will make aMule check for a new version at startup and once a day while running"
 msgstr "啟用後使 aMule 在啓動時檢查新版本"
 
-#: src/muuli_wdr.cpp:1273
-msgid "Start aMule automatically when I log in"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1274
 msgid "Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1281
-msgid "Register aMule for ed2k:// links"
-msgstr ""
-
 #: src/muuli_wdr.cpp:1282
 msgid "Makes aMule the default handler for ed2k:// links so clicking one in your browser or file manager opens it here."
-msgstr ""
-
-#: src/muuli_wdr.cpp:1285
-msgid "Register aMule for magnet: links"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1286
@@ -3719,13 +3905,6 @@ msgstr "瀏覽器設定"
 msgid "Enter your browser name here. Leave this field empty to use the system default browser."
 msgstr "請輸入瀏覽器的名稱，空白則使用系統預設。"
 
-#: src/muuli_wdr.cpp:1335 src/muuli_wdr.cpp:1352 src/muuli_wdr.cpp:1663
-#: src/muuli_wdr.cpp:1694 src/muuli_wdr.cpp:1706 src/muuli_wdr.cpp:2749
-#: src/utils/aLinkCreator/src/alcframe.cpp:135
-#: src/utils/wxCas/src/wxcasprefs.cpp:52 src/utils/wxCas/src/wxcasprefs.cpp:118
-msgid "Browse"
-msgstr "瀏覽"
-
 #: src/muuli_wdr.cpp:1339
 msgid "Open in new tab if possible"
 msgstr "在新分頁中開啟"
@@ -3754,10 +3933,6 @@ msgstr "位置分配"
 msgid "Ports"
 msgstr "通訊埠"
 
-#: src/muuli_wdr.cpp:1409
-msgid "Standard TCP Port "
-msgstr "標準 TCP 埠"
-
 #: src/muuli_wdr.cpp:1413
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr "標準 eD2k 通訊埠，不可停用。"
@@ -3770,17 +3945,9 @@ msgstr "伺服器要求 UDP 埠 (TCP+3)："
 msgid "4665"
 msgstr "4665"
 
-#: src/muuli_wdr.cpp:1421
-msgid "Extended UDP port (Kad / global search) "
-msgstr "擴充 UDP 埠 (Kad / 全球搜尋)"
-
 #: src/muuli_wdr.cpp:1425
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr "這個 UDP 埠用於 eD2k 擴充要求與 Kad 網路"
-
-#: src/muuli_wdr.cpp:1428
-msgid "Enable UPnP for router port forwarding"
-msgstr "啟用 UPnP 的路由通訊埠轉向"
 
 #: src/muuli_wdr.cpp:1432
 msgid "UPnP TCP Port (Optional):"
@@ -3811,10 +3978,6 @@ msgstr "每個檔案最大來源數："
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp:1481
-msgid "Kademlia"
-msgstr "Kad"
-
 #: src/muuli_wdr.cpp:1484 src/muuli_wdr.cpp:3156
 msgid "ED2K"
 msgstr "ED2K"
@@ -3838,10 +4001,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1521
 msgid "retries"
 msgstr "次重試"
-
-#: src/muuli_wdr.cpp:1526
-msgid "Auto-update server list at startup"
-msgstr "啟動時自動更新伺服器清單"
 
 #: src/muuli_wdr.cpp:1529
 msgid "List"
@@ -3975,10 +4134,6 @@ msgstr ""
 msgid "Search the standard install locations for an ffprobe binary and fill the path field."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1688
-msgid "Destination folder for downloads"
-msgstr "下載資料夾"
-
 #: src/muuli_wdr.cpp:1692
 msgid ""
 "Completed downloads are stored here. All files in this folder are automatically shared with other peers.\n"
@@ -3988,14 +4143,6 @@ msgstr ""
 #: src/muuli_wdr.cpp:1695
 msgid "Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."
 msgstr ""
-
-#: src/muuli_wdr.cpp:1699
-msgid "(All files in this folder are shared with other peers)"
-msgstr ""
-
-#: src/muuli_wdr.cpp:1701
-msgid "Folder for temporary download files"
-msgstr "暫存資料夾"
 
 #: src/muuli_wdr.cpp:1709
 msgid "Shared folders"
@@ -5249,7 +5396,7 @@ msgstr "正在分配"
 msgid "Insufficient disk space"
 msgstr "磁碟空間不足"
 
-#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1151
+#: src/PartFile.cpp:4428 src/SearchListCtrl.cpp:1155
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr "已下載"
@@ -5932,7 +6079,7 @@ msgstr "分享資料夾"
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
-#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:854
+#: src/SearchDlg.cpp:426 src/SearchListCtrl.cpp:858
 #, fuzzy
 msgid "Search error"
 msgstr "搜尋"
@@ -5945,7 +6092,7 @@ msgstr "最小值必須小於最大值，最大值已被忽略。"
 msgid "Search warning"
 msgstr "搜尋警告"
 
-#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:731
+#: src/SearchDlg.cpp:929 src/SearchListCtrl.cpp:735
 msgid "Main"
 msgstr "主要"
 
@@ -5987,37 +6134,37 @@ msgstr "未評價"
 msgid "Codec"
 msgstr ""
 
-#: src/SearchListCtrl.cpp:736
+#: src/SearchListCtrl.cpp:740
 msgid "Download in category"
 msgstr "分類下載"
 
-#: src/SearchListCtrl.cpp:741
+#: src/SearchListCtrl.cpp:745
 #, c-format
 msgid "Get %s for this file"
 msgstr "取得這個檔案的 %s"
 
-#: src/SearchListCtrl.cpp:745
+#: src/SearchListCtrl.cpp:749
 msgid "Search related files (eD2k, local server)"
 msgstr "搜尋相關檔案 (eD2k，本地伺服器)"
 
-#: src/SearchListCtrl.cpp:752
+#: src/SearchListCtrl.cpp:756
 msgid "Mark as known file"
 msgstr "標記為已知檔案"
 
-#: src/SearchListCtrl.cpp:756 src/ServerListCtrl.cpp:484
+#: src/SearchListCtrl.cpp:760 src/ServerListCtrl.cpp:484
 msgid "Copy eD2k link to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿"
 
-#: src/SearchListCtrl.cpp:852
+#: src/SearchListCtrl.cpp:856
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "現在正連線到要刪除的伺服器。請先中斷連線。"
 
-#: src/SearchListCtrl.cpp:1159
+#: src/SearchListCtrl.cpp:1163
 msgid "Canceled"
 msgstr "已取消"
 
-#: src/SearchListCtrl.cpp:1162
+#: src/SearchListCtrl.cpp:1166
 msgid "New"
 msgstr "新"
 
@@ -7043,10 +7190,6 @@ msgstr ""
 #, c-format
 msgid "Search started (id %u).\n"
 msgstr ""
-
-#: src/TextClient.cpp:894
-msgid "eD2k"
-msgstr "eD2k"
 
 #: src/TextClient.cpp:900
 #, c-format


### PR DESCRIPTION
`FirstRunWizard.cpp` (the first-run setup wizard) has ~48 translatable strings but was never added to `po/POTFILES.in`, so none of them were extracted — the wizard is currently untranslatable.

This adds `src/FirstRunWizard.cpp` to `POTFILES.in` (alphabetical, after `FileDetailListCtrl.cpp`) and regenerates the catalogs via `scripts/update-po.sh`.

The diff is large but mechanical:
- the wizard's own new msgids (added untranslated, for Weblate to fill);
- refreshed `#:` source-refs (CI strips these);
- re-positioning of shared strings the wizard now references first (`eD2k`, `Kademlia`, `Standard TCP Port `…).

No translations are lost. `update-po.sh` is idempotent here (a second run is a no-op), so the "App catalogs in sync" check converges to zero drift.
