### PR TITLE
feat(gui): add Alt+<letter> tab-switch shortcuts, mirrored as a macOS menu

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -546,29 +546,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -578,39 +616,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -620,175 +658,142 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:31+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -554,30 +554,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "بحث"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "تحميل"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "رسائل"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "احصائات"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "اعدادت"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "غير متوفر"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -587,41 +625,41 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "متصل"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "يتم الإتصال"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -631,178 +669,145 @@ msgstr ""
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "إيقاف محاولة اﻹتصال الحاليه"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "فصل"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "فصل من المستضيف الحالي"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "إتصال"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "رفع : %.1f |تحميل : %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "هل تريد حقا الخروج من البرنامج؟"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "تاكيد الخروج"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "بحث"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "نافذة البحث"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "تحميل"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "تحميل"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "نافذة ملفات المشاركة"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "رسائل"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "نافذة الرسائل"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "احصائات"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "نافذة اﻻحصائيات"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "اعدادت"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "نافذة اﻹعدادات"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -574,30 +574,68 @@ msgstr "Nun puede Crease un Ficheru Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto ye aMule %s basáu en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Executándose en %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar si hai una nueva versión disponible"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Guetar"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargues"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Ficheros compartíos"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mensaxes"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadístiques"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencies"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Non disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,39 +645,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "La cabera versión pues alcontrala siempres en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Diálogu aMule afaráu"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Coneutando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Coneutando"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconeutáu"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tres Tornafueos"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Coneutáu"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Coneutando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -649,177 +687,144 @@ msgstr "Kad: Apagada"
 msgid "Cancel"
 msgstr "Encaboxar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexón actuales"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Desconeutar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconeutase de les redes coneutaes"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Coneutar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Coneutase a les redes disponibles"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Xu: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Coneutáu)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconeutáu)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Daveres quies colar de aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmar colar."
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Llanzar comandu:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- Por defeutu -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El direutorio de tema '%s' nun esiste"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENCIÓN: Nun pue abrise'l ficheru de temes '%s' pa llectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Guetar"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Ventana de gueta"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargues"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Descargando"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Ficheros compartíos"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Ventana de ficheros compartíos"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mensaxes"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Ventana de mensaxes"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadístiques"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos d'estadístiques"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencies"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Ventana d'opciones"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "La ferramienta pa importar ficheros part"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tocante a"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Tocante a/Aida"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ensin rede"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:32+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -553,29 +553,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Съобщения"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Настройки"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -585,41 +623,41 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Връзкате е установена"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Свързва"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -629,178 +667,145 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Спира текущите опити за свързване"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Разкачи"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Изключване от текущия сървър"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Връзка"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кБ/с"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Кач.: %.1f | Свал.: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Наистина ли желаете да изключите aМуле?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Потвърждение за изход"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- по подразбиране -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Изтегляне"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Съобщения"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Настройки"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Няма мрежа"
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -545,29 +545,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -577,39 +615,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -619,175 +657,142 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -574,30 +574,68 @@ msgstr "No s'ha pogut crear el fitxer Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s basat en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "S'està executant sobre %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprovar si hi ha disponible una versió nova."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Xarxes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Cerques"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Baixades"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Compartits"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Missatges"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadístiques"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferències"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "No disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,39 +645,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Sempre podeu trobar l'última versió a https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Diàleg de l'aMule tancat"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connectant"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: S'està connectant"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconnectat"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Bloquejat"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Connectat"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Connectant"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -649,175 +687,142 @@ msgstr "Kad: Inativa"
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Atura els intents de connexió actuals"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Desconnecta"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconnecta de les xarxes on s'està connectat actualment"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Connecta"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Connecta a les xarxes habilitades actualment"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "PU: %.1f%s | BA: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connectat)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconnectat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Esteu segur que voleu eixir de %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmació de sortida"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Ordre: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- defecte -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directori del tema '%s' no existeix"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVÍS: No ha estat possible obrir el fitxer d'aparença '%s' per a lectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Xarxes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Finestra de les Xarxes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Cerques"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Finestra de cerques"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Baixades"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Finestra de baixades"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Compartits"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Finestra de fitxers compartits"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Missatges"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Finestra de Missatges"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadístiques"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Finestra del gràfic d'estadístiques"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferències"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Finestra de la configuració de preferències"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importa"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Eina d'importació de fitxers de parts"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Quant a"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Quant a / Ajuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Xarxa eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Xarxa Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Cap xarxa"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -567,30 +567,68 @@ msgstr "Nelze vytvořit soubor s PID"
 msgid "ERROR: %s"
 msgstr "CHYBA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Toto je aMule %s založená na eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Běží na %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontrolu, jestli není dostupná nová verze."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Sítě"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Vyhledávání"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Stahování"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Sdílené soubory"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Zprávy"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiky"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Nastavení"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nedostupný"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -600,39 +638,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Poslední verze jsou vždy k nalezení na https://github.com/amule-org/amule/releases/latest "
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Dialog aMule zničen"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Připojuji"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: připojuji"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: odpojeno"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Připojen"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Připojuji"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -642,176 +680,143 @@ msgstr "Kad: vypnut"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Zastaví aktuální pokusy o připojení"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Odpojit se od aktuálně připojených sítí"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Připojit"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Připojit se k povoleným sítím"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Od: %.1f(%.1f) | St: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Od: %.1f | St: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | připojen)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | odpojen)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Opravdu si přejete ukončit %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potvrzení ukončení"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Spustit příkaz: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- výchozí -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Adresář se skiny '%s' neexistuje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROVÁNÍ: Nelze otevřít soubor se vzhledem '%s' pro čtení"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Sítě"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Okno sítí"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Vyhledávání"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Vyhledávací okno"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Stahování"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Stahování"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Sdílené soubory"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Okno se sdílenými soubory"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Zprávy"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Okno zpráv"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiky"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Okno se statistikami"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Nastavení"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Okno s nastavením"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Nástroj pro import částečných souborů"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "O programu/Nápověda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Síť eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Síť Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Žádná síť"
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -555,30 +555,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Søg"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Beskeder"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistik"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Indstillinger"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ikke tilgængelig"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -588,43 +626,43 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den sidste nye version kan altid findes hos https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Forbundet"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Forbinder"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -634,178 +672,145 @@ msgstr " Kad: "
 msgid "Cancel"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Stop de nuværende forbindelses forsøg"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Afbryd"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Afbryd fra nuvÃŠrende server"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Forbind"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Op: %.1f | Ned: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du virkelig afslutte aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Bekræft afslut"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Søg"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Søge Vindue"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Henter"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Beskeder"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Besked Vindue"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistik"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Indstillinger"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -150,7 +150,7 @@ msgstr "Installieren"
 msgid "Not now"
 msgstr "Nicht jetzt"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Nicht erneut fragen"
 
@@ -581,30 +581,68 @@ msgstr "Kann keine Pid-Datei erstellen"
 msgid "ERROR: %s"
 msgstr "FEHLER: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dies ist aMule %s, basierend auf eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Läuft auf %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, ob eine neue Version verfügbar ist."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Netzwerke"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Suchen"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Freigegebene Dateien"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Nachrichten"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiken"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nicht verfügbar"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -614,39 +652,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Die neueste Version kann man immer auf https://github.com/amule-org/amule/releases/latest finden."
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule Dialog zerstört."
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Verbindung getrennt"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Verbunden"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Baue Verbindung auf"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: aus"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -656,175 +694,142 @@ msgstr "Kad: aus"
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Beendet die derzeitigen Verbindungsversuche"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Von den momentan verbundenen Netzwerken trennen."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Mit den aktuell aktivierten Netzwerken verbinden."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbunden)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Getrennt)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s wirklich beenden?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Beenden bestätigen"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Startbefehl: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- Voreinstellung -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-Verzeichnis '%s' existiert nicht"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WARNUNG: Öffnen der Skin-Datei '%s' zum Lesen nicht möglich"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Netzwerke"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Übersicht der verwendeten Netzwerke"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Suchen"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Dateisuche in den verbundenen Netzwerken"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Download-Fenster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Freigegebene Dateien"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Übersicht der freigegebenen Dateien"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Nachrichten"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Nachrichten, Chat, Freundesliste"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiken"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Diverse Statistiken über Up- und Download, Verbindungen, Clients usw."
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Fenster für Einstellungen"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importiere"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Das Importierwerkzeug für Part-Dateien"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Über"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Über/Hilfe - Hinweise zur Version usw."
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-Netzwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad-Netzwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Kein Netzwerk"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -579,30 +579,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ΣΦΑΛΜΑ: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Αυτό το aMule %s είναι βασισμένο στο eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Τρέχει στο %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/releases/latest για να δείτε αν υπάρχει νέα έκδοση."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Δίκτυα"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Αναζητήσεις"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Κατεβασμένα"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Κοινόχρηστα αρχεία"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Μηνύματα"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Στατιστικές"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Προτιμήσεις"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Δεν είναι διαθέσιμο"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -612,39 +650,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Η τελευταία έκδοση μπορεί να βρεθεί στο https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Συνδέοντας"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Συνδέεται"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Αποσυνδεδεμένο"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Πίσω από τοίχο προστασίας"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Συνδεδεμένο"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Σε διαδικασία σύνδεσης"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -654,177 +692,144 @@ msgstr "Kad: Εκτός"
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Σταμάτησε τις τρέχουσες απόπειρες σύνδεσης"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Αποσύνδεση από τα συνδεδεμένα δίκτυα"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Σύνδεση"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Σύνδεση στα ενεργοποιημένα δίκτυα"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Πάνω: %.1f | Κάτω: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Συνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Αποσυνδεδεμένο)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Σίγουρα θέλετε να κλείσετε το aMule;"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Έξοδος επιβεβαίωσης"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- Προεπιλεγμένο -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ο κατάλογος των θεμάτων '%s'  δεν υπάρχει"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν είναι δυνατή η ανάγνωση του αρχείου θέματος '%s' "
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Δίκτυα"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Παράθυρο δικτύων"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Αναζητήσεις"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Παράθυρο αναζητήσεων"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Κατεβασμένα"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Κατεβαίνει"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Κοινόχρηστα αρχεία"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Παράθυρο κοινόχρηστων αρχείων"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Μηνύματα"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Παράθυρό μηνυμάτων"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Στατιστικές"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Παράθυρο στατιστικών διαγραμμάτων"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Προτιμήσεις"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Παράθυρο ρυθμίσεων"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Εισαγωγή"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Το εργαλείο εισαγωγής ημιτελών αρχείων"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Σχετικά"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Σχετικά/Βοήθεια"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Δίκτυο eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Δίκτυο Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Κανένα δίκτυο"
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -546,29 +546,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -578,39 +616,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -620,175 +658,142 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -152,7 +152,7 @@ msgstr "Instalar"
 msgid "Not now"
 msgstr "Ahora no"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "No volver a preguntar"
 
@@ -582,29 +582,67 @@ msgstr "No se puede crear el archivo Pid"
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esto es aMule %s basado en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Ejecutándose en %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar si hay una nueva versión disponible."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Búsquedas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Compartidos"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mensajes"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -619,39 +657,39 @@ msgstr ""
 "\n"
 "¿Le gustaría abrir la página de descarga?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Diálogo de aMule destruido"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: tras cortafuegos"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: conectado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: conectando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: apagado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -661,175 +699,142 @@ msgstr "Kad: apagado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Detener los intentos de conexión actuales"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectarse de las redes conectadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectarse a las redes habilitadas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Su: %.1f%s | De: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "¿Realmente desea cerrar %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmación de salida"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Ejecutar comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- predeterminado -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "El directorio de tema '%s' no existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: no se puede abrir el archivo de tema '%s' para lectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Ventana de redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Búsquedas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Ventana de búsquedas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Ventana de descargas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Compartidos"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Ventana de archivos compartidos"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mensajes"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Ventana de mensajes"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Ventana de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Ventana de preferencias de configuración"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "La herramienta para importar archivos de partes"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca de"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Acerca de/Ayuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Red eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "No hay red"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -574,30 +574,68 @@ msgstr "Ei suuda luua PID faili"
 msgid "ERROR: %s"
 msgstr "VIGA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "See on eMulel põhinev aMule %s."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Jookseb %s peal"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk on uuem versioon saadaval."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Võrgud"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Otsingud"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Tõmbamised"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Jagatud failid"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Teated"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Seaded"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Info puudub"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,39 +645,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uuema aMule versiooni saad alati aadressilt https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoog hävitatud"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Ühendun"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ühendun"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Lahutatud"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tulemüüriga"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Ühendatud"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Ühendun"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -649,176 +687,143 @@ msgstr "Kad: Väljas"
 msgid "Cancel"
 msgstr "Loobu"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Lõpeta käimasolevad ühenduskatsed"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Lõpeta ühendus ühendatud võrkudega"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Ühenda"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Ühendu olemasolevate, aktiivsete võrkudega"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Üles: %.1f | Alla: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ühendatud)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ühenduseta)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Kas sa tõesti tahad %s'st väljuda?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Kinnitan väljumise"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Käivitamise korraldus: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- vaikimisi -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Rüüde kataloogi  '%s' ei eksiteeri"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "HOIATUS: Ei suuda rüüfaili '%s' lugemiseks avada"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Võrgud"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Võrgud"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Otsingud"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Otsingu aken"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Tõmbamised"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Tõmbamised"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Jagatud failid"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Jagatud failide Aken"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Teated"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Teadete Aken"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Statistiliste graafikute aken"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Seaded"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Seadete aken"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Impordi"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Osafailide importimise tööriist"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Info"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Info/Appi"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k võrk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad võrk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Võrk puudub"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -575,30 +575,68 @@ msgstr "Ezin da Pid fitxategia sortu"
 msgid "ERROR: %s"
 msgstr "ERROREA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Hau eMulen oinarrituriko aMule %s da."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s-n abiarazirik"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsio berriagorik eskuragarri dagoen jakiteko."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Sareak"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Bilaketak"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Deskargak"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Partekatutako fitxategiak"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mezuak"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatistikak"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Hobespenak"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ez dago erabilgarri"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -608,39 +646,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Azken bertsioa beti https://github.com/amule-org/amule/releases/latest webgunean aurki daiteke"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule elkarrizketa suntsitua"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Konektatzen"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Konektatzen"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deskonektatua"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Suebakirik"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Konektaturik"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Konektatzen"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -650,176 +688,143 @@ msgstr "Kad: Itzalia"
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Geratu uneko konexio saiakerak"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Deskonektatu konektatutako sareetatik"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Konektatu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Konektatu gaituriko sareetara"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gora: %.1f | Behera: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Konektaturik)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ez konektaturik)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Benetan %s utzi egin nahi duzu?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Irteera berrespena"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Abiarazi komandoa: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- lehenetsia -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Ez dago '%s' itxura direktorioa"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ABISUA: Ezin da '%s' azal fitxategia irakurri"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Sareak"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Sare leihoa"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Bilaketak"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Bilaketa leihoa"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Deskargak"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Deskargak leihoa"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Partekatutako fitxategiak"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Partekatutako fitxategi leihoa"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mezuak"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Mezu leihoa"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatistikak"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Estatistika grafiko leihoa"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Hobespenak"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Hobespen ezarpen leihoa"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Inportatu"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Zati fitxategi inportazio tresna"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Honi buruz"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Honi buruz/Laguntza"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k sarea"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad sarea"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sarerik ez"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -575,30 +575,68 @@ msgstr "Ei voitu luoda prosessinumerotiedostoa"
 msgid "ERROR: %s"
 msgstr "VIRHE: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Tämä on aMule %s ja pohjautuu eMuleen."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Käynnissä %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest tarkistaaksi uuden version saatavuuden."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Verkot"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Haut"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Lataukset"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Jaetut tiedostot"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Viestit"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Tilastot"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Asetukset"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ei saatavissa"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -608,39 +646,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Uusin version löytyy aina osoitteesta https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMulen dialogi tuhottu"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Yhdistetään"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Yhdistetään"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Ei yhdistetty"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Palomuurattu"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Yhdistety"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Yhdistetään"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -650,176 +688,143 @@ msgstr "Kad: Pois päältä"
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Pysäytä nykyiset yhteysyritykset"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Katkaise yhteys yhdistettyihin verkkoihin"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Yhdistä sallittuihin verkkoihin"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Ylös: %.1f | Alas: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Yhdistetty)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ei yhdistetty)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Haluatko varmasti sulkea %sn?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Lopettamisen varmistus"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Suorita komento: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- oletus -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Teemakansiota '%s' ei ole olemassa"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "VAROITUS: Ei voida avata teematiedostoa '%s' luettavaksi"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Verkot"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Verkkoikkuna"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Haut"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Hakujen ikkuna"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Lataukset"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Latausten ikkuna"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Jaetut tiedostot"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Jaettujen tiedostojen ikkuna"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Viestit"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Viestien ikkuna"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Tilastot"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Tilastokuvaajien ikkuna"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Asetukset"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Asetuksien säätöikkuna"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Tuonti"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Osatiedostojen tuontityökalu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Tietoja"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Tietoja/Ohje"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-verkko"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad-verkko"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ei verkkoa"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -149,7 +149,7 @@ msgstr "Installer"
 msgid "Not now"
 msgstr "Pas maintenant"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Ne plus me demander"
 
@@ -580,29 +580,67 @@ msgstr "Impossible de créer le fichier Pid"
 msgid "ERROR: %s"
 msgstr "Erreur : %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ceci est aMule %s basé sur eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Tourne sur %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifier si une nouvelle version est disponible."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Réseaux"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Recherches"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Téléchargements"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Fichiers partagés"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Messages"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiques"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Préférences"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Une nouvelle version est disponible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -617,39 +655,39 @@ msgstr ""
 "\n"
 "Souhaiteriez-vous ouvrir la page de téléchargement ?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "boîte de dialogue aMule détruite"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connexion en cours"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k : Connexion en cours"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k : Déconnecté"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad : Derrière un pare-feu"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad : Connecté"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad : Connexion en cours"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -659,175 +697,142 @@ msgstr "Kad : Coupé"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Stopper les essais de connexions en cours"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Se déconnecter des réseaux actuellement connectés"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Se connecter"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Se connecter aux réseaux actuellement activés"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " Mo/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " Ko/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "E : %.1f%s | R : %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connecté)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Déconnecté)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Voulez-vous vraiment quitter %s ?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmation de sortie"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Commande de lancement : "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- défaut -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Le répertoire de thèmes '%s' n'existe pas"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVERTISSEMENT : Impossible d'ouvrir le fichier thème '%s' pour la lecture"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Réseaux"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Fenêtre des réseaux"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Recherches"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Fenêtre de Recherche"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Téléchargements"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Fenêtre des Téléchargements"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Fichiers partagés"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Fenêtre des Fichiers Partagés"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Messages"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Fenêtre des Messages"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiques"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Fenêtre des Statistiques"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Préférences"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Fenêtre des Préférences"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importer"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "L'outil d'importation de fichier .part"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "À propos"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "À propos/Aide"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Réseau eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Réseau Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Pas de réseau"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:38+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -162,7 +162,7 @@ msgstr "Continuar"
 msgid "Not now"
 msgstr "Agora non"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Non preguntar de novo"
 
@@ -594,30 +594,68 @@ msgstr "Non se puido crear o ficheiro Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é aMule %s baseado en eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Executando en %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Buscas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descargas"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Ficheiros compartidos"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mensaxes"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Non dispoñible"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -627,39 +665,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Pode obter a última versión de aMule en https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Destruído o cadro de diálogo de aMule"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectando"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tras devasa"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -669,175 +707,142 @@ msgstr "Kad: Apagado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Deter a tentativa actual de conexión"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes conectadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar ás redes activas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Enviado: %.1f%s | Descargado: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Desexar saír de %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmación da saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Ordes de Arranque: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- por omisión -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Non existe o directorio de temas «%s»"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Non se puido abrir o ficheiro de temas «%s» en modo lectura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Xanela de Redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Buscas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Xanela de buscas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descargas"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Xanela de descargas"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Ficheiros compartidos"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Xanela de ficheiros compartidos"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mensaxes"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Xanela de mensaxes"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estadísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Xanela de gráficos de estadísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Xanela de Preferencias"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "A ferramenta para importar ficheiros «part»"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Sobre/Axuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Red Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sen rede"
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -561,30 +561,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "אירעה שגיאה: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "זהו אֵימיול %s המבוסס על אִמיול"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "פועל על %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לבדוק האם ישנה גירסה חדישה זמינה."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "רשתות"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "חיפושים"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "הורדות"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "הודעות"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "סטטיסטיקות"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "העדפות"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "לא זמין"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -594,39 +632,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "מתחבר"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "קאד: חסום חומתאש"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "קאד: מחובר"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "קאד: מתחבר"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -636,177 +674,144 @@ msgstr "קאד: מכובה"
 msgid "Cancel"
 msgstr "ביטול"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "מנותק"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "התנתק מהרשתות שאליהם אתה מחובר כעת"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "התחבר"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "התחבר לרשתות שמאופשרות כרגע"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "מ\"ב/ש"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " ק\"ב/ש"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "מעלה: %.1f | מוריד: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "אימיול (%s | מחובר)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "אימיול (%s | מנותק)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "האם אתה באמת רוצה לצאת מאימיול?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "אישרור יצאיה"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "ספריית הסקינים '%s' לא קיימת"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "רשתות"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "חלון הרשתות"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "חיפושים"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "חלון החיפושים"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "הורדות"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "מוריד מהרשת"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "חלון הקבצים המשותפים"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "הודעות"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "חלון ההודעות"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "סטטיסטיקות"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "חלון גרפי הסטטיסטיקה"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "העדפות"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "חלון הגדרת ההעדפות"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "ייבא"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "כלי הייבא עבור קובץ-החלקים"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "אודות"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "אודות/עזרה"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -138,7 +138,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -558,30 +558,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "POGREŠKA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Pretrage"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Poruke"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistike"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Opcije"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nije dostupno"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -591,41 +629,41 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "Veza uspostavljena"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "Spajanje"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -635,179 +673,146 @@ msgstr ""
 msgid "Cancel"
 msgstr "Otkaz"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "Zaustavlja trenutne pokusaje uspostavljanja veze"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekinuti vezu sa sadasnjim serverom"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Uspostavi vezu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gore: %.1f | Dole: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Da li zaista zelite iskljuciti aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potvrda izlaza"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Pretrage"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Prozor pretraga"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Downloading"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Prozor dijeljenih fajlova"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Poruke"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Prozor poruka"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistike"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Prozor grafova statistike"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Opcije"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Prozor postavke opcija"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Uvezi"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O autoru:"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:39+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -145,7 +145,7 @@ msgstr "Telepítés"
 msgid "Not now"
 msgstr "Most nem"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Ne kérdezze újra"
 
@@ -576,30 +576,68 @@ msgstr "Pid fájl létrehozása nem lehetséges"
 msgid "ERROR: %s"
 msgstr "HIBA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Ez az aMule %s, az eMule alapján."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s-en fut"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/releases/latest oldalt."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Hálózatok"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Keresések"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Letöltések"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Megosztott fájlok"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Üzenetek"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statisztikák"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Beállítások"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nem elérhető"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -609,39 +647,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A legújabb verzió mindig megtalálható a https://github.com/amule-org/amule/releases/latest honlapon."
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule dialógus elpusztítva"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Kapcsolódás"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2K: Kapcsolódás"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Szétkapcsolva"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Tűzfal mögött"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Csatlakozva"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Kapcsolódás"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -651,175 +689,142 @@ msgstr "Kad: Nincs kapcsolat"
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Aktuális kapcsolódási kísérletek leállítása"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Leválaszt az éppen kapcsolódott hálózatokról."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Kapcsolódás a pillanatnyilag engedélyezett hálózatokhoz."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Fel: %.1f%s | Le: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Kapcsolódva)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Nincs kapcsolat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Biztos, hogy ki szeretnél lépni a(z) %s alkalmazásból?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Kilépés megerősítése"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Parancs futtatása: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- alapértelmezett -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "A(z) '%s' felület könyvtár nem létezik"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "FIGYELEM: Nem tudom a(z) '%s' felület fáljt megnyitni olvasásra"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Hálózatok"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Hálózatok ablaka"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Keresések"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Keresés ablaka"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Letöltések"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Letöltések ablaka"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Megosztott fájlok"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Megosztott fájlok ablaka"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Üzenetek"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Üzenetek ablaka"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statisztikák"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Statisztikai grafikonok ablaka"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Beállítások"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Tulajdonságok beállításának ablaka"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importálás"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "A részfájl importáló eszköz"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Névjegy"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Névjegy/Súgó"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k hálózat"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad hálózat"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nincs hálózat"
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:40+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -151,7 +151,7 @@ msgstr "Installa"
 msgid "Not now"
 msgstr "Non ora"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Non chiedere più"
 
@@ -585,29 +585,67 @@ msgstr "Impossibile creare il file Pid"
 msgid "ERROR: %s"
 msgstr "ERRORE: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Questo è aMule %s basato su eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "In esecuzione su %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllare se è disponibile una nuova versione."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Reti"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Ricerca"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Download"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "File condivisi"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Messaggi"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistiche"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferenze"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -622,39 +660,39 @@ msgstr ""
 "\n"
 "Vuoi aprire la pagina di download?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Finestra di aMule chiusa"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Connessione in corso"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Connessione in corso"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Disconnesso"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Connesso"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Connessione in corso"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Spento"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -664,175 +702,142 @@ msgstr "Kad: Spento"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Ferma i tentativi di connessione in corso"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Disconnetti dalle reti a cui sei connesso"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Connetti"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Connetti alle reti attualmente abilitate"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Connesso)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Disconnesso)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vuoi veramente uscire da %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Chiedi conferma prima di uscire"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Comando di avvio: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- predefinita -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "La directory delle skin '%s' non esiste"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATTENZIONE: Impossibile aprire il file della skin '%s' in lettura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Reti"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Finestra reti"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Ricerca"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Finestra ricerche"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Download"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Finestra dei Download"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "File condivisi"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Finestra file condivisi"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Messaggi"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Finestra messaggi"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistiche"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Finestra grafici e statistiche"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Finestra Preferenze"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importazione"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Strumento per l'importazione dei file parziali"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informazioni"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Informazioni/Aiuto"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "rete eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rete Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nessuna rete"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -574,30 +574,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "エラー： %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "これはeMuleに基づいたaMule %s です。"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s に起動しています"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/releases/latestで。"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "ネットワーク"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "検索"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "ダウンロード数"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "メッセージ"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "統計"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "設定"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "利用不可"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,39 +645,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新バージョンはいつもhttps://github.com/amule-org/amule/releases/latestにあります"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "接続中"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: ファイアウォールされています"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: 接続"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: 接続中"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: オフ"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -649,178 +687,145 @@ msgstr "Kad: オフ"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "現在の接続試行を中止する"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "切断する"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "ネットワークから切断します。"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "接続する"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "ネットワークへ接続します。"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "アップ： %.1f | ダウン： %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 接続しています)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 切断しています)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "本当にaMuleを終了しますか？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "終了の確認"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 #, fuzzy
 msgid "Launch Command: "
 msgstr "コマンド： %s"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "スキンディレクトリ '%s' は存在しません"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "ネットワーク"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "ネットワークウィンドウ"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "検索"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "検索ウィンドウ"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "ダウンロード数"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "ダウンロード"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "共有ファイルウィンドウ"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "メッセージ"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "メッセージウィンドウ"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "統計"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "統計グラフウィインドウ"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "設定"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "個人設定ウィンドウ"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "インポート"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "部分ファイルをインポートするためのツール"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "情報"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "ソフトウェア情報／ヘルプ"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kadネットワーク"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "ネットワークなし"
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -572,30 +572,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "오류: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "이 어뮬 %s는 이뮬 기반으로 되어있습니다."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s에 동작중"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 새로운버젼이 있는지 확인하십시오."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "통신망"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "검색"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "내려받기"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "메시지"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "통계"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "환경설정"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "유효하지 않음"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -605,43 +643,43 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "최신 버젼은 항상 https://github.com/amule-org/amule/releases/latest 에서 찾을 수 있습니다."
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 #, fuzzy
 msgid "Kad: Firewalled"
 msgstr "방화벽"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 #, fuzzy
 msgid "Kad: Connected"
 msgstr "연결됨"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 #, fuzzy
 msgid "Kad: Connecting"
 msgstr "연결중"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 #, fuzzy
 msgid "Kad: Off"
 msgstr " Kad: "
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -651,182 +689,149 @@ msgstr " Kad: "
 msgid "Cancel"
 msgstr "취소"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 #, fuzzy
 msgid "Stop the current connection attempts"
 msgstr "현재 연결시도를 멈춤"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "연결 끊기"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 #, fuzzy
 msgid "Disconnect from the currently connected networks"
 msgstr "통신망으로부터 연결을 끊습니다."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "연결"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 #, fuzzy
 msgid "Connect to the currently enabled networks"
 msgstr "통신망에 연결합니다."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 #, fuzzy
 msgid " kB/s"
 msgstr "kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "올려주기: %.1f | 내려받기: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "어뮬 (%s | 연결됨)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "어뮬 (%s | 끊김)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "어뮬을 종료하시겠습니까?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "종료 확인"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 #, fuzzy
 msgid "Launch Command: "
 msgstr "명령: %s"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "외형 폴더 '%s'가 없습니다."
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "통신망"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "통신망 창"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "검색"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "검색 창"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "내려받기"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "받는중"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "공유 파일 창"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "메시지"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "메시지 창"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "통계"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "통계 그래프 창"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "환경설정"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "환경 설정 창"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "가져오기"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "부분파일 가져오기 도구"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "정보"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "정보/도움"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:41+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -578,30 +578,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KLAIDA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s, sukurta eMule pagrindu."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Vykdoma %s sistemoje"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasitikrinkite ar nėra naujesnės versijos."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Tinklas"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Paieška"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Siuntimai"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Dalinami failai"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Žinutės"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Parinktys"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nėra"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -611,39 +649,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Naujausią versiją bet kada galima atsisiųsti iš https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Jungiamasi"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: jungiamasi"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: atsijungta"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: už ugniasienės"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: prisijungta"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: jungiamasi"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -653,177 +691,144 @@ msgstr "Kad: išjungta"
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Nutraukti bandymus prisijungti"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Atsijungti"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Atsijungti nuo pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Prisijungti"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Prisijungti prie pasirinktų tinklų"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Išs.: %.1f | Ats.: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | prisijungta)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | neprisijungta)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ar tikrai norite baigti darbą su aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Baigimo patvirtinimas"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Išvaizdos failų aplankas %s neegzistuoja"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "DĖMESIO: nepavyko atverti temos failo „%s“ skaitymui"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Tinklas"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Tinklo langas"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Paieška"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Paieškos langas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Siuntimai"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Atsiunčiama"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Dalinami failai"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Dalinamų failų langas"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Žinutės"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Žinučių langas"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Statistikos grafikų langas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Parinktys"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Parinkčių langas"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Įkelti"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Dalinai atsiųstų failų įkėlimo įrankis"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Apie"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Apie/pagalba"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k tinklas"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad tinklas"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Jokio tinklo"
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -133,7 +133,7 @@ msgstr "Uzstādīt"
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -550,29 +550,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "KĻŪDA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, lai pārbaudītu, vai nav pieejama jauna versija."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Tīkli"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Lejupielādes"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Kopīgotās datnes"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Ziņojumi"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Iestatījumi"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Pieejama jauna versija"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -587,39 +625,39 @@ msgstr ""
 "\n"
 "Vai vēlaties atvērt lejupielādes lapu?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Pieslēdzas"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Pieslēdzas"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Atslēgts"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Aiz ugunsmūra"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Pieslēgts"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Pieslēdzas"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -629,175 +667,142 @@ msgstr "Kad: Izslēgts"
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Atslēgties"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Atslēgties no tīkliem, kuriem pašlaik esiet pieslēdzies"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Pieslēgties"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Pieslēgties pašlaik iespējotajiem tīkliem"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "↑Augšup.: %.1f%s | ↓Lejup.: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Pieslēgts)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Atslēgts)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vai tiešām vēlaties aizvērt %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Tīkli"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Lejupielādes"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Lejupielādes logs"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Kopīgotās datnes"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Ziņojumi"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Iestatījumi"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Par programmu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Par programmu/Palīdzība"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k tīkls"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad tīkls"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -576,30 +576,68 @@ msgstr "Kan Pid-bestand niet aanmaken"
 msgid "ERROR: %s"
 msgstr "FOUT: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dit is aMule %s gebaseerd op eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Draaiend op %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of een nieuwe versie beschikbaar is."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Netwerken"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Zoeken"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Gedeelde bestanden"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Berichten"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistieken"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Voorkeuren"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Niet beschikbaar"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -609,39 +647,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "De nieuwste versie kan altijd gevonden worden op https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule dialoogvenster afgesloten"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Aan het verbinden"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2K: Verbinden"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2K: Verbinding verbroken"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Firewalled"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Verbonden"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Verbinden"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -651,175 +689,142 @@ msgstr "Kad: Uitgeschakeld"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Beëindig de huidige verbindingspogingen"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Verbreek"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Verbreek de huidige verbonden netwerken"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Verbind met de momenteel ingeschakelde netwerken"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upload: %.1f%s | Download: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Verbonden)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Niet verbonden)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Wilt u %s echt afsluiten?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Bevestig afsluiten"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Voer commando uit: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- standaard -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinmap '%s' bestaat niet"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "WAARSCHUWING: Kon skin-bestand '%s' niet openen om te lezen"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Netwerken"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Netwerkvenster"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Zoeken"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Zoekvenster"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Downloadsvenster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Gedeelde bestanden"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Gedeelde bestanden-venster"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Berichten"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Berichtenvenster"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistieken"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Statistiekenvenster (Grafieken)"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Voorkeuren"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Voorkeureninstellingen-venster"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importeer"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Het deelbestand importeerprogramma"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Over"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Over/Help"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-netwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad netwerk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Geen netwerk"
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -577,30 +577,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "Feil: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Dette er aMule %s basert på eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Køyrer på %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke om ei ny utgåve er tilgjengeleg."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Nettverk"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Søk"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Nedlastingar"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Delte filer"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Meldingar"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistikk"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Innstillingar"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ikkje tilgjengeleg"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -610,39 +648,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den siste utgåva finst alltid på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Koplar til"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Koplar til"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Fråkopla"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Brannmura"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Tilkopla"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Koplar til"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -652,177 +690,144 @@ msgstr "Kad: Av"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Stopp inneverande oppkoplingsfreistingar"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Kople frå"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Kople frå dei aktive nettverka"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Kople til"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Kople til dei valde nettverka"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Opp:·%.1f·|·Ned:·%.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule·(%s·|·Tilkopla)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule·(%s·|·Fråkopla)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vil du verkeleg avslutte aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Stadfesting av avslutting"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skinnkatalogen '%s' finst ikkje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ÅTVARING: Greidde ikkje å opne hudfila '%s' for lesing"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Nettverk"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Nettverksavindauge"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Søk"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Søkjevindauge"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Nedlastingar"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Lastar ned"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Delte filer"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Vindauge for delte filer"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Meldingar"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Meldingsvindauge"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistikk"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Statistikkgrafvindauge"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Innstillingar"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Innstillingsvalsvindauge"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importér"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Verkty for delfilimport"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Om/hjelp"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "ed2k nettverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad nettverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ikkje noko nettverk"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -576,30 +576,68 @@ msgstr "Nie można utworzyć pliku Pid"
 msgid "ERROR: %s"
 msgstr "BŁĄD: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To jest aMule %s oparty na eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Uruchomiony na %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzić czy jest dostępna nowa wersja."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Sieci"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Szukaj"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Pobieranie"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Udostępnione pliki"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Wiadomości"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statystyki"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencje"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Niedostępny"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -609,39 +647,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnowsza wersja jest zawsze dostępna na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "dialog aMule zniszczony"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Łączenie"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Łączenie"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Rozłączony"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Za firewallem"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Połączony"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Łączenie"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -651,176 +689,143 @@ msgstr "Kad: Wyłączony"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Zatrzymaj aktualne próby połączenia"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Rozłącz z aktualnie połączonymi sieciami"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Podłącz"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Połącz z aktualnie włączonymi sieciami"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Wysł: %.1f | Pobr: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Połączony)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Rozłączony)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Czy na pewno chcesz opuścić %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potwierdzenie wyjścia"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Uruchomienie polecenia: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- domyślnie -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Katalog skórek '%s' nie istnieje"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OSTRZEŻENIE: Nie udało się otworzyć pliku skórki '%s' do odczytu"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Sieci"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Okno sieci"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Szukaj"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Okno wyszukiwania"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Pobieranie"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Okno pobierań"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Udostępnione pliki"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Okno udostępnionych plików"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Wiadomości"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Okno wiadomości"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statystyki"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Okno wykresów statystyk"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Okno preferencji"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Import"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Narzędzie importowania plików części"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Informacje o"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Informacje/Pomoc"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Sieć eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Sieć Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Brak sieci"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -150,7 +150,7 @@ msgstr "Instalar"
 msgid "Not now"
 msgstr "Agora não"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Não perguntar novamente"
 
@@ -581,29 +581,67 @@ msgstr "Incapaz Criar Arquivo Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Esse é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Executando em %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se há nova versão disponível."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Pesquisas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Arquivos compartilhados"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mensagens"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Uma versão mais nova está disponível"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -618,39 +656,39 @@ msgstr ""
 "\n"
 "Você gostaria de abrir a página de download?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "destruído caixa de diálogo do aMule"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Conectando"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Conectado"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desconectado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de Firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Conectado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Conectando"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -660,175 +698,142 @@ msgstr "Kad: Desligado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Cancelar as tentativas atuais de conexão"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desconectar das redes atualmente conectadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectar às redes ativas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f%s | Down: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desconectado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Você realmente quer sair %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Lançar Comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- padrão -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "O diretório '%s' de skins não existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "CUIDADO: Incapaz de abrir o arquivo de pele '%s' para leitura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Janela de redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Pesquisas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Arquivos compartilhados"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Janela de compartilhados"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mensagens"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferências"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Ferramenta de importação de arquivos .part"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Sobre"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Sobre/Ajuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "rede Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sem redes"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -581,30 +581,68 @@ msgstr "Não foi Possível Criar o Ficheiro de Pid"
 msgid "ERROR: %s"
 msgstr "ERRO: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Este é o aMule %s, baseado no eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "A correr em %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar se há novas versões."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Redes"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Pesquisas"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Downloads"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Ficheiros partilhados"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mensagens"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Estatísticas"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponível"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -614,39 +652,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "A última versão pode ser sempre encontrada em https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Caixa de diálogo do aMule destruída"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "A Ligar"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: A Ligar"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Desligado"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Atrás de firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Ligado"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: A Ligar"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -656,176 +694,143 @@ msgstr "Kad: Desligado"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Cancela as tentativas de ligação actuais"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Desligar"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Desligar das redes presentemente ligadas"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Ligar"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Ligar às redes presentemente activadas"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Up: %.1f | Down: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ligado)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Desligado)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Quer mesmo fechar o %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmação de saída"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Executar Comando: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- predefinição -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Pasta para os temas '%s' não existe"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "AVISO: Não é possível abrir ficheiro de tema '%s' para leitura"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Redes"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Janela de Redes"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Pesquisas"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Janela de Pesquisas"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Downloads"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Janela de Downloads"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Ficheiros partilhados"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Janela de Ficheiros Partilhados"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mensagens"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Janela de Mensagens"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Estatísticas"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Janela de Estatísticas"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferências"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Janela de Preferências"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "A ferramenta de importação de ficheiro de partes"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Acerca"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Acerca/Ajuda"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rede eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rede Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Sem rede"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -573,30 +573,68 @@ msgstr "Nu se poate crea fișierul Pid"
 msgid "ERROR: %s"
 msgstr "EROARE: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Acesta este aMule %s bazat pe eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Rulând pe %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a verifica dacă este disponibilă o nouă versiune."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Rețele"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Căutări"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Descărcări"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Fișiere partajate"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mesaje"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistici"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferințe"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Indisponibil"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -606,39 +644,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Ultima versiune poate fi găsită mereu la https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "dialogul aMule distrus"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Se conecteză"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Se conectează"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Deconectat"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Prin firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Conectat"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Se conectează"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Închis"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -648,176 +686,143 @@ msgstr "Kad: Închis"
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Oprește încercările curente de conectare"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Deconectează"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Deconectează de la rețelele curent conectate"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Conectează"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Conectează la rețelele activate curent"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MO/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "În: %.1f | Desc: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Conectat)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Deconectat)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Sigur doriți să închideți %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Confirmare închidere"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Lansare comandă:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- implicit -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Directorul aspectului aplicației '%s' nu există"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ATENȚIE: Nu se poate deschide fișierul aspect '%s' pentru citit"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Rețele"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Fereastra rețelelor"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Căutări"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Fereastra căutărilor"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Descărcări"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Fereastra descărcărilor"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Fișiere partajate"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Fereastra fișierelor partajate"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mesaje"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Fereastra mesajelor"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistici"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Fereastra graficului statisticilor"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferințe"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Fereastra configurare preferințe"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importă"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Unealta de importat fișiere parțiale"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Despre"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Despre/Ajutor"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Rețea eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rețea Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nicio rețea"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -584,30 +584,68 @@ msgstr "Не удалось создать pid-файл"
 msgid "ERROR: %s"
 msgstr "Ошибка: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "aMule %s (основан на eMule)."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Работает на %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Посетите https://github.com/amule-org/amule/releases/latest для проверки наличия новой версии."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Сети"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Поиск"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Загрузки"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Публикуемые файлы"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Сообщения"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Настройки"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступен"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -617,39 +655,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Актуальная версия aMule всегда доступна тут:  https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "диалоговое окно aMule уничтожено"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Идет подключение"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Соединение"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: не соединено"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: За брандмауэром"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Подключена"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Идет подключение"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr " Kad: Выключено"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -659,176 +697,143 @@ msgstr " Kad: Выключено"
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Прекратить попытки соединения"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Отключиться"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Отключиться от работающих сетей"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Подключиться"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Подключиться к разрешенным сетям"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Передача: %.1f(%.1f) | Прием: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "МБ/с"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr "kB/сек"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Передача: %.1f | Прием: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Подключен)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Отключен)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Вы действительно хотите выйти из %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Подтверждение выхода"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Команда запуска:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- по умолчанию -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Каталог с темами оформления '%s' не существует."
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: невозможно открыть для чтения файл скина '%s'"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Сети"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Окно сетей"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Поиск"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Окно поиска"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Загрузки"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Окно загрузки"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Публикуемые файлы"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Окно публикуемых файлов"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Сообщения"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Сообщения"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Статистика"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Настройки"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Окно настроек клиента"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Импорт"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Инструмент импортирования частично загруженных файлов (part files)"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "О программе"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "О программе/Помощь"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Сеть eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Сеть Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Нет сети"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -577,31 +577,69 @@ msgstr "Ni moč ustvariti datoteke PID"
 msgid "ERROR: %s"
 msgstr "NAPAKA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "To je aMule %s, ki temelji na eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Operacijski sistem: %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 #, fuzzy
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Omrežja"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Iskanja"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Prejemanja"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Deljene datoteke"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Sporočila"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistika"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Nastavitve"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Ni na voljo"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -611,39 +649,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Pogovorno okno aMule je bilo uničeno"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Povezovanje"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: povezovanje"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: povezava prekinjena"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: za požarnim zidom"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: povezano"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: povezovanje"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -653,175 +691,142 @@ msgstr "Kad: izklopljen"
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Ustavi trenutne poskuse povezovanja"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Prekini povezavo s trenutno povezanimi omrežji"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Poveži se"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Poveži se s trenutno omogočenimi omrežji"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MiB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gor: %.1f%s | Dol: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Povezano)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Ni povezave)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ali res želite zapustiti %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Potrditev izhoda"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Zaženi ukaz: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "– privzeto –"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Mapa za preobleke »%s« ne obstaja"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "OPOZORILO: datoteke s preobleko »%s« ni moč odpreti za branje"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Omrežja"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Okno z omrežji"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Iskanja"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Okno z iskanji"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Prejemanja"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Okno s prejemanji"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Deljene datoteke"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Okno z deljenimi datotekami"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Sporočila"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Okno s sporočili"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistika"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Okno s statističnimi grafi"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Nastavitve"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Okno z nastavitvami"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Uvoz"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Orodje za uvažanje delnih datotek"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "O programu"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "O programu/pomoč"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Omrežje eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Omrežje Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Brez omrežja"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -574,30 +574,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "GABIM: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Kjo eshte aMule %s dhe bazohet ne eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Duke punuar ne %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontrolluar nqs eshte ne dispozicion nje version i ri."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Rrjetet"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Kerkimet"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Shkarkime"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Mesazhe"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistikat"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Preferencat"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Nuk eshte ne dispozicion"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -607,39 +645,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Versioni i fundit mund te gjendet gjithmone tek https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Duke u lòidhur"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Me Firewall"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: I lidhur"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Po lidhet"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -649,177 +687,144 @@ msgstr "Kad: Fikur"
 msgid "Cancel"
 msgstr "Fshij"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Ndalo tentativat e lidhjes qe po behen"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Shkeputu"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Shkeputu nga rrjetet e lidhura"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Lidhu"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Lidhu tek rrjetet"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Larte: %.1f | Poshte: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | e lidhur)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | e shkeputur)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vertet deshironi qe te dilni nga aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Konfirmimi i daljes"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Direktoria e skin '%s' nuk ekziston"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Rrjetet"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Dritaret e rrjeteve"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Kerkimet"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Dritaret e kerkimeve"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Shkarkime"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Duke shkarkuar"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Dritarja e faileve te ndara"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Mesazhe"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Dritarja e mesazheve"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistikat"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Dritarja e grafikut te statistikave"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Preferencat"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Dritarja e rregullimeve te preferencave"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importimi"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Veglat per importimin e pjeseve te faileve"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Rreth"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Rreth/Ndihme"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Rrjeti Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Nuk ka rrjet"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -573,30 +573,68 @@ msgstr "Kan inte skapa Pid-fil"
 msgid "ERROR: %s"
 msgstr "FEL: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Det här är aMule %s baserad på eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Kör på %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om en ny version finns tillgänglig."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Nätverk"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Sökningar"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Hämtningar"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Delade filer"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Meddelanden"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Statistik"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Inte tillgänglig"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -606,39 +644,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Den senaste versionen kan alltid hittas på https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule-dialog avslutad"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Ansluter"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Ansluter"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Frånkopplad"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Via brandvägg"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Ansluten"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Ansluter"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Av"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -648,176 +686,143 @@ msgstr "Kad: Av"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Stoppa de nuvarande anslutningsförsöken"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Koppla från"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Koppla från de nätverk som nu är anslutna."
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Anslut"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Anslut till de nätverk som är aktiverade."
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Upp: %.1f | Ner: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Ansluten)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Frånkopplad)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Vill du verkligen avsluta %s?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Bekräfta avslutning"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Kör kommando:"
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- standard -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Skin-mappen '%s' finns inte"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "Varning: Kan inte öppna skin-filen '%s' för läsning"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Nätverk"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Nätverksfönster"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Sökningar"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Sökfönster"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Hämtningar"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "Hämtningsfönster"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Delade filer"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Delade filer-fönster"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Meddelanden"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Meddelandefönster"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Statistik"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Statistiksgrafsfönster"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Inställningar"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Inställningsfönster"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Importera"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Partfile-importerings-verktyget"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Om"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Om/Hjälp"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k-nätverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad-nätverk"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Inget nätverk"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -545,29 +545,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -577,39 +615,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -619,175 +657,142 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -143,7 +143,7 @@ msgstr "Kur"
 msgid "Not now"
 msgstr "Şimdi değil"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "Tekrar sorma"
 
@@ -573,29 +573,67 @@ msgstr "Pid dosyası oluşturulamıyor"
 msgid "ERROR: %s"
 msgstr "HATA: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Bu, eMule üzerine kurulu olan aMule %s yazılımıdır."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "%s üzerinde çalışıyor"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/latest adresini ziyaret ediniz."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Ağlar"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Aramalar"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "İndirmeler"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Paylaşılan dosyalar"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Sohbet"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "İstatistikler"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Ayarlar"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "Yeni bir sürüm mevcuttur"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -610,39 +648,39 @@ msgstr ""
 "\n"
 "İndirme sayfasını açmak ister misiniz?"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule diyaloğu imha edildi"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "Bağlanıyor"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: Bağlanıyor"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: Bağlantı kesildi"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: Güvenlik Duvarı"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: Bağlandı"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: Bağlanıyor"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -652,175 +690,142 @@ msgstr "Kad: Kapalı"
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Durdur"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Bağlanılmış olan ağlar ile bağlantıyı Kes"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "Etkinleştirilmiş olan ağlara bağlan"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/sn"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Gön: %.1f%s | İnd: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | Bağlandı)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Bağlantı kesildi)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "%s üzerinden çıkmayı gerçekten istiyor musunuz?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Çıkışı onaylayınız"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Çalıştırma Komutu: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- ön tanımlı -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Kaplama dizini '%s' yok"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "UYARI: Kaplama dosyası '%s' okuma için açılamıyor"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Ağlar"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Ağ Penceresi"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Aramalar"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Arama Penceresi"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "İndirmeler"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "İndirme Penceresi"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Paylaşılan dosyalar"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Paylaşılan Dosya Penceresi"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Sohbet"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Sohbet Penceresi"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "İstatistikler"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "İstatistik Grafik Penceresi"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Ayarlar"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Ayar Penceresi"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Parça dosyası içe aktarım aracı"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Hakkında"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Hakkında/Yardım"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k ağı"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kademlia ağı"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Ağ yok"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:47+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -573,30 +573,68 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr "ПОМИЛКА: %s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "Це aMule %s оснований на eMule."
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "Запущений на %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest, щоб перевірити наявність нових версій."
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "Мережі"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "Пошук"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "Звантаження"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "Спільні файли"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "Повідомлення"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "Статистика"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "Налаштування"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "Недоступний"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -606,39 +644,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "Остання версія може бути завжди знайдена на https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "Діалог aMule знищений"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "З'єднується"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: з'єднання"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: від'єднаний"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: за фаєрволом"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: з'єднаний"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: з'єднуюсь"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -648,177 +686,144 @@ msgstr "Kad: вимкнена"
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "Зупинити поточні спроби з'єднань"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "Від'єднатися від з'єднаних мереж"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "З'єднатися з дозволеними мережами"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "Мбайт/с"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " кбайт/с"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "Вивантаження: %.1f | Звантаження: %.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | З'єднано)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | Від'єднано)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, fuzzy, c-format
 msgid "Do you really want to exit %s?"
 msgstr "Ви справді хочете вийти з aMule?"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "Підтвердження виходу"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "Команда для запуску: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- за замовчуванням -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "Тека з шкірами '%s' не існує"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "ЗАСТЕРЕЖЕННЯ: Неможливо відкрити файл шкіри '%s' для читання"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "Мережі"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "Вікно мереж"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "Пошук"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "Вікно пошуку"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "Звантаження"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 #, fuzzy
 msgid "Downloads Window"
 msgstr "Звантажується"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "Спільні файли"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "Вікно спільних файлів"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "Повідомлення"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "Вікно повідомлень"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "Статистика"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "Вікно статистики"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "Налаштування"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "Вікно налаштувань"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "Зовн. внесення"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "Засіб зовнішнього внесення частково звантажених файлів"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "Про програму"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "Про/Допомога"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "Мережа eD2k"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Мережа Kad"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "Немає мережі"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -545,29 +545,67 @@ msgstr ""
 msgid "ERROR: %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr ""
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr ""
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr ""
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr ""
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr ""
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr ""
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr ""
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr ""
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr ""
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr ""
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr ""
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr ""
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -577,39 +615,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr ""
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr ""
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr ""
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr ""
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr ""
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr ""
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr ""
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -619,175 +657,142 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr ""
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr ""
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr ""
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr ""
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr ""
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr ""
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr ""
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr ""
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr ""
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr ""
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr ""
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr ""
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr ""
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr ""
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr ""
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr ""
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr ""
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr ""
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -147,7 +147,7 @@ msgstr "安装"
 msgid "Not now"
 msgstr "不是现在"
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr "不要再提醒我"
 
@@ -577,29 +577,67 @@ msgstr "不能创建 Pid 文件"
 msgid "ERROR: %s"
 msgstr "错误：%s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "这是基于 eMule 的 aMule %s。"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "运行于 %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是否有新版本。"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "网络"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "搜索"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "下载"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "共享文件"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "消息"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "统计"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "设置"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 msgid "New version available"
 msgstr "有新版"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -614,39 +652,39 @@ msgstr ""
 "\n"
 "要打开下载页吗？"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule 对话框损坏"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "正在连接"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k: 正在连接"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k: 已断开"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad: 通过防火墙"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad: 已连接"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad: 正在连接"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -656,175 +694,142 @@ msgstr "Kad: 关闭"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "终止本次连接尝试"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "从当前已连接的网络断开"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "连接"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "连接至当前已启用的网络"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 msgid " MB/s"
 msgstr " MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " kB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上传: %.1f%s | 下载: %.1f%s"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule（%s | 已连接）"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule（%s | 已断开）"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您确定要退出 %s 吗？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "退出确认"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "运行命令: "
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- 默认 -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "皮肤目录 %s 不存在"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：无法打开皮肤文件 %s 进行读取"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "网络"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "网络窗口"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "搜索"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "搜索窗口"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "下载"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "下载窗口"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "共享文件"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "共享文件窗口"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "消息"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "消息窗口"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "统计"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "统计图窗口"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "设置"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "设置窗口"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "导入"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "part 文件导入工具"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "关于"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "关于/帮助"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k 网络"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "Kad 网络"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "无网络"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-27 21:41+0200\n"
+"POT-Creation-Date: 2026-07-28 07:37+0200\n"
 "PO-Revision-Date: 2026-07-27 11:48+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Not now"
 msgstr ""
 
-#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:600
+#: src/AppImageIntegration.cpp:422 src/amuleDlg.cpp:665
 msgid "Don't ask again"
 msgstr ""
 
@@ -579,30 +579,68 @@ msgstr "無法建立 pid 檔案"
 msgid "ERROR: %s"
 msgstr "錯誤：%s"
 
-#: src/amuleDlg.cpp:236
+#: src/amuleDlg.cpp:250
 #, c-format
 msgid "This is aMule %s based on eMule."
 msgstr "這是 aMule %s (源自 eMule)。"
 
-#: src/amuleDlg.cpp:237
+#: src/amuleDlg.cpp:251
 #, c-format
 msgid "Running on %s"
 msgstr "執行於 %s"
 
-#: src/amuleDlg.cpp:239
+#: src/amuleDlg.cpp:253
 msgid "Visit https://github.com/amule-org/amule/releases/latest to check if a new version is available."
 msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新版本。"
 
-#: src/amuleDlg.cpp:268
+#: src/amuleDlg.cpp:282
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
 
-#: src/amuleDlg.cpp:592
+#: src/amuleDlg.cpp:361 src/amuleDlg.cpp:1787 src/amuleDlg.cpp:2033
+#: src/muuli_wdr.cpp:1485 src/muuli_wdr.cpp:3405
+msgid "Networks"
+msgstr "網路"
+
+#: src/amuleDlg.cpp:362 src/amuleDlg.cpp:1793 src/muuli_wdr.cpp:3406
+msgid "Searches"
+msgstr "搜尋"
+
+#: src/amuleDlg.cpp:363 src/amuleDlg.cpp:1799 src/DownloadListCtrl.cpp:740
+#: src/muuli_wdr.cpp:392 src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407
+#: src/Statistics.cpp:829
+msgid "Downloads"
+msgstr "下載"
+
+#: src/amuleDlg.cpp:364 src/amuleDlg.cpp:1805 src/muuli_wdr.cpp:3281
+msgid "Shared files"
+msgstr "檔案分享"
+
+#: src/amuleDlg.cpp:365 src/amuleDlg.cpp:1811 src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:3363 src/muuli_wdr.cpp:3410
+msgid "Messages"
+msgstr "訊息"
+
+#: src/amuleDlg.cpp:366 src/amuleDlg.cpp:1817 src/muuli_wdr.cpp:3411
+#: src/PrefsUnifiedDlg.cpp:312 src/Statistics.cpp:779 src/Statistics.cpp:1235
+msgid "Statistics"
+msgstr "統計"
+
+#: src/amuleDlg.cpp:368 src/amuleDlg.cpp:1824 src/muuli_wdr.cpp:3413
+#: src/PrefsUnifiedDlg.cpp:328 src/utils/wxCas/src/wxcasprefs.cpp:39
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: src/amuleDlg.cpp:371
+msgid "Navigate"
+msgstr ""
+
+#: src/amuleDlg.cpp:657
 #, fuzzy
 msgid "New version available"
 msgstr "不可用"
 
-#: src/amuleDlg.cpp:596
+#: src/amuleDlg.cpp:661
 #, fuzzy, c-format
 msgid ""
 "A new version of aMule (%s) is available.\n"
@@ -612,39 +650,39 @@ msgid ""
 "Would you like to open the download page?"
 msgstr "最新版本可從這裏下載：https://github.com/amule-org/amule/releases/latest"
 
-#: src/amuleDlg.cpp:678
+#: src/amuleDlg.cpp:743
 msgid "aMule dialog destroyed"
 msgstr "aMule 對話方塊已銷毀"
 
-#: src/amuleDlg.cpp:701 src/DataToText.cpp:68 src/IPFilter.cpp:547
+#: src/amuleDlg.cpp:766 src/DataToText.cpp:68 src/IPFilter.cpp:547
 msgid "Connecting"
 msgstr "正在連線"
 
-#: src/amuleDlg.cpp:893
+#: src/amuleDlg.cpp:958
 msgid "eD2k: Connecting"
 msgstr "eD2k：正在連線"
 
-#: src/amuleDlg.cpp:897
+#: src/amuleDlg.cpp:962
 msgid "eD2k: Disconnected"
 msgstr "eD2k：已中斷連線"
 
-#: src/amuleDlg.cpp:903
+#: src/amuleDlg.cpp:968
 msgid "Kad: Firewalled"
 msgstr "Kad：防火牆內"
 
-#: src/amuleDlg.cpp:907
+#: src/amuleDlg.cpp:972
 msgid "Kad: Connected"
 msgstr "Kad：已連線"
 
-#: src/amuleDlg.cpp:912
+#: src/amuleDlg.cpp:977
 msgid "Kad: Connecting"
 msgstr "Kad：正在連線"
 
-#: src/amuleDlg.cpp:916
+#: src/amuleDlg.cpp:981
 msgid "Kad: Off"
 msgstr "Kad：關閉"
 
-#: src/amuleDlg.cpp:964 src/DownloadListCtrl.cpp:505
+#: src/amuleDlg.cpp:1029 src/DownloadListCtrl.cpp:505
 #: src/DownloadListCtrl.cpp:749 src/FriendListCtrl.cpp:180
 #: src/muuli_wdr.cpp:731 src/muuli_wdr.cpp:782 src/muuli_wdr.cpp:846
 #: src/muuli_wdr.cpp:898 src/muuli_wdr.cpp:2218 src/muuli_wdr.cpp:2303
@@ -654,176 +692,143 @@ msgstr "Kad：關閉"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/amuleDlg.cpp:965
+#: src/amuleDlg.cpp:1030
 msgid "Stop the current connection attempts"
 msgstr "停止連線作業"
 
-#: src/amuleDlg.cpp:970 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
+#: src/amuleDlg.cpp:1035 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:976
 #: src/muuli_wdr.cpp:2441
 msgid "Disconnect"
 msgstr "中斷連線"
 
-#: src/amuleDlg.cpp:971
+#: src/amuleDlg.cpp:1036
 msgid "Disconnect from the currently connected networks"
 msgstr "中斷已連線的網路"
 
-#: src/amuleDlg.cpp:976 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
+#: src/amuleDlg.cpp:1041 src/MuleTrayIcon.cpp:478 src/MuleTrayIcon.cpp:979
 #: src/muuli_wdr.cpp:2596 src/muuli_wdr.cpp:3048 src/muuli_wdr.cpp:3403
 msgid "Connect"
 msgstr "連線"
 
-#: src/amuleDlg.cpp:977
+#: src/amuleDlg.cpp:1042
 msgid "Connect to the currently enabled networks"
 msgstr "連線到目前已啟用的網路"
 
-#: src/amuleDlg.cpp:1089
+#: src/amuleDlg.cpp:1154
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #, fuzzy
 msgid " MB/s"
 msgstr "MB/s"
 
-#: src/amuleDlg.cpp:1091 src/amuleDlg.cpp:1093 src/amuleDlg.cpp:1097
-#: src/amuleDlg.cpp:1099 src/amuleDlg.cpp:1110 src/amuleDlg.cpp:1112
+#: src/amuleDlg.cpp:1156 src/amuleDlg.cpp:1158 src/amuleDlg.cpp:1162
+#: src/amuleDlg.cpp:1164 src/amuleDlg.cpp:1175 src/amuleDlg.cpp:1177
 #: src/MuleTrayIcon.cpp:796 src/MuleTrayIcon.cpp:799
 #: src/utils/wxCas/src/wxcasframe.cpp:1041
 msgid " kB/s"
 msgstr " KB/s"
 
-#: src/amuleDlg.cpp:1096
+#: src/amuleDlg.cpp:1161
 #, fuzzy, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
 msgstr "上傳：%.1f | 下載：%.1f"
 
-#: src/amuleDlg.cpp:1128
+#: src/amuleDlg.cpp:1193
 #, c-format
 msgid "aMule (%s | Connected)"
 msgstr "aMule (%s | 已連線)"
 
-#: src/amuleDlg.cpp:1130
+#: src/amuleDlg.cpp:1195
 #, c-format
 msgid "aMule (%s | Disconnected)"
 msgstr "aMule (%s | 已中斷連線)"
 
-#: src/amuleDlg.cpp:1183
+#: src/amuleDlg.cpp:1248
 #, c-format
 msgid "Do you really want to exit %s?"
 msgstr "您確定要離開 %s 嗎？"
 
-#: src/amuleDlg.cpp:1185
+#: src/amuleDlg.cpp:1250
 msgid "Exit confirmation"
 msgstr "確認離開"
 
-#: src/amuleDlg.cpp:1548
+#: src/amuleDlg.cpp:1613
 msgid "Launch Command: "
 msgstr "執行指令："
 
-#: src/amuleDlg.cpp:1567 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
+#: src/amuleDlg.cpp:1632 src/muuli_wdr.cpp:1965 src/Preferences.cpp:951
 msgid "- default -"
 msgstr "- 預設 -"
 
-#: src/amuleDlg.cpp:1595
+#: src/amuleDlg.cpp:1660
 #, c-format
 msgid "Skin directory '%s' does not exist"
 msgstr "面板目錄 %s 不存在"
 
-#: src/amuleDlg.cpp:1598
+#: src/amuleDlg.cpp:1663
 #, c-format
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr "警告：無法開啟面板檔案 %s 供讀取"
 
-#: src/amuleDlg.cpp:1722 src/amuleDlg.cpp:1968 src/muuli_wdr.cpp:1485
-#: src/muuli_wdr.cpp:3405
-msgid "Networks"
-msgstr "網路"
-
-#: src/amuleDlg.cpp:1726 src/muuli_wdr.cpp:3405
+#: src/amuleDlg.cpp:1791 src/muuli_wdr.cpp:3405
 msgid "Networks Window"
 msgstr "網路 視窗"
 
-#: src/amuleDlg.cpp:1728 src/muuli_wdr.cpp:3406
-msgid "Searches"
-msgstr "搜尋"
-
-#: src/amuleDlg.cpp:1732 src/muuli_wdr.cpp:3406
+#: src/amuleDlg.cpp:1797 src/muuli_wdr.cpp:3406
 msgid "Searches Window"
 msgstr "搜尋 視窗"
 
-#: src/amuleDlg.cpp:1734 src/DownloadListCtrl.cpp:740 src/muuli_wdr.cpp:392
-#: src/muuli_wdr.cpp:1578 src/muuli_wdr.cpp:3407 src/Statistics.cpp:829
-msgid "Downloads"
-msgstr "下載"
-
-#: src/amuleDlg.cpp:1738 src/muuli_wdr.cpp:3407
+#: src/amuleDlg.cpp:1803 src/muuli_wdr.cpp:3407
 msgid "Downloads Window"
 msgstr "下載 視窗"
 
-#: src/amuleDlg.cpp:1740 src/muuli_wdr.cpp:3281
-msgid "Shared files"
-msgstr "檔案分享"
-
-#: src/amuleDlg.cpp:1744 src/muuli_wdr.cpp:3409
+#: src/amuleDlg.cpp:1809 src/muuli_wdr.cpp:3409
 msgid "Shared Files Window"
 msgstr "檔案分享 視窗"
 
-#: src/amuleDlg.cpp:1746 src/muuli_wdr.cpp:2913 src/muuli_wdr.cpp:3363
-#: src/muuli_wdr.cpp:3410
-msgid "Messages"
-msgstr "訊息"
-
-#: src/amuleDlg.cpp:1750 src/muuli_wdr.cpp:3410
+#: src/amuleDlg.cpp:1815 src/muuli_wdr.cpp:3410
 msgid "Messages Window"
 msgstr "訊息 視窗"
 
-#: src/amuleDlg.cpp:1752 src/muuli_wdr.cpp:3411 src/PrefsUnifiedDlg.cpp:312
-#: src/Statistics.cpp:779 src/Statistics.cpp:1235
-msgid "Statistics"
-msgstr "統計"
-
-#: src/amuleDlg.cpp:1756 src/muuli_wdr.cpp:3411
+#: src/amuleDlg.cpp:1821 src/muuli_wdr.cpp:3411
 msgid "Statistics Graph Window"
 msgstr "統計 視窗"
 
-#: src/amuleDlg.cpp:1759 src/muuli_wdr.cpp:3413 src/PrefsUnifiedDlg.cpp:328
-#: src/utils/wxCas/src/wxcasprefs.cpp:39
-msgid "Preferences"
-msgstr "偏好設定"
-
-#: src/amuleDlg.cpp:1763 src/muuli_wdr.cpp:3413
+#: src/amuleDlg.cpp:1828 src/muuli_wdr.cpp:3413
 msgid "Preferences Settings Window"
 msgstr "偏好設定 視窗"
 
-#: src/amuleDlg.cpp:1766 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1831 src/muuli_wdr.cpp:3414
 msgid "Import"
 msgstr "匯入"
 
-#: src/amuleDlg.cpp:1770 src/muuli_wdr.cpp:3414
+#: src/amuleDlg.cpp:1835 src/muuli_wdr.cpp:3414
 msgid "The partfile importer tool"
 msgstr "暫存檔匯入工具"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 #: src/utils/aLinkCreator/src/alcframe.cpp:262
 msgid "About"
 msgstr "關於"
 
-#: src/amuleDlg.cpp:1773 src/muuli_wdr.cpp:3415
+#: src/amuleDlg.cpp:1838 src/muuli_wdr.cpp:3415
 msgid "About/Help"
 msgstr "關於/幫助"
 
-#: src/amuleDlg.cpp:1971
+#: src/amuleDlg.cpp:2036
 msgid "eD2k network"
 msgstr "eD2k 網路"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "Kad network"
 msgstr "kad 網路"
 
-#: src/amuleDlg.cpp:1974
+#: src/amuleDlg.cpp:2039
 msgid "No network"
 msgstr "無網路"
 

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -568,7 +568,16 @@ void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 			}
 		}
 
-		m_wndToolbar->ToggleTool(lastbutton, lastbutton == ev.GetId());
+		// A physical click auto-toggles the clicked wxITEM_CHECK tool, so
+		// historically this only had to untoggle the *previous* one. An
+		// accelerator or menu event (Alt+<letter>, the macOS Navigate menu)
+		// doesn't click anything, so the new tab's tool never lit up that
+		// way -- leaving no toolbar button active until the next mouse
+		// click (amule-org/amule#642 review). Toggle both ends explicitly.
+		if (lastbutton != ev.GetId()) {
+			m_wndToolbar->ToggleTool(lastbutton, false);
+		}
+		m_wndToolbar->ToggleTool(ev.GetId(), true);
 		lastbutton = ev.GetId();
 	}
 }
@@ -1779,44 +1788,44 @@ void CamuleDlg::Apply_Toolbar_Skin(wxToolBar *wndToolbar)
 		m_tblist[Toolbar_Network],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Networks Window (Alt+N)"));
+		_("Networks Window") + " (Alt+N)");
 	wndToolbar->AddTool(ID_BUTTONSEARCH,
 		_("Searches"),
 		m_tblist[Toolbar_Search],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Searches Window (Alt+S)"));
+		_("Searches Window") + " (Alt+S)");
 	wndToolbar->AddTool(ID_BUTTONDOWNLOADS,
 		_("Downloads"),
 		m_tblist[Toolbar_Transfers],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Downloads Window (Alt+T)"));
+		_("Downloads Window") + " (Alt+T)");
 	wndToolbar->AddTool(ID_BUTTONSHARED,
 		_("Shared files"),
 		m_tblist[Toolbar_Shared],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Shared Files Window (Alt+F)"));
+		_("Shared Files Window") + " (Alt+F)");
 	wndToolbar->AddTool(ID_BUTTONMESSAGES,
 		_("Messages"),
 		m_tblist[Toolbar_Messages],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Messages Window (Alt+M)"));
+		_("Messages Window") + " (Alt+M)");
 	wndToolbar->AddTool(ID_BUTTONSTATISTICS,
 		_("Statistics"),
 		m_tblist[Toolbar_Stats],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Statistics Graph Window (Alt+G)"));
+		_("Statistics Graph Window") + " (Alt+G)");
 	wndToolbar->AddSeparator();
 	wndToolbar->AddTool(ID_BUTTONNEWPREFERENCES,
 		_("Preferences"),
 		m_tblist[Toolbar_Prefs],
 		wxNullBitmap,
 		wxITEM_NORMAL,
-		_("Preferences Settings Window (Alt+P)"));
+		_("Preferences Settings Window") + " (Alt+P)");
 #ifndef CLIENT_GUI
 	wndToolbar->AddTool(ID_BUTTONIMPORT,
 		_("Import"),

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -109,6 +109,20 @@ wxBEGIN_EVENT_TABLE(CamuleDlg, wxFrame)
 
 	EVT_TOOL(ID_BUTTONCONNECT, CamuleDlg::OnBnConnect)
 
+	// Alt+<letter> tab-switch shortcuts. On Windows/Linux these come from
+	// the wxAcceleratorEntry table built in OnInit(); on macOS they come
+	// from real NSMenuItem key equivalents (see the __WXMAC__ menu bar
+	// built in OnInit()) since a plain accelerator-table entry on wxOSX
+	// only fires its wxEVT_MENU once per click-to-refocus. Either path
+	// lands here as a wxEVT_MENU with the same button ID.
+	EVT_MENU(ID_BUTTONNETWORKS, CamuleDlg::OnToolBarButton)
+	EVT_MENU(ID_BUTTONSEARCH, CamuleDlg::OnToolBarButton)
+	EVT_MENU(ID_BUTTONDOWNLOADS, CamuleDlg::OnToolBarButton)
+	EVT_MENU(ID_BUTTONSHARED, CamuleDlg::OnToolBarButton)
+	EVT_MENU(ID_BUTTONMESSAGES, CamuleDlg::OnToolBarButton)
+	EVT_MENU(ID_BUTTONSTATISTICS, CamuleDlg::OnToolBarButton)
+	EVT_MENU(ID_BUTTONNEWPREFERENCES, CamuleDlg::OnPrefButton)
+
 	EVT_CLOSE(CamuleDlg::OnClose)
 	EVT_ICONIZE(CamuleDlg::OnMinimize)
 	EVT_SHOW(CamuleDlg::OnShow)
@@ -328,9 +342,51 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	}
 
 	// Set shortcut keys
+#ifdef __WXMAC__
+	// Alt+<letter> tab-switch shortcuts, exposed as real NSMenuItem key
+	// equivalents rather than wxAcceleratorEntry entries: on wxOSX
+	// (tested with wxWidgets 3.3.3 / macOS 26) an accelerator-table
+	// entry fires its wxEVT_MENU exactly once per click-to-refocus --
+	// the *first* Alt+<letter> after the window (re)gains key status
+	// switches tabs as expected, but every subsequent press is silently
+	// swallowed by Cocoa's key-equivalent dispatch until the user
+	// clicks something in the window again. Real menu key equivalents
+	// are dispatched by the OS itself and don't share that bug -- and
+	// as a bonus, VoiceOver can navigate an actual menu directly, which
+	// the (currently VoiceOver-invisible, see #180) toolbar can't offer.
 	wxAcceleratorEntry entries[] = { wxAcceleratorEntry(wxACCEL_CTRL, 'Q', wxID_EXIT) };
-
 	SetAcceleratorTable(wxAcceleratorTable(itemsof(entries), entries));
+
+	wxMenu *navigateMenu = new wxMenu();
+	navigateMenu->Append(ID_BUTTONNETWORKS, _("Networks") + "\tAlt+N");
+	navigateMenu->Append(ID_BUTTONSEARCH, _("Searches") + "\tAlt+S");
+	navigateMenu->Append(ID_BUTTONDOWNLOADS, _("Downloads") + "\tAlt+T");
+	navigateMenu->Append(ID_BUTTONSHARED, _("Shared files") + "\tAlt+F");
+	navigateMenu->Append(ID_BUTTONMESSAGES, _("Messages") + "\tAlt+M");
+	navigateMenu->Append(ID_BUTTONSTATISTICS, _("Statistics") + "\tAlt+G");
+	navigateMenu->AppendSeparator();
+	navigateMenu->Append(ID_BUTTONNEWPREFERENCES, _("Preferences") + "\tAlt+P");
+
+	wxMenuBar *menuBar = new wxMenuBar();
+	menuBar->Append(navigateMenu, _("Navigate"));
+	SetMenuBar(menuBar);
+#else
+	// Alt+<letter> mirrors the classic eMule tab shortcuts (Alt+S for
+	// Search, etc.) and gives keyboard users a way to switch tabs
+	// without the mouse. macOS gets the same shortcuts via a real menu
+	// instead -- see the __WXMAC__ branch above.
+	wxAcceleratorEntry entries[] = {
+		wxAcceleratorEntry(wxACCEL_CTRL, 'Q', wxID_EXIT),
+		wxAcceleratorEntry(wxACCEL_ALT, 'N', ID_BUTTONNETWORKS),
+		wxAcceleratorEntry(wxACCEL_ALT, 'S', ID_BUTTONSEARCH),
+		wxAcceleratorEntry(wxACCEL_ALT, 'T', ID_BUTTONDOWNLOADS),
+		wxAcceleratorEntry(wxACCEL_ALT, 'F', ID_BUTTONSHARED),
+		wxAcceleratorEntry(wxACCEL_ALT, 'M', ID_BUTTONMESSAGES),
+		wxAcceleratorEntry(wxACCEL_ALT, 'G', ID_BUTTONSTATISTICS),
+		wxAcceleratorEntry(wxACCEL_ALT, 'P', ID_BUTTONNEWPREFERENCES),
+	};
+	SetAcceleratorTable(wxAcceleratorTable(itemsof(entries), entries));
+#endif
 	ShowED2KLinksHandler(thePrefs::GetFED2KLH());
 
 	wxNotebook *logs_notebook = CastChild(ID_SRVLOG_NOTEBOOK, wxNotebook);
@@ -1723,44 +1779,44 @@ void CamuleDlg::Apply_Toolbar_Skin(wxToolBar *wndToolbar)
 		m_tblist[Toolbar_Network],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Networks Window"));
+		_("Networks Window (Alt+N)"));
 	wndToolbar->AddTool(ID_BUTTONSEARCH,
 		_("Searches"),
 		m_tblist[Toolbar_Search],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Searches Window"));
+		_("Searches Window (Alt+S)"));
 	wndToolbar->AddTool(ID_BUTTONDOWNLOADS,
 		_("Downloads"),
 		m_tblist[Toolbar_Transfers],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Downloads Window"));
+		_("Downloads Window (Alt+T)"));
 	wndToolbar->AddTool(ID_BUTTONSHARED,
 		_("Shared files"),
 		m_tblist[Toolbar_Shared],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Shared Files Window"));
+		_("Shared Files Window (Alt+F)"));
 	wndToolbar->AddTool(ID_BUTTONMESSAGES,
 		_("Messages"),
 		m_tblist[Toolbar_Messages],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Messages Window"));
+		_("Messages Window (Alt+M)"));
 	wndToolbar->AddTool(ID_BUTTONSTATISTICS,
 		_("Statistics"),
 		m_tblist[Toolbar_Stats],
 		wxNullBitmap,
 		wxITEM_CHECK,
-		_("Statistics Graph Window"));
+		_("Statistics Graph Window (Alt+G)"));
 	wndToolbar->AddSeparator();
 	wndToolbar->AddTool(ID_BUTTONNEWPREFERENCES,
 		_("Preferences"),
 		m_tblist[Toolbar_Prefs],
 		wxNullBitmap,
 		wxITEM_NORMAL,
-		_("Preferences Settings Window"));
+		_("Preferences Settings Window (Alt+P)"));
 #ifndef CLIENT_GUI
 	wndToolbar->AddTool(ID_BUTTONIMPORT,
 		_("Import"),


### PR DESCRIPTION
## Summary
Gives keyboard/screen-reader users a way to switch between the main
tabs (Networks, Search, Downloads, Shared Files, Messages, Statistics,
Preferences) without the mouse, matching the classic eMule shortcuts
(Alt+S for Search, etc.) requested in #180 by a VoiceOver user, and
called out there by @got3nks as reasonable and independent of the
larger accessibility refactor also tracked in that issue.

## Implementation
- **Windows/Linux**: plain `wxAcceleratorEntry` additions to the
  existing shortcut table.
- **macOS**: a different mechanism was needed. An accelerator-table
  entry there only fires its `wxEVT_MENU` once per click-to-refocus
  (tested with wxWidgets 3.3.3 / macOS 26) — the first Alt+<letter>
  after the window regains key status works, every subsequent press
  is silently swallowed by Cocoa's key-equivalent dispatch until the
  user clicks something in the window again. A real `NSMenuItem` key
  equivalent doesn't share that bug, since the OS dispatches it
  directly rather than routing through the window's own event
  handling — so on macOS this adds a "Navigate" menu (aMule has no
  menu bar otherwise) whose items carry the same accelerators. As a
  side benefit, VoiceOver can navigate that menu directly, which the
  toolbar currently can't offer (also tracked in #180).

## Test plan
- [x] Built locally on macOS (arm64) with CMake/wxWidgets 3.3.3
- [x] Verified the "Navigate" menu appears correctly in the macOS menu bar with all 7 items and their accelerators
- [x] Verified real menu-item clicks land on the correct handler with the correct button ID
- [x] Verified Alt+<letter> keyboard shortcuts (via System Events key-code injection, spaced several seconds apart to avoid CGEventPost coalescing artifacts) land on the correct handler for every one of the 7 shortcuts

## Scope note
This addresses only the Alt-letter shortcuts sub-item discussed in
#180. The issue's two bigger accessibility bugs — the custom-drawn
search results list and the Preferences sidebar being invisible to
VoiceOver — remain open and need the larger `wxDataViewCtrl` refactor
discussed there. Not claiming to close #180 with this PR.