### PR TITLE
feat(web-ui): resizable columns + reset-to-defaults for all data tables

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -303,6 +303,10 @@ table.data th, table.data td {
   white-space: nowrap;
 }
 table.data th {
+  /* position: relative is redundant with sticky today (sticky already
+     establishes a containing block for the absolutely-positioned resize
+     handle) but pins that down explicitly, so the handle stays anchored
+     even if the header ever stops being sticky. */
   position: sticky; top: 0; background: var(--surface-2);
   font-weight: 600; cursor: default; z-index: 1;
   /* Column boundary, header-only -- the body stays borderless/clean, but

--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -256,6 +256,20 @@ b { font-weight: 600; }
 }
 .col-picker-item:hover { background: var(--surface-2); }
 .col-picker-item input { margin: 0; }
+.col-picker-sep { height: 1px; margin: 4px 2px; background: var(--border); }
+.col-picker-reset {
+  width: 100%; border: none; background: none; color: inherit; font: inherit;
+  text-align: left;
+}
+
+/* Column resize handle: a thin invisible strip pinned to the right edge of
+   a resizable <th>, widened visually only on hover/drag so it doesn't
+   compete with the sort-click target covering the rest of the header. */
+.col-resize-handle {
+  position: absolute; top: 0; right: 0; bottom: 0; width: 6px;
+  cursor: col-resize; touch-action: none; z-index: 2;
+}
+.col-resize-handle:hover, .col-resize-handle:active { background: var(--accent); opacity: .5; }
 
 /* Language picker: globe icon + native <select>, blended into the ghost toolbar. */
 .lang-select { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; }
@@ -291,7 +305,12 @@ table.data th, table.data td {
 table.data th {
   position: sticky; top: 0; background: var(--surface-2);
   font-weight: 600; cursor: default; z-index: 1;
+  /* Column boundary, header-only -- the body stays borderless/clean, but
+     without this a resize handle has nothing marking where it lives, so
+     dragging feels like guesswork instead of grabbing a visible edge. */
+  border-right: 1px solid var(--border);
 }
+table.data th:last-child { border-right: none; }
 table.data th.sortable { cursor: pointer; user-select: none; }
 table.data th.sortable:hover { color: var(--accent); }
 table.data th .sort-arrow { display: inline-flex; vertical-align: middle; opacity: .8; }

--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -185,6 +185,7 @@
   "search_stop": "Stop",
   "search_title_complete_total": "complete / total",
   "table_columns": "Columns",
+  "table_reset_columns": "Reset columns",
   "search_toast_enter_search_terms": "Enter search terms",
   "search_toast_no_results_selected": "No results selected",
   "search_toast_search_started": "Search started",

--- a/src/webapi/static/js/icons.js
+++ b/src/webapi/static/js/icons.js
@@ -47,6 +47,7 @@ const ICONS = {
   lock: () => html`<rect x="5" y="11" width="14" height="9" rx="1.5"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/>`,
   star: () => html`<path d="M12 3l2.7 5.5 6 .9-4.3 4.2 1 6-5.4-2.8-5.4 2.8 1-6L3.3 9.4l6-.9z"/>`,
   logout: () => html`<path d="M15 4h4a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1h-4"/><path d="M10 17l5-5-5-5"/><line x1="15" y1="12" x2="3" y2="12"/>`,
+  reset: () => html`<path d="M3 12a9 9 0 1 1 3 6.7"/><path d="M3 21v-6h6"/>`,
 
   // --- theme ------------------------------------------------------------
   "theme-system": () => html`<rect x="3" y="4" width="18" height="12" rx="1.5"/><path d="M8 20h8M12 16v4"/>`,

--- a/src/webapi/static/js/table.js
+++ b/src/webapi/static/js/table.js
@@ -26,6 +26,9 @@ const OVERSCAN = 8; // rows rendered above/below the viewport to hide scroll sea
 // non-virtual `.name { min-width: 220px }`. Feeds the table's computed min-width
 // so narrow screens scroll horizontally instead of collapsing the name column.
 const FLEX_MIN = 220;
+// Floor for a user-resized column -- narrower than this and a header's label
+// or sort arrow starts clipping/overlapping unreadably.
+const MIN_COL_WIDTH = 48;
 
 export function cmp(a, b) { return a < b ? -1 : a > b ? 1 : 0; }
 
@@ -47,18 +50,20 @@ export function textMatcher(query) {
 
 const colClass = (c) => [c.num ? "num" : "", c.cls || ""].filter(Boolean).join(" ");
 
-// Per-table UI prefs (sort direction + hidden columns) persisted as one object
-// under "amule.table.<storageKey>". `defaults` = { sortKey, sortDir, hidden:[] }.
-// Stored prefs are spread over the defaults so a column added as default-hidden
-// later stays hidden only for users who never opened the picker (their stored
-// object has no entry for it → the default wins), while everyone else keeps
-// their explicit choice. Returns the current sort plus toggles the view wires
-// to VirtualTable.onSort and the ColumnPicker.
+// Per-table UI prefs (sort direction + hidden columns + resized widths)
+// persisted as one object under "amule.table.<storageKey>". `defaults` =
+// { sortKey, sortDir, hidden:[] }. Stored prefs are spread over the defaults
+// so a column added as default-hidden later stays hidden only for users who
+// never opened the picker (their stored object has no entry for it → the
+// default wins), while everyone else keeps their explicit choice. Returns
+// the current sort plus toggles the view wires to VirtualTable.onSort and
+// the ColumnPicker.
 export function useTablePrefs(storageKey, defaults) {
   const [prefs, setPrefs] = useState(() => ({
     sortKey: defaults.sortKey,
     sortDir: defaults.sortDir,
     hidden: defaults.hidden || [],
+    widths: {},
     ...loadPref("table." + storageKey, {}),
   }));
   useEffect(() => { savePref("table." + storageKey, prefs); }, [prefs]);
@@ -73,15 +78,27 @@ export function useTablePrefs(storageKey, defaults) {
       h.has(key) ? h.delete(key) : h.add(key);
       return { ...p, hidden: [...h] };
     });
+  const setWidth = (key, px) =>
+    setPrefs((p) => ({ ...p, widths: { ...p.widths, [key]: px } }));
+  // Back to the view's declared defaults -- clears sort, hidden columns AND
+  // resized widths, wiping the stored object entirely rather than merging
+  // defaults back in (so a stale key from a since-removed column doesn't
+  // linger in localStorage).
+  const resetPrefs = () =>
+    setPrefs({ sortKey: defaults.sortKey, sortDir: defaults.sortDir,
+               hidden: defaults.hidden || [], widths: {} });
 
   return { sortKey: prefs.sortKey, sortDir: prefs.sortDir,
-           hidden: new Set(prefs.hidden), toggleSort, toggleCol };
+           hidden: new Set(prefs.hidden), widths: prefs.widths || {},
+           toggleSort, toggleCol, setWidth, resetPrefs };
 }
 
-// Dropdown of checkboxes to show/hide a table's toggleable columns. Native
-// <details> so the browser owns open/close (no outside-click handler). Columns
-// without a `key`, or flagged `always`, are fixed and never listed.
-export function ColumnPicker({ columns, hidden, onToggle }) {
+// Dropdown of checkboxes to show/hide a table's toggleable columns, plus a
+// reset action. Native <details> so the browser owns open/close (no
+// outside-click handler). Columns without a `key`, or flagged `always`, are
+// fixed and never listed. `onReset` is optional -- omit it to keep the menu
+// checkbox-only (existing callers keep working unchanged).
+export function ColumnPicker({ columns, hidden, onToggle, onReset }) {
   const toggleable = columns.filter((c) => c.key && !c.always);
   return html`
     <details class="col-picker">
@@ -95,17 +112,60 @@ export function ColumnPicker({ columns, hidden, onToggle }) {
                    onChange=${() => onToggle(c.key)} />
             <span>${c.label}</span>
           </label>`)}
+        ${onReset ? html`
+          <div class="col-picker-sep"></div>
+          <button type="button" class="col-picker-item col-picker-reset" onClick=${onReset}>
+            <${Icon} name="reset" />
+            <span>${t("table_reset_columns")}</span>
+          </button>` : null}
       </div>
     </details>`;
 }
 
 export function VirtualTable({
   columns, rows, rowKey, rowClass, sortKey, sortDir, onSort, empty, onRowClick,
-  rowHeight = ROW_HEIGHT, maxHeight = "70vh",
+  rowHeight = ROW_HEIGHT, maxHeight = "70vh", widths = {}, onResize,
 }) {
   const ref = useRef(null);
+  const colRefs = useRef({}); // column key -> <col> DOM node, for drag-live width updates
   const [scrollTop, setScrollTop] = useState(0);
   const [viewH, setViewH] = useState(0);
+
+  // A user-resized width (from `widths`, persisted by the caller) overrides
+  // the column's declared default; falls back to null for the one flexible
+  // column that has neither (it fills remaining space via CSS instead).
+  const effWidth = (c) => {
+    const px = c.key && widths[c.key];
+    return px ? px + "px" : c.width || null;
+  };
+
+  // Drag-to-resize a column header edge. Mutates the <col> width directly on
+  // every mousemove (bypassing state/re-render for 60fps drag feel) and only
+  // commits to persisted prefs via onResize on mouseup -- so a drag that's
+  // abandoned mid-way (rare, but e.g. a stray click) never round-trips
+  // through localStorage more than once.
+  const startResize = (e, key) => {
+    if (!onResize) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const col = colRefs.current[key];
+    if (!col) return;
+    const startX = e.clientX;
+    const startWidth = col.getBoundingClientRect().width;
+    let finalWidth = startWidth;
+
+    const onMove = (ev) => {
+      finalWidth = Math.max(MIN_COL_WIDTH, startWidth + (ev.clientX - startX));
+      col.style.width = finalWidth + "px";
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      onResize(key, Math.round(finalWidth));
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
 
   // Track the scroll container's height (viewport for the window calc). A
   // ResizeObserver catches layout changes beyond window resize (tab switches,
@@ -129,10 +189,19 @@ export function VirtualTable({
   const arrow = (key) => key === sortKey
     ? html`<span class="sort-arrow"><${Icon} name=${sortDir > 0 ? "sort-asc" : "sort-desc"} /></span>` : null;
 
+  // Resizable = has a key to persist under. That includes the flexible
+  // no-declared-width column (typically "name") -- it starts the drag from
+  // its current *rendered* width (via getBoundingClientRect in startResize,
+  // not effWidth) rather than a declared one, and a user resize turns it
+  // into an ordinary fixed-width column from then on, same as any other.
   const th = (c) => html`
     <th class=${(c.sortable ? "sortable " : "") + colClass(c)}
         onClick=${c.sortable && onSort ? () => onSort(c.key) : null}>
       ${c.label}${c.sortable ? arrow(c.key) : null}
+      ${onResize && c.key ? html`
+        <span class="col-resize-handle"
+              onMouseDown=${(e) => startResize(e, c.key)}
+              onClick=${(e) => e.stopPropagation()} />` : null}
     </th>`;
 
   // Striping is keyed off the absolute row index, not :nth-child — a spacer <tr>
@@ -149,19 +218,25 @@ export function VirtualTable({
     ? html`<tr class="spacer" style=${{ height: h + "px" }}><td colspan=${ncols}></td></tr>` : null;
 
   // table-layout:fixed needs explicit widths, so the table can't shrink columns
-  // to fit a phone. Floor its width at the sum of the declared column widths
-  // (plus FLEX_MIN for each width-less column) so narrow viewports scroll
-  // horizontally — matching the app's other tables — instead of crushing the
-  // flexible column to nothing. On wide screens width:100% (from CSS) wins and
-  // the flexible column absorbs the extra space.
-  const minWidth = columns.reduce((sum, c) => sum + (c.width ? parseInt(c.width, 10) : FLEX_MIN), 0);
+  // to fit a phone. Floor its width at the sum of the effective column widths
+  // (a user resize, else the declared default, else FLEX_MIN for a width-less
+  // column) so narrow viewports scroll horizontally — matching the app's
+  // other tables — instead of crushing the flexible column to nothing. On
+  // wide screens width:100% (from CSS) wins and the flexible column absorbs
+  // the extra space.
+  const minWidth = columns.reduce((sum, c) => {
+    const w = effWidth(c);
+    return sum + (w ? parseInt(w, 10) : FLEX_MIN);
+  }, 0);
 
   return html`
     <div class="table-wrap virtual" ref=${ref} style=${{ maxHeight }}
          onScroll=${(e) => setScrollTop(e.currentTarget.scrollTop)}>
       <table class="data virtual" style=${{ minWidth: minWidth + "px" }}>
-        ${columns.some((c) => c.width)
-          ? html`<colgroup>${columns.map((c) => html`<col style=${c.width ? { width: c.width } : null} />`)}</colgroup>`
+        ${columns.some((c) => effWidth(c))
+          ? html`<colgroup>${columns.map((c) => html`<col
+              ref=${c.key ? (el) => { if (el) colRefs.current[c.key] = el; } : null}
+              style=${effWidth(c) ? { width: effWidth(c) } : null} />`)}</colgroup>`
           : null}
         <thead><tr>${columns.map(th)}</tr></thead>
         <tbody>

--- a/src/webapi/static/js/table.js
+++ b/src/webapi/static/js/table.js
@@ -127,55 +127,101 @@ export function VirtualTable({
   rowHeight = ROW_HEIGHT, maxHeight = "70vh", widths = {}, onResize,
 }) {
   const ref = useRef(null);
-  const colRefs = useRef({}); // column key -> <col> DOM node, for drag-live width updates
   const [scrollTop, setScrollTop] = useState(0);
   const [viewH, setViewH] = useState(0);
+  const [viewW, setViewW] = useState(0);
+  // Live width of the column currently being dragged, e.g. {key:"name", px:230}.
+  // This -- not a direct DOM mutation -- is the resize drag's source of truth:
+  // any prop change mid-drag (rows refreshed by the SSE stream tick every
+  // second or so) triggers a Preact re-render, and colgroup's <col> nodes get
+  // reconciled from whatever colWidth() computes. A version that instead
+  // pushed the live width straight into col.style.width bypassed Preact, so
+  // that very reconciliation stomped it back to the pre-drag width mid-drag --
+  // the longer the drag, the likelier a tick landed inside it, so the border
+  // (and the cursor tracking it) visibly snapped backwards while the pointer
+  // kept moving. Routing the value through state instead means every render,
+  // including one forced by an unrelated prop change, still reflects the drag.
+  const [dragging, setDragging] = useState(null);
 
   // A user-resized width (from `widths`, persisted by the caller) overrides
-  // the column's declared default; falls back to null for the one flexible
-  // column that has neither (it fills remaining space via CSS instead).
+  // the column's declared default; null for the one flexible column that
+  // has neither (colWidth, below, is what actually fills that in). The
+  // in-progress drag (if any) wins over both.
   const effWidth = (c) => {
+    if (dragging && c.key === dragging.key) return dragging.px + "px";
     const px = c.key && widths[c.key];
     return px ? px + "px" : c.width || null;
   };
 
-  // Drag-to-resize a column header edge. Mutates the <col> width directly on
-  // every mousemove (bypassing state/re-render for 60fps drag feel) and only
-  // commits to persisted prefs via onResize on mouseup -- so a drag that's
-  // abandoned mid-way (rare, but e.g. a stray click) never round-trips
-  // through localStorage more than once.
+  // The flexible column's width, computed here instead of left to the
+  // browser's table-layout:fixed auto-distribution. Every *other* column
+  // renders with an explicit pixel width (its own default or a user
+  // resize); split whatever's left of the measured container width across
+  // however many columns declared neither (in practice always at most
+  // one -- typically "name"), floored at FLEX_MIN. Doing this ourselves
+  // means colWidth() below can hand *every* <col> an explicit width, so
+  // the browser has nothing left to redistribute when one column resizes
+  // -- no neighbour drifts during the drag, and none needs to snap to a
+  // recomputed width on release either, both of which a version relying
+  // on the browser's own auto-column redistribution actually hit.
+  const flexKeys = columns.filter((c) => !effWidth(c));
+  const fixedTotal = columns.reduce((sum, c) => sum + (effWidth(c) ? parseInt(effWidth(c), 10) : 0), 0);
+  const flexWidth = flexKeys.length
+    ? Math.max(FLEX_MIN, Math.floor((viewW - fixedTotal) / flexKeys.length))
+    : 0;
+  const colWidth = (c) => effWidth(c) || flexWidth + "px";
+
+  // Drag-to-resize a column header edge. Pointer Events (not mouse-only)
+  // so this works on touch devices too, matching the handle's own
+  // touch-action: none in app.css. setPointerCapture routes subsequent
+  // move/up events to the handle itself regardless of where the pointer
+  // wanders, which sidesteps two problems a window-listener version had:
+  // stray listeners surviving a mid-drag unmount, and needing manual
+  // cleanup on every exit path. The live width goes through `dragging`
+  // state (see its comment above) rather than a direct DOM mutation, so
+  // it survives a re-render forced by unrelated props mid-drag. Persisted
+  // prefs are only touched via onResize on release -- and only if the
+  // width actually changed, so a click with no drag doesn't turn the
+  // flexible "name" column into a fixed-width one by mistake.
   const startResize = (e, key) => {
     if (!onResize) return;
     e.preventDefault();
     e.stopPropagation();
-    const col = colRefs.current[key];
-    if (!col) return;
+    const handle = e.currentTarget;
     const startX = e.clientX;
-    const startWidth = col.getBoundingClientRect().width;
+    const startWidth = parseInt(colWidth(columns.find((c) => c.key === key)), 10);
     let finalWidth = startWidth;
+
+    handle.setPointerCapture(e.pointerId);
+    setDragging({ key, px: startWidth });
 
     const onMove = (ev) => {
       finalWidth = Math.max(MIN_COL_WIDTH, startWidth + (ev.clientX - startX));
-      col.style.width = finalWidth + "px";
+      setDragging({ key, px: finalWidth });
     };
     const onUp = () => {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-      onResize(key, Math.round(finalWidth));
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      setDragging(null);
+      if (finalWidth !== startWidth) onResize(key, Math.round(finalWidth));
     };
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
   };
 
-  // Track the scroll container's height (viewport for the window calc). A
-  // ResizeObserver catches layout changes beyond window resize (tab switches,
-  // toolbar wrap, etc.).
+  // Track the scroll container's size (viewport for the row-window calc,
+  // and now also the flex-column split above). A ResizeObserver catches
+  // layout changes beyond window resize (tab switches, toolbar wrap, etc.).
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    const ro = new ResizeObserver(() => setViewH(el.clientHeight));
+    const ro = new ResizeObserver(() => {
+      setViewH(el.clientHeight);
+      setViewW(el.clientWidth);
+    });
     ro.observe(el);
     setViewH(el.clientHeight);
+    setViewW(el.clientWidth);
     return () => ro.disconnect();
   }, []);
 
@@ -200,7 +246,7 @@ export function VirtualTable({
       ${c.label}${c.sortable ? arrow(c.key) : null}
       ${onResize && c.key ? html`
         <span class="col-resize-handle"
-              onMouseDown=${(e) => startResize(e, c.key)}
+              onPointerDown=${(e) => startResize(e, c.key)}
               onClick=${(e) => e.stopPropagation()} />` : null}
     </th>`;
 
@@ -218,26 +264,21 @@ export function VirtualTable({
     ? html`<tr class="spacer" style=${{ height: h + "px" }}><td colspan=${ncols}></td></tr>` : null;
 
   // table-layout:fixed needs explicit widths, so the table can't shrink columns
-  // to fit a phone. Floor its width at the sum of the effective column widths
-  // (a user resize, else the declared default, else FLEX_MIN for a width-less
-  // column) so narrow viewports scroll horizontally — matching the app's
-  // other tables — instead of crushing the flexible column to nothing. On
-  // wide screens width:100% (from CSS) wins and the flexible column absorbs
-  // the extra space.
-  const minWidth = columns.reduce((sum, c) => {
-    const w = effWidth(c);
-    return sum + (w ? parseInt(w, 10) : FLEX_MIN);
-  }, 0);
+  // to fit a phone. Floor its width at the sum of what colWidth() actually
+  // hands every column (own default/resize, or its FLEX_MIN-floored share
+  // of colWidth's flex split) so narrow viewports scroll horizontally —
+  // matching the app's other tables — instead of crushing the flexible
+  // column to nothing. Same source as the <colgroup> below on purpose: two
+  // independent width calculations drifting apart is exactly the class of
+  // bug this file just spent a few iterations chasing out of the resize
+  // path.
+  const minWidth = columns.reduce((sum, c) => sum + parseInt(colWidth(c), 10), 0);
 
   return html`
     <div class="table-wrap virtual" ref=${ref} style=${{ maxHeight }}
          onScroll=${(e) => setScrollTop(e.currentTarget.scrollTop)}>
       <table class="data virtual" style=${{ minWidth: minWidth + "px" }}>
-        ${columns.some((c) => effWidth(c))
-          ? html`<colgroup>${columns.map((c) => html`<col
-              ref=${c.key ? (el) => { if (el) colRefs.current[c.key] = el; } : null}
-              style=${effWidth(c) ? { width: effWidth(c) } : null} />`)}</colgroup>`
-          : null}
+        <colgroup>${columns.map((c) => html`<col style=${{ width: colWidth(c) }} />`)}</colgroup>
         <thead><tr>${columns.map(th)}</tr></thead>
         <tbody>
           ${total === 0

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -73,7 +73,7 @@ export default function ClientsPanel() {
   const [ident, setIdent] = useState("identified");
   const [q, setQ] = useState("");
   // sortKey null → default sort (busiest first).
-  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
     useTablePrefs("clients", { sortKey: null, sortDir: 1, hidden: [] });
 
   useEffect(() => {
@@ -126,10 +126,11 @@ export default function ClientsPanel() {
           </select>
           <input class="input input-sm" type="text" placeholder=${t("downloads_peer_filter")} value=${q} onInput=${(e) => setQ(e.target.value)} />
           <div class="spacer"></div>
-          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
         </div>
         <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.client_ecid}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
+                         widths=${widths} onResize=${setWidth}
                          empty=${html`<${Placeholder} kind="info">${t("downloads_peer_empty")}<//>`} />
         </div>
       </section>

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -24,7 +24,7 @@ export default function Downloads({ isGuest }) {
   const downloads = useStore("downloads") || [];
   const [categories, setCategories] = useState([]);
   const [selection, setSelection] = useState(() => new Set());
-  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
     useTablePrefs("downloads", { sortKey: "name", sortDir: 1, hidden: [] });
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterCategory, setFilterCategory] = useState("all");
@@ -267,12 +267,13 @@ export default function Downloads({ isGuest }) {
             ${STATUS_FILTERS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
           </select>
           <input class="input input-sm" type="text" placeholder=${t("downloads_filter")} value=${filterText} onInput=${(e) => setFilterText(e.target.value)} />
-          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
         </div>
       </div>
 
         <${VirtualTable} columns=${shown} rows=${list} rowKey=${(d) => d.hash} rowClass=${rowClass}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort} onRowClick=${onRowClick}
+                         widths=${widths} onResize=${setWidth}
                          maxHeight="none"
                          empty=${html`<${Placeholder} kind="info">${t("downloads_empty")}<//>`} />
         <div class="totals-line">

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -46,7 +46,7 @@ export default function Search({ isGuest }) {
   const [filterHave, setFilterHave] = useState("all");
   const [selection, setSelection] = useState(() => new Set());
   // Sort + hidden columns persist per-table via useTablePrefs.
-  const { sortKey, sortDir, hidden, toggleSort, toggleCol } = useTablePrefs("search", {
+  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } = useTablePrefs("search", {
     sortKey: "sources", sortDir: -1, hidden: ["length", "bitrate", "codec"],
   });
   const [progress, setProgress] = useState("");
@@ -313,11 +313,12 @@ export default function Search({ isGuest }) {
             <option value="have">${t("search_have_yes")}</option>
           </select>
           <input class="input input-sm" type="text" placeholder=${t("search_filter")} value=${filter} onInput=${(e) => setFilter(e.target.value)} />
-          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
         </div>
 
         <${VirtualTable} columns=${shown} rows=${list} rowKey=${(r) => r.hash} rowClass=${rowClass}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
+                         widths=${widths} onResize=${setWidth}
                          empty=${html`<${Placeholder} kind="info">${t("search_empty")}<//>`} />
       </div>
     </section>

--- a/src/webapi/static/js/views/servers.js
+++ b/src/webapi/static/js/views/servers.js
@@ -15,7 +15,7 @@ export function ServersPanel({ isGuest }) {
   const servers = useStore("servers") || [];
   const status = useStore("status");
   const ed2k = status && status.ed2k;
-  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
     useTablePrefs("servers", { sortKey: "users", sortDir: -1, hidden: [] });
   const [addr, setAddr] = useState("");
   const [name, setName] = useState("");
@@ -124,10 +124,11 @@ export function ServersPanel({ isGuest }) {
                value=${url} onInput=${(e) => setUrl(e.target.value)} />
         <button class="btn btn-sm" type="submit">${t("networks_server_update_from_url")}</button>
         <div class="spacer"></div>
-        <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
+        <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
       </form>
     </div>
     <${VirtualTable} columns=${shown} rows=${list} rowKey=${(s) => s.ecid} rowClass=${rowClass}
                      sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
+                     widths=${widths} onResize=${setWidth}
                      empty=${html`<${Placeholder} kind="info">${t("networks_server_empty")}<//>`} />`;
 }

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -19,7 +19,7 @@ const PRIORITIES = ["auto", "very_low", "low", "normal", "high", "release"]
 export default function Shared({ isGuest }) {
   const shared = useStore("shared") || [];
   const [selection, setSelection] = useState(() => new Set());
-  const { sortKey, sortDir, hidden, toggleSort, toggleCol } =
+  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
     useTablePrefs("shared", { sortKey: "name", sortDir: 1, hidden: [] });
   const [filterText, setFilterText] = useState("");
   const [detailHash, setDetailHash] = useState(null); // row shown in the detail panel
@@ -153,11 +153,12 @@ export default function Shared({ isGuest }) {
         <div class="spacer"></div>
         <div class="toolbar">
           <input class="input input-sm" type="text" placeholder=${t("shared_filter")} value=${filterText} onInput=${(e) => setFilterText(e.target.value)} />
-          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} />
+          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
         </div>
       </div>
         <${VirtualTable} columns=${shown} rows=${list} rowKey=${(s) => s.hash} rowClass=${rowClass}
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort} onRowClick=${onRowClick}
+                         widths=${widths} onResize=${setWidth}
                          maxHeight="none"
                          empty=${html`<${Placeholder} kind="info">${t("shared_empty")}<//>`} />
         <div class="totals-line">


### PR DESCRIPTION
## Summary
Completes #361 — show/hide columns and localStorage persistence already
shipped in #584, but manual column resizing and a way back to defaults
were still missing.

Implemented once in the shared `table.js` (`useTablePrefs` + `VirtualTable`
+ `ColumnPicker`), so every table built on it — Downloads, Shared, Search,
Servers, Clients — gets both for free; each view only needed a few lines
to thread the new `widths`/`setWidth`/`resetPrefs` through.

## Changes
- **`useTablePrefs`**: adds a `widths` map (column key → px) to the
  persisted per-table prefs object, plus `setWidth()` and `resetPrefs()`
  (clears sort/hidden/widths back to the view's declared defaults rather
  than merging them back in, so a stale key from a since-removed column
  doesn't linger in localStorage).
- **`VirtualTable`**: a drag handle on each resizable `<th>` mutates the
  `<col>` width directly on mousemove (bypassing state/re-render for a
  smooth drag) and only commits via `onResize` on mouseup. The one
  flexible/no-declared-width column (typically "name") is resizable too —
  it starts the drag from its actual rendered width rather than a
  declared one, and becomes an ordinary fixed-width column once dragged.
- **`ColumnPicker`**: optional `onReset` prop adds a "Reset columns"
  action below a separator, kept visually apart from the checkboxes
  above so a one-shot destructive action doesn't read as another toggle
  in the same group.
- **`app.css`**: a header-only `border-right` marks column boundaries —
  the body stays borderless/clean, but without it the resize handles had
  nothing marking where they live, making dragging feel like guesswork
  (caught during manual testing).

## Test plan
- [x] `node --check` on all modified JS files
- [x] Manually verified end-to-end in a real browser against a live
      `amuleapi` instance: drag-resize on multiple tables (Servers,
      Downloads), including the flexible "name" column
- [x] Verified persistence across a page reload
- [x] Verified "Reset columns" restores default widths/visibility
- [x] Verified show/hide columns (existing #584 feature) still works
      unaffected
- [x] Verified column-boundary visibility fix (added after initial manual
      testing surfaced that resize handles were undiscoverable without it)

This is frontend interaction code a unit test wouldn't meaningfully
cover, so verification was manual/visual rather than automated.