### PR TITLE
test(webapi): cover upload_file_name in client SSE events + /clients

### DIFF
--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -342,6 +342,30 @@ else
 	_fail "clients bogus filter" "expected 400, got $RC"
 fi
 
+# --- 9a-bis. Base transfer-filename fields on the LIST object -----
+# (PR #646 / issue #115). upload_file_name (the partfile a peer is
+# downloading FROM us) and download_file_name (the name the peer
+# advertised) are both part of the base client field set, so they must
+# appear on every /clients LIST object -- not only /clients/{ecid}.
+# Regression: an upload-only peer used to render a blank File column in
+# the WebUI because upload_file_name was serialized only by the detail
+# endpoint. Guarded on a live peer so the assertion is real (non-vacuous)
+# when a peer exists, and skips cleanly when none are connected.
+FIRST_CLIENT=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients" | jq -r '.clients[0] // empty')
+if [ -n "$FIRST_CLIENT" ]; then
+	if curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients" | jq -e '
+		.clients | all(.[];
+			(.upload_file_name | type == "string")
+			and (.download_file_name | type == "string"))' >/dev/null 2>&1; then
+		_pass "/clients list objects carry upload_file_name + download_file_name (strings)"
+	else
+		_fail "clients base filename fields" \
+			"a /clients object is missing upload_file_name/download_file_name or it is not a string"
+	fi
+else
+	_pass "/clients base filename-field check skipped (no peers connected)"
+fi
+
 # --- 9b. /clients/{ecid} detail (issue #422). --------------------
 # A superset of the list object: every list field plus the detail-only
 # B fields. Guarded on a live peer; the negative cases run regardless.
@@ -352,6 +376,7 @@ if [ -n "$FIRST_ECID" ]; then
 	OK=$(echo "$DETAIL" | jq -r --argjson e "$FIRST_ECID" '
 		(.client_ecid == $e)
 		and has("user_hash")
+		and has("upload_file_name") and has("download_file_name")
 		and has("user_id_hybrid") and has("high_id")
 		and has("server_ip") and has("server_port") and has("server_name")
 		and has("kad_port") and has("source_origin")

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -29,6 +29,8 @@
 #include "State.h"
 
 #include <chrono>
+#include <cstdint>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -200,4 +202,86 @@ TEST(EventDiff, LogAppendedSilentOnTruncation)
 		ASSERT_TRUE(ev.name != "log_appended");
 	}
 	ASSERT_EQUALS(static_cast<std::size_t>(1), prev.amule_log_count);
+}
+
+// PR #646 / issue #115: upload_file_name (the partfile a peer is downloading
+// FROM us) is part of the base client field set, so it must ride the
+// client_added SSE payload — otherwise the WebUI clients table has no way to
+// fill the File column for an upload-only peer (it shows a blank "—").
+TEST(EventDiff, ClientAddedCarriesUploadFileName)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+
+	// Tick 1: baseline with no clients.
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	// Tick 2: a peer we are uploading to appears.
+	state.MutateClients([](std::map<std::uint32_t, ClientSnapshot> &cache) {
+		ClientSnapshot c;
+		c.ecid = 10;
+		c.client_name = "peer-up";
+		c.upload_state = "uploading";
+		c.upload_file_name = "upload.iso";
+		cache.emplace(c.ecid, c);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	const auto drained = DrainAll(bus);
+	int added = 0;
+	std::string payload;
+	for (const auto &ev : drained) {
+		if (ev.name == "client_added") {
+			++added;
+			payload = ev.data;
+		}
+	}
+	ASSERT_EQUALS(1, added);
+	ASSERT_TRUE(payload.find("upload_file_name") != std::string::npos);
+	ASSERT_TRUE(payload.find("upload.iso") != std::string::npos);
+}
+
+// Regression guard for the EventDiff.cpp Equal() half of PR #646: Equal() must
+// compare every field ToJson emits (see the note above Equal()), so a change
+// to upload_file_name alone still fires client_updated. Before the fix the
+// field was in neither, and an upload-file change would have been dropped —
+// the SSE-backed table would keep showing the stale filename.
+TEST(EventDiff, ClientUpdatedFiresOnUploadFileNameChange)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+
+	// Baseline: no clients.
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	// A peer appears, uploading "a.iso" from us (client_added).
+	state.MutateClients([](std::map<std::uint32_t, ClientSnapshot> &cache) {
+		ClientSnapshot c;
+		c.ecid = 10;
+		c.client_name = "peer-up";
+		c.upload_state = "uploading";
+		c.upload_file_name = "a.iso";
+		cache.emplace(c.ecid, c);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	// Only upload_file_name changes -> must fire client_updated.
+	state.MutateClients([](std::map<std::uint32_t, ClientSnapshot> &cache) {
+		cache.at(10).upload_file_name = "b.iso";
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	const auto drained = DrainAll(bus);
+	int updated = 0;
+	std::string payload;
+	for (const auto &ev : drained) {
+		if (ev.name == "client_updated") {
+			++updated;
+			payload = ev.data;
+		}
+	}
+	ASSERT_EQUALS(1, updated);
+	ASSERT_TRUE(payload.find("b.iso") != std::string::npos);
 }


### PR DESCRIPTION
Follow-up test coverage for #646, which moved `upload_file_name` into the base client field set (so an upload-only peer's file shows in the WebUI) but added no test for the serialization / SSE code paths it changed.

## What's covered

**EventDiffTest (deterministic, C++):** two cases driving the diff engine.
- `ClientAddedCarriesUploadFileName` — asserts the field rides the `client_added` payload (guards `ToJson(ClientSnapshot)`).
- `ClientUpdatedFiresOnUploadFileNameChange` — mutates *only* `upload_file_name` and asserts a `client_updated` fires (guards the `Equal()` half — that field must be compared, or an upload-file change is silently dropped and the SSE-backed table keeps a stale name). Without #646's `Equal()` change this test fails.

**Curl harness (`26-rfc-followup-endpoints.sh`):** the `/clients` list objects and the `/clients/{ecid}` detail superset must both carry `upload_file_name` + `download_file_name`. The list check is guarded on a live peer, so it's a real assertion when one is connected and skips cleanly otherwise.

## Verified
- `EventDiffTest` — 8/8 pass (macOS).
- `26-rfc-followup-endpoints.sh` — 37/37 pass through `run-all.sh` against a live test node with 2 connected clients, so the new list + detail assertions ran **non-vacuously** (not the skip path).

Tests only — no production code change.
