### PR TITLE
feat: include AICH in generated magnet links, parse it back on load

### DIFF
--- a/src/MagnetURI.cpp
+++ b/src/MagnetURI.cpp
@@ -113,6 +113,31 @@ bool CMagnetED2KConverter::CanConvertToED2K() const
 	return has_urn && has_xl;
 }
 
+namespace
+{
+
+// A base32-encoded AICH master hash is always 32 characters from [A-Z2-7]
+// (RFC 4648, no padding -- 20 raw bytes need exactly ceil(160/5) = 32
+// symbols). ED2KLink.cpp's parser throws on anything else, so a magnet
+// carrying a junk/truncated urn:aich: must have it dropped here rather than
+// embedded -- otherwise a perfectly valid ed2k hash would be rejected
+// wholesale just because the AICH tagalong was malformed. Plain char-range
+// check (no CAICHHash dependency) so it works in both build modes.
+bool IsWellFormedAich(const STRING &s)
+{
+	if (s.length() != 32) {
+		return false;
+	}
+	for (size_t i = 0; i < s.length(); ++i) {
+		if (!((s[i] >= _C('A') && s[i] <= _C('Z')) || (s[i] >= _C('2') && s[i] <= _C('7')))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace
+
 STRING CMagnetED2KConverter::GetED2KLink() const
 {
 	if (CanConvertToED2K()) {
@@ -150,7 +175,7 @@ STRING CMagnetED2KConverter::GetED2KLink() const
 				      .append(1, _C('|'))
 				      .append(hash)
 				      .append(1, _C('|'));
-		if (!aich.empty()) {
+		if (IsWellFormedAich(aich)) {
 			link.append(_T("h=")).append(aich).append(1, _C('|'));
 		}
 		return link.append(_T("/"));

--- a/src/MagnetURI.cpp
+++ b/src/MagnetURI.cpp
@@ -129,23 +129,31 @@ STRING CMagnetED2KConverter::GetED2KLink() const
 			dn = _T("FileName.ext");
 		}
 		Value_List urn_list = GetField(_T("xt"));
-		// Use the first ed2k-hash found.
+		STRING aich;
+		// Use the first ed2k-hash found, and separately the first AICH
+		// urn if the magnet carries one (amule-org/amule#331) -- both
+		// loop over the same xt list since either can come in any order
+		// relative to the other.
 		for (Value_List::iterator it = urn_list.begin(); it != urn_list.end(); ++it) {
-			if (it->compare(0, 9, _T("urn:ed2k:")) == 0) {
+			if (hash.empty() && it->compare(0, 9, _T("urn:ed2k:")) == 0) {
 				hash = it->substr(9);
-				break;
-			} else if (it->compare(0, 13, _T("urn:ed2khash:")) == 0) {
+			} else if (hash.empty() && it->compare(0, 13, _T("urn:ed2khash:")) == 0) {
 				hash = it->substr(13);
-				break;
+			} else if (aich.empty() && it->compare(0, 9, _T("urn:aich:")) == 0) {
+				aich = it->substr(9);
 			}
 		}
-		return STRING(_T("ed2k://|file|"))
-			.append(dn)
-			.append(1, _C('|'))
-			.append(len)
-			.append(1, _C('|'))
-			.append(hash)
-			.append(_T("|/"));
+		STRING link = STRING(_T("ed2k://|file|"))
+				      .append(dn)
+				      .append(1, _C('|'))
+				      .append(len)
+				      .append(1, _C('|'))
+				      .append(hash)
+				      .append(1, _C('|'));
+		if (!aich.empty()) {
+			link.append(_T("h=")).append(aich).append(1, _C('|'));
+		}
+		return link.append(_T("/"));
 	} else {
 		return STRING();
 	}

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -220,6 +220,13 @@ wxString CamuleAppCommon::CreateMagnetLink(const CAbstractFile *f)
 	uri.AddField("xt", wxString("urn:ed2khash:") + f->GetFileHash().Encode().Lower());
 	uri.AddField("xl", CFormat("%d") % f->GetFileSize());
 
+	// AICH, when we have one -- same source and condition CreateED2kLink()
+	// uses for the ed2k link's "h=" field (amule-org/amule#331).
+	const CKnownFile *kf = dynamic_cast<const CKnownFile *>(f);
+	if (kf && kf->HasProperAICHHashSet()) {
+		uri.AddField("xt", wxString("urn:aich:") + kf->GetAICHMasterHash());
+	}
+
 	return uri.GetLink();
 }
 

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -244,6 +244,27 @@ target_link_libraries (CMuleCollectionTest
 	muleunit
 )
 
+add_executable (MagnetURITest
+	MagnetURITest.cpp
+	${CMAKE_SOURCE_DIR}/src/MagnetURI.cpp
+	# See the CMuleCollectionTest comment above -- same Linux-backtrace need.
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+)
+
+add_test (NAME MagnetURITest
+	COMMAND MagnetURITest
+)
+
+target_include_directories (MagnetURITest
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (MagnetURITest
+	muleunit
+)
+
 add_executable (TextFileTest
 	TextFileTest.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp

--- a/unittests/tests/MagnetURITest.cpp
+++ b/unittests/tests/MagnetURITest.cpp
@@ -1,0 +1,94 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include <MagnetURI.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(MagnetURI)
+
+namespace
+{
+// A syntactically plausible (32-char) AICH-shaped base32 string -- the
+// converter treats it as an opaque token, so it doesn't need to be a real
+// hash for these tests.
+const char *const AICH = "QVVWMK4S7ZJUV3ASZLPFYU4A5WOAAAAA";
+const char *const ED2K_HASH = "d41d8cd98f00b204e9800998ecf8427e";
+} // namespace
+
+TEST(MagnetURI, GetLinkIncludesAichField)
+{
+	CMagnetURI uri;
+	uri.AddField("dn", "example.iso");
+	uri.AddField("xt", wxString("urn:ed2k:") + ED2K_HASH);
+	uri.AddField("xt", wxString("urn:aich:") + AICH);
+
+	wxString link = uri.GetLink();
+
+	ASSERT_TRUE(link.Contains(wxString("xt=urn:aich:") + AICH));
+}
+
+TEST(MagnetURI, ConvertsAichUrnIntoEd2kHField)
+{
+	wxString magnet =
+		wxString("magnet:?xt=urn:ed2k:") + ED2K_HASH + "&dn=example.iso&xl=42&xt=urn:aich:" + AICH;
+
+	CMagnetED2KConverter conv(magnet);
+
+	ASSERT_TRUE(conv.CanConvertToED2K());
+	wxString ed2k = conv.GetED2KLink();
+	ASSERT_TRUE(ed2k.Contains(wxString("|h=") + AICH + "|"));
+	// The AICH segment must land before the closing "/", not appended after it.
+	ASSERT_TRUE(ed2k.EndsWith("/"));
+	ASSERT_TRUE(ed2k.Contains(wxString("h=") + AICH + "|/"));
+}
+
+TEST(MagnetURI, NoAichUrnMeansNoHField)
+{
+	wxString magnet = wxString("magnet:?xt=urn:ed2k:") + ED2K_HASH + "&dn=example.iso&xl=42";
+
+	CMagnetED2KConverter conv(magnet);
+
+	ASSERT_TRUE(conv.CanConvertToED2K());
+	wxString ed2k = conv.GetED2KLink();
+	ASSERT_TRUE(!ed2k.Contains("h="));
+	ASSERT_TRUE(ed2k.EndsWith("|/"));
+}
+
+TEST(MagnetURI, AichUrnOrderBeforeEd2kUrnStillWorks)
+{
+	// Field order in the magnet isn't guaranteed -- the converter shouldn't
+	// care whether the AICH urn or the ed2k urn comes first.
+	wxString magnet = wxString("magnet:?xt=urn:aich:") + AICH + "&xt=urn:ed2k:" + ED2K_HASH +
+			  "&dn=example.iso&xl=42";
+
+	CMagnetED2KConverter conv(magnet);
+
+	ASSERT_TRUE(conv.CanConvertToED2K());
+	wxString ed2k = conv.GetED2KLink();
+	ASSERT_TRUE(ed2k.Contains(wxString("h=") + AICH + "|/"));
+	ASSERT_TRUE(ed2k.Contains(wxString("|") + ED2K_HASH + "|h="));
+}

--- a/unittests/tests/MagnetURITest.cpp
+++ b/unittests/tests/MagnetURITest.cpp
@@ -78,6 +78,30 @@ TEST(MagnetURI, NoAichUrnMeansNoHField)
 	ASSERT_TRUE(ed2k.EndsWith("|/"));
 }
 
+TEST(MagnetURI, MalformedAichUrnIsDropped)
+{
+	// ED2KLink.cpp's parser throws on a bad master-hash, so a magnet with a
+	// junk/truncated urn:aich: must convert as if the AICH urn were absent
+	// -- not embed the garbage into "h=" and make the whole link unusable,
+	// even though its ed2k hash is perfectly valid.
+	wxString tooShort =
+		wxString("magnet:?xt=urn:ed2k:") + ED2K_HASH + "&dn=example.iso&xl=42&xt=urn:aich:TOOSHORT";
+	CMagnetED2KConverter convShort(tooShort);
+	ASSERT_TRUE(convShort.CanConvertToED2K());
+	wxString ed2kShort = convShort.GetED2KLink();
+	ASSERT_TRUE(!ed2kShort.Contains("h="));
+	ASSERT_TRUE(ed2kShort.EndsWith("|/"));
+
+	// Right length (32), but not base32 (lowercase letters plus a '!').
+	wxString notBase32 = wxString("magnet:?xt=urn:ed2k:") + ED2K_HASH +
+			     "&dn=example.iso&xl=42&xt=urn:aich:qvvwmk4s7zju!3aszlpfyu4a5woaaaaa";
+	CMagnetED2KConverter convBad(notBase32);
+	ASSERT_TRUE(convBad.CanConvertToED2K());
+	wxString ed2kBad = convBad.GetED2KLink();
+	ASSERT_TRUE(!ed2kBad.Contains("h="));
+	ASSERT_TRUE(ed2kBad.EndsWith("|/"));
+}
+
 TEST(MagnetURI, AichUrnOrderBeforeEd2kUrnStillWorks)
 {
 	// Field order in the magnet isn't guaranteed -- the converter shouldn't


### PR DESCRIPTION
## Summary
Fixes #331 — two related asks:
- Generated magnet links should include the AICH hash when available.
- A magnet link carrying an AICH hash should have it parsed and used when converted to an ed2k link on download add.

## Implementation
`CreateMagnetLink()` now adds an `xt=urn:aich:<hash>` field alongside the
existing ed2k/ed2khash ones whenever the file has a proper AICH hash set —
same source and guard `CreateED2kLink()` already uses for the ed2k link's
`h=` field.

`CMagnetED2KConverter::GetED2KLink()` — used both when a user pastes a
`magnet:` link (`CDownloadQueue::AddLink`) and by the `ed2k` CLI tool —
now looks for that `urn:aich:` field alongside the ed2k one and, when
present, embeds it as `h=<aich>|` in the ed2k link it builds. That string
then flows through the **existing** ed2k link parser (`ED2KLink.cpp`
already handles `h=`), so the AICH hash reaches the download with no
second parsing path to add or keep in sync — the second half of the
request falls out of the first for free.

## Test plan
Added `MagnetURITest` (4 cases) since this is pure string logic with no
GUI/network dependency — more reliable than exercising it by hand through
the app:
- [x] `GetLinkIncludesAichField` — field round-trips into the generated magnet link
- [x] `ConvertsAichUrnIntoEd2kHField` — AICH urn converts into the ed2k `h=` field, correctly positioned before the closing `/`
- [x] `NoAichUrnMeansNoHField` — no AICH urn means no `h=` field (regression check)
- [x] `AichUrnOrderBeforeEd2kUrnStillWorks` — field order in the magnet doesn't matter

- [x] Verified both compile modes `MagnetURI.cpp` supports build cleanly: the main `amule` app (wxString) and the standalone `ed2k` CLI tool (`USE_STD_STRING`)
- [ ] Not verified end-to-end through the GUI with a real peer serving an AICH-bearing file (impractical to simulate) — the conversion logic is unit-tested in isolation and the downstream parser is pre-existing/unchanged, so residual risk is low