### PR TITLE
fix(upload): don't lock an IP out of the upload queue over departed clients

### DIFF
--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -497,17 +497,6 @@ void CClientList::AddTrackClient(CUpDownClient *toadd)
 	}
 }
 
-uint16 CClientList::GetClientsFromIP(uint32 dwIP)
-{
-	std::map<uint32, CDeletedClient *>::iterator it = m_trackedClientsList.find(dwIP);
-
-	if (it != m_trackedClientsList.end()) {
-		return it->second->m_ItemsList.size();
-	} else {
-		return 0;
-	}
-}
-
 void CClientList::Process()
 {
 	const uint64 cur_tick = ::GetTickCount64();

--- a/src/ClientList.h
+++ b/src/ClientList.h
@@ -188,14 +188,6 @@ public:
 	void AddTrackClient(CUpDownClient *toadd);
 
 	/**
-	 * Returns the number of tracked client.
-	 *
-	 * @param dwIP The IP-address which of the clients.
-	 * @return The number of clients tracked at the specified IP.
-	 */
-	uint16 GetClientsFromIP(uint32 dwIP);
-
-	/**
 	 * Checks if a client has changed its user-hash.
 	 *
 	 * @param dwIP The IP of the client.

--- a/src/UploadQueue.cpp
+++ b/src/UploadQueue.cpp
@@ -484,10 +484,19 @@ void CUploadQueue::AddClientToQueue(CUpDownClient *client)
 		}
 	}
 
-	// We do not accept more than 3 clients from the same IP
+	// We do not accept more than 3 clients (currently on the upload queue) from the
+	// same IP. Only clients actually on the queue are counted (ipCount, above); we
+	// deliberately do NOT also reject based on how many clients from this IP were
+	// recently *removed* from the queue. That earlier check counted the tracked
+	// "deleted clients" list, so a client behind a shared/NAT IP that simply
+	// cancelled a few downloads got locked out of the queue for up to two hours
+	// (only cleared by a restart), even though none of those clients were still
+	// queued. Flood protection is handled separately by the aggressiveness/ban path.
 	if (ipCount > 3) {
-		return;
-	} else if (theApp->clientlist->GetClientsFromIP(client->GetIP()) >= 3) {
+		AddDebugLogLineN(logLocalClient,
+			CFormat("Rejected upload request from %s: too many clients (%d) from the same IP "
+				"already on the upload queue") %
+				client->GetFullIP() % ipCount);
 		return;
 	}
 


### PR DESCRIPTION
## Problem

Reported in #610: a client stays stuck on **"Queue Full"** against an aMule source that is reachable and has free slots, and only restarting the *source* clears it. It reproduces when someone runs several ed2k clients behind one public IP and cancels + re-adds downloads.

## Cause

`CUploadQueue::AddClientToQueue()` refuses a request when `GetClientsFromIP()` reports 3+ clients from the requester's IP:

```cpp
if (ipCount > 3) {
    return;
} else if (theApp->clientlist->GetClientsFromIP(client->GetIP()) >= 3) {
    return;
}
```

But `GetClientsFromIP()` does **not** count clients on the queue — it counts `m_trackedClientsList`, the clients **recently *removed*** from the upload queue (kept for `KEEPTRACK_TIME` = 2 h, and the timer refreshed on every insertion). Every `OP_CANCELTRANSFER` runs `RemoveFromUploadQueue()` → `AddTrackClient()`, so each distinct client (IP + port) that cancels behind an IP leaves a tracked entry. Once three accumulate, **every** further request from that IP is dropped — though none of those clients are still queued — and the constantly-refreshed 2 h timer means it never ages out under normal activity. Only a restart (which empties `m_trackedClientsList`) recovers it.

## Fix

Remove that branch. The concurrent-per-IP limit is already enforced by the `ipCount > 3` check immediately above, which counts only clients **actually on the upload queue** (`GetClientsByIP()` filtered by `IsOnUploadQueue()`). The rejection is now logged at debug level (`logLocalClient`).

`GetClientsFromIP()` had no other caller and is removed. `m_trackedClientsList` / `AddTrackClient()` are untouched — still used by `ComparePriorUserhash()` (hash-spoofing detection) and corruption/ban tracking.

## Abuse protection is preserved

This removes no flood protection. A misbehaving peer that spams upload requests (e.g. cancel + re-request every second) is still banned by `CheckForAggressive()`, which runs on every `OP_STARTUPLOADREQ` and reask **before** `AddClientToQueue`: a request within `MIN_REQUESTTIME` (~10 min) of the previous one adds +3 to the client's aggressiveness score, and it is banned at ≥10 (≈4 rapid requests, i.e. a few seconds). Cancelling does not reset that score. The removed check never contributed to this — `AddTrackClient()` dedups by (IP, user port), so a single flooding client collapses to one tracked entry and never reaches the `>= 3` threshold; that check only tripped on 3+ *distinct* clients from one IP.

## Validation

Root cause confirmed with the reporter via an instrumented build, which logged `AddClientToQueue → DROPPED: >=3 clients from same IP` at the moment the client got stuck. Builds clean; clang-format and Tier-2 clang-tidy pass on the diff.
