### PR TITLE
fix(gui): rebuild the download list in one pass when filtering or switching category

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -284,33 +284,58 @@ void CDownloadListCtrl::EndBatchUpdate(bool doSort)
 	Thaw();
 }
 
-void CDownloadListCtrl::ShowFileList()
+void CDownloadListCtrl::RebuildVisibleList()
 {
-	// Batch counterpart to AddFile()'s per-item path: show every model
-	// item that belongs in the current category, then sort the list a
-	// single time. Used after a deferred bulk load (remote GUI first
-	// sync) so a large queue populates in one pass instead of paying an
-	// O(n^2) per-item sort. Freeze()/Thaw() collapses the repaints into
-	// one. Mirrors CSharedFilesCtrl::ShowFileList().
+	// Batch counterpart to AddFile()'s per-item path: drop the visible rows and
+	// re-append every model item that passes the current category + text
+	// filter, then sort once.
+	//
+	// Doing this incrementally instead -- ShowFile(file, false) per row that
+	// should disappear -- costs a full RebuildRowIndex() inside
+	// RemoveItemData() for *every* removal, i.e. O(n^2) overall. On a 10k
+	// queue that is seconds of frozen GUI per keystroke in the filter field
+	// (issue #669). Appending into a cleared model and finishing with a single
+	// FinishBulkLoad() (one SetItemCount + one index rebuild + one sort) is
+	// O(n log n) and a single repaint. Mirrors CSharedFilesCtrl::ShowFileList().
 	Freeze();
 
+	// The rebuild renumbers every row, so keep selection + focus by item
+	// identity (the incremental path kept them for free by leaving surviving
+	// rows untouched).
+	wxUIntPtr focused = 0;
+	const std::vector<wxUIntPtr> selected = SaveSelection(focused);
+
+	ClearItemData();
+
 	bool hasCompletedDownloads = false;
+	int shown = 0;
 
 	for (const auto &entry : m_ListItems) {
 		CPartFile *file = entry.second->GetFile();
-		if (IsVisibleInCat(file, m_category)) {
-			ShowFile(file, true);
-			if (file->IsCompleted()) {
-				hasCompletedDownloads = true;
-			}
+		if (!IsVisibleInCat(file, m_category)) {
+			continue;
+		}
+		AppendItemData(reinterpret_cast<wxUIntPtr>(entry.second));
+		++shown;
+		if (file->IsCompleted()) {
+			hasCompletedDownloads = true;
 		}
 	}
 
-	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(hasCompletedDownloads);
+	FinishBulkLoad();
+	RestoreSelection(selected, focused);
 
-	SortList();
+	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(hasCompletedDownloads);
+	SetFilesCount(shown);
 
 	Thaw();
+}
+
+void CDownloadListCtrl::ShowFileList()
+{
+	// Used after a deferred bulk load (remote GUI first sync), where the model
+	// is populated but no rows are shown yet.
+	RebuildVisibleList();
 }
 
 void CDownloadListCtrl::RemoveFile(CPartFile *file)
@@ -400,36 +425,12 @@ void CDownloadListCtrl::ShowFile(CPartFile *file, bool show)
 
 void CDownloadListCtrl::ChangeCategory(int newCategory)
 {
-	Freeze();
-
-	bool hasCompletedDownloads = false;
-
-	// remove all displayed files with a different cat and show the correct ones
-	for (ListItems::const_iterator it = m_ListItems.begin(); it != m_ListItems.end(); ++it) {
-
-		CPartFile *file = it->second->GetFile();
-
-		bool curVisibility = IsVisibleInCat(file, m_category);
-		bool newVisibility = IsVisibleInCat(file, newCategory);
-
-		if (newVisibility && file->IsCompleted()) {
-			hasCompletedDownloads = true;
-		}
-
-		// Check if the visibility of the file has changed. However, if the
-		// current category is the default (0) category, then we can't use
-		// curVisiblity to see if the visibility has changed but instead
-		// have to let ShowFile() check if the file is or isn't on the list.
-		if (curVisibility != newVisibility || !newCategory) {
-			ShowFile(file, newVisibility);
-		}
-	}
-
-	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(hasCompletedDownloads);
-
-	Thaw();
-
+	// Same one-pass rebuild as the text filter: hiding the rows of the old
+	// category individually paid an O(n) row-index rebuild per removal, so
+	// switching category on a large queue froze the GUI just like filtering
+	// did (issue #669).
 	m_category = newCategory;
+	RebuildVisibleList();
 }
 
 uint8 CDownloadListCtrl::GetCategory() const
@@ -437,39 +438,16 @@ uint8 CDownloadListCtrl::GetCategory() const
 	return m_category;
 }
 
-bool CDownloadListCtrl::PassesTextFilter(const CPartFile *file) const
-{
-	if (m_filterText.IsEmpty()) {
-		return true;
-	}
-	// Case-insensitive substring match on the file name (m_filterText is
-	// already lower-cased by SetFilterText()).
-	return file->GetFileName().GetPrintable().Lower().Contains(m_filterText);
-}
-
 bool CDownloadListCtrl::IsVisibleInCat(CPartFile *file, int category) const
 {
-	return file->CheckShowItemInGivenCat(category) && PassesTextFilter(file);
+	return file->CheckShowItemInGivenCat(category) && MatchesFilter(file->GetFileName().GetPrintable());
 }
 
-void CDownloadListCtrl::SetFilterText(const wxString &text)
+void CDownloadListCtrl::RebuildFilteredView()
 {
-	const wxString lower = text.Lower();
-	if (lower == m_filterText) {
-		return;
-	}
-	m_filterText = lower;
-
-	// Re-evaluate visibility of every model item against the new filter,
-	// mirroring ChangeCategory(): the model in m_ListItems always holds every
-	// file, so we just add/remove rows to match. One repaint, one sort.
-	Freeze();
-	for (const auto &entry : m_ListItems) {
-		CPartFile *file = entry.second->GetFile();
-		ShowFile(file, IsVisibleInCat(file, m_category));
-	}
-	SortList();
-	Thaw();
+	// Filter hook from CMuleVirtualListCtrl: the model in m_ListItems always
+	// holds every file, so the visible set is rebuilt from it in one pass.
+	RebuildVisibleList();
 }
 
 /**
@@ -1350,7 +1328,12 @@ void CDownloadListCtrl::ClearCompleted()
 
 void CDownloadListCtrl::ShowFilesCount(int diff)
 {
-	m_filecount += diff;
+	SetFilesCount(m_filecount + diff);
+}
+
+void CDownloadListCtrl::SetFilesCount(int count)
+{
+	m_filecount = count;
 
 	wxStaticText *label = CastByName("downloadsLabel", GetParent(), wxStaticText);
 

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -94,13 +94,10 @@ public:
 	 */
 	void ShowFileList();
 
-	/**
-	 * Sets the live text filter. Only files whose name contains @a text
-	 * (case-insensitive) are shown, AND-ed with the current category. An
-	 * empty string clears the filter. Purely GUI-side, so it works the same
-	 * in the monolithic app and the remote GUI (amulegui).
-	 */
-	void SetFilterText(const wxString &text);
+	// The live text filter (SetFilterText) is inherited from
+	// CMuleVirtualListCtrl; here it is AND-ed with the current category, and
+	// the rebuild it triggers is RebuildFilteredView() below. Purely GUI-side,
+	// so it behaves the same in the monolithic app and the remote GUI.
 
 	/**
 	 * Bracket a burst of AddFile()/UpdateItem() calls (a reconnect resync —
@@ -174,6 +171,23 @@ private:
 	 * Updates the displayed number representing the amount of files currently shown.
 	 */
 	void ShowFilesCount(int diff);
+
+	/**
+	 * Sets the displayed file count to an absolute value.
+	 */
+	void SetFilesCount(int count);
+
+	/**
+	 * Rebuilds the visible rows from the model in a single pass, keeping the
+	 * files that pass the current category + text filter. Used whenever the
+	 * visible set changes wholesale (category switch, filter edit).
+	 */
+	void RebuildVisibleList();
+
+	/**
+	 * @see CMuleVirtualListCtrl::RebuildFilteredView
+	 */
+	virtual void RebuildFilteredView();
 
 	/**
 	 * @see CMuleListCtrl::GetTTSText
@@ -261,11 +275,7 @@ private:
 	//! The currently displayed category
 	uint8 m_category;
 
-	//! Live text filter (lower-cased), empty when inactive. See SetFilterText().
-	wxString m_filterText;
-
 	//! True if @a file passes the current text filter (name substring match).
-	bool PassesTextFilter(const CPartFile *file) const;
 
 	//! Whether @a file should be displayed in @a category: the category
 	//! predicate AND-ed with the text filter. Takes a non-const file because

--- a/src/MuleVirtualListCtrl.cpp
+++ b/src/MuleVirtualListCtrl.cpp
@@ -195,6 +195,53 @@ void CMuleVirtualListCtrl::RemoveItemData(wxUIntPtr data)
 	RefreshFromRow(pos);
 }
 
+void CMuleVirtualListCtrl::SetFilterText(const wxString &text)
+{
+	const wxString lower = text.Lower();
+	if (lower == m_filterText) {
+		return;
+	}
+	m_filterText = lower;
+	RebuildFilteredView();
+}
+
+bool CMuleVirtualListCtrl::MatchesFilter(const wxString &name) const
+{
+	if (m_filterText.IsEmpty()) {
+		return true;
+	}
+	// m_filterText is already lower-cased by SetFilterText().
+	return name.Lower().Contains(m_filterText);
+}
+
+std::vector<wxUIntPtr> CMuleVirtualListCtrl::SaveSelection(wxUIntPtr &focused) const
+{
+	std::vector<wxUIntPtr> selected;
+	for (long p = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED); p != -1;
+		p = GetNextItem(p, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED)) {
+		selected.push_back(ItemAt(p));
+	}
+	const long focusPos = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_FOCUSED);
+	focused = (focusPos == -1) ? 0 : ItemAt(focusPos);
+	return selected;
+}
+
+void CMuleVirtualListCtrl::RestoreSelection(const std::vector<wxUIntPtr> &selected, wxUIntPtr focused)
+{
+	for (wxUIntPtr data : selected) {
+		const long row = RowOfData(data);
+		if (row != -1) {
+			SetItemState(row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+		}
+	}
+	if (focused) {
+		const long row = RowOfData(focused);
+		if (row != -1) {
+			SetItemState(row, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+		}
+	}
+}
+
 void CMuleVirtualListCtrl::ClearItemData()
 {
 	m_items.clear();
@@ -252,13 +299,8 @@ void CMuleVirtualListCtrl::SortList()
 	// Preserve selection + focus by item identity (in virtual mode the control
 	// tracks selection by row index, so after the sort those indices point at
 	// different items).
-	std::vector<wxUIntPtr> selected;
-	for (long p = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED); p != -1;
-		p = GetNextItem(p, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED)) {
-		selected.push_back(ItemAt(p));
-	}
-	long focusPos = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_FOCUSED);
-	wxUIntPtr focused = focusPos == -1 ? 0 : ItemAt(focusPos);
+	wxUIntPtr focused = 0;
+	const std::vector<wxUIntPtr> selected = SaveSelection(focused);
 
 	const std::vector<wxUIntPtr> before = m_items; // snapshot for the moved-span diff
 	std::sort(m_items.begin(), m_items.end(), [this](wxUIntPtr a, wxUIntPtr b) {
@@ -286,18 +328,7 @@ void CMuleVirtualListCtrl::SortList()
 		for (long idx = first; idx <= last; ++idx) {
 			SetItemState(idx, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
 		}
-		for (wxUIntPtr d : selected) {
-			auto it = m_rowOf.find(d);
-			if (it != m_rowOf.end()) {
-				SetItemState(it->second, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
-			}
-		}
-		if (focused) {
-			auto it = m_rowOf.find(focused);
-			if (it != m_rowOf.end()) {
-				SetItemState(it->second, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
-			}
-		}
+		RestoreSelection(selected, focused);
 		RefreshItems(first, last);
 	}
 

--- a/src/MuleVirtualListCtrl.h
+++ b/src/MuleVirtualListCtrl.h
@@ -86,6 +86,10 @@ public:
 	 *  preserving selection + focus by item identity. */
 	virtual void SortList();
 
+	/** Set the live, case-insensitive substring filter; an empty string clears
+	 *  it. Calls RebuildFilteredView() when the text actually changes. */
+	void SetFilterText(const wxString &text);
+
 protected:
 	// --- model mutation -------------------------------------------------
 	/** Insert one item at its sorted position (current sort sequence). */
@@ -107,6 +111,30 @@ protected:
 	long RowOfData(wxUIntPtr data) const;
 	/** Repaint one item's row; if sorted by a live column, schedule a re-sort. */
 	void RefreshItemData(wxUIntPtr data);
+
+	// --- selection across row renumbering ---------------------------------
+	/** Snapshot the selection by item identity, returning the selected items
+	 *  and writing the focused one (or 0) to @a focused. In virtual mode the
+	 *  control tracks selection and focus by *row index*, so anything that
+	 *  renumbers rows -- a sort, or a ClearItemData() + re-append rebuild --
+	 *  has to save and restore them this way or the selection lands on
+	 *  whichever items happen to occupy the old row numbers. */
+	std::vector<wxUIntPtr> SaveSelection(wxUIntPtr &focused) const;
+
+	/** Re-apply a SaveSelection() snapshot. Items no longer in the model
+	 *  (filtered out, removed) are skipped. */
+	void RestoreSelection(const std::vector<wxUIntPtr> &selected, wxUIntPtr focused);
+
+	// --- text filter ------------------------------------------------------
+	/** True if @a name passes the current filter; an empty filter passes
+	 *  everything. Deliberately string-based: the filter lives here so the
+	 *  lists don't each carry a copy, but the control itself stays agnostic
+	 *  about what its rows represent. */
+	bool MatchesFilter(const wxString &name) const;
+
+	/** Rebuild the visible rows against the current filter. Overridden by the
+	 *  lists that support filtering; lists without one need nothing. */
+	virtual void RebuildFilteredView() {}
 
 	// --- subclass hooks -------------------------------------------------
 	/** Text for a cell, used by the virtual control (text-rendered lists and
@@ -142,6 +170,9 @@ private:
 	// lockstep for O(1) update/remove (rebuilt after any insert/erase/sort).
 	std::vector<wxUIntPtr> m_items;
 	std::unordered_map<wxUIntPtr, long> m_rowOf;
+
+	//! Live text filter, lower-cased; empty when inactive. See SetFilterText().
+	wxString m_filterText;
 
 	// Live auto-sort state.
 	bool m_resortPending;

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -303,39 +303,33 @@ bool CSharedFilesCtrl::IsLiveSortColumn() const
 void CSharedFilesCtrl::ShowFileList()
 {
 	Freeze();
+
+	// The rebuild renumbers every row, so keep selection + focus by item
+	// identity -- otherwise editing the filter (which comes through here)
+	// drops whatever the user had selected.
+	wxUIntPtr focused = 0;
+	const std::vector<wxUIntPtr> selected = SaveSelection(focused);
+
 	ClearItemData();
 
 	std::vector<CKnownFile *> files;
 	theApp->sharedfiles->CopyFileList(files);
 	for (CKnownFile *file : files) {
-		if (PassesTextFilter(file)) {
+		if (MatchesFilter(file->GetFileName().GetPrintable())) {
 			AppendItemData(reinterpret_cast<wxUIntPtr>(file));
 		}
 	}
 	FinishBulkLoad();
+	RestoreSelection(selected, focused);
 	ShowFilesCount();
 
 	Thaw();
 }
 
-bool CSharedFilesCtrl::PassesTextFilter(const CKnownFile *file) const
+void CSharedFilesCtrl::RebuildFilteredView()
 {
-	if (m_filterText.IsEmpty()) {
-		return true;
-	}
-	// Case-insensitive substring match on the file name (m_filterText is
-	// already lower-cased by SetFilterText()).
-	return file->GetFileName().GetPrintable().Lower().Contains(m_filterText);
-}
-
-void CSharedFilesCtrl::SetFilterText(const wxString &text)
-{
-	const wxString lower = text.Lower();
-	if (lower == m_filterText) {
-		return;
-	}
-	m_filterText = lower;
-	// Rebuild the model from the master share, applying the new filter.
+	// Filter hook from CMuleVirtualListCtrl: the master share is the model, so
+	// the visible set is rebuilt from it in one pass.
 	ShowFileList();
 }
 
@@ -378,7 +372,7 @@ void CSharedFilesCtrl::ShowFile(CKnownFile *file)
 {
 	// A newly-shared file that doesn't match the active filter stays hidden;
 	// it'll appear if the filter is cleared/changed (which rebuilds the model).
-	if (!PassesTextFilter(file)) {
+	if (!MatchesFilter(file->GetFileName().GetPrintable())) {
 		return;
 	}
 

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -58,7 +58,8 @@ public:
 	 * (case-insensitive) are shown; an empty string clears the filter. Purely
 	 * GUI-side, so it works the same in the monolithic app and amulegui.
 	 */
-	void SetFilterText(const wxString &text);
+	// SetFilterText() is inherited from CMuleVirtualListCtrl; the rebuild it
+	// triggers is RebuildFilteredView() below.
 
 	/** Empties the list (virtual-mode: clears the model + row index). */
 	void ClearList();
@@ -242,11 +243,11 @@ private:
 	//! Pointer used to ensure that the menu isn't displayed twice.
 	wxMenu *m_menu;
 
-	//! Live text filter (lower-cased), empty when inactive. See SetFilterText().
-	wxString m_filterText;
-
 	//! True if @a file passes the current text filter (name substring match).
-	bool PassesTextFilter(const CKnownFile *file) const;
+	/**
+	 * @see CMuleVirtualListCtrl::RebuildFilteredView
+	 */
+	virtual void RebuildFilteredView();
 
 	//! When true, UpdateItem() short-circuits and the bulk caller is
 	//! responsible for issuing a single Refresh() at end-of-bulk.


### PR DESCRIPTION
Fixes #669.

Typing in the transfer-window text filter froze the GUI for seconds on a large queue — @ghysler reports ~10 s per keystroke with 10k downloads, with keystrokes stacking up. The shared-files filter is instant at the same scale.

## Root cause

`SetFilterText()` re-evaluated every model item and called `ShowFile(file, visible)` for each. Every row that had to disappear went through `RemoveItemData()`, which does a full `RebuildRowIndex()` plus a `RefreshFromRow()` — **O(n) per removal**, so **O(n²)** for one keystroke. The shared-files filter is fast because it does the opposite: clears the model, re-appends the passing items, and finishes with a single `FinishBulkLoad()`.

`ChangeCategory()` had the identical shape, so switching category on a large queue was equally slow. That wasn't reported, but it's the same bug and is fixed here.

## Fix

`RebuildVisibleList()` clears, appends every item passing the current category + text filter, and finishes with one `FinishBulkLoad()` (one `SetItemCount`, one index rebuild, one sort) — **O(n log n) and a single repaint**. `ShowFileList()`, the filter and `ChangeCategory()` all route through it, so the three paths no longer duplicate the visibility loop. `ShowFilesCount(diff)` delegates to a new `SetFilesCount(count)` so the rebuild can set the count absolutely without duplicating the label update.

## De-duplicating the filter

The two lists had grown a filter each: identical `m_filterText` members, identical `SetFilterText()` bodies, and byte-identical `PassesTextFilter()` implementations differing only in the parameter type (`const CPartFile*` vs `const CKnownFile*`).

That now lives once in `CMuleVirtualListCtrl` — `m_filterText`, `SetFilterText()` and a string-based `MatchesFilter()`, plus a `RebuildFilteredView()` hook each list overrides with its own rebuild. `MatchesFilter()` takes a name rather than a file so the generic control keeps knowing nothing about what its rows represent, and each subclass is left owning only what is genuinely specific: which model it walks and what it matches on. (`CSearchListCtrl`'s filter is a regex on the non-virtual base and is untouched.)

## Selection preservation

A clear-and-re-append rebuild renumbers every row, and the virtual control tracks selection and focus by *row index* — so both would be dropped, where the incremental path kept them for free by leaving surviving rows untouched.

`CMuleVirtualListCtrl` grows `SaveSelection()` / `RestoreSelection()` for this. `SortList()` already did the same save-and-reapply inline and now shares them, and so does `CSharedFilesCtrl::ShowFileList()` — which fixes a pre-existing bug of its own: editing the shared-files filter dropped the selection.

## Testing

Built `amule` and `amulegui` clean. The algorithmic change is the substance here; a 10k-download reproduction wasn't available locally, so a real-world check on the reporter's setup is welcome before this is relied on.
