### PR TITLE
feat(search): EC_OP_SEARCH_LIST -- reachability fix for restored/foreign searches (#641)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -91,6 +91,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/stats/graphs/{graph}`](#get-apiv0statsgraphsgraph) — time-series points (`download`, `upload`, `connections`, `kad`)
 
 **Search**
+- [`GET /api/v0/search`](#get-apiv0search) — enumerate every search amuled currently holds, including ones this session never started
 - [`POST /api/v0/search`](#post-apiv0search) — start a search (global / local / kad), returns its `search_id`
 - [`GET /api/v0/search/results`](#get-apiv0searchresults) — one search's results + progress envelope (`?search_id=`)
 - [`POST /api/v0/search/stop`](#post-apiv0searchstop) — stop (and optionally free) a search by id
@@ -1910,6 +1911,27 @@ Each point is an object with `t` (ISO-8601 UTC), `t_unix` (unix seconds), and `v
 
 The search surface is admin-only because firing a global ed2k search has real network cost.
 
+#### `GET /api/v0/search`
+
+**Auth:** `GUEST`
+
+Lists every search amuled currently holds — including ones started by a **different** client (another amuleapi request, the monolithic GUI, an amulegui session). Each call is a direct round trip to amuled (`EC_OP_SEARCH_LIST`), independent of the Refresher-maintained `m_state` cache, so a search this process never saw a `POST /search` for still shows up here as soon as amuled is holding it. [`GET /search/results`](#get-apiv0searchresults) can then fetch that same `search_id` — on a cache miss it does its own one-off `EC_OP_SEARCH_LIST` check before returning `404`, so a search this endpoint just listed is never a dead end there.
+
+```json
+{
+  "searches": [
+    { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished" },
+    { "search_id": 43, "query": "debian",              "kind": "kad",    "state": "running"  }
+  ]
+}
+```
+
+`search_id` is the value to pass to [`GET /search/results`](#get-apiv0searchresults) (`?search_id=`) to read that search's hits, or to [`POST /search/stop`](#post-apiv0searchstop) to stop it. `kind` is `"local"` | `"global"` | `"kad"`, same vocabulary as `POST /search`'s `type`. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/results`'s `progress.state`.
+
+amuled only tracks multiple concurrent searches for clients that advertise multi-search support; `amuleapi` does, so this always reflects the full live set. `searches` is an empty array when amuled holds no searches, never an error.
+
+**Errors:** `503 ec_unavailable`.
+
 #### `POST /api/v0/search`
 
 **Auth:** `ADMIN`
@@ -1940,11 +1962,11 @@ Only `query` is required. `type` defaults to `"global"`; valid values are `"loca
 
 **Auth:** `GUEST`
 
-**Query:** `?search_id=N` (optional) — which search to read. Omit it to read the **current** (most-recently-started) search. An explicit `search_id` that names no live search (never started, or evicted — see below) returns `404 not_found`, distinct from a known-but-empty search which returns an idle/empty envelope.
+**Query:** `?search_id=N` (optional) — which search to read. Omit it to read the **current** (most-recently-started, by *this session* -- see below) search. An explicit `search_id` that names no live search (never started anywhere, or evicted from amuled's ring — see below) returns `404 not_found`, distinct from a known-but-empty search which returns an idle/empty envelope.
 
 Returns one search's results buffer at the moment of the call PLUS a progress envelope so an empty `results` array isn't ambiguous between "no search running", "search in flight with no hits yet", and "search finished with zero hits". The envelope's top-level `search_id` echoes the resolved search (the one requested, or the current one) so a client polling without an id learns which search it is watching and can pin it on later calls.
 
-This endpoint does NOT busy-wait — it returns whatever amuled has in its result buffer right now. A client that wants to wait for completion should poll while `progress.state == "running"`. There is no per-GET TTL cache: `POST /search` seeds the search and the refresher polls amuled (`EC_OP_SEARCH_RESULTS` + `EC_OP_SEARCH_PROGRESS`, addressed by `search_id`) every tick for each active search, so this GET reads straight from that refresher-maintained snapshot — successive polls see the growing result set with no extra EC roundtrip.
+This endpoint does NOT busy-wait — it returns whatever amuled has in its result buffer right now. A client that wants to wait for completion should poll while `progress.state == "running"`. There is no per-GET TTL cache: the refresher polls amuled (`EC_OP_SEARCH_RESULTS` + `EC_OP_SEARCH_PROGRESS`, addressed by `search_id`) every tick for each active search, so this GET reads straight from that refresher-maintained snapshot — successive polls see the growing result set with no extra EC roundtrip. `POST /search` is one way a search becomes active; an unknown `search_id` (one this session never started) triggers a one-off `EC_OP_SEARCH_LIST` check before the `404`, and once confirmed the search is active from that request on, with the refresher polling it every tick from there — so a search another client (or the monolithic GUI) started is fetchable by `search_id` too, not just listable via [`GET /search`](#get-apiv0search). Discovery alone never changes what "the current search" (the no-`search_id` default) means, though: that stays whichever search *this* session's own `POST /search` most recently started.
 
 amuled keeps a bounded ring of recent searches (20). A search evicted from that ring (because 20 newer searches were started) is reported to amuleapi as expired: its slot is retired as `finished` and reads with its `search_id` then return `404`.
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -303,7 +303,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -5918,6 +5918,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -5927,10 +5931,6 @@ msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -310,7 +310,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -6001,6 +6001,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6011,10 +6015,6 @@ msgstr "بحث"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -322,7 +322,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FALLU"
 
@@ -6111,6 +6111,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Alerta de gueta"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6122,10 +6126,6 @@ msgstr "Guetar"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamañu mínimu tien de ser menor al tamañu máximu. Tamañu máximu inoráu."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Alerta de gueta"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -310,7 +310,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -5977,6 +5977,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -5987,10 +5991,6 @@ msgstr "Търсене"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -302,7 +302,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -5917,6 +5917,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -5926,10 +5930,6 @@ msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -322,7 +322,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -6085,6 +6085,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Avís de cerca"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 
@@ -6095,10 +6099,6 @@ msgstr "Error en la cerca"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La mida mínima ha de ser menor que la màxima. S'ignorarà la mida màxima."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Avís de cerca"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -315,7 +315,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -6080,6 +6080,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Varování při vyhledávání"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6091,10 +6095,6 @@ msgstr "Vyhledávání"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost musí být menší než max. velikost. Ignoruji max. velikost."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Varování při vyhledávání"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -311,7 +311,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -6018,6 +6018,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6028,10 +6032,6 @@ msgstr "Søg"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -330,7 +330,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -6081,6 +6081,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Suchwarnung"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deaktiviert sind."
 
@@ -6091,10 +6095,6 @@ msgstr "Suchfehler"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Mindestgröße muss kleiner sein, als die Höchstgröße: Höchstgröße ignoriert."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Suchwarnung"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -326,7 +326,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
@@ -6125,6 +6125,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Προειδοποίηση ψαξίματος"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6136,10 +6140,6 @@ msgstr "Αναζητήσεις"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Το ελάχιστο μέγεθος πρέπει να είναι μικρότερο από το μέγιστο. Το μέγιστο μέγεθος θα αγνοηθεί."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Προειδοποίηση ψαξίματος"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -303,7 +303,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -5918,6 +5918,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -5927,10 +5931,6 @@ msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -332,7 +332,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -6066,6 +6066,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Aviso de búsqueda"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
@@ -6076,10 +6080,6 @@ msgstr "Error de búsqueda"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "El tamaño mínimo debe ser menor que el tamaño máximo. Tamaño máximo ignorado."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Aviso de búsqueda"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -322,7 +322,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIGA"
 
@@ -6088,6 +6088,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Otsingu hoiatus"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6099,10 +6103,6 @@ msgstr "Otsingud"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min suurus peab olema väiksem kui max suurus. Ignoreerin Max suurust."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Otsingu hoiatus"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -323,7 +323,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROREA"
 
@@ -6087,6 +6087,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Bilaketa oharra"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6098,10 +6102,6 @@ msgstr "Bilaketak"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Gutxienezko tamaina gehienezkoa baino txikiagoa izan behar da. Gehienezkoa alde batetara utziko da."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Bilaketa oharra"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -323,7 +323,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -6087,6 +6087,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Hakuvaroitus"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6098,10 +6102,6 @@ msgstr "Haut"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Vähimmäiskoon pitää olla pienempi kuin enimmäiskoon. Enimmäiskokoa ei huomioida."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Hakuvaroitus"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -330,7 +330,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -6060,6 +6060,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Avertissement dans la recherche"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossible d'effectuer une recherche."
 
@@ -6070,10 +6074,6 @@ msgstr "Erreur de recherche"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "La taille minimum doit être inférieur à la taille maximum. Taille maximum ignorée."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Avertissement dans la recherche"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -343,7 +343,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -6095,6 +6095,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Aviso na busca"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 
@@ -6105,10 +6109,6 @@ msgstr "Erro na busca"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O tamaño mínimo debe ser máis pequeno que o máximo. Tamaño máximo ignorado."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Aviso na busca"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -317,7 +317,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -6051,6 +6051,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6061,10 +6065,6 @@ msgstr "חיפושים"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -314,7 +314,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -6041,6 +6041,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6051,10 +6055,6 @@ msgstr "Pretrage"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -325,7 +325,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HIBA"
 
@@ -6062,6 +6062,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Keresési figyelmeztetés"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva."
 
@@ -6072,10 +6076,6 @@ msgstr "Keresési hiba"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "A minimum méretnek kisebbnek kell lennie a maximum méretnél. Maximum méret figyelmen kívül hagyva."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Keresési figyelmeztetés"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -335,7 +335,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -6066,6 +6066,10 @@ msgid "Clear search history"
 msgstr "Cancella la cronologia delle ricerche"
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Avviso di ricerca"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 
@@ -6076,10 +6080,6 @@ msgstr "Errore di ricerca"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min size deve essere più piccola di max size. Ignoro max size."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Avviso di ricerca"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -322,7 +322,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -6082,6 +6082,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "検索の注意"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6093,10 +6097,6 @@ msgstr "検索"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小サイズは最大サイズより小さくなければなりません。最大サイズを無視します。"
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "検索の注意"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -320,7 +320,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -6115,6 +6115,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "검색 경고"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6126,10 +6130,6 @@ msgstr "검색"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "최소 크기가 최대 크기보다 작아야 합니다. 최대 크기는 무시됩니다.."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "검색 경고"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -324,7 +324,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "KLAIDA"
 
@@ -6140,6 +6140,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Dėmesio"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6151,10 +6155,6 @@ msgstr "Paieška"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Apatinė dydžio riba turi būti mažesnė už viršutinę dydžio ribą. Įvestos viršutinės ribos nebus paisoma."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Dėmesio"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -306,7 +306,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' iestatījumu, taču amuleweb izpildāmo (bināro) datni nevar palaist. Lūdzu, uzstādiet pakotni, kas satur aMule tīmekļa serveri (amuleweb), vai pārkompilējiet aMule no pirmkoda ar -DBUILD_WEBSERVER=YES parametru un uzstādiet to."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "KĻŪDA"
 
@@ -5952,6 +5952,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
@@ -5961,10 +5965,6 @@ msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -324,7 +324,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amuleweb kan niet gestart worden. Installeer het pakket met de aMule webserver, of compileer aMule met --enable-webserver en draai make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -6090,6 +6090,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Zoekwaarschuwing"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 
@@ -6100,10 +6104,6 @@ msgstr "Fout tijdens zoeken"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min grootte moet kleiner zijn dan max grootte. Max grootte wordt genegeerd."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Zoekwaarschuwing"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -324,7 +324,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEIL"
 
@@ -6116,6 +6116,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Søkeåtvaring"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6127,10 +6131,6 @@ msgstr "Søk"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storleik må vere mindre enn maks storleik. Maks storleik ignorert."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Søkeåtvaring"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -324,7 +324,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -6119,6 +6119,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Ostrzeżenie wyszukiwania"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6130,10 +6134,6 @@ msgstr "Szukaj"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. rozmiar musi być mniejszy od maks. Zignorowano maks. rozmiar."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Ostrzeżenie wyszukiwania"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -330,7 +330,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -6063,6 +6063,10 @@ msgid "Clear search history"
 msgstr "Limpar o histórico de busca"
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Alerta da busca"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabilitadas."
 
@@ -6073,10 +6077,6 @@ msgstr "Erro na busca"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Tamanho min deve ser menor que tamanho max. Tamanho max ignorado."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Alerta da busca"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -329,7 +329,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -6095,6 +6095,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Aviso de pesquisa"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6106,10 +6110,6 @@ msgstr "Pesquisas"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "O Tamanho mínimo tem de ser menor que o tamanho máximo. Tamanho máximo ignorado."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Aviso de pesquisa"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -321,7 +321,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "EROARE"
 
@@ -6102,6 +6102,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Atenționare căutare"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6113,10 +6117,6 @@ msgstr "Căutări"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Dimensiunea mică trebuie să fie mai mică decât dimensiunea mare. Dimensiunea maximă s-a ignorat."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Atenționare căutare"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -328,7 +328,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Вы хотите запускать веб-сервер при загрузке, но исполняемый файл amuleweb не может быть запущен. Установите пакет содержащий веб-сервер aMule или скомпилируйте его с опцией --enable-webserver и запустите make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -6142,6 +6142,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Предупреждение поиска"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6153,10 +6157,6 @@ msgstr "Поиск"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Мин. размер должен быть меньше макс. размера. Игнорирую макс. размер."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Предупреждение поиска"
 
 # It's about default category to download to.
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -323,7 +323,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "NAPAKA"
 
@@ -6137,6 +6137,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Opozorilo iskanja"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 
@@ -6147,10 +6151,6 @@ msgstr "Napaka iskanja"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min. velikost mora biti manjša kot maks. velikost. Maks. velikost ni upoštevana."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Opozorilo iskanja"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -322,7 +322,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -6106,6 +6106,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "PoParalajmerim per kerkim"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6117,10 +6121,6 @@ msgstr "Kerkimet"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Masa minimale duhet te jete me e vogel se masa maksimale.Po injoroj Masen Maksimale.."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "PoParalajmerim per kerkim"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -321,7 +321,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEL"
 
@@ -6083,6 +6083,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Sökvarning"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6094,10 +6098,6 @@ msgstr "Sökningar"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Min storlek måste vara mindre än max storlek. Max storlek ignoreras."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Sökvarning"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -302,7 +302,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -5917,6 +5917,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -5926,10 +5930,6 @@ msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -323,7 +323,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HATA"
 
@@ -6053,6 +6053,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Arama uyarısı."
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak mümkün değildir."
 
@@ -6063,10 +6067,6 @@ msgstr "Arama hatası"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "En küçük boyut, en büyük boyuttan küçük olmalıdır. En büyük boyut göz ardı ediliyor."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Arama uyarısı."
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -321,7 +321,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
@@ -6142,6 +6142,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "Очікування пошуку"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6153,10 +6157,6 @@ msgstr "Пошук"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "Найменший розмір має бути меншим ніж найбільший. Найбільшим розміром знехтувано."
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "Очікування пошуку"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -302,7 +302,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr ""
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -5917,6 +5917,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr ""
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -5926,10 +5930,6 @@ msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
-msgstr ""
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
 msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -327,7 +327,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "错误"
 
@@ -6052,6 +6052,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "搜索警告"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 
@@ -6062,10 +6066,6 @@ msgstr "搜索错误"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必须小于最大值，最大值已被忽略。"
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "搜索警告"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 15:59+0200\n"
+"POT-Creation-Date: 2026-07-30 08:45+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -327,7 +327,7 @@ msgid "You requested to run web server on startup, but the amuleweb binary canno
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "錯誤"
 
@@ -6070,6 +6070,10 @@ msgid "Clear search history"
 msgstr ""
 
 #: src/SearchDlg.cpp
+msgid "Search warning"
+msgstr "搜尋警告"
+
+#: src/SearchDlg.cpp
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
 
@@ -6081,10 +6085,6 @@ msgstr "搜尋"
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr "最小值必須小於最大值，最大值已被忽略。"
-
-#: src/SearchDlg.cpp
-msgid "Search warning"
-msgstr "搜尋警告"
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Main"

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1647,6 +1647,22 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		// display a browse anyway).
 		const uint32 browseId = multiSearch ? AllocateBrowseSearchId() : 0;
 		const CECTag *reftag = tag->GetTagByName(EC_TAG_SEARCH_REF);
+		// A browse failure needs the correlation token for the same reason a
+		// failed search start does: amuleGUI created its optimistic browse tab
+		// (EnsureBrowseTab) before sending and has no other way to tell which
+		// browse this verdict answers, so without the echo the tab is stranded.
+		// "Client not found." is the ordinary case -- the peer gets reaped
+		// between the user seeing the row and clicking View Files (got3nks,
+		// PR #680 review).
+		auto browseFailure = [reftag](const wxString &msg) {
+			CECPacket *fail = new CECPacket(EC_OP_FAILED);
+			fail->AddTag(CECTag(EC_TAG_STRING, msg));
+			if (reftag) {
+				fail->AddTag(
+					CECTag(EC_TAG_SEARCH_REF, static_cast<uint32>(reftag->GetInt())));
+			}
+			return fail;
+		};
 		const CECTag *subtag = tag->GetTagByName(EC_TAG_FRIEND);
 		if (subtag) {
 			CFriend *Friend = theApp->friendlist->FindFriend(subtag->GetInt());
@@ -1654,8 +1670,7 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 				theApp->friendlist->RequestSharedFileList(Friend, browseId);
 				response = BuildBrowseReply(browseId, reftag);
 			} else {
-				response = new CECPacket(EC_OP_FAILED);
-				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Friend not found.")));
+				response = browseFailure(wxTRANSLATE("Friend not found."));
 			}
 		} else if ((subtag = tag->GetTagByName(EC_TAG_CLIENT))) {
 			CUpDownClient *client = theApp->clientlist->FindClientByECID(subtag->GetInt());
@@ -1664,14 +1679,11 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 				client->RequestSharedFileList();
 				response = BuildBrowseReply(browseId, reftag);
 			} else {
-				response = new CECPacket(EC_OP_FAILED);
-				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Client not found.")));
+				response = browseFailure(wxTRANSLATE("Client not found."));
 			}
 		} else {
-			response = new CECPacket(EC_OP_FAILED);
-			response->AddTag(CECTag(EC_TAG_STRING,
-				wxTRANSLATE(
-					"EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT.")));
+			response = browseFailure(
+				wxTRANSLATE("EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."));
 		}
 	}
 
@@ -1738,11 +1750,13 @@ public:
 
 	bool Has(uint32 id) const { return std::find(m_lru.begin(), m_lru.end(), id) != m_lru.end(); }
 
-	// Explicit close (tab close): stop activity, free results, drop from ring.
-	void Close(uint32 id)
+	// Drop id from the ring/current without touching core search state.
+	// For a search this registry tracks, call alongside the caller's own
+	// (unconditional) CSearchList::RemoveResults, instead of Close(), when
+	// the id may or may not be one this registry knows about.
+	void Forget(uint32 id)
 	{
 		m_lru.remove(id);
-		theApp->searchlist->RemoveResults(id);
 		if (m_current == id) {
 			m_current = 0;
 		}
@@ -1879,16 +1893,22 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // which demuxes by search ID), and its container's bulk-delete-on-poll works
 // correctly across the union. Only reached for m_multiSearchActive clients.
 //
-// Enumerates CSearchList::GetKnownSearchIds() -- every search the core holds,
-// started by the monolithic GUI or by any EC client -- rather than
-// s_ecSearches.ActiveIds(), which only ever holds EC-initiated searches
-// (Register() is called from exactly one place, the EC_OP_SEARCH_START
-// handler). A monolithic-started search's results would otherwise never
-// reach amulegui even once Get_EC_Response_Search_List (below) learned to
-// enumerate it: the two have to agree on the same set, or a discovered tab
-// appears and never fills. s_ecSearches keeps governing EC-client lifecycle
-// and eviction only -- folding monolithic searches into that 20-entry LRU
-// would let unrelated EC traffic evict, and so stop, a local user's own
+// Enumerates CSearchList::GetKnownSearchIds() + GetBrowseSearchIds() -- every
+// search AND "View Files" browse tab the core holds, started by the
+// monolithic GUI or by any EC client -- rather than s_ecSearches.ActiveIds(),
+// which only ever holds EC-initiated searches (Register() is called from
+// exactly one place, the EC_OP_SEARCH_START handler). A monolithic-started
+// search's results would otherwise never reach amulegui even once
+// Get_EC_Response_Search_List (below) learned to enumerate it: the two have
+// to agree on the same set, or a discovered tab appears and never fills.
+// Browses need their own second source here (but NOT in
+// Get_EC_Response_Search_List -- see that function) since a browse tab is
+// not a CSearchList search and so is absent from m_searchStrings; without
+// it, a browse's own STRINGS reply (BuildBrowseReply) tells the client to
+// expect results on this id, but this union never sends any (got3nks, PR
+// #680 review). s_ecSearches keeps governing EC-client lifecycle and
+// eviction only -- folding monolithic searches into that 20-entry LRU would
+// let unrelated EC traffic evict, and so stop, a local user's own
 // still-running Kad search.
 static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 {
@@ -1898,7 +1918,7 @@ static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 	// container retains its items across searches (it no longer flushes on a
 	// new search), so a result is never re-created from a diffed tag — no
 	// ghosts — while re-sending unchanged results every poll stays cheap.
-	for (uint32 sid : theApp->searchlist->GetKnownSearchIds()) {
+	auto emitResultsFor = [&](uint32 sid) {
 		const CSearchResultList &list = theApp->searchlist->GetSearchResults(sid);
 		for (CSearchFile *sf : list) {
 			CValueMap &valuemap = tagmap.GetValueMap(sf->ECID());
@@ -1911,20 +1931,36 @@ static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 				}
 			}
 		}
+	};
+	for (const auto &entry : theApp->searchlist->GetKnownSearchIds()) {
+		emitResultsFor(entry.first);
+	}
+	for (const auto &entry : theApp->searchlist->GetBrowseSearchIds()) {
+		emitResultsFor(static_cast<uint32>(entry.first));
 	}
 	return response;
 }
 
-// Enumerates every search the core currently holds
-// (CSearchList::GetKnownSearchIds(), the same source the union poll above
-// now reads) so a client that never started any of them locally -- a
-// freshly (re)connected amulegui, a stateless amuleapi request, or a search
-// typed directly into the monolithic GUI -- can discover what to ask about
-// and build tabs for it. One entry per known search: EC_TAG_SEARCH_ID as the
-// entry's own value, with name/kind/state as children. Only reached for
-// m_multiSearchActive clients (see the EC_OP_SEARCH_LIST case below): a
-// legacy client has no concept of more than the single 0xffffffff sentinel
-// search, so there is nothing meaningful to enumerate for it.
+// Enumerates every *search* the core currently holds
+// (CSearchList::GetKnownSearchIds() -- deliberately narrow, unlike the union
+// poll above, which also reads GetBrowseSearchIds()) so a client that never
+// started any of them locally -- a freshly (re)connected amulegui, a
+// stateless amuleapi request, or a search typed directly into the monolithic
+// GUI -- can discover what to ask about and build tabs for it. One entry per
+// known search: EC_TAG_SEARCH_ID as the entry's own value, with name/kind/
+// state as children. Only reached for m_multiSearchActive clients (see the
+// EC_OP_SEARCH_LIST case below): a legacy client has no concept of more than
+// the single 0xffffffff sentinel search, so there is nothing meaningful to
+// enumerate for it.
+//
+// Must NOT also enumerate browse ids: a "View Files" tab already gets its own
+// tab via BuildBrowseReply's STRINGS reply (which rekeys through the same
+// RemapSearch path a search START does) the moment the user opens it, so
+// there is nothing here for a browse to be *discovered* by another client
+// for -- browsing is inherently per-request, not a standing search another
+// client could ever come to know about. Folding it in here anyway would
+// surface every open browse as a bogus search tab, with a made-up name, on
+// every connected client (got3nks, PR #680 review).
 // amuleapi's SearchKindToString/SearchLifecycleStateToString (Api.cpp) decode
 // the two wire values written below from raw numeric literals, since amuleapi
 // cannot include SearchList.h. This file can see both CSearchList's enums and
@@ -1946,9 +1982,12 @@ static CECPacket *Get_EC_Response_Search_List()
 {
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_LIST);
 
-	for (uint32 sid : theApp->searchlist->GetKnownSearchIds()) {
+	for (const auto &known : theApp->searchlist->GetKnownSearchIds()) {
+		uint32 sid = known.first;
 		CECTag entry(EC_TAG_SEARCH_ID, sid);
-		entry.AddTag(EC_TAG_SEARCH_NAME, theApp->searchlist->GetSearchStringById(sid));
+		// known.second is the same string GetSearchStringById(sid) would
+		// look up -- already have it from this map entry, no need to re-find.
+		entry.AddTag(EC_TAG_SEARCH_NAME, known.second);
 		entry.AddTag(EC_TAG_SEARCH_LIFECYCLE_KIND,
 			static_cast<uint64_t>(
 				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleKindById(sid))));
@@ -1991,13 +2030,29 @@ static CECPacket *Get_EC_Response_Search_Stop(const CECPacket *request, bool mul
 {
 	CECPacket *reply = new CECPacket(EC_OP_MISC_DATA);
 	if (multiSearch) {
-		// Per-ID stop. No ID => the most-recently-started search.
+		// Per-ID stop. No ID => the most-recently-started search. Gate on the
+		// core's own knowledge (CSearchList::IsKnownSearchId), not
+		// s_ecSearches: a monolithic-started search is known to the core but
+		// was never Register()'d into that EC-only registry, so gating on
+		// the registry alone silently no-ops both Stop and Close for it --
+		// the search never actually goes away and reappears as a tab on the
+		// next connect.
 		const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 		uint32 sid = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
-		if (sid != 0 && s_ecSearches.Has(sid)) {
+		if (sid != 0 && theApp->searchlist->IsKnownSearchId(sid)) {
 			if (request->GetTagByName(EC_TAG_SEARCH_CLOSE)) {
 				// Tab close: stop activity, free results, drop from the ring.
-				s_ecSearches.Close(sid);
+				// Free the core's state unconditionally -- that is what
+				// actually stops a running Kad search and erases the
+				// per-id maps (including m_searchStrings, which is what
+				// stops the search reappearing as a discovered tab). Only
+				// touch the registry's own bookkeeping (LRU/current) when
+				// it's a search the registry actually tracks -- same
+				// discipline as guarding Touch() behind Has() last round.
+				theApp->searchlist->RemoveResults(sid);
+				if (s_ecSearches.Has(sid)) {
+					s_ecSearches.Forget(sid);
+				}
 			} else {
 				// Stop button: halt activity but keep the results.
 				theApp->searchlist->StopSearchById(sid);
@@ -2016,11 +2071,15 @@ static CECPacket *Get_EC_Response_Search_Request_More(const CECPacket *request, 
 	// single source of truth shared with the monolithic GUI); that line is
 	// forwarded back to amuleGUI over EC, so the reply here is a plain ack.
 	CECPacket *reply = new CECPacket(EC_OP_MISC_DATA);
-	// Per-ID. No ID => the most-recently-started search.
+	// Per-ID. No ID => the most-recently-started search. Gate on the core's
+	// own knowledge (CSearchList::IsKnownSearchId), not s_ecSearches -- see
+	// the matching comment in Get_EC_Response_Search_Stop: a monolithic-
+	// started Kad search's "More results" button would otherwise silently
+	// do nothing.
 	const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 	uint32 sid =
 		idTag ? static_cast<uint32>(idTag->GetInt()) : (multiSearch ? s_ecSearches.Current() : 0);
-	if (sid != 0 && (!multiSearch || s_ecSearches.Has(sid))) {
+	if (sid != 0 && (!multiSearch || theApp->searchlist->IsKnownSearchId(sid))) {
 		theApp->searchlist->RequestMoreResults(sid);
 	}
 	return reply;
@@ -2099,9 +2158,20 @@ static CECPacket *Get_EC_Response_Search(const CECPacket *request, bool multiSea
 	reply->AddTag(CECTag(EC_TAG_STRING, response));
 	if (multiSearch && started) {
 		// Hand the daemon-allocated ID back so the client can address this
-		// search, and echo the client's correlation token (if any) so it can
-		// match this reply to the tab it created before the reply arrived.
+		// search.
 		reply->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
+	}
+	if (multiSearch) {
+		// Echo the client's correlation token (if any) on BOTH outcomes, not
+		// just success: the client created its optimistic tab before sending
+		// and has no other way to tell which start this verdict answers. On
+		// failure it needs the token to drop that phantom tab and release the
+		// discovery deferral -- otherwise the id sits in m_pendingSearchStarts
+		// until the user happens to close exactly that tab, with an
+		// EC_OP_SEARCH_LIST round trip every tick and discovery off in the
+		// meantime. Same principle as echoing the id on EC_TAG_SEARCH_EXPIRED:
+		// a verdict the client cannot correlate is one it cannot act on
+		// (got3nks, PR #680 review).
 		const CECTag *ref = request->GetTagByName(EC_TAG_SEARCH_REF);
 		if (ref) {
 			reply->AddTag(CECTag(EC_TAG_SEARCH_REF, static_cast<uint32>(ref->GetInt())));
@@ -2808,6 +2878,20 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			// monolithic-started search's progress isn't reported as expired.
 			if (want == 0 || !theApp->searchlist->IsKnownSearchId(want)) {
 				response->AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
+				// Echo the id this verdict is about. amulegui reads the
+				// whole progress reply under `if (idTag)` -- it has to,
+				// since it polls several searches and the replies are not
+				// correlated any other way -- so an EXPIRED carrying no id
+				// was silently unreadable: the tab for a search the core
+				// had already freed stayed open forever, its results
+				// dropped by the next union poll, leaving a tab whose rows
+				// point at nothing (sorting/scrolling it does nothing).
+				// `want` is safe to echo even for an unknown id: it is the
+				// value the client itself just asked about (got3nks, PR
+				// #680 review).
+				if (want != 0) {
+					response->AddTag(CECTag(EC_TAG_SEARCH_ID, want));
+				}
 				break;
 			}
 			if (s_ecSearches.Has(want)) {

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1878,6 +1878,18 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // routes each result to the right tab by that ID (mirrors the monolithic GUI,
 // which demuxes by search ID), and its container's bulk-delete-on-poll works
 // correctly across the union. Only reached for m_multiSearchActive clients.
+//
+// Enumerates CSearchList::GetKnownSearchIds() -- every search the core holds,
+// started by the monolithic GUI or by any EC client -- rather than
+// s_ecSearches.ActiveIds(), which only ever holds EC-initiated searches
+// (Register() is called from exactly one place, the EC_OP_SEARCH_START
+// handler). A monolithic-started search's results would otherwise never
+// reach amulegui even once Get_EC_Response_Search_List (below) learned to
+// enumerate it: the two have to agree on the same set, or a discovered tab
+// appears and never fills. s_ecSearches keeps governing EC-client lifecycle
+// and eviction only -- folding monolithic searches into that 20-entry LRU
+// would let unrelated EC traffic evict, and so stop, a local user's own
+// still-running Kad search.
 static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 {
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_RESULTS);
@@ -1886,7 +1898,7 @@ static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 	// container retains its items across searches (it no longer flushes on a
 	// new search), so a result is never re-created from a diffed tag — no
 	// ghosts — while re-sending unchanged results every poll stays cheap.
-	for (uint32 sid : s_ecSearches.ActiveIds()) {
+	for (uint32 sid : theApp->searchlist->GetKnownSearchIds()) {
 		const CSearchResultList &list = theApp->searchlist->GetSearchResults(sid);
 		for (CSearchFile *sf : list) {
 			CValueMap &valuemap = tagmap.GetValueMap(sf->ECID());
@@ -1900,6 +1912,52 @@ static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 			}
 		}
 	}
+	return response;
+}
+
+// Enumerates every search the core currently holds
+// (CSearchList::GetKnownSearchIds(), the same source the union poll above
+// now reads) so a client that never started any of them locally -- a
+// freshly (re)connected amulegui, a stateless amuleapi request, or a search
+// typed directly into the monolithic GUI -- can discover what to ask about
+// and build tabs for it. One entry per known search: EC_TAG_SEARCH_ID as the
+// entry's own value, with name/kind/state as children. Only reached for
+// m_multiSearchActive clients (see the EC_OP_SEARCH_LIST case below): a
+// legacy client has no concept of more than the single 0xffffffff sentinel
+// search, so there is nothing meaningful to enumerate for it.
+// amuleapi's SearchKindToString/SearchLifecycleStateToString (Api.cpp) decode
+// the two wire values written below from raw numeric literals, since amuleapi
+// cannot include SearchList.h. This file can see both CSearchList's enums and
+// the EC ones, so it is the one place that can catch a reorder at compile
+// time instead of amuleapi silently mislabelling a search.
+static_assert(CSearchList::SEARCH_LIFECYCLE_IDLE == 0 && CSearchList::SEARCH_LIFECYCLE_RUNNING == 1 &&
+		      CSearchList::SEARCH_LIFECYCLE_FINISHED == 2,
+	"CSearchList::SearchLifecycleState numeric values must stay in sync with "
+	"the wire values EC_TAG_SEARCH_LIFECYCLE_STATE carries and Api.cpp's "
+	"SearchLifecycleStateToString decodes");
+static_assert(static_cast<int>(LocalSearch) == static_cast<int>(EC_SEARCH_LOCAL) &&
+		      static_cast<int>(GlobalSearch) == static_cast<int>(EC_SEARCH_GLOBAL) &&
+		      static_cast<int>(KadSearch) == static_cast<int>(EC_SEARCH_KAD),
+	"CSearchList::SearchType must stay numerically aligned with EC_SEARCH_TYPE "
+	"since EC_TAG_SEARCH_LIFECYCLE_KIND carries a SearchType value that "
+	"amuleapi's SearchKindToString (Api.cpp) decodes against EC_SEARCH_*");
+
+static CECPacket *Get_EC_Response_Search_List()
+{
+	CECPacket *response = new CECPacket(EC_OP_SEARCH_LIST);
+
+	for (uint32 sid : theApp->searchlist->GetKnownSearchIds()) {
+		CECTag entry(EC_TAG_SEARCH_ID, sid);
+		entry.AddTag(EC_TAG_SEARCH_NAME, theApp->searchlist->GetSearchStringById(sid));
+		entry.AddTag(EC_TAG_SEARCH_LIFECYCLE_KIND,
+			static_cast<uint64_t>(
+				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleKindById(sid))));
+		entry.AddTag(EC_TAG_SEARCH_LIFECYCLE_STATE,
+			static_cast<uint64_t>(
+				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleStateById(sid))));
+		response->AddTag(entry);
+	}
+
 	return response;
 }
 
@@ -2686,6 +2744,13 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = Get_EC_Response_Search_Request_More(request, m_multiSearchActive);
 		break;
 
+	case EC_OP_SEARCH_LIST:
+		// Legacy (non-multi) clients have only the single sentinel search
+		// and no tab-per-id concept, so there is nothing to enumerate.
+		response = m_multiSearchActive ? Get_EC_Response_Search_List()
+					       : new CECPacket(EC_OP_SEARCH_LIST);
+		break;
+
 	case EC_OP_SEARCH_RESULTS: {
 		const bool incUpdate = (request->GetDetailLevel() == EC_DETAIL_INC_UPDATE);
 		// amulegui (multi + INC_UPDATE) polls all its searches at once: return
@@ -2701,14 +2766,26 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		if (m_multiSearchActive) {
 			const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 			uint32 want = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
-			if (want == 0 || !s_ecSearches.Has(want)) {
+			// Gate on the core's own knowledge (CSearchList::IsKnownSearchId),
+			// not s_ecSearches: that registry only ever holds EC-initiated
+			// searches (Register() runs from the EC_OP_SEARCH_START handler
+			// alone), so gating on it reports a monolithic-started search as
+			// expired even while it is still running.
+			if (want == 0 || !theApp->searchlist->IsKnownSearchId(want)) {
 				// Evicted or never-known: tell the client it expired rather
 				// than returning a misleading empty result set.
 				response = new CECPacket(EC_OP_SEARCH_RESULTS);
 				response->AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
 				break;
 			}
-			s_ecSearches.Touch(want);
+			// Only bump the EC-session LRU for a search that registry
+			// actually tracks -- Touch() on an id it doesn't know would
+			// silently insert it (push_front has no "was it found" guard),
+			// growing the ring past kMaxEcSearches for ids Register() never
+			// admitted through its own eviction loop.
+			if (s_ecSearches.Has(want)) {
+				s_ecSearches.Touch(want);
+			}
 			sid = want;
 		}
 		if (incUpdate) {
@@ -2726,11 +2803,16 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		if (m_multiSearchActive) {
 			const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 			uint32 want = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
-			if (want == 0 || !s_ecSearches.Has(want)) {
+			// See the matching comment in the EC_OP_SEARCH_RESULTS case above:
+			// gate on the core's own knowledge, not the EC-only registry, so a
+			// monolithic-started search's progress isn't reported as expired.
+			if (want == 0 || !theApp->searchlist->IsKnownSearchId(want)) {
 				response->AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
 				break;
 			}
-			s_ecSearches.Touch(want);
+			if (s_ecSearches.Has(want)) {
+				s_ecSearches.Touch(want);
+			}
 			sid = want;
 			// A browse ("View Files") ID is not a CSearchList search: report its
 			// lifecycle from the persisted browse state (browsing / finished /

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -699,6 +699,15 @@ void Browse_Status(uint64 NOT_ON_DAEMON(searchID), uint32 NOT_ON_DAEMON(status))
 // so a const-ref parameter would dangle. This mirrors every other wxString
 // notify handler here.
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
+void Search_Removed(wxUIntPtr NOT_ON_DAEMON(searchID))
+{
+#ifndef AMULE_DAEMON
+	if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+		theApp->amuledlg->m_searchwnd->CloseSearchTab(searchID);
+	}
+#endif
+}
+
 void Browse_Started(uint32 NOT_ON_DAEMON(ecid), wxString NOT_ON_DAEMON(name), uint64 NOT_ON_DAEMON(searchID))
 {
 #ifndef AMULE_DAEMON

--- a/src/GuiEvents.h
+++ b/src/GuiEvents.h
@@ -126,6 +126,17 @@ void KnownFileBeingDestroyed(CKnownFile *file);
 // its pointer instead of dangling. See CCommentDialogLst::DropReferencesTo.
 void SearchFileBeingDestroyed(CSearchFile *file);
 
+// Fired from CSearchList::RemoveResults, once per search whose bucket is
+// freed, so a tab still open on it closes instead of outliving the results.
+// Needed the moment closing a tab genuinely frees the search (got3nks, PR
+// #680 review): in a monolithic build the GUI and core share the same
+// CSearchFile objects, which CSearchListCtrl holds as raw pointers via
+// SetItemPtrData and in m_filteredOut, so a tab left open over a freed
+// bucket faults on the next repaint, sort, scroll or click. It also gives
+// the monolithic GUI the local counterpart of amulegui's remote-driven tab
+// close, rather than two mechanisms for one idea.
+void Search_Removed(wxUIntPtr searchID);
+
 void ServerAdd(CServer *server);
 void ServerRemove(CServer *server);
 void ServerRemoveDead();
@@ -519,6 +530,10 @@ typedef void (wxEvtHandler::*MuleNotifyEventFunction)(CMuleGUIEvent &);
 // doc-comment in this header.
 #define Notify_SearchFileBeingDestroyed(file) \
 	MuleNotify::DoNotify(&MuleNotify::SearchFileBeingDestroyed, file)
+
+// A search's result bucket was freed — see MuleNotify::Search_Removed
+// doc-comment in this header.
+#define Notify_Search_Removed(id) MuleNotify::DoNotify(&MuleNotify::Search_Removed, id)
 
 // server
 #define Notify_ServerAdd(ptr) MuleNotify::DoNotify(&MuleNotify::ServerAdd, ptr)

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -93,6 +93,8 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 : wxPanel(pParent, -1)
 {
 	m_last_search_time = 0;
+	m_expiringSearchID = 0;
+	m_inSearchClosing = false;
 
 	wxSizer *content = searchDlg(this, true);
 	content->Show(this, true);
@@ -501,19 +503,62 @@ void CSearchDlg::OnFilterCheckChange(wxCommandEvent &event)
 	}
 }
 
+namespace
+{
+// Sets a bool for the lifetime of the scope. Local to this file: the one
+// use is OnSearchClosing's re-entrancy guard, which is not worth a shared
+// utility header.
+class CScopedFlag
+{
+public:
+	explicit CScopedFlag(bool &flag)
+	: m_flag(flag)
+	{
+		m_flag = true;
+	}
+	~CScopedFlag() { m_flag = false; }
+	CScopedFlag(const CScopedFlag &) = delete;
+	CScopedFlag &operator=(const CScopedFlag &) = delete;
+
+private:
+	bool &m_flag;
+};
+} // namespace
+
 void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 {
 	CSearchListCtrl *ctrl = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(evt.GetSelection()));
 	wxASSERT(ctrl);
+	// Capture the ID *before* ShowResults(0), which sets m_nResultsID = 0 --
+	// so every GetSearchId() after that line returns 0, and the stop/free
+	// calls below silently addressed search 0 rather than this tab's search:
+	// no EC_OP_SEARCH_STOP was ever sent, RemoveResults(0) freed nothing, and
+	// m_searchProgress.erase(0) left the real entry behind. Predates the
+	// multi-search work -- identical on master, ordering and all -- but it is
+	// what made the daemon-side close gate look correct while the request it
+	// gates never actually arrived (got3nks, PR #680 review).
+	const wxUIntPtr searchID = ctrl->GetSearchId();
+	// RemoveResults below fires MuleNotify::Search_Removed, which routes back
+	// into CloseSearchTab for this very tab; the flag makes that a no-op
+	// instead of a recursive close (see m_inSearchClosing). Scoped so it
+	// clears on every exit path.
+	CScopedFlag closingGuard(m_inSearchClosing);
 	// Zero to avoid results added while destructing.
 	ctrl->ShowResults(0);
-	m_searchProgress.erase(ctrl->GetSearchId());
+	m_searchProgress.erase(searchID);
 #ifdef CLIENT_GUI
 	// Remote multi-search: closing a tab stops *and* frees that specific
 	// search on the daemon (leaving other tabs' searches running). On a
 	// legacy daemon this degrades to a parameterless stop of the single
 	// search — which is the same "abort on close" behaviour as before.
-	theApp->searchlist->StopSearchById(ctrl->GetSearchId(), true);
+	// Skipped when CloseSearchTab is the one driving this (DeletePage
+	// fires this handler synchronously): the daemon already discarded
+	// this id, so a stop request for it would be a wasted round trip
+	// (got3nks, PR #680 review).
+	if (searchID != m_expiringSearchID) {
+		theApp->searchlist->StopSearchById(searchID, true);
+	}
+	m_expiringSearchID = 0;
 #else
 	// Monolithic: abort the global search if it was the last tab closed;
 	// RemoveResults below stops any Kad search and frees the bucket in-process.
@@ -521,12 +566,86 @@ void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 		OnBnClickedStop(nullEvent);
 	}
 #endif
-	theApp->searchlist->RemoveResults(ctrl->GetSearchId());
+	theApp->searchlist->RemoveResults(searchID);
 
 	// Do cleanups if this was the last tab
 	if (m_notebook->GetPageCount() == 1) {
 		FindWindow(IDC_SDOWNLOAD)->Enable(false);
 		FindWindow(IDC_CLEAR_RESULTS)->Enable(false);
+	}
+}
+
+void CSearchDlg::OnStartRejected(wxUIntPtr searchID, const wxString &error)
+{
+	// A rejected browse ("View Files") reaches this same path in amuleGUI --
+	// SendBrowseRequest sends the same EC_TAG_SEARCH_REF and the daemon echoes
+	// it on its failure exits too. It needs the tab dropped and the reason
+	// shown, but NOT the search-button reset below: the user never pressed
+	// Search, so clearing Download/Stop would disable them for whatever search
+	// tab happens to be visible. Read the tab's kind before closing it.
+	const CSearchListCtrl *ctrl = GetSearchList(searchID);
+	const bool wasBrowse = ctrl && ctrl->IsBrowse();
+
+	// Drop the tab the client optimistically created for a start that never
+	// happened (no-op in the monolithic build, which creates none).
+	CloseSearchTab(searchID);
+
+	if (!error.IsEmpty()) {
+		// Deferred off the current call stack: in amuleGUI this runs inside
+		// CECSocket's reply handling, and wxMessageBox spins a nested event
+		// loop that re-enters CECSocket::OnInput and clobbers its rx state --
+		// the same hazard CAddLinkHandler documents. Harmless in the
+		// monolithic build, so both go through the one path.
+		//
+		// `error` is captured BY VALUE, not by reference: it is a const& to
+		// the caller's string and this body runs after that caller has
+		// returned. (The capture is also why there is no named local copy --
+		// performance-unnecessary-copy-initialization flags that, while the
+		// copy itself is required.)
+		const wxString title = wasBrowse ? _("ERROR") : _("Search warning");
+		wxTheApp->CallAfter([error, title]() {
+			wxMessageBox(error, title, wxOK | wxCENTRE | wxICON_INFORMATION);
+		});
+	}
+
+	if (!wasBrowse) {
+		// Back to the pre-search button state: the search never started, so
+		// "Stop" must not stay armed for it.
+		FindWindow(IDC_STARTS)->Enable();
+		FindWindow(IDC_SDOWNLOAD)->Disable();
+		FindWindow(IDC_CANCELS)->Disable();
+	}
+}
+
+void CSearchDlg::CloseSearchTab(wxUIntPtr searchID)
+{
+	if (m_inSearchClosing) {
+		// Already closing a tab: this is the monolithic close path calling
+		// back into us (OnSearchClosing -> CSearchList::RemoveResults ->
+		// MuleNotify::Search_Removed -> here) for the tab it is itself in
+		// the middle of removing. That path does the whole job already.
+		return;
+	}
+	CSearchListCtrl *ctrl = GetSearchList(searchID);
+	if (!ctrl) {
+		return; // no tab open for this id -- nothing to do
+	}
+	int nPages = (int)m_notebook->GetPageCount();
+	for (int i = 0; i < nPages; i++) {
+		if (m_notebook->GetPage(i) != ctrl) {
+			continue;
+		}
+		// DeletePage fires PAGE_CLOSING synchronously (see MuleNotebook.cpp),
+		// which re-enters OnSearchClosing on this same call stack and does
+		// all the cleanup -- ShowResults(0), m_searchProgress.erase,
+		// RemoveResults, last-tab button disabling -- itself. Setting this
+		// first tells it to skip only the StopSearchById call: the core has
+		// already discarded this id (amuleGUI got EC_TAG_SEARCH_EXPIRED for
+		// it; monolithic freed the bucket), so a stop request for it would
+		// be a wasted round trip (got3nks, PR #680 review).
+		m_expiringSearchID = searchID;
+		m_notebook->DeletePage(i);
+		break;
 	}
 }
 
@@ -1008,11 +1127,12 @@ void CSearchDlg::StartNewSearch()
 #endif
 	wxString error = theApp->searchlist->StartNewSearch(&real_id, search_type, params);
 	if (!error.IsEmpty()) {
-		// Search failed / Remote in progress
-		wxMessageBox(error, _("Search warning"), wxOK | wxCENTRE | wxICON_INFORMATION, this);
-		FindWindow(IDC_STARTS)->Enable();
-		FindWindow(IDC_SDOWNLOAD)->Disable();
-		FindWindow(IDC_CANCELS)->Disable();
+		// Search failed / Remote in progress. Shared with amuleGUI's
+		// EC_OP_FAILED path so both builds report a rejected start the same
+		// way (got3nks, PR #680 review). Note amuleGUI never reaches here:
+		// CSearchListRem::StartNewSearch returns "" unconditionally and the
+		// rejection arrives later over EC.
+		OnStartRejected(real_id, error);
 	} else {
 		CreateNewTab(((search_type == KadSearch) ? "!" : "") + params.searchString + " (0)", real_id);
 	}

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -132,6 +132,44 @@ public:
 	// local ID to the daemon-allocated one once the START reply arrives.
 	void RekeySearch(wxUIntPtr oldID, wxUIntPtr newID);
 
+	// The core rejected something this dialog optimistically opened a tab for:
+	// report the reason and undo the tab. Covers both a search start and a
+	// "View Files" browse, since in amuleGUI both are optimistic and both come
+	// back as EC_OP_FAILED carrying the same EC_TAG_SEARCH_REF (got3nks, PR
+	// #680 review).
+	//
+	// The monolithic build calls it directly from OnBnClickedStart, which has
+	// the error string in hand; amuleGUI reaches it from the EC_OP_FAILED
+	// reply, since CSearchListRem::StartNewSearch returns "" unconditionally
+	// and the rejection only arrives later over EC. Sharing the one path is
+	// what keeps a rejected start looking the same in both builds.
+	//
+	// searchID is the optimistic tab id: amuleGUI has already created that tab
+	// and needs it dropped, the monolithic build never created one and
+	// CloseSearchTab no-ops there. The search-button reset is skipped for a
+	// browse -- the user never pressed Search, so it would wrongly disable
+	// Download/Stop for whichever search tab is visible.
+	void OnStartRejected(wxUIntPtr searchID, const wxString &error);
+
+	// This search's results are gone -- close its tab, since a tab left open
+	// on a freed search can only mislead (in amuleGUI "Download" would
+	// silently do nothing, the daemon's m_results no longer having the hash;
+	// in the monolithic build the rows hold raw CSearchFile pointers that
+	// have just been deleted). One entry point for both builds, since it is
+	// one idea (got3nks, PR #680 review):
+	//   - amuleGUI: EC_TAG_SEARCH_EXPIRED, i.e. another client closed the
+	//     search or the daemon's LRU evicted it.
+	//   - monolithic: MuleNotify::Search_Removed, fired by
+	//     CSearchList::RemoveResults whenever a bucket is freed.
+	// Goes through the normal DeletePage path so OnSearchClosing does the
+	// actual cleanup in one place; m_expiringSearchID tells it to skip
+	// StopSearchById, which for both callers would address a search the core
+	// has already discarded. No-op if no tab matches id (e.g. it was never
+	// opened here), or if OnSearchClosing is already on the stack -- which
+	// is what stops the monolithic close path (OnSearchClosing ->
+	// RemoveResults -> Search_Removed -> here) from recursing.
+	void CloseSearchTab(wxUIntPtr searchID);
+
 	// "View Files" (browse): find-or-create the tab for a peer's shared-file
 	// listing, keyed by the peer's ECID so a re-browse refreshes the same tab.
 	// searchID is the result-routing ID (daemon-allocated over EC, or the local
@@ -224,6 +262,22 @@ private:
 	// bottom bar can be refreshed instantly when the visible tab changes
 	// (rather than waiting for the next poll). Empty on monolithic.
 	std::map<wxUIntPtr, uint32> m_searchProgress;
+
+	// Set by CloseSearchTab immediately before DeletePage(), which fires
+	// PAGE_CLOSING synchronously and re-enters OnSearchClosing on the same
+	// call stack. Tells that handler to skip StopSearchById for this one
+	// id -- the core has already discarded it -- while still running its
+	// other cleanup (ShowResults, m_searchProgress.erase, RemoveResults,
+	// last-tab button disabling), so that cleanup exists in exactly one
+	// place (got3nks, PR #680 review). 0 the rest of the time.
+	wxUIntPtr m_expiringSearchID;
+
+	// True while OnSearchClosing is on the stack. In the monolithic build
+	// that handler calls CSearchList::RemoveResults, which now fires
+	// MuleNotify::Search_Removed -> CloseSearchTab for the very tab being
+	// closed; without this the pair would recurse (and double-delete the
+	// page). Set/cleared by a scoped guard in OnSearchClosing.
+	bool m_inSearchClosing;
 
 	// Set the bottom progress bar from a per-search status sentinel: a finished
 	// search (0xffff/0xfffe) resets it, otherwise it shows the running percent.

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -295,6 +295,7 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 	m_finishedKadSearches.erase(static_cast<uint32_t>(searchID));
 	m_searchStartTimes.erase(static_cast<uint32_t>(searchID));
 	m_searchKinds.erase(static_cast<uint32_t>(searchID));
+	m_searchStrings.erase(static_cast<uint32_t>(searchID));
 	m_browseBar.erase(searchID);
 	m_browseStatus.erase(searchID);
 
@@ -445,6 +446,7 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 	// wrong kind. `type` is this search's real type regardless of the scalar
 	// anchor bookkeeping.
 	m_searchKinds[static_cast<uint32_t>(*searchID)] = type;
+	m_searchStrings[static_cast<uint32_t>(*searchID)] = params.searchString;
 
 	return "";
 }
@@ -896,6 +898,27 @@ bool CSearchList::IsOrWasKadSearch(uint32_t searchID) const
 	// sentinel pick 0xfffe (Kad done, clears the "!") vs 0xffff (ed2k done) for
 	// an arbitrary search, not just the current one.
 	return IsKadSearch(searchID) || m_finishedKadSearches.count(searchID) != 0;
+}
+
+wxString CSearchList::GetSearchStringById(uint32_t searchID) const
+{
+	std::map<uint32_t, wxString>::const_iterator it = m_searchStrings.find(searchID);
+	return it != m_searchStrings.end() ? it->second : wxString();
+}
+
+bool CSearchList::IsKnownSearchId(uint32_t searchID) const
+{
+	return m_searchStrings.count(searchID) != 0;
+}
+
+std::vector<uint32_t> CSearchList::GetKnownSearchIds() const
+{
+	std::vector<uint32_t> ids;
+	ids.reserve(m_searchStrings.size());
+	for (const auto &entry : m_searchStrings) {
+		ids.push_back(entry.first);
+	}
+	return ids;
 }
 
 SearchType CSearchList::GetSearchLifecycleKindById(wxUIntPtr searchID) const

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -274,6 +274,7 @@ CSearchList::CSearchList()
 , m_KadSearchFinished(true)
 , m_ed2kSearchFinished(true)
 , m_searchStart(0)
+, m_shuttingDown(false)
 {
 }
 
@@ -281,6 +282,10 @@ CSearchList::~CSearchList()
 {
 	StopSearch();
 
+	// Teardown: the GUI is being dismantled around us, so suppress the
+	// Search_Removed broadcast below -- there is no tab left worth closing
+	// and the notify would reach a half-destroyed CamuleDlg.
+	m_shuttingDown = true;
 	while (!m_results.empty()) {
 		RemoveResults(m_results.begin()->first);
 	}
@@ -290,6 +295,17 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 {
 	// A non-existent search id will just be ignored
 	Kademlia::CSearchManager::StopSearch(searchID, true);
+
+	// Tell the GUI before the CSearchFile objects below are deleted: in a
+	// monolithic build CSearchListCtrl holds them as raw pointers (via
+	// SetItemPtrData and m_filteredOut) and nothing else removes those rows,
+	// so a tab left open on this search would fault on the next repaint,
+	// sort, scroll or click. Also the local counterpart of amuleGUI's
+	// EC_TAG_SEARCH_EXPIRED-driven close, so "the search is gone" closes its
+	// tab through one path in both builds (got3nks, PR #680 review).
+	if (!m_shuttingDown) {
+		Notify_Search_Removed(searchID);
+	}
 
 	// Drop any per-search tracking for this ID (bounded growth).
 	m_finishedKadSearches.erase(static_cast<uint32_t>(searchID));
@@ -908,17 +924,7 @@ wxString CSearchList::GetSearchStringById(uint32_t searchID) const
 
 bool CSearchList::IsKnownSearchId(uint32_t searchID) const
 {
-	return m_searchStrings.count(searchID) != 0;
-}
-
-std::vector<uint32_t> CSearchList::GetKnownSearchIds() const
-{
-	std::vector<uint32_t> ids;
-	ids.reserve(m_searchStrings.size());
-	for (const auto &entry : m_searchStrings) {
-		ids.push_back(entry.first);
-	}
-	return ids;
+	return m_searchStrings.count(searchID) != 0 || m_browseBar.count(searchID) != 0;
 }
 
 SearchType CSearchList::GetSearchLifecycleKindById(wxUIntPtr searchID) const

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -124,6 +124,35 @@ public:
 	bool IsOrWasKadSearch(uint32_t searchID) const;
 
 	/**
+	 * Returns the query string this search was started with, or an empty
+	 * string if searchID is unknown. Used to label a search enumerated via
+	 * EC_OP_SEARCH_LIST for a client that never started it locally.
+	 */
+	wxString GetSearchStringById(uint32_t searchID) const;
+
+	/**
+	 * True if this core currently knows about searchID -- same lifetime as
+	 * GetSearchStringById/GetKnownSearchIds (m_searchStrings, populated in
+	 * StartNewSearch, pruned in RemoveResults). Use this to gate per-ID EC
+	 * replies (SEARCH_PROGRESS, single-ID SEARCH_RESULTS) instead of the
+	 * EC-only s_ecSearches registry: a monolithic-started search is known
+	 * here but was never Register()'d into that registry, so gating on it
+	 * alone reports a live search as EC_TAG_SEARCH_EXPIRED.
+	 */
+	bool IsKnownSearchId(uint32_t searchID) const;
+
+	/**
+	 * Every search ID this core currently knows the query string for --
+	 * populated in StartNewSearch and pruned in RemoveResults, so this
+	 * covers a search regardless of how it was started (monolithic GUI or
+	 * an EC client) and is not bounded by any EC-connection-specific
+	 * registry. Used by EC_OP_SEARCH_LIST / the multi-search results union
+	 * poll so a remote client discovers every search the core holds, not
+	 * only ones an EC client itself started.
+	 */
+	std::vector<uint32_t> GetKnownSearchIds() const;
+
+	/**
 	 * Ask the Kad search identified by searchID to widen its frontier
 	 * via KADEMLIA_FIND_VALUE_MORE.  Wired to the search dialog "More"
 	 * button.  Returns true if a reask was dispatched, false otherwise.
@@ -378,6 +407,13 @@ private:
 	//! m_searchType (which only tracks the most-recently-started search).
 	//! Pruned in RemoveResults.
 	std::map<uint32_t, SearchType> m_searchKinds;
+
+	//! This search's original query string, keyed by id (same lifetime as
+	//! m_searchKinds -- recorded in StartNewSearch, pruned in RemoveResults).
+	//! Needed to label a search enumerated via EC_OP_SEARCH_LIST for a
+	//! client that didn't start it locally and so has no tab-title string
+	//! of its own to fall back on.
+	std::map<uint32_t, wxString> m_searchStrings;
 
 	//! Bar value for "View Files" browse tabs, keyed by routing ID and set by
 	//! the browsing client (0..100 percent, or 0xffff finished/failed). Read by

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -131,13 +131,16 @@ public:
 	wxString GetSearchStringById(uint32_t searchID) const;
 
 	/**
-	 * True if this core currently knows about searchID -- same lifetime as
-	 * GetSearchStringById/GetKnownSearchIds (m_searchStrings, populated in
-	 * StartNewSearch, pruned in RemoveResults). Use this to gate per-ID EC
-	 * replies (SEARCH_PROGRESS, single-ID SEARCH_RESULTS) instead of the
-	 * EC-only s_ecSearches registry: a monolithic-started search is known
-	 * here but was never Register()'d into that registry, so gating on it
-	 * alone reports a live search as EC_TAG_SEARCH_EXPIRED.
+	 * True if this core currently routes results/progress for searchID --
+	 * either a CSearchList search (m_searchStrings, populated in
+	 * StartNewSearch, pruned in RemoveResults) or a "View Files" browse tab
+	 * (m_browseBar; browses are not CSearchList searches but share the same
+	 * per-ID result-routing and EC lifecycle -- got3nks, PR #680 review).
+	 * Use this to gate per-ID EC replies (SEARCH_PROGRESS, single-ID
+	 * SEARCH_RESULTS, Stop, Request_More) instead of the EC-only
+	 * s_ecSearches registry: a monolithic-started search (or a browse) is
+	 * known here but was never Register()'d into that registry, so gating
+	 * on it alone reports a live search as EC_TAG_SEARCH_EXPIRED.
 	 */
 	bool IsKnownSearchId(uint32_t searchID) const;
 
@@ -146,11 +149,25 @@ public:
 	 * populated in StartNewSearch and pruned in RemoveResults, so this
 	 * covers a search regardless of how it was started (monolithic GUI or
 	 * an EC client) and is not bounded by any EC-connection-specific
-	 * registry. Used by EC_OP_SEARCH_LIST / the multi-search results union
-	 * poll so a remote client discovers every search the core holds, not
-	 * only ones an EC client itself started.
+	 * registry. Used by EC_OP_SEARCH_LIST, which must stay narrow: a browse
+	 * tab is not a search and must not surface as one (got3nks, PR #680
+	 * review). Returned by reference -- called once per explicit
+	 * EC_OP_SEARCH_LIST request, but a copy is still needless. Neither
+	 * caller needs ownership.
 	 */
-	std::vector<uint32_t> GetKnownSearchIds() const;
+	const std::map<uint32_t, wxString> &GetKnownSearchIds() const { return m_searchStrings; }
+
+	/**
+	 * Every ID this core currently routes results for: CSearchList searches
+	 * plus "View Files" browse tabs (see IsKnownSearchId). Used by the
+	 * multi-search results union poll, which -- unlike EC_OP_SEARCH_LIST --
+	 * must go wide, or a browse's results never reach the tab BuildBrowseReply
+	 * (ExternalConn.cpp) already told the client to expect them in (got3nks,
+	 * PR #680 review). Returned by reference; runs every poll tick for every
+	 * connected multi-search client, so a per-call copy here is the one that
+	 * would actually show up in the arithmetic.
+	 */
+	const std::map<wxUIntPtr, uint16> &GetBrowseSearchIds() const { return m_browseBar; }
 
 	/**
 	 * Ask the Kad search identified by searchID to widen its frontier
@@ -436,6 +453,12 @@ private:
 	//! StartNewSearch; feeds the Kad cosmetic progress ramp in
 	//! GetSearchLifecyclePercent.
 	time_t m_searchStart;
+
+	//! Set by the destructor before it drains m_results, so RemoveResults
+	//! skips its MuleNotify::Search_Removed broadcast during teardown --
+	//! the GUI is being dismantled around us and there is no tab left worth
+	//! closing.
+	bool m_shuttingDown;
 
 	//! Queue of servers to ask when doing global searches.
 	//! TODO: Replace with 'cookie' system.

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3003,6 +3003,10 @@ wxString CSearchListRem::StartNewSearch(
 		// routed back to this handler.
 		search_req.AddTag(CECTag(EC_TAG_SEARCH_REF, *nSearchID));
 		m_conn->SendRequest(this, &search_req);
+		// See m_pendingSearchStarts's declaration: closes the window where an
+		// EC_OP_SEARCH_LIST reply could double-tab this not-yet-remapped
+		// search before RemapSearch erases this ID again.
+		m_pendingSearchStarts.insert(*nSearchID);
 	} else {
 		// Legacy single-search daemon: no ID negotiation, sentinel bucket.
 		m_conn->SendPacket(&search_req);
@@ -3050,6 +3054,13 @@ void CSearchListRem::StopSearchById(wxUIntPtr searchID, bool andClose)
 			// Tab closed: stop tracking this search's lifecycle.
 			m_activeSearches.erase((uint32)searchID);
 			m_kadActive.erase((uint32)searchID);
+			// Also the backstop for a START whose reply never attributed
+			// itself (EC_OP_FAILED carries no ID -- see HandlePacket's
+			// EC_OP_FAILED branch): closing the tab the failed start left
+			// behind clears its entry, so the discovery deferral can't be
+			// held open for the rest of the session. A no-op for the normal
+			// case, where RemapSearch already erased it.
+			m_pendingSearchStarts.erase((uint32)searchID);
 		}
 	}
 	// Legacy: parameterless stop of the single current search.
@@ -3084,6 +3095,14 @@ bool CSearchListRem::RequestMoreResults(uint32_t searchID)
 
 void CSearchListRem::RemapSearch(uint32 localID, uint32 daemonID)
 {
+	// Closes this ID's m_pendingSearchStarts window regardless of whether the
+	// local and daemon ids happen to match (the early return below is only
+	// about whether a rekey is needed, not whether the START round trip this
+	// tracks has completed). Keyed by ID, so a *browse* remap -- which also
+	// lands here, via BuildBrowseReply's own EC_OP_STRINGS -- erases nothing
+	// and can no longer lift the deferral for someone else's in-flight
+	// search start (got3nks, PR #680 review).
+	m_pendingSearchStarts.erase(localID);
 	if (localID == daemonID) {
 		return;
 	}
@@ -3130,28 +3149,47 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 				} else {
 					const bool expired =
 						packet->GetTagByName(EC_TAG_SEARCH_EXPIRED) != nullptr;
-					// Cache whether this tab is a *running* Kad search so
-					// IsKadSearch can gate the "More" button — enabled only while
-					// the search runs, disabled once it completes (the progress
-					// lifecycle is the gate; no extra status). An expired search
-					// is gone. Update before the progress call, which refreshes
-					// that button for the visible tab.
-					const CECTag *kindTag =
-						packet->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
-					const CECTag *stateTag =
-						packet->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
 					if (expired) {
-						m_kadActive[(uint32)idTag->GetInt()] = false;
-					} else if (kindTag && stateTag) {
-						m_kadActive[(uint32)idTag->GetInt()] =
-							(kindTag->GetInt() == KadSearch) &&
-							(stateTag->GetInt() ==
-								CSearchList::SEARCH_LIFECYCLE_RUNNING);
+						// The daemon has discarded this search -- a deliberate
+						// close from another client, or LRU eviction -- so
+						// its tab here can only mislead: mapping this to the
+						// plain "finished" status (0xfffe) would make it
+						// indistinguishable from a search that ended
+						// normally, and "Download" on one of its results
+						// would silently do nothing (the daemon's m_results
+						// no longer has the hash). Close the tab locally
+						// instead -- CloseSearchTab does not send
+						// EC_OP_SEARCH_STOP, since the daemon already
+						// doesn't know this id (got3nks, PR #680 review).
+						// CSearchListRem::RemoveResults (called from there)
+						// also erases m_kadActive for this id.
+						const uint32 sid = (uint32)idTag->GetInt();
+						m_activeSearches.erase(sid);
+						if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+							theApp->amuledlg->m_searchwnd->CloseSearchTab(sid);
+						}
+					} else {
+						// Cache whether this tab is a *running* Kad search so
+						// IsKadSearch can gate the "More" button — enabled
+						// only while the search runs, disabled once it
+						// completes (the progress lifecycle is the gate; no
+						// extra status). Update before the progress call,
+						// which refreshes that button for the visible tab.
+						const CECTag *kindTag =
+							packet->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+						const CECTag *stateTag =
+							packet->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
+						if (kindTag && stateTag) {
+							m_kadActive[(uint32)idTag->GetInt()] =
+								(kindTag->GetInt() == KadSearch) &&
+								(stateTag->GetInt() ==
+									CSearchList::
+										SEARCH_LIFECYCLE_RUNNING);
+						}
+						theApp->amuledlg->m_searchwnd->UpdateSearchProgress(
+							idTag->GetInt(),
+							(uint32)packet->GetFirstTagSafe()->GetInt());
 					}
-					uint32 status = expired ? 0xfffe
-								: (uint32)packet->GetFirstTagSafe()->GetInt();
-					theApp->amuledlg->m_searchwnd->UpdateSearchProgress(
-						idTag->GetInt(), status);
 				}
 			}
 		} else {
@@ -3166,6 +3204,40 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 		if (idTag && refTag) {
 			RemapSearch(refTag->GetInt(), idTag->GetInt());
 		}
+	} else if (packet->GetOpCode() == EC_OP_FAILED) {
+		// A rejected EC_OP_SEARCH_START or browse (EC_OP_FRIEND, via
+		// SendBrowseRequest -- both route their replies here). Both send
+		// EC_TAG_SEARCH_REF, the optimistic tab id, and the daemon now echoes
+		// it on the failure paths too, so the verdict is attributable: without
+		// it, StartNewSearch's unconditional "" return means OnBnClickedStart
+		// already took its success branch and created a tab, leaving a phantom
+		// tab plus an id stuck in m_pendingSearchStarts -- which disables
+		// discovery and costs an EC_OP_SEARCH_LIST round trip every tick until
+		// the user happens to close exactly that tab (got3nks, PR #680 review).
+		//
+		// The branch also has to exist at all: without it an EC_OP_FAILED falls
+		// through to CRemoteContainer::HandlePacket, which hits wxFAIL in IDLE
+		// and, if a DoRequery happened to be outstanding, consumes that reply's
+		// state instead.
+		if (const CECTag *refTag = packet->GetTagByName(EC_TAG_SEARCH_REF)) {
+			const uint32 localID = static_cast<uint32>(refTag->GetInt());
+			m_pendingSearchStarts.erase(localID);
+			// Report it and undo the optimistic tab/button state, through the
+			// same path the monolithic build uses for a rejected start. The
+			// daemon sends the reason as EC_TAG_STRING (a wxTRANSLATE'd
+			// literal, so translate it here like CAddLinkHandler does);
+			// without this the user clicks Search and nothing at all happens.
+			if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+				const CECTag *msgTag = packet->GetTagByName(EC_TAG_STRING);
+				const wxString reason = (msgTag && msgTag->IsString())
+								? wxGetTranslation(msgTag->GetStringData())
+								: wxString();
+				theApp->amuledlg->m_searchwnd->OnStartRejected(localID, reason);
+			}
+			// Nothing to prune from m_activeSearches / m_kadActive: both are
+			// only ever keyed by a daemon-allocated id (RemapSearch, or the
+			// discovery branch), never by an optimistic one.
+		}
 	} else if (packet->GetOpCode() == EC_OP_SEARCH_LIST) {
 		// Reachability fix (#641): one entry per search the daemon currently
 		// holds, so a search this client never started locally -- one
@@ -3175,7 +3247,19 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 		// looks up a tab that doesn't exist yet). Skips any ID that already
 		// has a tab (a search this client itself started) rather than
 		// recreating it.
-		if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+		//
+		// Deferred whole, rather than per-id, while m_pendingSearchStarts
+		// is non-empty: this reply's ids reflect the daemon's state at send
+		// time, which can already include a search THIS client just
+		// started but hasn't been told the id of yet (see that member's
+		// declaration) -- and the ids in it are the client's *optimistic*
+		// ones, which by construction never match the daemon ids here, so
+		// there is nothing to match per-entry against. Re-arming for the
+		// next tick costs one extra poll, not correctness, since the set
+		// only stays non-empty for one EC round trip.
+		if (!m_pendingSearchStarts.empty()) {
+			m_needSearchListRequery = true;
+		} else if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
 			for (const CECTag &entry : *packet) {
 				uint32 sid = static_cast<uint32>(entry.GetInt());
 				if (sid == 0 || theApp->amuledlg->m_searchwnd->GetSearchList(sid)) {
@@ -3199,6 +3283,20 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 				// marker would stay frozen forever -- exactly like a search
 				// this client started itself once RemapSearch runs.
 				m_activeSearches.insert(sid);
+				// Backfill (got3nks, PR #680 review): a result for this sid may
+				// already have arrived and been dropped by CreateItem (no tab
+				// existed yet to AddResult into), and the daemon's
+				// EC_DETAIL_INC_UPDATE diffing never re-sends an
+				// already-delivered result -- so without this, that result is
+				// lost permanently rather than merely delayed. The container
+				// (m_items) still holds it: CreateItem always keeps every
+				// CSearchFile it builds, tab or no tab. Walk it now, once, for
+				// this newly-discovered sid -- no extra EC traffic.
+				for (CSearchFile *file : m_items) {
+					if (file->GetSearchID() == sid) {
+						theApp->amuledlg->m_searchwnd->AddResult(file);
+					}
+				}
 			}
 		}
 	} else {

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -340,9 +340,34 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			// update both downloads and shared files
 			knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
 		} else if (amuledlg->m_searchwnd->IsShown()) {
-			if (searchlist->m_curr_search != 0) {
-				searchlist->DoRequery(EC_OP_SEARCH_RESULTS, EC_TAG_SEARCHFILE);
+			// Reachability fix (#641): ask what searches the daemon
+			// currently holds -- independent of m_curr_search, which only
+			// ever reflects a search THIS client itself started -- so a
+			// search opened by another client, or one day restored from
+			// disk, gets a tab created here (CSearchListRem::HandlePacket).
+			// Search entries are near-static (id/name/kind barely change),
+			// so unlike the results union poll below this isn't asked every
+			// tick: once on (re)connect, and again only when a result turns
+			// up bearing a search ID with no tab yet (CreateItem sets
+			// m_needSearchListRequery) -- the daemon-side registry this
+			// reads never changes without a result also arriving for it.
+			// RequestSearchList (not DoRequery) on purpose: HandlePacket's
+			// EC_OP_SEARCH_LIST branch never reaches the base class's
+			// STATUS_REQ_SENT -> IDLE transition, so going through
+			// DoRequery would wedge this container's request state machine
+			// forever and silently drop every later EC_OP_SEARCH_RESULTS
+			// poll (got3nks, PR #680 review).
+			if (searchlist->m_needSearchListRequery) {
+				searchlist->RequestSearchList();
+				searchlist->m_needSearchListRequery = false;
 			}
+			// The union poll below already returns every active search's
+			// results regardless of m_curr_search (Get_EC_Response_Search_
+			// Results_Union iterates the daemon's own registry) -- the old
+			// m_curr_search-only gate just meant a client that never
+			// started a search of its own never asked at all, even once a
+			// tab existed for one it learned about above.
+			searchlist->DoRequery(EC_OP_SEARCH_RESULTS, EC_TAG_SEARCHFILE);
 		}
 		// Stats polling is always on, even when the Statistics dialog
 		// isn't the active tab. statgraphs->HandlePacket() also feeds
@@ -2941,6 +2966,7 @@ void CFriendListRem::RequestSharedFileList(CClientRef &client)
  */
 CSearchListRem::CSearchListRem(CRemoteConnect *conn)
 : CRemoteContainer<CSearchFile, uint32, CEC_SearchFile_Tag>(conn, true)
+, m_needSearchListRequery(true)
 {
 	m_curr_search = 0;
 }
@@ -3073,6 +3099,12 @@ void CSearchListRem::RemapSearch(uint32 localID, uint32 daemonID)
 	m_activeSearches.insert(daemonID);
 }
 
+void CSearchListRem::RequestSearchList()
+{
+	CECPacket req(EC_OP_SEARCH_LIST);
+	m_conn->SendRequest(this, &req);
+}
+
 void CSearchListRem::HandlePacket(const CECPacket *packet)
 {
 	if (packet->GetOpCode() == EC_OP_SEARCH_PROGRESS) {
@@ -3133,6 +3165,41 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 		const CECTag *refTag = packet->GetTagByName(EC_TAG_SEARCH_REF);
 		if (idTag && refTag) {
 			RemapSearch(refTag->GetInt(), idTag->GetInt());
+		}
+	} else if (packet->GetOpCode() == EC_OP_SEARCH_LIST) {
+		// Reachability fix (#641): one entry per search the daemon currently
+		// holds, so a search this client never started locally -- one
+		// already open in another amulegui session, or restored from disk
+		// once persistence lands -- gets a tab here instead of silently
+		// having its results dropped by AddResult/UpdateResult (neither
+		// looks up a tab that doesn't exist yet). Skips any ID that already
+		// has a tab (a search this client itself started) rather than
+		// recreating it.
+		if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+			for (const CECTag &entry : *packet) {
+				uint32 sid = static_cast<uint32>(entry.GetInt());
+				if (sid == 0 || theApp->amuledlg->m_searchwnd->GetSearchList(sid)) {
+					continue;
+				}
+				const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
+				// "(0)" matches CSearchDlg::CreateNewTab's own callers (e.g.
+				// SearchDlg.cpp:1017) -- no leading "!" even for a Kad search:
+				// that marker is a live indicator normal callers seed only
+				// because they know at creation time they just started a Kad
+				// search, and it is only ever cleared (KadSearchEnd), never
+				// set, by the progress path below. Making this tab first-class
+				// in m_activeSearches is what lets that live path take over
+				// from here -- the "!" appears on the next progress poll if
+				// this is in fact a running Kad search, same as any other tab.
+				theApp->amuledlg->m_searchwnd->CreateNewTab(
+					(nameTag ? nameTag->GetStringData() : wxString()) + " (0)", sid);
+				// Reachability fix (#641): without this, a discovered tab never
+				// gets polled for progress at all (Phase1Done only loops over
+				// m_activeSearches), so its hit count, progress bar and "!"
+				// marker would stay frozen forever -- exactly like a search
+				// this client started itself once RemapSearch runs.
+				m_activeSearches.insert(sid);
+			}
 		}
 	} else {
 		CRemoteContainer<CSearchFile, uint32, CEC_SearchFile_Tag>::HandlePacket(packet);
@@ -3199,6 +3266,16 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 {
 	CSearchFile *file = new CSearchFile(tag);
 	ProcessItemUpdate(tag, file);
+
+	// Reachability fix (#641): a result bearing a search ID with no tab
+	// is exactly the symptom EC_OP_SEARCH_LIST exists to fix -- ask for
+	// the list again on the next poll so a tab gets created for it
+	// (CSearchListRem::HandlePacket's EC_OP_SEARCH_LIST branch) instead
+	// of polling that op every tick regardless of whether anything new
+	// showed up.
+	if (file->m_searchID != 0 && !theApp->amuledlg->m_searchwnd->GetSearchList(file->m_searchID)) {
+		m_needSearchListRequery = true;
+	}
 
 	theApp->amuledlg->m_searchwnd->AddResult(file);
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -630,6 +630,16 @@ class CSearchListRem : public CRemoteContainer<CSearchFile, uint32, CEC_SearchFi
 public:
 	CSearchListRem(CRemoteConnect *);
 
+	// Reachability fix (#641): true when OnPollTimer should ask amuled
+	// what searches it currently holds (EC_OP_SEARCH_LIST) on its next
+	// poll. Starts true so a freshly (re)connected client discovers
+	// every search once up front; CreateItem sets it again whenever a
+	// result arrives for a search ID with no local tab, which is the
+	// only signal that amuled is holding a search this client doesn't
+	// know about yet. Cleared by OnPollTimer right after sending the
+	// request, so steady state (every tab already known) costs nothing.
+	bool m_needSearchListRequery;
+
 	// Most-recently-started search ID (0 = none). uint32 so it correctly
 	// holds a daemon-allocated Kad ID (top half of the range); as a signed
 	// int those wrapped negative and corrupted the STOP/remap round-trip.
@@ -669,6 +679,17 @@ public:
 	// Multi-search: remap the optimistic local tab ID to the daemon-allocated
 	// ID once the START reply echoes the correlation token.
 	void RemapSearch(uint32 localID, uint32 daemonID);
+
+	// Reachability fix (#641): a direct one-off EC_OP_SEARCH_LIST request,
+	// bypassing DoRequery's single-request-in-flight state machine on
+	// purpose. HandlePacket answers EC_OP_SEARCH_LIST in its own branch
+	// (below) and never reaches the base class's STATUS_REQ_SENT -> IDLE
+	// transition, so routing this through DoRequery wedges m_state
+	// permanently and silently drops every later
+	// DoRequery(EC_OP_SEARCH_RESULTS, ...) call -- exactly the mirror of
+	// Phase1Done's EC_OP_SEARCH_PROGRESS requests just below, which bypass
+	// the state machine the same way for the same reason.
+	void RequestSearchList();
 
 	// Monolithic CSearchList API parity over EC. IsKadSearch reports whether a
 	// given tab is a *live* Kad search — the SearchDlg "More" button gate —

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -640,6 +640,28 @@ public:
 	// request, so steady state (every tab already known) costs nothing.
 	bool m_needSearchListRequery;
 
+	// Optimistic local IDs of this session's own EC_OP_SEARCH_START requests
+	// sent but not yet remapped (see RemapSearch). While non-empty, the
+	// EC_OP_SEARCH_LIST discovery branch defers creating any new tab: the
+	// daemon already knows about a just-started search before this client's
+	// START reply (carrying EC_TAG_SEARCH_REF/EC_TAG_SEARCH_ID) comes back,
+	// so a list reply landing in that window would otherwise be
+	// indistinguishable from a genuinely foreign search and create a second
+	// tab for the same one, which RemapSearch then rekeys onto -- two tabs,
+	// one search (got3nks, PR #680 review). Inserted in StartNewSearch's
+	// multi-search branch, erased in RemapSearch.
+	//
+	// A set of IDs rather than a bare count so an unattributable reply can
+	// never clear it: EC_OP_FAILED reaches this same handler for a failed
+	// *browse* too (SendBrowseRequest routes EC_OP_FRIEND here, and the
+	// daemon's EC_TAG_FRIEND_SHARED branch has "Friend not found." /
+	// "Client not found." / malformed exits), and "client not found" is
+	// ordinary -- the peer gets reaped between the user seeing the row and
+	// clicking View Files. A count would have let that decrement lift the
+	// deferral a round trip early, reopening the very double-tab window
+	// this exists to close (got3nks, PR #680 review).
+	std::set<uint32> m_pendingSearchStarts;
+
 	// Most-recently-started search ID (0 = none). uint32 so it correctly
 	// holds a daemon-allocated Kad ID (top half of the range); as a signed
 	// int those wrapped negative and corrupted the STOP/remap round-trip.

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -165,6 +165,8 @@ EC_OP_SET_SHARED_DIRS               0x5E
 
 EC_OP_SEARCH_REQUEST_MORE           0x5F
 
+EC_OP_SEARCH_LIST                   0x60
+
 [/Section]
 
 [Section Content]

--- a/src/libs/ec/cpp/ECCodes.h
+++ b/src/libs/ec/cpp/ECCodes.h
@@ -27,6 +27,8 @@
 #ifndef __ECCODES_H__
 #define __ECCODES_H__
 
+#include <cstdint>
+
 typedef uint8_t ec_opcode_t;
 typedef uint16_t ec_tagname_t;
 typedef uint8_t ec_tagtype_t;
@@ -133,7 +135,8 @@ enum ECOpCodes
 	EC_OP_CHAT_MESSAGES = 0x5C,
 	EC_OP_GET_SHARED_DIRS = 0x5D,
 	EC_OP_SET_SHARED_DIRS = 0x5E,
-	EC_OP_SEARCH_REQUEST_MORE = 0x5F
+	EC_OP_SEARCH_REQUEST_MORE = 0x5F,
+	EC_OP_SEARCH_LIST = 0x60
 };
 
 enum ECTagNames
@@ -807,6 +810,8 @@ wxString GetDebugNameECOpCodes(uint8 arg)
 		return "EC_OP_SET_SHARED_DIRS";
 	case EC_OP_SEARCH_REQUEST_MORE:
 		return "EC_OP_SEARCH_REQUEST_MORE";
+	case EC_OP_SEARCH_LIST:
+		return "EC_OP_SEARCH_LIST";
 	default:
 		return CFormat("unknown %d 0x%x") % arg % arg;
 	}

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1032,10 +1032,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	// search.
 	if (path == "/api/v0/search") {
+		if (req.method == "GET" || req.method == "HEAD") {
+			return HandleSearchList(req);
+		}
 		if (req.method != "POST") {
 			return ErrorResponse(405,
 				"method_not_allowed",
-				"only POST on /search (use GET /search/results for results)");
+				"only GET or POST on /search (GET lists active searches, POST starts one -- "
+				"use GET /search/results for a search's results)");
 		}
 		return HandleSearchStart(req);
 	}
@@ -4977,6 +4981,46 @@ void WriteSearchObject(CJsonWriter &w, const webapi::SearchResult &r)
 
 } // namespace
 
+namespace
+{
+// Reverse of SearchTypeFromString (below, further down this file).
+// EC_SEARCH_LOCAL/GLOBAL/KAD share their numeric values with CSearchList's
+// own SearchType (LocalSearch/GlobalSearch/KadSearch), which is what
+// EC_TAG_SEARCH_LIFECYCLE_KIND carries on the wire (see ExternalConn.cpp's
+// Get_EC_Response_Search_List), so a plain uint8 in is enough -- no
+// separate SearchType include needed here.
+wxString SearchKindToString(std::uint8_t kind)
+{
+	switch (kind) {
+	case EC_SEARCH_LOCAL:
+		return wxString::FromAscii("local");
+	case EC_SEARCH_KAD:
+		return wxString::FromAscii("kad");
+	case EC_SEARCH_GLOBAL:
+	default:
+		return wxString::FromAscii("global");
+	}
+}
+
+// Shared by HandleSearchResults' `progress.state` and HandleSearchList's
+// `state`, so the two endpoints cannot drift into reporting different
+// strings for the same search's lifecycle. state_val is a raw
+// CSearchList::SearchLifecycleState numeric value (IDLE=0/RUNNING=1/
+// FINISHED=2); ExternalConn.cpp's static_assert next to
+// Get_EC_Response_Search_List keeps that alignment honest at compile time.
+wxString SearchLifecycleStateToString(std::uint8_t state_val)
+{
+	switch (state_val) {
+	case 2:
+		return wxString::FromAscii("finished");
+	case 1:
+		return wxString::FromAscii("running");
+	default:
+		return wxString::FromAscii("idle");
+	}
+}
+} // namespace
+
 CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -5162,8 +5206,43 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	// from a known-but-empty search, which returns an idle/empty envelope.
 	const SearchIdParam sidp = ParseSearchIdParam(QueryOf(req));
 	if (sidp.provided && sidp.value != 0 && !m_state.HasSearch(sidp.value)) {
-		return ErrorResponse(
-			404, "not_found", "no search with that search_id (never started or expired)");
+		// Cache miss: before giving up, ask the core once whether it is
+		// holding this id anyway -- a search another client (or the
+		// monolithic GUI) started. GET /api/v0/search already lists such
+		// searches via the same EC_OP_SEARCH_LIST; without this, a search
+		// id the enumeration just reported would still 404 here (got3nks,
+		// PR #680 review). Deliberately a one-off round trip on the miss,
+		// not a per-tick refresher poll -- discovery is rare, so paying for
+		// it only when actually asked about keeps the steady-state EC cost
+		// at zero, same reasoning as amulegui's own event-driven discovery.
+		std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SEARCH_LIST));
+		const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+		bool found = false;
+		if (ec_resp) {
+			for (const CECTag &entry : *ec_resp) {
+				if (static_cast<std::uint32_t>(entry.GetInt()) != sidp.value)
+					continue;
+				const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+				m_state.MarkSearchDiscovered(sidp.value,
+					SearchKindToString(
+						kindTag ? static_cast<std::uint8_t>(kindTag->GetInt())
+							: EC_SEARCH_GLOBAL)
+						.ToStdString());
+				found = true;
+				break;
+			}
+			delete ec_resp;
+		}
+		if (!found) {
+			return ErrorResponse(
+				404, "not_found", "no search with that search_id (never started or expired)");
+		}
+		// Discovered but not yet polled: the next refresher tick fills in
+		// real results/progress via the active-search loop. Until then this
+		// falls through to the normal read below, which sees the slot
+		// MarkSearchDiscovered just seeded -- an idle/empty envelope for
+		// this one request, same shape as any other known-but-not-yet-
+		// polled search, rather than a 404 for something just listed.
 	}
 	const std::uint32_t report_id = sidp.value != 0 ? sidp.value : m_state.CurrentSearchId();
 	const std::vector<webapi::SearchResult> results_vec = m_state.Search(sidp.value);
@@ -5223,9 +5302,7 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	w.Key("progress");
 	w.BeginObject();
 	w.Key("state");
-	w.ValueString(wxString::FromAscii(progress.complete ? "finished"
-					  : progress.active ? "running"
-							    : "idle"));
+	w.ValueString(SearchLifecycleStateToString(progress.complete ? 2 : progress.active ? 1 : 0));
 	w.Key("kind");
 	w.ValueString(wxString::FromUTF8(progress.kind.c_str()));
 	w.Key("percent");
@@ -5233,6 +5310,57 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	w.EndObject();
 	w.EndObject();
 	FinalizeJsonBody(w, r);
+	return r;
+}
+
+// Reachability fix (amule-org/amule#641): enumerates every search the
+// daemon currently holds via EC_OP_SEARCH_LIST, rather than reading the
+// Refresher-cached m_state (which -- like m_curr_search on amulegui --
+// only ever knows about searches THIS session started with POST /search).
+// A direct one-off EC round trip, same pattern HandleSearchStart already
+// uses for SEARCH_START; no Refresher/m_state changes needed to make a
+// search started by another client (or, once persistence lands, restored
+// from disk) discoverable here.
+CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SEARCH_LIST));
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for SEARCH_LIST");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("searches");
+	w.BeginArray();
+	for (const CECTag &entry : *ec_resp) {
+		w.BeginObject();
+		w.Key("search_id");
+		w.ValueInt(static_cast<int64_t>(entry.GetInt()));
+		const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
+		w.Key("query");
+		w.ValueString(nameTag ? nameTag->GetStringData() : wxString());
+		const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+		w.Key("kind");
+		w.ValueString(SearchKindToString(
+			kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : EC_SEARCH_GLOBAL));
+		const CECTag *stateTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
+		const std::uint8_t state_val = stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0;
+		w.Key("state");
+		w.ValueString(SearchLifecycleStateToString(state_val));
+		w.EndObject();
+	}
+	w.EndArray();
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	delete ec_resp;
 	return r;
 }
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5207,33 +5207,8 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	const SearchIdParam sidp = ParseSearchIdParam(QueryOf(req));
 	if (sidp.provided && sidp.value != 0 && !m_state.HasSearch(sidp.value)) {
 		// Cache miss: before giving up, ask the core once whether it is
-		// holding this id anyway -- a search another client (or the
-		// monolithic GUI) started. GET /api/v0/search already lists such
-		// searches via the same EC_OP_SEARCH_LIST; without this, a search
-		// id the enumeration just reported would still 404 here (got3nks,
-		// PR #680 review). Deliberately a one-off round trip on the miss,
-		// not a per-tick refresher poll -- discovery is rare, so paying for
-		// it only when actually asked about keeps the steady-state EC cost
-		// at zero, same reasoning as amulegui's own event-driven discovery.
-		std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SEARCH_LIST));
-		const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
-		bool found = false;
-		if (ec_resp) {
-			for (const CECTag &entry : *ec_resp) {
-				if (static_cast<std::uint32_t>(entry.GetInt()) != sidp.value)
-					continue;
-				const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
-				m_state.MarkSearchDiscovered(sidp.value,
-					SearchKindToString(
-						kindTag ? static_cast<std::uint8_t>(kindTag->GetInt())
-							: EC_SEARCH_GLOBAL)
-						.ToStdString());
-				found = true;
-				break;
-			}
-			delete ec_resp;
-		}
-		if (!found) {
+		// holding this id anyway -- see DiscoverSearchIfHeldByCore.
+		if (!DiscoverSearchIfHeldByCore(sidp.value)) {
 			return ErrorResponse(
 				404, "not_found", "no search with that search_id (never started or expired)");
 		}
@@ -5311,6 +5286,31 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
+}
+
+// See the declaration in Api.h for why this is shared rather than inlined
+// at each call site.
+bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
+{
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SEARCH_LIST));
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return false;
+	}
+	bool found = false;
+	for (const CECTag &entry : *ec_resp) {
+		if (static_cast<std::uint32_t>(entry.GetInt()) != search_id)
+			continue;
+		const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+		m_state.MarkSearchDiscovered(search_id,
+			SearchKindToString(
+				kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : EC_SEARCH_GLOBAL)
+				.ToStdString());
+		found = true;
+		break;
+	}
+	delete ec_resp;
+	return found;
 }
 
 // Reachability fix (amule-org/amule#641): enumerates every search the
@@ -7854,7 +7854,13 @@ CHttpServer::Response CApiDispatcher::HandleSearchStop(const CHttpServer::Reques
 
 	// Resolve to a concrete id: an explicit body id, else the current search.
 	// An explicit id that names no live slot is a 404 (mirrors GET results).
-	if (body_search_id != 0 && !m_state.HasSearch(body_search_id)) {
+	// On a cache miss, ask the core first: GET /api/v0/search enumerates
+	// searches this session never started, so without this you could see a
+	// search here and still get a 404 trying to stop or close it -- the same
+	// contradiction already fixed for /search/results, found again by driving
+	// two clients against one daemon (got3nks, PR #680 review).
+	if (body_search_id != 0 && !m_state.HasSearch(body_search_id) &&
+		!DiscoverSearchIfHeldByCore(body_search_id)) {
 		return ErrorResponse(
 			404, "not_found", "no search with that search_id (never started or expired)");
 	}

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -212,6 +212,18 @@ private:
 	CHttpServer::Response HandleCategoryDelete(
 		const CHttpServer::Request &, const std::string &index_str);
 	// search.
+	// Cache miss on a search_id: ask the core once (EC_OP_SEARCH_LIST)
+	// whether it holds this id anyway -- a search another client, or the
+	// monolithic GUI, started. Seeds the local slot via
+	// CState::MarkSearchDiscovered and returns true when found. Shared by
+	// every endpoint that addresses a search by id, so none of them can
+	// 404 on an id GET /api/v0/search just enumerated (got3nks, PR #680
+	// review): that contradiction was fixed once for /search/results and
+	// then found again in /search/stop, which is what made it a helper
+	// rather than a second copy. Deliberately a one-off round trip on the
+	// miss, not a per-tick refresher poll -- discovery is rare, so paying
+	// only when actually asked keeps the steady-state EC cost at zero.
+	bool DiscoverSearchIfHeldByCore(std::uint32_t search_id);
 	CHttpServer::Response HandleSearchList(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchStart(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchStop(const CHttpServer::Request &);

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -212,6 +212,7 @@ private:
 	CHttpServer::Response HandleCategoryDelete(
 		const CHttpServer::Request &, const std::string &index_str);
 	// search.
+	CHttpServer::Response HandleSearchList(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchStart(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchStop(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchDownload(const CHttpServer::Request &, const std::string &hash);

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -163,6 +163,14 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// Api.cpp drive their own EC roundtrips under m_ec_mtx. Per-tick
 	// refresh would have been pure waste when nothing is listening.
 
+	// Searches this session never started itself (another EC client, or
+	// the monolithic GUI) are NOT discovered here per-tick -- that would
+	// pay an EC_OP_SEARCH_LIST roundtrip every tick forever to serve
+	// something that happens rarely. Instead, HandleSearchResults in
+	// Api.cpp does a one-off EC_OP_SEARCH_LIST check on a cache miss and
+	// seeds the slot via MarkSearchDiscovered right there; from the next
+	// tick on, the loop below picks it up like any other active search.
+
 	// /search/results — poll each ACTIVE search independently (amuleapi runs
 	// several at once). POST /search seeds a slot with active=true; the
 	// daemon's per-id EC_TAG_SEARCH_LIFECYCLE_STATE tells us when to flip it

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -226,6 +226,45 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind)
 	}
 }
 
+void CState::MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	if (m_searches.count(search_id)) {
+		// Already known (self-started, or discovered on an earlier
+		// cache-miss check): leave its accumulated results/progress
+		// alone. Re-seeding here would stomp whatever
+		// WriteSearchProgress/ApplySearchFull already recorded for it
+		// this session.
+		return;
+	}
+	SearchSlot &slot = m_searches[search_id];
+	slot.progress.active = true;
+	slot.progress.kind = kind;
+	slot.seq = ++m_search_seq;
+	// Deliberately NOT touching m_current_search_id: a no-id GET
+	// /search/results should keep meaning "the search THIS session
+	// started", not silently jump to whatever was last discovered.
+
+	// Same bound as MarkSearchStarted, for the same reason -- a busy core
+	// with many concurrent searches shouldn't let discovery alone grow
+	// this session's slot map without limit.
+	while (m_searches.size() > kMaxSearchSlots) {
+		auto victim = m_searches.end();
+		for (auto it = m_searches.begin(); it != m_searches.end(); ++it) {
+			if (it->first == m_current_search_id || it->second.progress.active) {
+				continue;
+			}
+			if (victim == m_searches.end() || it->second.seq < victim->second.seq) {
+				victim = it;
+			}
+		}
+		if (victim == m_searches.end()) {
+			break;
+		}
+		m_searches.erase(victim);
+	}
+}
+
 void CState::WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1193,6 +1193,19 @@ public:
 	// polls EC_OP_SEARCH_RESULTS / _PROGRESS for it each tick, mapping
 	// EC_TAG_SEARCH_LIFECYCLE_STATE into `complete` / `active`.
 	void MarkSearchStarted(std::uint32_t search_id, const std::string &kind);
+	// Seeds a slot for a search this session did NOT start itself -- a
+	// search another client, or the monolithic GUI, started. Called
+	// on-demand from HandleSearchResults on a cache miss, after a one-off
+	// EC_OP_SEARCH_LIST confirms the core actually holds it (deliberately
+	// NOT a per-tick refresher poll: that would pay an EC roundtrip every
+	// tick, forever, to serve something that happens rarely). Unlike
+	// MarkSearchStarted: does not touch m_current_search_id (a no-id GET
+	// /search/results should keep meaning "the search THIS session
+	// started", not silently jump to whatever was last discovered), and
+	// is idempotent -- a search already known (self-started or previously
+	// discovered) is left untouched rather than having its accumulated
+	// results/progress reset.
+	void MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind);
 	// Refresher-side write path for one search's progress snapshot.
 	void WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s);
 	// Drop a search's slot entirely: POST /search/stop with close=true, or the

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -3,6 +3,7 @@
 # amuleapi 19-search — search.
 #
 # Endpoints:
+#   GET  /api/v0/search                                    — EC_OP_SEARCH_LIST
 #   POST /api/v0/search                                   — EC_OP_SEARCH_START
 #       body: {query, type?, file_type?, extension?,
 #              min_size?, max_size?, min_avail?}
@@ -35,6 +36,14 @@ set -o pipefail
 HOST=${HOST:-localhost:4713}
 ADMIN_PASS=${ADMIN_PASS:-adminpass}
 GUEST_PASS=${GUEST_PASS:-guestpass}
+
+# EC connection info for the second amuleapi instance spun up in section
+# 3.2 below — must point at the SAME amuled as the primary instance at
+# $HOST. Defaults match run-all.sh's regtest daemon.
+EC_HOST=${EC_HOST:-127.0.0.1}
+EC_PORT=${EC_PORT:-4712}
+EC_PASSWORD=${EC_PASSWORD:-amule}
+AMULEAPI_BIN=${AMULEAPI_BIN:-$(cd "$(dirname "$0")/../../.." && pwd)/build-macos/src/webapi/amuleapi}
 
 # A query likely to return results on any operator's daemon connected
 # to ed2k. "ubuntu" is a safe choice — well-seeded across the network.
@@ -104,6 +113,9 @@ HAVE_GUEST=0
 sleep 4
 
 # --- 1. Auth + admin gate. -----------------------------------------
+_curl "$HOST/api/v0/search"
+_assert_status 401 "GET /search (no token) → 401"
+
 _curl -X POST -H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\"}" "$HOST/api/v0/search"
 _assert_status 401 "POST /search (no token) → 401"
@@ -166,6 +178,74 @@ _assert_json_eq '.search_id | type' number 'POST /search returns a numeric searc
 FIRST_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
 _assert_json_eq '.search_id' "$FIRST_SID" 'GET /search/results (no id) echoes the current search_id'
+
+# --- 3.1 GET /api/v0/search enumerates the search just started. ---
+# Reachability fix (issue #641): GET /api/v0/search reads live daemon
+# state via EC_OP_SEARCH_LIST rather than this session's own m_state
+# cache, so the search just started via POST /search must appear here
+# too -- proving the two endpoints agree on what amuled currently holds.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+_assert_status 200 "GET /search → 200"
+_assert_json_eq '.searches | type' array 'GET /search .searches is an array'
+_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)] | length" 1 \
+	'GET /search lists the search just started via POST /search'
+_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].query" "$TEST_QUERY" \
+	'GET /search entry echoes the query'
+_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].kind" global \
+	'GET /search entry reports kind==global'
+_assert_json_eq "[[.searches[] | select(.search_id == $FIRST_SID)][0].state] | inside([\"running\",\"finished\"])" \
+	true 'GET /search entry state is running or finished (never idle for an active search)'
+
+if [ "$HAVE_GUEST" = "1" ]; then
+	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/search"
+	_assert_status 200 "GET /search (guest) → 200 (GUEST-readable)"
+fi
+
+# --- 3.2 Cross-session discovery: a second amuleapi instance against the
+# same amuled sees $FIRST_SID even though it never called POST /search
+# itself (got3nks, PR #680 review point 6 — no amulecmd needed, two
+# amuleapi sessions against one daemon exercise the same discovery path).
+# SECOND_HOST's HTTP server is independent, but both instances share the
+# one daemon at EC_HOST:EC_PORT, so EC_OP_SEARCH_LIST on session B finds
+# the search session A started.
+SECOND_HOST="localhost:4714"
+SECOND_CONFIG_DIR=$(mktemp -d -t amuleapi_19_search_second.XXXXXX)
+SECOND_LOG=$(mktemp -t amuleapi_19_search_second_log.XXXXXX)
+"$AMULEAPI_BIN" --config-dir="$SECOND_CONFIG_DIR" \
+	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+"$AMULEAPI_BIN" --config-dir="$SECOND_CONFIG_DIR" \
+	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--http-port=4714 >"$SECOND_LOG" 2>&1 &
+SECOND_PID=$!
+
+for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+	curl -s -o /dev/null --max-time 1 "http://$SECOND_HOST/api/v0/version" 2>/dev/null && break
+	sleep 0.5
+done
+sleep 4
+
+SECOND_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "http://$SECOND_HOST/api/v0/auth/login?type=bearer" \
+	| jq -r .token)
+
+if [ -n "$SECOND_TOKEN" ] && [ "$SECOND_TOKEN" != "null" ]; then
+	_curl -H "Authorization: Bearer $SECOND_TOKEN" "http://$SECOND_HOST/api/v0/search"
+	_assert_status 200 "second amuleapi instance: GET /search → 200"
+	_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)] | length" 1 \
+		'second amuleapi instance (never POSTed) still lists the first instance'"'"'s search'
+
+	_curl -H "Authorization: Bearer $SECOND_TOKEN" \
+		"http://$SECOND_HOST/api/v0/search/results?search_id=$FIRST_SID"
+	_assert_status 200 'second amuleapi instance: GET /search/results?search_id=<foreign id> → 200 (not 404)'
+	_assert_json_eq '.search_id' "$FIRST_SID" 'second amuleapi instance /search/results echoes the discovered search_id'
+else
+	_fail "second amuleapi instance: admin login" "could not obtain a token; log: $(tail -c 300 "$SECOND_LOG")"
+fi
+
+kill "$SECOND_PID" >/dev/null 2>&1
+wait "$SECOND_PID" 2>/dev/null
+rm -rf "$SECOND_CONFIG_DIR" "$SECOND_LOG"
 
 # --- 3.5 Regression: progress shouldn't claim finished right after POST. -
 # amuled briefly reports raw=100 in the "queue-empty-at-start" window
@@ -298,8 +378,8 @@ else
 fi
 
 # --- 8. Method gates. ---------------------------------------------
-_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-_assert_status 405 "GET /search → 405"
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+_assert_status 405 "PATCH /search → 405"
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/stop"
 _assert_status 405 "PATCH /search/stop → 405"

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -608,6 +608,194 @@ else
 	_fail "Multi-search setup" "POST /search did not return search_ids (G=$SID_G K=$SID_K)"
 fi
 
+# --- 12. Close actually frees the search on the daemon. ------------
+# The assertion the earlier rounds were missing. Every previous check
+# here confirmed something *appeared* (a tab, an entry, a result); none
+# confirmed something was *gone*. That gap let a close path that never
+# reached the daemon look correct for several rounds: the GUI tab
+# vanished locally, so the symptom matched, while the search stayed
+# alive in the core (got3nks, PR #680 review point 6).
+#
+# GET /api/v0/search is the right oracle for this because it is a live
+# EC_OP_SEARCH_LIST round trip to amuled, not amuleapi's own m_state
+# cache -- so a search still listed here is still held by the core,
+# whatever any one client's local view says.
+#
+# POST /search/stop {close:true} sends exactly the EC request amulegui's
+# tab close sends (EC_OP_SEARCH_STOP + EC_TAG_SEARCH_CLOSE), so this
+# exercises the same daemon-side path from a scriptable client.
+CLOSE_RES=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
+SID_CLOSE=$(printf '%s' "$CLOSE_RES" | jq -r '.search_id')
+
+if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
+	# Precondition: the daemon holds it. Without this the "gone" assertion
+	# below would also pass against a search that was never there.
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 1 \
+		'close: daemon lists the search before the close'
+
+	# A plain stop (no close) halts activity but must KEEP the search --
+	# the contrapositive that proves the removal below is close's doing
+	# and not a side effect of stopping.
+	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"search_id\":$SID_CLOSE}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 1 \
+		'close: a plain stop (no close) leaves the search on the daemon'
+
+	# Now close it, and assert it is GONE from the daemon's own list.
+	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"search_id\":$SID_CLOSE,\"close\":true}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+	_assert_status 200 'close: GET /search after close → 200'
+	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 0 \
+		'close: the closed search is GONE from the daemon list'
+
+	# And it is gone for everyone, not just the session that closed it --
+	# a second instance re-reads the same core state. This is what a
+	# second amulegui would have shown had it still been open.
+	SECOND2_CONFIG_DIR=$(mktemp -d -t amuleapi_19_close_second.XXXXXX)
+	SECOND2_LOG=$(mktemp -t amuleapi_19_close_second_log.XXXXXX)
+	"$AMULEAPI_BIN" --config-dir="$SECOND2_CONFIG_DIR" \
+		--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+		--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+	"$AMULEAPI_BIN" --config-dir="$SECOND2_CONFIG_DIR" \
+		--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+		--http-port=4715 >"$SECOND2_LOG" 2>&1 &
+	SECOND2_PID=$!
+	for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+		curl -s -o /dev/null --max-time 1 "http://localhost:4715/api/v0/version" 2>/dev/null && break
+		sleep 0.5
+	done
+	sleep 2
+	SECOND2_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+		-d "{\"password\":\"$ADMIN_PASS\"}" \
+		"http://localhost:4715/api/v0/auth/login?type=bearer" | jq -r .token)
+	if [ -n "$SECOND2_TOKEN" ] && [ "$SECOND2_TOKEN" != "null" ]; then
+		_curl -H "Authorization: Bearer $SECOND2_TOKEN" "http://localhost:4715/api/v0/search"
+		_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 0 \
+			'close: a second session also no longer sees the closed search'
+	else
+		_fail "close: second instance login" "no token; log: $(tail -c 300 "$SECOND2_LOG")"
+	fi
+	kill "$SECOND2_PID" >/dev/null 2>&1
+	wait "$SECOND2_PID" 2>/dev/null
+	rm -rf "$SECOND2_CONFIG_DIR" "$SECOND2_LOG"
+
+	# Its results are unaddressable afterwards, too -- the bucket is freed,
+	# not merely hidden from the listing.
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/results?search_id=$SID_CLOSE"
+	_assert_status 404 'close: GET /search/results for the closed id → 404'
+else
+	_fail "close setup" "POST /search did not return a search_id ($CLOSE_RES)"
+fi
+
+# --- 12.1 A foreign search must be stoppable, not just visible. ----
+# Found by driving two clients against one daemon and using the other as
+# an oracle: GET /api/v0/search enumerates live core state, so it lists
+# searches this session never started -- but POST /search/stop gated on
+# the local m_state cache alone and answered 404 for exactly those. You
+# could see a search you could not close. Same contradiction previously
+# fixed for /search/results; the shared DiscoverSearchIfHeldByCore helper
+# is what stops it recurring a third time (got3nks, PR #680 review).
+#
+# Stage a genuinely foreign search: a second amuleapi instance starts it,
+# so the primary at $HOST has never seen the id in its own cache.
+FOREIGN_CONFIG_DIR=$(mktemp -d -t amuleapi_19_foreign.XXXXXX)
+FOREIGN_LOG=$(mktemp -t amuleapi_19_foreign_log.XXXXXX)
+"$AMULEAPI_BIN" --config-dir="$FOREIGN_CONFIG_DIR" \
+	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+"$AMULEAPI_BIN" --config-dir="$FOREIGN_CONFIG_DIR" \
+	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--http-port=4716 >"$FOREIGN_LOG" 2>&1 &
+FOREIGN_PID=$!
+for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+	curl -s -o /dev/null --max-time 1 "http://localhost:4716/api/v0/version" 2>/dev/null && break
+	sleep 0.5
+done
+sleep 2
+FOREIGN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"http://localhost:4716/api/v0/auth/login?type=bearer" | jq -r .token)
+
+if [ -n "$FOREIGN_TOKEN" ] && [ "$FOREIGN_TOKEN" != "null" ]; then
+	FOREIGN_RES=$(curl -s -X POST -H "Authorization: Bearer $FOREIGN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" \
+		"http://localhost:4716/api/v0/search")
+	SID_FOREIGN=$(printf '%s' "$FOREIGN_RES" | jq -r '.search_id')
+
+	if [ -n "$SID_FOREIGN" ] && [ "$SID_FOREIGN" != "null" ]; then
+		# The primary session can SEE it (this already worked).
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		_assert_json_eq "[.searches[] | select(.search_id == $SID_FOREIGN)] | length" 1 \
+			'foreign stop: primary session lists the foreign search'
+
+		# ...and can also CLOSE it. This is the assertion that was 404ing.
+		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+			-H "Content-Type: application/json" \
+			-d "{\"search_id\":$SID_FOREIGN,\"close\":true}" "$HOST/api/v0/search/stop"
+		_assert_status 200 'foreign stop: closing a foreign search → 200 (not 404)'
+
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		_assert_json_eq "[.searches[] | select(.search_id == $SID_FOREIGN)] | length" 0 \
+			'foreign stop: the foreign search is actually gone afterwards'
+	else
+		_fail "foreign stop setup" "second instance POST /search returned no id ($FOREIGN_RES)"
+	fi
+else
+	_fail "foreign stop: second instance login" "no token; log: $(tail -c 300 "$FOREIGN_LOG")"
+fi
+kill "$FOREIGN_PID" >/dev/null 2>&1
+wait "$FOREIGN_PID" 2>/dev/null
+rm -rf "$FOREIGN_CONFIG_DIR" "$FOREIGN_LOG"
+
+# --- 13. A failed search start must not wedge discovery. -----------
+# amulegui defers EC_OP_SEARCH_LIST-driven tab creation while it has a
+# START in flight, so a START that fails without ever being accounted
+# for used to leave that deferral armed for the rest of the session --
+# discovery silently dead, plus a per-tick EC round trip (got3nks, PR
+# #680 review point 5). amuleapi does not share amulegui's counter, but
+# it does share the daemon: this asserts the daemon stays healthy and
+# enumerable across a rejected start, which is the half a script can
+# observe. The client-side set-keyed-by-id fix is what closes the rest.
+BAD_START=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+	-H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+	-d '{"query":"","type":"global"}' "$HOST/api/v0/search")
+if [ "$BAD_START" = "400" ] || [ "$BAD_START" = "422" ]; then
+	_pass "failed start: empty query rejected ($BAD_START)"
+else
+	_fail "failed start: empty query rejected" "expected 400/422, got $BAD_START"
+fi
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+_assert_status 200 'failed start: GET /search still 200 afterwards'
+_assert_json_eq '.searches | type' array 'failed start: /search still enumerable afterwards'
+
+# A good start still works right after a rejected one -- i.e. the
+# rejected attempt left no residue that blocks the next search.
+AFTER_BAD=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
+SID_AFTER=$(printf '%s' "$AFTER_BAD" | jq -r '.search_id')
+if [ -n "$SID_AFTER" ] && [ "$SID_AFTER" != "null" ] && [ "$SID_AFTER" != "0" ]; then
+	_pass "failed start: a subsequent search still starts (id $SID_AFTER)"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+	_assert_json_eq "[.searches[] | select(.search_id == $SID_AFTER)] | length" 1 \
+		'failed start: the subsequent search is discoverable'
+	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"search_id\":$SID_AFTER,\"close\":true}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+else
+	_fail "failed start: subsequent search" "POST /search returned no id ($AFTER_BAD)"
+fi
+
 # --- Browse ("View Files") contract. -------------------------------
 # POST /clients/{ecid}/shared_files starts a browse and returns a
 # search_id; the files themselves arrive over the network from the peer,


### PR DESCRIPTION
Reachability fix for #641, scoped and confirmed with @got3nks before starting (see the plan comment on #641). Split out as its own contained PR, deliberately independent of `StoredSearches.met` (a later phase) so it's testable against today's in-session multi-search state.

## Root cause (verified against master)

All three client surfaces hit the identical gap for the identical reason -- nothing lets a client ask the daemon "what searches do you currently hold":

- **Monolithic**: `CSearchDlg::AddResult`/`UpdateResult` look up a tab via `GetSearchList(searchID)` and silently drop the result if none exists; `CreateNewTab` is only ever called from user-initiated paths.
- **amulegui**: `CEcSearchRegistry` (`ExternalConn.cpp`) already tracks every daemon-side active search and already feeds a multi-search `INC_UPDATE` union poll that returns every active search's results -- but the client's poll loop only sends that request when `m_curr_search != 0`, so a session that never started a search of its own never asks, regardless of what the daemon would report.
- **amuleapi**: `GET /search/results` takes a `search_id` but nothing enumerates which ids exist; the Refresher-cached `m_state` only ever learns about a search via `POST /search` from the same session.

## Fix

One new EC op, `EC_OP_SEARCH_LIST`, exposing the same `s_ecSearches.ActiveIds()` registry the union poll already reads, plus a thin client-side consumer per surface.

Per the four review notes on the plan:

1. amuleapi's route is `GET /api/v0/search` (not `/search/list`) -- REST-conventional collection GET, consistent with the existing `POST /search` route.
2. `ECCodes.abstract` + `ECCodes.h` (the committed, hand-maintained header) both edited by hand -- one enum entry + one debug-name case -- rather than regenerated, which would reflow the whole license block into an unreviewable diff.
3. **Documented limitation**: the union poll (and now this enumeration) is gated on `m_multiSearchActive`, so restored searches will surface only for clients that advertise multi-search; legacy clients stay on the single `0xffffffff` sentinel bucket and won't see them.
4. Tab creation precedes result delivery on the amulegui side by construction: `CreateNewTab` is called directly from the `EC_OP_SEARCH_LIST` handler, before any `EC_OP_SEARCH_RESULTS` for that id can be usefully delivered.

## Per-surface changes

- `CSearchList` gained `m_searchStrings` (mirrors the existing `m_searchKinds`: recorded in `StartNewSearch`, pruned in `RemoveResults`) so an enumerated search can be labelled without the requesting client having started it.
- `ExternalConn.cpp`: `Get_EC_Response_Search_List()` builds one entry per active search (id + name + kind + lifecycle state as child tags). Legacy (non-multi) clients get an empty reply.
- `amule-remote-gui.cpp`: `CSearchListRem::HandlePacket` creates a tab directly with the daemon's own id for any enumerated search with no existing tab. The `OnPollTimer` gate that used to skip `EC_OP_SEARCH_RESULTS` entirely when `m_curr_search == 0` is gone -- the union poll already returns every active search regardless of that scalar, so the gate only ever prevented *asking*, never affected what came back.
- `webapi/Api.cpp`: `GET /api/v0/search` does a direct one-off EC round trip (`m_app.SendRecvSerialized`, the same pattern `HandleSearchStart` already uses for POST), rather than reading the Refresher-cached `m_state` -- no Refresher/State changes needed.

## Testing

All three (`amule`, `amulegui`, `amuleapi`) build clean on Windows (MSYS2/MinGW-w64).

Verified interactively end-to-end: started a global search ("debian") from the monolithic aMule GUI, then confirmed a **separately-launched amuleapi process** -- which never called `POST /search` itself -- reports it via `GET /api/v0/search`:

```
$ curl -b cookies.txt http://127.0.0.1:4713/api/v0/search
{"searches":[{"search_id":1,"query":"debian","kind":"global","state":"finished"}]}
```

This proves the endpoint reads live daemon state rather than a stale per-process cache: an earlier search ("ubuntu") started through that *same* amuleapi process no longer appeared once the daemon's registry moved on to the GUI-started one.

Did not get a clean interactive screenshot of amulegui's own tab-creation in this environment -- a second GUI instance's connection-dialog window failed to paint on-screen despite Win32 reporting it visible/foregrounded (looks like a wxWidgets rendering quirk specific to this headless/remote display setup, unrelated to the code change). That path is verified by code review and clean build/link instead; happy to chase down a real screenshot if that's wanted before merge.
