### PR TITLE
packaging: use libupnp 22.0.4 across all bundles

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -69,7 +69,6 @@ env:
     mingw-w64-x86_64-libmaxminddb
     mingw-w64-x86_64-ninja
     mingw-w64-x86_64-pkgconf
-    mingw-w64-x86_64-pupnp
     mingw-w64-x86_64-readline
     mingw-w64-x86_64-toolchain
     mingw-w64-x86_64-wxwidgets3.2-msw
@@ -230,6 +229,24 @@ jobs:
           msystem: MINGW64
           update: true
           install: ${{ env.cmake_mingw_w64_deps }}
+      # MSYS2 only packages pupnp 1.14.x; build the pinned 22.x from source so
+      # Windows gets the UPnP fixes released in 22.0.4 (issue #242). Installed
+      # into $MINGW_PREFIX so find_package(UPNP CONFIG) picks it up and the DLL
+      # bundles into the portable.
+      - name: build libupnp (pupnp) from source
+        run: |
+          set -euo pipefail
+          . packaging/linux/versions.env
+          curl -L -o /tmp/libupnp.tar.gz "$LIBUPNP_TARBALL_URL"
+          echo "$LIBUPNP_SHA256  /tmp/libupnp.tar.gz" | sha256sum -c -
+          mkdir -p /tmp/libupnp
+          tar -xf /tmp/libupnp.tar.gz -C /tmp/libupnp --strip-components=1
+          cmake -S /tmp/libupnp -B /tmp/libupnp/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DUPNP_BUILD_SHARED=ON -DUPNP_BUILD_STATIC=OFF \
+            -DUPNP_BUILD_SAMPLES=OFF -DUPNP_BUILD_TESTS=OFF -Dreuseaddr=ON -Dipv6=ON \
+            -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX"
+          cmake --build /tmp/libupnp/build
+          cmake --install /tmp/libupnp/build
       - name: create build system
         run: |
           cmake \

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -482,8 +482,8 @@ jobs:
             ${{ matrix.pkg_prefix }}-libgd
             ${{ matrix.pkg_prefix }}-libmaxminddb
             ${{ matrix.pkg_prefix }}-make
+            ${{ matrix.pkg_prefix }}-ninja
             ${{ matrix.pkg_prefix }}-pkgconf
-            ${{ matrix.pkg_prefix }}-pupnp
             ${{ matrix.pkg_prefix }}-readline
             ${{ matrix.pkg_prefix }}-toolchain
             ${{ matrix.pkg_prefix }}-wxwidgets3.2-msw
@@ -511,6 +511,24 @@ jobs:
         # aMule-snapshot-Windows-*.zip instead of
         # aMule-<tag>-Windows-*.zip.
         run: git config --global --add safe.directory '*'
+      # MSYS2 only packages pupnp 1.14.x; build the pinned 22.x from source so
+      # the Windows portable gets the UPnP fixes released in 22.0.4 (issue
+      # #242). Installed into $MINGW_PREFIX so find_package(UPNP CONFIG) picks
+      # it up and build.sh's dependency bundling ships the 22.x DLL.
+      - name: Build libupnp (pupnp) from source
+        run: |
+          set -euo pipefail
+          . packaging/linux/versions.env
+          curl -L -o /tmp/libupnp.tar.gz "$LIBUPNP_TARBALL_URL"
+          echo "$LIBUPNP_SHA256  /tmp/libupnp.tar.gz" | sha256sum -c -
+          mkdir -p /tmp/libupnp
+          tar -xf /tmp/libupnp.tar.gz -C /tmp/libupnp --strip-components=1
+          cmake -S /tmp/libupnp -B /tmp/libupnp/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DUPNP_BUILD_SHARED=ON -DUPNP_BUILD_STATIC=OFF \
+            -DUPNP_BUILD_SAMPLES=OFF -DUPNP_BUILD_TESTS=OFF -Dreuseaddr=ON -Dipv6=ON \
+            -DCMAKE_INSTALL_PREFIX="$MINGW_PREFIX"
+          cmake --build /tmp/libupnp/build
+          cmake --install /tmp/libupnp/build
       - name: Build portable .zip
         env:
           WINDOWS_MSYSTEM: ${{ matrix.msystem }}

--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -98,8 +98,8 @@ modules:
       - -DCMAKE_INSTALL_LIBDIR=lib
     sources:
       - type: archive
-        url: https://github.com/pupnp/pupnp/archive/refs/tags/release-1.14.21.tar.gz
-        sha256: d176a6028b02ab36e9d334372dd64780d9a8e577a2d8d4c1d70ef8ced15d7d19
+        url: https://github.com/pupnp/pupnp/archive/refs/tags/release-22.0.4.tar.gz
+        sha256: 7028d2a151372ff8a34341e0a269f516676c1af95b0a2ba811a2f0a2fe91ea36
 
   - name: boost
     buildsystem: simple

--- a/packaging/linux/appimage/Dockerfile
+++ b/packaging/linux/appimage/Dockerfile
@@ -9,6 +9,9 @@ ARG WX_VERSION
 ARG WX_SHA256
 ARG LINUXDEPLOY_VERSION
 ARG LINUXDEPLOY_GTK_SHA
+ARG LIBUPNP_VERSION
+ARG LIBUPNP_TARBALL_URL
+ARG LIBUPNP_SHA256
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -40,7 +43,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         # redistribution; users drop it in ~/.aMule/.
         libmaxminddb-dev \
         libreadline-dev \
-        libupnp-dev \
+        # libupnp-dev intentionally omitted: Ubuntu 22.04 only ships the
+        # ancient 1.8.x line. The pinned 22.x is built from source below.
         # libcurl: backend for wxWebRequest, which aMule's HTTP path requires.
         libcurl4-openssl-dev \
         # GTK3 dev headers (linker target for wx) + Wayland/X11 client headers
@@ -67,6 +71,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         squashfs-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# libupnp / pupnp from source: Ubuntu 22.04 only packages the ancient 1.8.x
+# line, so build the pinned 22.x (shared, so linuxdeploy bundles the .so into
+# the AppImage). pupnp 22.x is CMake-only. CMAKE_INSTALL_LIBDIR=lib keeps
+# libupnp.pc / .so / the UPNP CMake config out of lib64 where pkg-config, cmake
+# and ldconfig wouldn't find them.
+RUN wget -qO /tmp/libupnp.tar.gz "${LIBUPNP_TARBALL_URL}" \
+    && echo "${LIBUPNP_SHA256}  /tmp/libupnp.tar.gz" | sha256sum -c - \
+    && mkdir -p /tmp/libupnp && tar -xf /tmp/libupnp.tar.gz -C /tmp/libupnp --strip-components=1 \
+    && cmake -S /tmp/libupnp -B /tmp/libupnp/build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+        -DUPNP_BUILD_SHARED=ON -DUPNP_BUILD_STATIC=OFF \
+        -DUPNP_BUILD_SAMPLES=OFF -DUPNP_BUILD_TESTS=OFF -Dreuseaddr=ON -Dipv6=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib \
+    && cmake --build /tmp/libupnp/build && cmake --install /tmp/libupnp/build \
+    && ldconfig \
+    && rm -rf /tmp/libupnp /tmp/libupnp.tar.gz
 
 # wxWidgets from source. --disable-shared so wx links statically into
 # aMule, sidestepping the wxGTK-SONAME-mismatch problem AppImage users

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -100,6 +100,9 @@ build_appimage() {
         --build-arg "WX_SHA256=${WX_SHA256}" \
         --build-arg "LINUXDEPLOY_VERSION=${LINUXDEPLOY_VERSION}" \
         --build-arg "LINUXDEPLOY_GTK_SHA=${LINUXDEPLOY_GTK_SHA}" \
+        --build-arg "LIBUPNP_VERSION=${LIBUPNP_VERSION}" \
+        --build-arg "LIBUPNP_TARBALL_URL=${LIBUPNP_TARBALL_URL}" \
+        --build-arg "LIBUPNP_SHA256=${LIBUPNP_SHA256}" \
         -t "${image_tag}" \
         "${SCRIPT_DIR}/appimage"
 

--- a/packaging/linux/static/Dockerfile
+++ b/packaging/linux/static/Dockerfile
@@ -72,21 +72,25 @@ RUN wget -qO /tmp/wx.tar.bz2 "${WX_TARBALL_URL}" \
  && make -j"$(nproc)" && make install
 
 # --- libupnp / pupnp (static; no static Alpine package, build from source) ---
-# versions.env pins the GitHub source archive (autotools not pre-generated),
-# so bootstrap with autoreconf first. The autotools build installs no CMake
-# config, letting aMule's find_package(UPNP CONFIG) cleanly fall back to
-# pkg-config and pick up the static libupnp.a / libixml.a.
-# CFLAGS="-include stddef.h": pupnp 1.14.x's threadutil sources use NULL
-# without pulling in <stddef.h> transitively, which fails on musl (glibc /
-# the GNOME SDK happen to include it via other headers, so the Flatpak
-# build of the same archive is unaffected).
+# pupnp 22.x is CMake-only (upstream dropped autotools), so build with CMake:
+# static libs only (UPNP_BUILD_SHARED=OFF), no samples/tests.
+# CMAKE_INSTALL_LIBDIR=lib keeps libupnp.pc out of lib64. The install also
+# drops a UPNP CMake package config that exposes only a UPNP::Static target,
+# but aMule links UPNP::Shared -- so remove lib/cmake/{UPNP,IXML} to make
+# aMule's find_package(UPNP CONFIG) fall back to pkg-config, which synthesises
+# UPNP::Shared from the static libupnp.a / libixml.a (the same path the 1.14.x
+# autotools build relied on). 22.x no longer needs the musl "-include stddef.h"
+# workaround the 1.14.x threadutil sources did.
 RUN wget -qO /tmp/libupnp.tar.gz "${LIBUPNP_TARBALL_URL}" \
  && echo "${LIBUPNP_SHA256}  /tmp/libupnp.tar.gz" | sha256sum -c - \
  && mkdir -p /tmp/libupnp && tar -xf /tmp/libupnp.tar.gz -C /tmp/libupnp --strip-components=1 \
- && cd /tmp/libupnp && ./bootstrap \
- && ./configure --disable-shared --enable-static --disable-samples --prefix=/usr/local \
-        CFLAGS="-include stddef.h" \
- && make -j"$(nproc)" && make install
+ && cd /tmp/libupnp \
+ && cmake -B build -DCMAKE_BUILD_TYPE=Release \
+        -DUPNP_BUILD_SHARED=OFF -DUPNP_BUILD_STATIC=ON \
+        -DUPNP_BUILD_SAMPLES=OFF -DUPNP_BUILD_TESTS=OFF -Dreuseaddr=ON -Dipv6=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib \
+ && cmake --build build -j"$(nproc)" && cmake --install build \
+ && rm -rf /usr/local/lib/cmake/UPNP /usr/local/lib/cmake/IXML
 
 # Force static resolution for deps that ship BOTH .so and .a. CMake's
 # find_library prefers the .so dev symlink and hands its ABSOLUTE path to the

--- a/packaging/linux/versions.env
+++ b/packaging/linux/versions.env
@@ -55,9 +55,9 @@ CRYPTOPP_VERSION=8.9.0
 # for git tags: 8.9.0 -> 8_9_0 (full tag is CRYPTOPP_8_9_0).
 CRYPTOPP_TAG_SUFFIX=8_9_0
 
-LIBUPNP_VERSION=1.14.21
+LIBUPNP_VERSION=22.0.4
 LIBUPNP_TARBALL_URL=https://github.com/pupnp/pupnp/archive/refs/tags/release-${LIBUPNP_VERSION}.tar.gz
-LIBUPNP_SHA256=d176a6028b02ab36e9d334372dd64780d9a8e577a2d8d4c1d70ef8ced15d7d19
+LIBUPNP_SHA256=7028d2a151372ff8a34341e0a269f516676c1af95b0a2ba811a2f0a2fe91ea36
 
 LIBGD_VERSION=2.3.3
 LIBGD_TARBALL_URL=https://github.com/libgd/libgd/releases/download/gd-${LIBGD_VERSION}/libgd-${LIBGD_VERSION}.tar.xz


### PR DESCRIPTION
pupnp **22.0.4** carries the UPnP fixes Windows needs (#242 — the persistent-LowID-on-Windows report; 22.0.4 was released specifically with that fix). MSYS2 still ships only 1.14.x, so Windows builds it from source. This also lands every packaging bundle on one pinned 22.0.4, since they'd drifted across three libupnp versions (AppImage on Ubuntu 22.04's ancient 1.8.x, the source bundles on 1.14.21, macOS already on 22.0.4).

**Changes**
- `versions.env`: LIBUPNP 1.14.21 → 22.0.4.
- **Windows CI (`ccpp.yml`) + portable (`packaging.yml`)**: drop the MSYS2 `pupnp` package, build the pinned 22.x from source into `$MINGW_PREFIX` (pupnp 22.x isn't in MSYS2 yet).
- **static musl daemon**: pupnp 22.x is CMake-only (upstream dropped autotools), so build static via CMake; the install's `UPNP::Static` config is removed so aMule's `find_package(UPNP CONFIG)` falls back to pkg-config and synthesises `UPNP::Shared` from the static `.a`. 22.x also drops the need for the musl `-include stddef.h` workaround.
- **AppImage**: Ubuntu 22.04 only ships libupnp 1.8.x, so build 22.x from source (shared) instead of apt `libupnp-dev`; linuxdeploy bundles the `.so`.
- **Flatpak / Flathub** manifests: bump to 22.0.4.

macOS already builds against 22.0.4 via Homebrew — no change.

**Testing** — verified aMule reports `libupnp 22.0.4` on: macOS `.app`; Windows ARM64 portable (`amule.exe` links the 22.x `libupnp.dll`); Linux static musl (`amuled --version` runs, statically linked); AppImage (bundles `libupnp.so.22`); Flatpak (GNOME SDK build).
