### PR TITLE
fix(gui): shrink the per-network connect button and name its network

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1358,7 +1358,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1581,11 +1582,6 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, c-format
-msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2921,7 +2917,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr ""
 
@@ -3213,7 +3209,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Extend"
+msgid "More"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3814,7 +3810,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4850,6 +4846,10 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -4885,12 +4885,23 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Cancel %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Disconnect %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Connect %s"
 msgstr ""
 
 #: src/OScopeCtrl.cpp
@@ -6661,11 +6672,6 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr ""
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6882,6 +6888,11 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
+msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4455,15 +4455,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1582,6 +1582,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4832,10 +4837,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6658,6 +6659,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6874,11 +6880,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3203,7 +3203,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2582,12 +2582,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4474,10 +4468,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -4504,15 +4504,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2614,12 +2614,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4522,10 +4516,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1606,6 +1606,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "تحميل (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4889,11 +4894,6 @@ msgstr "رفع نشط :"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "مجموع الملفات"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
@@ -6767,6 +6767,11 @@ msgstr "يجب ان تكون ذا هوية مرتفعة لتتمكن من انش
 msgid "Shared Files (%i)"
 msgstr "ملفات مشاركة (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "مجموع حجم ملفات المشاركة : %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -6985,11 +6990,6 @@ msgstr "إحتلال الخادم: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8397,6 +8397,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "مجموع الملفات"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3242,8 +3242,9 @@ msgid "Start"
 msgstr "ابدء"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "إمتداد"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1379,7 +1379,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1605,11 +1606,6 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "تحميل (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2959,7 +2955,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "فصل"
 
@@ -3252,9 +3248,8 @@ msgid "Start"
 msgstr "ابدء"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "إمتداد"
+msgid "More"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3859,7 +3854,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4907,6 +4902,11 @@ msgstr "رفع نشط :"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
+msgid "Percent of total files"
+msgstr "مجموع الملفات"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
@@ -4946,13 +4946,24 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "ملفات مشاركة"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "إلغاء"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "فصل"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "إتصال"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6769,11 +6780,6 @@ msgstr "يجب ان تكون ذا هوية مرتفعة لتتمكن من انش
 msgid "Shared Files (%i)"
 msgstr "ملفات مشاركة (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "مجموع حجم ملفات المشاركة : %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -6992,6 +6998,11 @@ msgstr "إحتلال الخادم: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8399,10 +8410,6 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
-
-#, fuzzy
-#~ msgid "Percent of total files"
-#~ msgstr "مجموع الملفات"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1624,6 +1624,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargues (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4972,10 +4977,6 @@ msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
@@ -6872,6 +6873,11 @@ msgstr "Necesites IDAlta pa criar un enllaz fonte válidu"
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamañu total de ficheros compartíos: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7090,11 +7096,6 @@ msgstr "Ocupación de Sirvidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Númberu de ficheros compartíos: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamañu total de ficheros compartíos: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3302,8 +3302,9 @@ msgid "Start"
 msgstr "Entamar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Más"
+#, fuzzy
+msgid "Extend"
+msgstr "Estensión"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8573,6 +8574,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Más"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2670,14 +2670,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Coneutar dende \n"
-"veceros conocíos"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodos (%u)"
@@ -4604,13 +4596,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Puertu:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"Coneutar dende \n"
-"veceros conocíos"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8588,6 +8573,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Coneutar dende \n"
+#~ "veceros conocíos"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Coneutar dende \n"
+#~ "veceros conocíos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Coneutar a cualesquier sirvidor y/o Kad"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -4583,16 +4583,16 @@ msgid "Nodes stats"
 msgstr "Estadístiques nodos"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Coneutar"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Coneutar dende \n"
+"veceros conocíos"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nuevu nodu"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8575,18 +8575,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Coneutar"
+
+#~ msgid "New node"
+#~ msgstr "Nuevu nodu"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Más"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Coneutar dende \n"
-#~ "veceros conocíos"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Coneutar dende \n"
 #~ "veceros conocíos"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1396,7 +1396,8 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1623,11 +1624,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargues (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3020,7 +3016,7 @@ msgstr "Llímite de xuba"
 msgid "Download limit"
 msgstr "Llímite de descarga"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Desconeutar"
 
@@ -3314,9 +3310,8 @@ msgid "Start"
 msgstr "Entamar"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Estensión"
+msgid "More"
+msgstr "Más"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3930,7 +3925,7 @@ msgstr "Max. fontes descargando un ficheru:"
 msgid "Max simultaneous connections:"
 msgstr "Máx. conexones al empar:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4991,6 +4986,10 @@ msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
@@ -5031,13 +5030,24 @@ msgstr "Unviar un mensax específicu."
 msgid "Close this chat-session."
 msgstr "Zarrar esta sesión de charra"
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Coneutar a cualesquier sirvidor y/o Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Fich compartíos"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Encaboxar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Desconeutar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Coneutar"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6876,11 +6886,6 @@ msgstr "Necesites IDAlta pa criar un enllaz fonte válidu"
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamañu total de ficheros compartíos: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7099,6 +7104,11 @@ msgstr "Ocupación de Sirvidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Númberu de ficheros compartíos: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamañu total de ficheros compartíos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8579,8 +8589,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Más"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Coneutar a cualesquier sirvidor y/o Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconeutar Kad"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1601,6 +1601,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Файлове за сваляне (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Общ размер на споределните файлове : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4877,11 +4882,6 @@ msgstr "Активни качвания: %i"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "Общо файлове"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
@@ -6741,6 +6741,11 @@ msgstr "Трябва да имате HighID, за да създадете вал
 msgid "Shared Files (%i)"
 msgstr "Споделени файлове (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общ размер на споределните файлове : %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -6959,11 +6964,6 @@ msgstr ""
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общ размер на споределните файлове : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8369,6 +8369,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "Общо файлове"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2609,12 +2609,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4514,10 +4508,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1374,7 +1374,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1600,11 +1601,6 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Файлове за сваляне (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Общ размер на споределните файлове : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2953,7 +2949,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Разкачи"
 
@@ -3245,9 +3241,8 @@ msgid "Start"
 msgstr "Старт"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Разширение"
+msgid "More"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3851,7 +3846,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4895,6 +4890,11 @@ msgstr "Активни качвания: %i"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
+msgid "Percent of total files"
+msgstr "Общо файлове"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
@@ -4933,13 +4933,24 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Отказ"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Разкачи"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Връзка"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6743,11 +6754,6 @@ msgstr "Трябва да имате HighID, за да създадете вал
 msgid "Shared Files (%i)"
 msgstr "Споделени файлове (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общ размер на споределните файлове : %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -6966,6 +6972,11 @@ msgstr ""
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общ размер на споределните файлове : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8371,10 +8382,6 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
-
-#, fuzzy
-#~ msgid "Percent of total files"
-#~ msgstr "Общо файлове"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3235,8 +3235,9 @@ msgid "Start"
 msgstr "Старт"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Разширение"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -4496,15 +4496,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4454,15 +4454,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1357,7 +1357,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1580,11 +1581,6 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, c-format
-msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2920,7 +2916,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr ""
 
@@ -3212,7 +3208,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Extend"
+msgid "More"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3813,7 +3809,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4849,6 +4845,10 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -4884,12 +4884,23 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Cancel %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Disconnect %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Connect %s"
 msgstr ""
 
 #: src/OScopeCtrl.cpp
@@ -6660,11 +6671,6 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr ""
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6881,6 +6887,11 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
+msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1581,6 +1581,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4831,10 +4836,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6657,6 +6658,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6873,11 +6879,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3202,7 +3202,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2581,12 +2581,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4473,10 +4467,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1621,6 +1621,11 @@ msgstr "%d/%m/%y %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Baixades (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total BA: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4954,10 +4959,6 @@ msgid "Active Uploads"
 msgstr "Pujades actives"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Percentatge del total de fitxers"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
@@ -6832,6 +6833,11 @@ msgstr "Necessiteu ID Alta per crear un enllaç font vàlid"
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Mida total dels fitxers compartits: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom de fitxer remot"
@@ -7049,11 +7055,6 @@ msgstr "Càrrega del servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Fitxers compartits: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Mida total dels fitxers compartits: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8517,6 +8518,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Percentatge del total de fitxers"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Arrancada"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1393,7 +1393,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1620,11 +1621,6 @@ msgstr "%d/%m/%y %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Baixades (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total BA: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3010,7 +3006,7 @@ msgstr "Límit de pujada"
 msgid "Download limit"
 msgstr "Límit de baixada"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Desconnecta"
 
@@ -3304,9 +3300,8 @@ msgid "Start"
 msgstr "Inicia"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extensió"
+msgid "More"
+msgstr "Més"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3918,7 +3913,7 @@ msgstr "Nombre màxim de fonts per descàrrega:"
 msgid "Max simultaneous connections:"
 msgstr "Nombre màxim de connexions simultànies:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4972,6 +4967,10 @@ msgid "Active Uploads"
 msgstr "Pujades actives"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Percentatge del total de fitxers"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
@@ -5007,13 +5006,24 @@ msgstr "Envia el missatge especificat."
 msgid "Close this chat-session."
 msgstr "Tanca aquesta sessió de xat."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Connecta amb qualsevol servidor i/o Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Compartits"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Cancel·la"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Desconnecta"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Connecta"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6835,11 +6845,6 @@ msgstr "Necessiteu ID Alta per crear un enllaç font vàlid"
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Mida total dels fitxers compartits: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom de fitxer remot"
@@ -7057,6 +7062,11 @@ msgstr "Càrrega del servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Fitxers compartits: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Mida total dels fitxers compartits: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8521,11 +8531,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Percentatge del total de fitxers"
-
-#~ msgid "More"
-#~ msgstr "Més"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Connecta amb qualsevol servidor i/o Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconnecta Kad"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -4569,16 +4569,14 @@ msgid "Nodes stats"
 msgstr "Estadístiques de nodes"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Arrancada"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Inicia des dels clients coneguts"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nou node"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8520,6 +8518,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Arrancada"
+
+#~ msgid "New node"
+#~ msgstr "Nou node"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Més"
 
@@ -8529,9 +8536,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Inicia des dels \n"
 #~ "clients coneguts"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Inicia des dels clients coneguts"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Connecta amb qualsevol servidor i/o Kad"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3292,8 +3292,9 @@ msgid "Start"
 msgstr "Inicia"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Més"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensió"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8518,6 +8519,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Més"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2660,14 +2660,6 @@ msgid "IP filter is ready"
 msgstr "El filtre d'IP està llest"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Inicia des dels \n"
-"clients coneguts"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodes (%u)"
@@ -4590,10 +4582,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Inicia des dels clients coneguts"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8530,6 +8518,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Inicia des dels \n"
+#~ "clients coneguts"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Inicia des dels clients coneguts"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Connecta amb qualsevol servidor i/o Kad"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3281,8 +3281,9 @@ msgid "Start"
 msgstr "Spustit"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Více"
+#, fuzzy
+msgid "Extend"
+msgstr "Přípona"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8504,6 +8505,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Více"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -4558,16 +4558,14 @@ msgid "Nodes stats"
 msgstr "Statistiky uzlů"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bootstrap od známých klientů"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nový uzel"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Zadejte IP serveru ve tvaru x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8506,6 +8504,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Nový uzel"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Více"
 
@@ -8515,9 +8522,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bootstrap od \n"
 #~ "známých klientů"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bootstrap od známých klientů"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Připojit k nějakému serveru a/nebo Kadu"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2644,14 +2644,6 @@ msgid "IP filter is ready"
 msgstr "IP filtr je připraven"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap od \n"
-"známých klientů"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Uzly (%u)"
@@ -4579,10 +4571,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bootstrap od známých klientů"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8516,6 +8504,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap od \n"
+#~ "známých klientů"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bootstrap od známých klientů"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Připojit k nějakému serveru a/nebo Kadu"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1617,6 +1617,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Stahování (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Celkem DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4943,10 +4948,6 @@ msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
@@ -6844,6 +6845,11 @@ msgstr "K vytvoření platného odkazu potřebujete HighID"
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Celková velikost sdílených souborů: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7062,11 +7068,6 @@ msgstr "Zaplnění serveru: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Počet sdílených souborů: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Celková velikost sdílených souborů: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1389,7 +1389,8 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1616,11 +1617,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Stahování (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Celkem DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2999,7 +2995,7 @@ msgstr "Limit odesílání"
 msgid "Download limit"
 msgstr "Limit stahování"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Odpojit"
 
@@ -3293,9 +3289,8 @@ msgid "Start"
 msgstr "Spustit"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Přípona"
+msgid "More"
+msgstr "Více"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3905,7 +3900,7 @@ msgstr "Max. zdrojů na stahovaný soubor:"
 msgid "Max simultaneous connections:"
 msgstr "Maximum připojení naráz:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4961,6 +4956,10 @@ msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
@@ -5000,13 +4999,24 @@ msgstr "Odešle zadanou zprávu."
 msgid "Close this chat-session."
 msgstr "Zavře tento chat."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Připojit k nějakému serveru a/nebo Kadu"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Sdílené soubory"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Zrušit"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Odpojit"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Připojit"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6847,11 +6857,6 @@ msgstr "K vytvoření platného odkazu potřebujete HighID"
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Celková velikost sdílených souborů: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7070,6 +7075,11 @@ msgstr "Zaplnění serveru: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Počet sdílených souborů: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Celková velikost sdílených souborů: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8507,8 +8517,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Více"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Připojit k nějakému serveru a/nebo Kadu"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Odpojit Kad"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1609,6 +1609,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4904,11 +4909,6 @@ msgstr "Aktive Uploads"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "Antal Filer Total"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
@@ -6784,6 +6784,11 @@ msgstr "Du skal have et HighID for at lave et godkendt kildelink"
 msgid "Shared Files (%i)"
 msgstr "Delte Filer (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total Størrelse Af Delte Filer: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7002,11 +7007,6 @@ msgstr ""
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8424,6 +8424,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "Antal Filer Total"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3252,8 +3252,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Endelse"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1382,7 +1382,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1608,11 +1609,6 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2969,7 +2965,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Afbryd"
 
@@ -3262,9 +3258,8 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Endelse"
+msgid "More"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3871,7 +3866,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4922,6 +4917,11 @@ msgstr "Aktive Uploads"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
+msgid "Percent of total files"
+msgstr "Antal Filer Total"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
@@ -4961,13 +4961,24 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Delte Filer"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Afbryd"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Afbryd"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Forbind"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6786,11 +6797,6 @@ msgstr "Du skal have et HighID for at lave et godkendt kildelink"
 msgid "Shared Files (%i)"
 msgstr "Delte Filer (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total Størrelse Af Delte Filer: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7009,6 +7015,11 @@ msgstr ""
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8426,10 +8437,6 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
-
-#, fuzzy
-#~ msgid "Percent of total files"
-#~ msgstr "Antal Filer Total"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2620,12 +2620,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4539,10 +4533,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4521,15 +4521,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3290,8 +3290,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mehr"
+#, fuzzy
+msgid "Extend"
+msgstr "Dateiendung"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8532,6 +8533,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Mehr"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2665,14 +2665,6 @@ msgid "IP filter is ready"
 msgstr "IP-Filter ist bereit"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap von \n"
-"bekannten Clients"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Knoten (%u)"
@@ -4588,10 +4580,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bootstrap von bekannten Clients"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8544,6 +8532,16 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap von \n"
+#~ "bekannten Clients"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bootstrap von bekannten Clients"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Mit irgendeinem Server und/oder Kad verbinden"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -4567,16 +4567,14 @@ msgid "Nodes stats"
 msgstr "Knotenstatistik"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bootstrap von bekannten Clients"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Neuer Knoten"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8534,6 +8532,15 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Neuer Knoten"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Mehr"
 
@@ -8543,9 +8550,6 @@ msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
 #~ msgstr ""
 #~ "Bootstrap von \n"
 #~ "bekannten Clients"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bootstrap von bekannten Clients"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Mit irgendeinem Server und/oder Kad verbinden"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1629,6 +1629,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Gesamt-DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4950,10 +4955,6 @@ msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Prozent aller Dateien"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
@@ -6827,6 +6828,11 @@ msgstr "Du brauchst eine hohe ID, um einen gültigen Quellenverweis zu erstellen
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Gesamtgröße der freigegebenen Dateien: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Ferndateiname"
@@ -7044,11 +7050,6 @@ msgstr "Server-Auslastung: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Anzahl freigegebener Dateien: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Gesamtgröße der freigegebenen Dateien: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8531,6 +8532,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Prozent aller Dateien"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1402,7 +1402,8 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1628,11 +1629,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Gesamt-DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3008,7 +3004,7 @@ msgstr "Upload-Einstellung"
 msgid "Download limit"
 msgstr "Download-Einstellung"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Trennen"
 
@@ -3302,9 +3298,8 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Dateiendung"
+msgid "More"
+msgstr "Mehr"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3916,7 +3911,7 @@ msgstr "Maximale Anzahl Quellen pro heruntergeladener Datei:"
 msgid "Max simultaneous connections:"
 msgstr "Maximale gleichzeitige Verbindungen:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -4968,6 +4963,10 @@ msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Prozent aller Dateien"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
@@ -5003,13 +5002,24 @@ msgstr "Sendet die angegebene Nachricht."
 msgid "Close this chat-session."
 msgstr "Schließe diese Chat-Sitzung."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Mit irgendeinem Server und/oder Kad verbinden"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Freigaben"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Abbruch"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Trennen"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Verbinden"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6830,11 +6840,6 @@ msgstr "Du brauchst eine hohe ID, um einen gültigen Quellenverweis zu erstellen
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Gesamtgröße der freigegebenen Dateien: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Ferndateiname"
@@ -7052,6 +7057,11 @@ msgstr "Server-Auslastung: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Anzahl freigegebener Dateien: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Gesamtgröße der freigegebenen Dateien: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8535,11 +8545,8 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
 
-#~ msgid "Percent of total files"
-#~ msgstr "Prozent aller Dateien"
-
-#~ msgid "More"
-#~ msgstr "Mehr"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Mit irgendeinem Server und/oder Kad verbinden"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad trennen"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1404,7 +1404,8 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1631,11 +1632,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Κατεβασμένα (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Συνολικό Κατέβασμα: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3031,7 +3027,7 @@ msgstr "Όριο ανεβάσματος"
 msgid "Download limit"
 msgstr "Όριο κατεβάσματος"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Αποσύνδεση"
 
@@ -3325,9 +3321,8 @@ msgid "Start"
 msgstr "Εκκίνηση"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Κατάληξη"
+msgid "More"
+msgstr "Περισσότερα"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3941,7 +3936,7 @@ msgstr "Μέγιστος αριθμός πηγών ανά εισερχόμενο
 msgid "Max simultaneous connections:"
 msgstr "Μέγιστος αριθμός παράλληλων συνδέσεων:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -5002,6 +4997,10 @@ msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
@@ -5042,13 +5041,24 @@ msgstr "Αποστολή του προσδιορισμένου μηνύματο�
 msgid "Close this chat-session."
 msgstr "Κλείσιμο της συνομιλίας."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Κοινόχρηστα αρχεία"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Ακύρωση"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Αποσύνδεση"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Σύνδεση"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6893,11 +6903,6 @@ msgstr "Χρειάζεται Υψηλή Προτεραιότητα για τη �
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7116,6 +7121,11 @@ msgstr "Κατοχή διακομιστών: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Αριθμός κοινόχρηστων αρχείων: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8598,8 +8608,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Περισσότερα"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Αποσυνδεδεμένο Kad"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -4594,16 +4594,16 @@ msgid "Nodes stats"
 msgstr "Στατιστικές κόμβων"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Εκκινητήρας"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Εκκίνηση από\n"
+"γνωστούς πελάτες"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Καινούριος κόμβος"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8594,18 +8594,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Εκκινητήρας"
+
+#~ msgid "New node"
+#~ msgstr "Καινούριος κόμβος"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Περισσότερα"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Εκκίνηση από\n"
-#~ "γνωστούς πελάτες"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Εκκίνηση από\n"
 #~ "γνωστούς πελάτες"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2679,14 +2679,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Εκκίνηση από\n"
-"γνωστούς πελάτες"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Κόμβοι (%u)"
@@ -4615,13 +4607,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Θύρα:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"Εκκίνηση από\n"
-"γνωστούς πελάτες"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8607,6 +8592,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Εκκίνηση από\n"
+#~ "γνωστούς πελάτες"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Εκκίνηση από\n"
+#~ "γνωστούς πελάτες"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Σύνδεση σε κάθε διακομιστή ή/και Kad"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1632,6 +1632,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Κατεβασμένα (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Συνολικό Κατέβασμα: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4983,10 +4988,6 @@ msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
@@ -6889,6 +6890,11 @@ msgstr "Χρειάζεται Υψηλή Προτεραιότητα για τη �
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7107,11 +7113,6 @@ msgstr "Κατοχή διακομιστών: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Αριθμός κοινόχρηστων αρχείων: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3313,8 +3313,9 @@ msgid "Start"
 msgstr "Εκκίνηση"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Περισσότερα"
+#, fuzzy
+msgid "Extend"
+msgstr "Κατάληξη"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8592,6 +8593,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Περισσότερα"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3203,7 +3203,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4455,15 +4455,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1358,7 +1358,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1581,11 +1582,6 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, c-format
-msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2921,7 +2917,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr ""
 
@@ -3213,7 +3209,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Extend"
+msgid "More"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3814,7 +3810,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4850,6 +4846,10 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -4885,12 +4885,23 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Cancel %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Disconnect %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Connect %s"
 msgstr ""
 
 #: src/OScopeCtrl.cpp
@@ -6661,11 +6672,6 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr ""
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6882,6 +6888,11 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
+msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2582,12 +2582,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4474,10 +4468,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1582,6 +1582,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4832,10 +4837,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6658,6 +6659,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6874,11 +6880,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2668,14 +2668,6 @@ msgid "IP filter is ready"
 msgstr "El filtro de IP está listo"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Inicializar desde \n"
-"clientes conocidos"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodos (%u)"
@@ -4575,10 +4567,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Puerto:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Inicializar desde clientes conocidos"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8525,6 +8513,16 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Inicializar desde \n"
+#~ "clientes conocidos"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Inicializar desde clientes conocidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectar a cualquier servidor y/o a Kad"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3289,8 +3289,9 @@ msgid "Start"
 msgstr "Comenzar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Más"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensión"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8513,6 +8514,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Más"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -4554,16 +4554,14 @@ msgid "Nodes stats"
 msgstr "Estadísticas de nodos"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Inicialización"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Inicializar desde clientes conocidos"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nuevo nodo"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Introduzca aquí la IP del servidor, usando el formato \"x.x.x.x\"."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8515,6 +8513,15 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
 
+#~ msgid "Bootstrap"
+#~ msgstr "Inicialización"
+
+#~ msgid "New node"
+#~ msgstr "Nuevo nodo"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Más"
 
@@ -8524,9 +8531,6 @@ msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
 #~ msgstr ""
 #~ "Inicializar desde \n"
 #~ "clientes conocidos"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Inicializar desde clientes conocidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectar a cualquier servidor y/o a Kad"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1632,6 +1632,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DES: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4946,10 +4951,6 @@ msgid "Active Uploads"
 msgstr "Subidas activas"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Porcentaje del total de archivos"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
@@ -6809,6 +6810,11 @@ msgstr "Necesita Id Alta para crear un enlace fuente válido"
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total de los archivos compartidos: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nombre del archivo remoto"
@@ -7026,11 +7032,6 @@ msgstr "Ocupación de servidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de archivos compartidos: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total de los archivos compartidos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8512,6 +8513,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Porcentaje del total de archivos"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Inicialización"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1405,7 +1405,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1631,11 +1632,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total DES: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3009,7 +3005,7 @@ msgstr "Límite de subida"
 msgid "Download limit"
 msgstr "Límite de descarga"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -3301,9 +3297,8 @@ msgid "Start"
 msgstr "Comenzar"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extensión"
+msgid "More"
+msgstr "Más"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3906,7 +3901,7 @@ msgstr "Número máximo de fuentes descargando un archivo:"
 msgid "Max simultaneous connections:"
 msgstr "Número máximo de conexiones simultáneas:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4964,6 +4959,10 @@ msgid "Active Uploads"
 msgstr "Subidas activas"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Porcentaje del total de archivos"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
@@ -4999,13 +4998,24 @@ msgstr "Envía el mensaje especificado."
 msgid "Close this chat-session."
 msgstr "Cerrar esta sesión de chat."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Conectar a cualquier servidor y/o a Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Compartidos"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Cancelar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Desconectar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Conectar"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6812,11 +6822,6 @@ msgstr "Necesita Id Alta para crear un enlace fuente válido"
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total de los archivos compartidos: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nombre del archivo remoto"
@@ -7034,6 +7039,11 @@ msgstr "Ocupación de servidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de archivos compartidos: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total de los archivos compartidos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8516,11 +8526,8 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
 
-#~ msgid "Percent of total files"
-#~ msgstr "Porcentaje del total de archivos"
-
-#~ msgid "More"
-#~ msgstr "Más"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Conectar a cualquier servidor y/o a Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconectar Kad"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1394,7 +1394,8 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1621,11 +1622,6 @@ msgstr "%H:%M:%S %d/%m/%y"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Tõmbamised (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Kokku AL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3011,7 +3007,7 @@ msgstr "Saatmise limiit"
 msgid "Download limit"
 msgstr "Tõmbamise limiit"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Ühendu lahti"
 
@@ -3305,9 +3301,8 @@ msgid "Start"
 msgstr "Alusta"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Laiend"
+msgid "More"
+msgstr "Rohkem"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3919,7 +3914,7 @@ msgstr "Maksimaalseid allikaid tõmmatava faili kohta:"
 msgid "Max simultaneous connections:"
 msgstr "Maksimaalselt samaaegseid ühendusi:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4975,6 +4970,10 @@ msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Protsenti kogufailidest"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
@@ -5010,13 +5009,24 @@ msgstr "Saada määratud teade."
 msgid "Close this chat-session."
 msgstr "Sulge see vestlus-seanss."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Jagatud failid"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Loobu"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Ühendu lahti"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Ühenda"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6845,11 +6855,6 @@ msgstr "Allika lingi loomiseks pead omama HighID'd."
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jagatud failide suurus kokku: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Kaugfaili nimi"
@@ -7067,6 +7072,11 @@ msgstr "Serveri hõivatus: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jagatud failide arv: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jagatud failide suurus kokku: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8524,11 +8534,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Protsenti kogufailidest"
-
-#~ msgid "More"
-#~ msgstr "Rohkem"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Ühendu suvalise serveri ja/või Kad võrguga"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Lõpeta Kad ühendus"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2661,14 +2661,6 @@ msgid "IP filter is ready"
 msgstr "IP filter on lähtestatud"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Tuntud klientide \n"
-"Bootstrap"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Sõlmed (%u)"
@@ -4592,10 +4584,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Tuntud klientide Bootstrap"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8533,6 +8521,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Tuntud klientide \n"
+#~ "Bootstrap"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Tuntud klientide Bootstrap"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Ühendu suvalise serveri ja/või Kad võrguga"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -4571,16 +4571,14 @@ msgid "Nodes stats"
 msgstr "Sõlmede statistika"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Tuntud klientide Bootstrap"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Uus sõlm"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8523,6 +8521,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Uus sõlm"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Rohkem"
 
@@ -8532,9 +8539,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Tuntud klientide \n"
 #~ "Bootstrap"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Tuntud klientide Bootstrap"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Ühendu suvalise serveri ja/või Kad võrguga"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3293,8 +3293,9 @@ msgid "Start"
 msgstr "Alusta"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Rohkem"
+#, fuzzy
+msgid "Extend"
+msgstr "Laiend"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8521,6 +8522,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Rohkem"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1622,6 +1622,11 @@ msgstr "%H:%M:%S %d/%m/%y"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Tõmbamised (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Kokku AL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4957,10 +4962,6 @@ msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Protsenti kogufailidest"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
@@ -6842,6 +6843,11 @@ msgstr "Allika lingi loomiseks pead omama HighID'd."
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jagatud failide suurus kokku: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Kaugfaili nimi"
@@ -7059,11 +7065,6 @@ msgstr "Serveri hõivatus: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jagatud failide arv: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jagatud failide suurus kokku: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8520,6 +8521,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Protsenti kogufailidest"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2662,14 +2662,6 @@ msgid "IP filter is ready"
 msgstr "IP iragazkia presta dago"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Hemendik abiarazi:\n"
-"bezero ezagunak"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodoak (%u)"
@@ -4592,10 +4584,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Ataka:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bezero ezagunetarik abiarazi"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8533,6 +8521,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Hemendik abiarazi:\n"
+#~ "bezero ezagunak"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bezero ezagunetarik abiarazi"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Konektatu edozein zerbitzari eta/edo Kad"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -4571,16 +4571,14 @@ msgid "Nodes stats"
 msgstr "Nodo estatistikak"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Autoabioa"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bezero ezagunetarik abiarazi"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nodo berria"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8523,6 +8521,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Autoabioa"
+
+#~ msgid "New node"
+#~ msgstr "Nodo berria"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Gehiago"
 
@@ -8532,9 +8539,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Hemendik abiarazi:\n"
 #~ "bezero ezagunak"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bezero ezagunetarik abiarazi"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Konektatu edozein zerbitzari eta/edo Kad"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3294,8 +3294,9 @@ msgid "Start"
 msgstr "Hasi"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Gehiago"
+#, fuzzy
+msgid "Extend"
+msgstr "Hedapena"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8521,6 +8522,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Gehiago"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1623,6 +1623,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Deskargak (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DE guztira: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4957,10 +4962,6 @@ msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "fitxategi guztien ehunekoa"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
@@ -6838,6 +6839,11 @@ msgstr "ID altua behar duzu baliozko jatorri lotura bat sortzeko"
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Guztira partekatutako fitxategi tamaina: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Urruneko fitxategiaren izena"
@@ -7055,11 +7061,6 @@ msgstr "Zerbitzari lan karga %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Partekatutako fitxategi kopurua: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Guztira partekatutako fitxategi tamaina: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8520,6 +8521,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "fitxategi guztien ehunekoa"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Autoabioa"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1395,7 +1395,8 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1622,11 +1623,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Deskargak (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "DE guztira: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3012,7 +3008,7 @@ msgstr "Igoera muga"
 msgid "Download limit"
 msgstr "Deskarga muga"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Deskonektatu"
 
@@ -3306,9 +3302,8 @@ msgid "Start"
 msgstr "Hasi"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Hedapena"
+msgid "More"
+msgstr "Gehiago"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3920,7 +3915,7 @@ msgstr "Jatorri muga deskarga bakoitzerako:"
 msgid "Max simultaneous connections:"
 msgstr "Aldibereko konexioa muga:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4975,6 +4970,10 @@ msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "fitxategi guztien ehunekoa"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
@@ -5010,13 +5009,24 @@ msgstr "Zehaztutako mezua bidali."
 msgid "Close this chat-session."
 msgstr "Itxi elkarrizketa saio hau."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Konektatu edozein zerbitzari eta/edo Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Partekatutako fitxategiak"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Utzi"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Deskonektatu"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Konektatu"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6841,11 +6851,6 @@ msgstr "ID altua behar duzu baliozko jatorri lotura bat sortzeko"
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Guztira partekatutako fitxategi tamaina: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Urruneko fitxategiaren izena"
@@ -7063,6 +7068,11 @@ msgstr "Zerbitzari lan karga %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Partekatutako fitxategi kopurua: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Guztira partekatutako fitxategi tamaina: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8524,11 +8534,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "fitxategi guztien ehunekoa"
-
-#~ msgid "More"
-#~ msgstr "Gehiago"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Konektatu edozein zerbitzari eta/edo Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad deskonektatu"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2662,14 +2662,6 @@ msgid "IP filter is ready"
 msgstr "IP-suodatin on valmiina"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Käytä tunnettuja \n"
-"asiakkaita yhdistämisapuna"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Yhteyspisteitä (%u)"
@@ -4592,10 +4584,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Portti:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8533,6 +8521,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Käytä tunnettuja \n"
+#~ "asiakkaita yhdistämisapuna"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1395,7 +1395,8 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1622,11 +1623,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lataukset (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Yht alas: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3012,7 +3008,7 @@ msgstr "Lähetysraja"
 msgid "Download limit"
 msgstr "Latausraja"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
@@ -3306,9 +3302,8 @@ msgid "Start"
 msgstr "Käynnistä haku"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Pääte"
+msgid "More"
+msgstr "Hae lisää"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3920,7 +3915,7 @@ msgstr "Lähteitä enintään tiedostoa kohden:"
 msgid "Max simultaneous connections:"
 msgstr "Yhtäaikaisten yhteyksien enimmäismäärä:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4975,6 +4970,10 @@ msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Prosenttia kaikista tiedostoista"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
@@ -5010,13 +5009,24 @@ msgstr "Lähettää annetun viestin."
 msgid "Close this chat-session."
 msgstr "Sulje tämä keskustelu."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Jaetut tiedostot"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Peruuta"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Katkaise yhteys"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Yhdistä"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6841,11 +6851,6 @@ msgstr "Tarvitset HighID:een luodaksesi voimassa olevan lähdelinkin"
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Tiedoston nimi etäpäässä"
@@ -7063,6 +7068,11 @@ msgstr "Palvelimien käyttö: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jaettuja tiedostoja: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8524,11 +8534,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Prosenttia kaikista tiedostoista"
-
-#~ msgid "More"
-#~ msgstr "Hae lisää"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Katkaise Kad-yhteys"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4571,16 +4571,14 @@ msgid "Nodes stats"
 msgstr "Yhteyspisteiden tilastot"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Yhdistämisapu"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Uusi yhteyspiste"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8523,6 +8521,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Yhdistämisapu"
+
+#~ msgid "New node"
+#~ msgstr "Uusi yhteyspiste"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Hae lisää"
 
@@ -8532,9 +8539,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Käytä tunnettuja \n"
 #~ "asiakkaita yhdistämisapuna"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Yhdistä mihin tahansa palvelimeen ja/tai Kadiin"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3294,8 +3294,9 @@ msgid "Start"
 msgstr "Käynnistä haku"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Hae lisää"
+#, fuzzy
+msgid "Extend"
+msgstr "Pääte"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8521,6 +8522,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Hae lisää"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1623,6 +1623,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lataukset (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Yht alas: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4957,10 +4962,6 @@ msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Prosenttia kaikista tiedostoista"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
@@ -6838,6 +6839,11 @@ msgstr "Tarvitset HighID:een luodaksesi voimassa olevan lähdelinkin"
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Tiedoston nimi etäpäässä"
@@ -7055,11 +7061,6 @@ msgstr "Palvelimien käyttö: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jaettuja tiedostoja: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8520,6 +8521,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Prosenttia kaikista tiedostoista"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Yhdistämisapu"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2666,14 +2666,6 @@ msgid "IP filter is ready"
 msgstr "IP filter est prêt"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Amorçage depuis\n"
-"les clients connus"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nœuds (%u)"
@@ -4569,10 +4561,6 @@ msgstr "IP :"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port :"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Amorçage depuis les clients connus"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8517,6 +8505,16 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Amorçage depuis\n"
+#~ "les clients connus"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Amorçage depuis les clients connus"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Se connecter à n'importe quel serveur et/ou Kad"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1403,7 +1403,8 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1629,11 +1630,6 @@ msgstr "%y/%m/%d %H : %M : %S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Téléchargements (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Reçu au total : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3007,7 +3003,7 @@ msgstr "Limite d'émission"
 msgid "Download limit"
 msgstr "Limite de téléchargement"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Déconnecter"
 
@@ -3299,9 +3295,8 @@ msgid "Start"
 msgstr "Démarrer"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extension"
+msgid "More"
+msgstr "Plus"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3904,7 +3899,7 @@ msgstr "Sources maximales par fichier téléchargé :"
 msgid "Max simultaneous connections:"
 msgstr "Connexions simultanées maximales :"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4958,6 +4953,10 @@ msgid "Active Uploads"
 msgstr "Envois Actifs"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Pourcentage du total de fichiers"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
@@ -4993,13 +4992,24 @@ msgstr "Envoie le message spécifié."
 msgid "Close this chat-session."
 msgstr "Ferme cette session de discussion."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Se connecter à n'importe quel serveur et/ou Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Fichiers partagés"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Annuler"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Déconnecter"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Se connecter"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6804,11 +6814,6 @@ msgstr "Vous devez être en HighID pour créer un lien valide"
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Taille totale des Fichiers Partagés : %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom du fichier à distance"
@@ -7026,6 +7031,11 @@ msgstr "Occupation du Serveur : %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Nombre de Fichiers Partagés : %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Taille totale des Fichiers Partagés : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8508,11 +8518,8 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
 
-#~ msgid "Percent of total files"
-#~ msgstr "Pourcentage du total de fichiers"
-
-#~ msgid "More"
-#~ msgstr "Plus"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Se connecter à n'importe quel serveur et/ou Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Déconnecter Kad"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1630,6 +1630,11 @@ msgstr "%y/%m/%d %H : %M : %S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Téléchargements (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Reçu au total : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4940,10 +4945,6 @@ msgid "Active Uploads"
 msgstr "Envois Actifs"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Pourcentage du total de fichiers"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
@@ -6801,6 +6802,11 @@ msgstr "Vous devez être en HighID pour créer un lien valide"
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Taille totale des Fichiers Partagés : %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom du fichier à distance"
@@ -7018,11 +7024,6 @@ msgstr "Occupation du Serveur : %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Nombre de Fichiers Partagés : %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Taille totale des Fichiers Partagés : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8504,6 +8505,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Percent of total files"
+#~ msgstr "Pourcentage du total de fichiers"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Amorçage"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -4548,16 +4548,14 @@ msgid "Nodes stats"
 msgstr "Statistiques des nœuds"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Amorçage"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Amorçage depuis les clients connus"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nouveau nœud"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP :"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Entrer ici l'adresse IP du serveur, avec le format x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8507,6 +8505,15 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
 
+#~ msgid "Bootstrap"
+#~ msgstr "Amorçage"
+
+#~ msgid "New node"
+#~ msgstr "Nouveau nœud"
+
+#~ msgid "IP:"
+#~ msgstr "IP :"
+
 #~ msgid "More"
 #~ msgstr "Plus"
 
@@ -8516,9 +8523,6 @@ msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
 #~ msgstr ""
 #~ "Amorçage depuis\n"
 #~ "les clients connus"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Amorçage depuis les clients connus"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Se connecter à n'importe quel serveur et/ou Kad"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3287,8 +3287,9 @@ msgid "Start"
 msgstr "Démarrer"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Plus"
+#, fuzzy
+msgid "Extend"
+msgstr "Extension"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8505,6 +8506,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "More"
+#~ msgstr "Plus"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3303,8 +3303,9 @@ msgid "Start"
 msgstr "Comezar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Máis"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensión"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8542,6 +8543,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Máis"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2678,14 +2678,6 @@ msgid "IP filter is ready"
 msgstr "O filtro de IP está listo"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Arrancando dende cero a partir de \n"
-"clientes coñecidos"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodos (%u)"
@@ -4601,10 +4593,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porto:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Arrancar a partir de clientes coñecidos"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8554,6 +8542,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Arrancando dende cero a partir de \n"
+#~ "clientes coñecidos"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Arrancar a partir de clientes coñecidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectar a calquera servidor e/ou Kad"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1642,6 +1642,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4964,10 +4969,6 @@ msgid "Active Uploads"
 msgstr "Envíos activos"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Porcentaxe de todos os ficheiros"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
@@ -6842,6 +6843,11 @@ msgstr "Precísase ter IDAlta para crear unha ligazón á fonte válido"
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total dos ficheiros compartidos: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome remoto do ficheiro"
@@ -7059,11 +7065,6 @@ msgstr "Ocupación do servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de ficheiros compartidos: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total dos ficheiros compartidos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8541,6 +8542,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Porcentaxe de todos os ficheiros"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Arranque autónomo (dende cero)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1415,7 +1415,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1641,11 +1642,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3021,7 +3017,7 @@ msgstr "Límite de envío"
 msgid "Download limit"
 msgstr "Límite de descarga"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -3315,9 +3311,8 @@ msgid "Start"
 msgstr "Comezar"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extensión"
+msgid "More"
+msgstr "Máis"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3929,7 +3924,7 @@ msgstr "Límite de fontes por ficheiro descargado:"
 msgid "Max simultaneous connections:"
 msgstr "Conexións simultáneas máximas:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4982,6 +4977,10 @@ msgid "Active Uploads"
 msgstr "Envíos activos"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Porcentaxe de todos os ficheiros"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
@@ -5017,13 +5016,24 @@ msgstr "Enviar a mensaxe especificada."
 msgid "Close this chat-session."
 msgstr "Pechar esta conversa."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Conectar a calquera servidor e/ou Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Ficheiros compartidos"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Cancelar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Desconectar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Conectar"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6845,11 +6855,6 @@ msgstr "Precísase ter IDAlta para crear unha ligazón á fonte válido"
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total dos ficheiros compartidos: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome remoto do ficheiro"
@@ -7067,6 +7072,11 @@ msgstr "Ocupación do servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de ficheiros compartidos: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total dos ficheiros compartidos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8545,11 +8555,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Porcentaxe de todos os ficheiros"
-
-#~ msgid "More"
-#~ msgstr "Máis"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Conectar a calquera servidor e/ou Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconectar Kad"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -4580,16 +4580,14 @@ msgid "Nodes stats"
 msgstr "Estatísticas de nodos"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Arranque autónomo (dende cero)"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Arrancar a partir de clientes coñecidos"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Novo nodo"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8544,6 +8542,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Arranque autónomo (dende cero)"
+
+#~ msgid "New node"
+#~ msgstr "Novo nodo"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Máis"
 
@@ -8553,9 +8560,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Arrancando dende cero a partir de \n"
 #~ "clientes coñecidos"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Arrancar a partir de clientes coñecidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectar a calquera servidor e/ou Kad"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1385,7 +1385,8 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "קאד"
 
@@ -1610,11 +1611,6 @@ msgstr "%y/%m/%d·%H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "הורדות (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "סכום כולל: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2981,7 +2977,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "מנותק"
 
@@ -3275,9 +3271,8 @@ msgid "Start"
 msgstr "התחל"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "סיומת"
+msgid "More"
+msgstr "עוד"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3884,7 +3879,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4935,6 +4930,10 @@ msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
@@ -4974,13 +4973,24 @@ msgstr "שולח את ההודעה המצויינת."
 msgid "Close this chat-session."
 msgstr "סגור את הצ'אט הנוכחי."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "קבצים משותפים"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "ביטול"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "מנותק"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "התחבר"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6817,11 +6827,6 @@ msgstr "אתה צריך מ\"ז גבוה (HighID) כדי לחןר קישור-מק
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "גודל כולל של קבצים משותפים: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7040,6 +7045,11 @@ msgstr "תעסוקת שרתים: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "מספר קבצים משותפים: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "גודל כולל של קבצים משותפים: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8496,9 +8506,6 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
-
-#~ msgid "More"
-#~ msgstr "עוד"
 
 #~ msgid "Stop the current connection attempts"
 #~ msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1611,6 +1611,11 @@ msgstr "%y/%m/%d·%H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "הורדות (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "סכום כולל: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4918,10 +4923,6 @@ msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
@@ -6815,6 +6816,11 @@ msgstr "אתה צריך מ\"ז גבוה (HighID) כדי לחןר קישור-מק
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "גודל כולל של קבצים משותפים: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7033,11 +7039,6 @@ msgstr "תעסוקת שרתים: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "מספר קבצים משותפים: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "גודל כולל של קבצים משותפים: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2632,12 +2632,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "צמתים (%u)"
@@ -4552,10 +4546,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -4534,15 +4534,12 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr ""
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "קבצים זמניים"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3265,8 +3265,9 @@ msgid "Start"
 msgstr "התחל"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "עוד"
+#, fuzzy
+msgid "Extend"
+msgstr "סיומת"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8496,6 +8497,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "עוד"
 
 #~ msgid "Stop the current connection attempts"
 #~ msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1388,7 +1388,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1614,11 +1615,6 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2979,7 +2975,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Prekinuti vezu"
 
@@ -3272,9 +3268,8 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Ekstenzija"
+msgid "More"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3879,7 +3874,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4932,6 +4927,11 @@ msgstr "Aktivni uploadovi :"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
+msgid "Percent of total files"
+msgstr "Ukupni fajlovi"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
@@ -4971,13 +4971,24 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Dijeljeni fajlovi"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Otkaz"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Prekinuti vezu"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Uspostavi vezu"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6815,11 +6826,6 @@ msgstr "Za ispravan izvorni link, potrebna je HIGH ID"
 msgid "Shared Files (%i)"
 msgstr "Dijeljeni fajlovi (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Ukupna velicina dijeljenih fajlova: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7038,6 +7044,11 @@ msgstr "Zauzetost servera: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8445,10 +8456,6 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
-
-#, fuzzy
-#~ msgid "Percent of total files"
-#~ msgstr "Ukupni fajlovi"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3262,8 +3262,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Ekstenzija"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1615,6 +1615,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4915,11 +4920,6 @@ msgstr "Aktivni uploadovi :"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "Ukupni fajlovi"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
@@ -6814,6 +6814,11 @@ msgstr "Za ispravan izvorni link, potrebna je HIGH ID"
 msgid "Shared Files (%i)"
 msgstr "Dijeljeni fajlovi (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7032,11 +7037,6 @@ msgstr "Zauzetost servera: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8444,6 +8444,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "Ukupni fajlovi"
 
 #~ msgid "IP:"
 #~ msgstr "IP:"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -4529,16 +4529,13 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr ""
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Privremene datoteke"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8447,6 +8444,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2628,12 +2628,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4547,10 +4541,6 @@ msgstr "IP:"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -4550,16 +4550,14 @@ msgid "Nodes stats"
 msgstr "Csomópont statisztikák"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Rendszerbetöltés"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Indítás ismert kliensektől"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Új csomópont (node)"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8492,6 +8490,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Rendszerbetöltés"
+
+#~ msgid "New node"
+#~ msgstr "Új csomópont (node)"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Több"
 
@@ -8501,9 +8508,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Indítás ismert \n"
 #~ "kliensektől"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Indítás ismert kliensektől"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2651,14 +2651,6 @@ msgid "IP filter is ready"
 msgstr "IP szűrő készen áll"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Indítás ismert \n"
-"kliensektől"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Csomópontok (%u)"
@@ -4571,10 +4563,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Indítás ismert kliensektől"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8502,6 +8490,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Indítás ismert \n"
+#~ "kliensektől"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Indítás ismert kliensektől"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3273,8 +3273,9 @@ msgid "Start"
 msgstr "Indít"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Több"
+#, fuzzy
+msgid "Extend"
+msgstr "Kiterjesztés"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8490,6 +8491,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Több"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1392,7 +1392,8 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1618,11 +1619,6 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Letöltések (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Összes letöltés: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2991,7 +2987,7 @@ msgstr "Feltöltési korlát"
 msgid "Download limit"
 msgstr "Letöltési korlát"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Szétkapcsolás"
 
@@ -3285,9 +3281,8 @@ msgid "Start"
 msgstr "Indít"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Kiterjesztés"
+msgid "More"
+msgstr "Több"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3899,7 +3894,7 @@ msgstr "Max források letöltési fájlonként:"
 msgid "Max simultaneous connections:"
 msgstr "Max egyidejű kapcsolatok:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4960,6 +4955,10 @@ msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Összes fájl százalékaként"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
@@ -4995,13 +4994,24 @@ msgstr "Megadott üzenet küldése."
 msgid "Close this chat-session."
 msgstr "Csevegési folyamat bezárása."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Megosztott fájlok"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Mégsem"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Szétkapcsolás"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Kapcsolatfelvétel"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6805,11 +6815,6 @@ msgstr "Érvényes forráshivatkozáshoz magas azonosító (HighID) szükséges"
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Megosztott fájlok teljes mérete: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Távoli fájlnév"
@@ -7027,6 +7032,11 @@ msgstr "Kiszolgáló leterheltség: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Megosztott fájlok száma: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Megosztott fájlok teljes mérete: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8493,11 +8503,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Összes fájl százalékaként"
-
-#~ msgid "More"
-#~ msgstr "Több"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Kapcsolódás bármelyik kiszolgálóhoz és/vagy a Kad-hoz"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Leválasztás a Kad-ról"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1619,6 +1619,11 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Letöltések (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Összes letöltés: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4942,10 +4947,6 @@ msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Összes fájl százalékaként"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
@@ -6802,6 +6803,11 @@ msgstr "Érvényes forráshivatkozáshoz magas azonosító (HighID) szükséges"
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Megosztott fájlok teljes mérete: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Távoli fájlnév"
@@ -7019,11 +7025,6 @@ msgstr "Kiszolgáló leterheltség: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Megosztott fájlok száma: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Megosztott fájlok teljes mérete: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8489,6 +8490,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Összes fájl százalékaként"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Rendszerbetöltés"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2680,14 +2680,6 @@ msgid "IP filter is ready"
 msgstr "Filtro IP pronto"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap dai\n"
-"client noti"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodi (%u)"
@@ -4579,10 +4571,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porta:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bootstrap dai client noti"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8521,6 +8509,16 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap dai\n"
+#~ "client noti"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bootstrap dai client noti"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Connetti a qualsiasi server e/o a Kad"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1408,7 +1408,8 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1634,11 +1635,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Download (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "DL totale: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3021,7 +3017,7 @@ msgstr "Limite di invio"
 msgid "Download limit"
 msgstr "Limite di scaricamento"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Disconnetti"
 
@@ -3313,9 +3309,8 @@ msgid "Start"
 msgstr "Cerca"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Estensione"
+msgid "More"
+msgstr "Ancora"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3917,7 +3912,7 @@ msgstr "Fonti massime per file in scaricamento:"
 msgid "Max simultaneous connections:"
 msgstr "Connessioni massime simultanee:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4968,6 +4963,10 @@ msgid "Active Uploads"
 msgstr "Upload attivi"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Percentuale di file totali"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
@@ -5003,13 +5002,24 @@ msgstr "Invia messaggio specificato."
 msgid "Close this chat-session."
 msgstr "Chiude questa sessione di chat."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Connetti a qualsiasi server e/o a Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "File condivisi"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Annulla"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Disconnetti"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Connetti"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6809,11 +6819,6 @@ msgstr "Hai bisogno di un ID alto per creare un sourcelink valido"
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensione totale file condivisi: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome file remoto"
@@ -7031,6 +7036,11 @@ msgstr "Occupazione server: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numero di file condivisi: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensione totale file condivisi: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8512,11 +8522,8 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
 
-#~ msgid "Percent of total files"
-#~ msgstr "Percentuale di file totali"
-
-#~ msgid "More"
-#~ msgstr "Ancora"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Connetti a qualsiasi server e/o a Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Disconnetti rete Kad"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3301,8 +3301,9 @@ msgid "Start"
 msgstr "Cerca"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Ancora"
+#, fuzzy
+msgid "Extend"
+msgstr "Estensione"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8509,6 +8510,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Ancora"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -4558,16 +4558,14 @@ msgid "Nodes stats"
 msgstr "Statistiche nodi"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bootstrap dai client noti"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nuovo nodo"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Inserisci qui l'IP del server, nel formato x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8511,6 +8509,15 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Nuovo nodo"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Ancora"
 
@@ -8520,9 +8527,6 @@ msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
 #~ msgstr ""
 #~ "Bootstrap dai\n"
 #~ "client noti"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bootstrap dai client noti"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Connetti a qualsiasi server e/o a Kad"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1635,6 +1635,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Download (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DL totale: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4950,10 +4955,6 @@ msgid "Active Uploads"
 msgstr "Upload attivi"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Percentuale di file totali"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
@@ -6806,6 +6807,11 @@ msgstr "Hai bisogno di un ID alto per creare un sourcelink valido"
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensione totale file condivisi: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome file remoto"
@@ -7023,11 +7029,6 @@ msgstr "Occupazione server: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numero di file condivisi: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensione totale file condivisi: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8508,6 +8509,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Percentuale di file totali"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -4566,16 +4566,16 @@ msgid "Nodes stats"
 msgstr "ノードの統計"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "ブートストラップ"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"既知のクライアントから\n"
+"ブートストラップする"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "新しいノード"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP："
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8524,18 +8524,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "ブートストラップ"
+
+#~ msgid "New node"
+#~ msgstr "新しいノード"
+
+#~ msgid "IP:"
+#~ msgstr "IP："
+
 #~ msgid "More"
 #~ msgstr "もっと"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "既知のクライアントから\n"
-#~ "ブートストラップする"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "既知のクライアントから\n"
 #~ "ブートストラップする"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2661,14 +2661,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"既知のクライアントから\n"
-"ブートストラップする"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "ノード数（%u）"
@@ -4587,13 +4579,6 @@ msgstr "IP："
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "ポート："
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"既知のクライアントから\n"
-"ブートストラップする"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8537,6 +8522,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "既知のクライアントから\n"
+#~ "ブートストラップする"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "既知のクライアントから\n"
+#~ "ブートストラップする"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "すべてのサーバ、もしくはKadに接続する"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1395,7 +1395,8 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1622,11 +1623,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "ダウンロード数（%i）"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "DLの合計：%s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3009,7 +3005,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "切断する"
 
@@ -3303,9 +3299,8 @@ msgid "Start"
 msgstr "開始"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "拡張子"
+msgid "More"
+msgstr "もっと"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3916,7 +3911,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4974,6 +4969,10 @@ msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
@@ -5014,13 +5013,24 @@ msgstr "指示するメッセージを送信します。"
 msgid "Close this chat-session."
 msgstr "チャット・セションを閉じます。"
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "すべてのサーバ、もしくはKadに接続する"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "共有ファイル"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "キャンセル"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "切断する"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "接続する"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6843,11 +6853,6 @@ msgstr "有効なソースリンクを作るにはHighIDが必要です"
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共有ファイルの合計サイズ： %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7066,6 +7071,11 @@ msgstr "サーバ占有： %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共有ファイル数： %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共有ファイルの合計サイズ： %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8528,8 +8538,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "もっと"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "すべてのサーバ、もしくはKadに接続する"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kadを切断する"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3291,8 +3291,9 @@ msgid "Start"
 msgstr "開始"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "もっと"
+#, fuzzy
+msgid "Extend"
+msgstr "拡張子"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8522,6 +8523,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "もっと"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1623,6 +1623,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "ダウンロード数（%i）"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DLの合計：%s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4955,10 +4960,6 @@ msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
@@ -6839,6 +6840,11 @@ msgstr "有効なソースリンクを作るにはHighIDが必要です"
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共有ファイルの合計サイズ： %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7057,11 +7063,6 @@ msgstr "サーバ占有： %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共有ファイル数： %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共有ファイルの合計サイズ： %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1403,7 +1403,8 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1629,11 +1630,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "내려받기 (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "전체 내려받기: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3029,7 +3025,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "연결 끊기"
 
@@ -3323,9 +3319,8 @@ msgid "Start"
 msgstr "시작"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "확장자"
+msgid "More"
+msgstr "추가"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3936,7 +3931,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4993,6 +4988,10 @@ msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
@@ -5033,13 +5032,24 @@ msgstr "지정된 메시지를 보냅니다."
 msgid "Close this chat-session."
 msgstr "이 채팅세션을 닫습니다."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "서버 혹은 Kad에 연결"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "공유 파일"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "취소"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "연결 끊기"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "연결"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6891,11 +6901,6 @@ msgstr "유효한 자료 링크를 만들기 위해서 높은아이디가 필요
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "공유파일의 전체 크기: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7114,6 +7119,11 @@ msgstr "서버 할당: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "공유된 파일의 수: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "공유파일의 전체 크기: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8578,8 +8588,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "추가"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "서버 혹은 Kad에 연결"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad 끊김"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3311,8 +3311,9 @@ msgid "Start"
 msgstr "시작"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "추가"
+#, fuzzy
+msgid "Extend"
+msgstr "확장자"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8572,6 +8573,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "추가"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2678,14 +2678,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"알려진 클라이언트로부터 \n"
-"초기적재"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "노드 (%u)"
@@ -4607,13 +4599,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "포트:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"알려진 클라이언트로부터 \n"
-"초기적재"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8587,6 +8572,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "알려진 클라이언트로부터 \n"
+#~ "초기적재"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "알려진 클라이언트로부터 \n"
+#~ "초기적재"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "서버 혹은 Kad에 연결"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -4586,16 +4586,16 @@ msgid "Nodes stats"
 msgstr "노드 상태"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "초기적재"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"알려진 클라이언트로부터 \n"
+"초기적재"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "새로운 노드"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8574,18 +8574,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "초기적재"
+
+#~ msgid "New node"
+#~ msgstr "새로운 노드"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "추가"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "알려진 클라이언트로부터 \n"
-#~ "초기적재"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "알려진 클라이언트로부터 \n"
 #~ "초기적재"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1630,6 +1630,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "내려받기 (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "전체 내려받기: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4974,10 +4979,6 @@ msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
@@ -6887,6 +6888,11 @@ msgstr "유효한 자료 링크를 만들기 위해서 높은아이디가 필요
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "공유파일의 전체 크기: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7105,11 +7111,6 @@ msgstr "서버 할당: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "공유된 파일의 수: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "공유파일의 전체 크기: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2688,14 +2688,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Inicializuoti iš \n"
-"žinomų klientų"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Mazgai (%u)"
@@ -4622,13 +4614,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Prievadas:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"Inicializuoti iš \n"
-"žinomų klientų"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8624,6 +8609,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Inicializuoti iš \n"
+#~ "žinomų klientų"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Inicializuoti iš \n"
+#~ "žinomų klientų"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1636,6 +1636,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Atsiuntimai (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Iš viso atsiųsta: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4990,10 +4995,6 @@ msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
@@ -6911,6 +6912,11 @@ msgstr "Norėdami sukurti šaltinio nuorodą, privalote turėti aukštą ID"
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Bendras dalinamų failų dydis: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7129,11 +7135,6 @@ msgstr "Serverių užimtumas: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Dalinamų failų kiekis: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Bendras dalinamų failų dydis: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1408,7 +1408,8 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kademlia"
 
@@ -1635,11 +1636,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Atsiuntimai (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Iš viso atsiųsta: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3043,7 +3039,7 @@ msgstr "Išsiuntimo apribojimas"
 msgid "Download limit"
 msgstr "Atsiuntimo apribojimas"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Atsijungti"
 
@@ -3337,9 +3333,8 @@ msgid "Start"
 msgstr "Pradėti"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Plėtinys"
+msgid "More"
+msgstr "Daugiau"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3950,7 +3945,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -5009,6 +5004,10 @@ msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
@@ -5049,13 +5048,24 @@ msgstr "Išsiųsti įrašytą žinutę."
 msgid "Close this chat-session."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Dalinami failai"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Atšaukti"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Atsijungti"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Prisijungti"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6915,11 +6925,6 @@ msgstr "Norėdami sukurti šaltinio nuorodą, privalote turėti aukštą ID"
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Bendras dalinamų failų dydis: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7138,6 +7143,11 @@ msgstr "Serverių užimtumas: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Dalinamų failų kiekis: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Bendras dalinamų failų dydis: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8615,8 +8625,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Daugiau"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Prisijungti prie bet kurio serverio ir/ar Kademlia tinklo"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Atjungti Kademlia"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -4601,16 +4601,16 @@ msgid "Nodes stats"
 msgstr "Mazgų statistika"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Inicializavimas"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Inicializuoti iš \n"
+"žinomų klientų"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Naujas mazgas"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8611,18 +8611,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Inicializavimas"
+
+#~ msgid "New node"
+#~ msgstr "Naujas mazgas"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Daugiau"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Inicializuoti iš \n"
-#~ "žinomų klientų"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Inicializuoti iš \n"
 #~ "žinomų klientų"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3325,8 +3325,9 @@ msgid "Start"
 msgstr "Pradėti"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Daugiau"
+#, fuzzy
+msgid "Extend"
+msgstr "Plėtinys"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8609,6 +8610,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Daugiau"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3218,8 +3218,9 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Paplašinājums"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1369,7 +1369,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1593,11 +1594,6 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lejupielādes (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, c-format
-msgid "Total queue size: %s"
-msgstr ""
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2936,7 +2932,7 @@ msgstr "Augšupielādes ātruma ierob."
 msgid "Download limit"
 msgstr "Lejupielādes ātruma ierob."
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Atslēgties"
 
@@ -3228,9 +3224,8 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Paplašinājums"
+msgid "More"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3834,7 +3829,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr "Maksimālais vienlaicīgo savienojumu skaits:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4876,6 +4871,10 @@ msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -4911,13 +4910,24 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Kopīgotās datnes"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Atcelt"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Atslēgties"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Pieslēgties"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6701,11 +6711,6 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr ""
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6922,6 +6927,11 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
+msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4481,16 +4481,12 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8333,6 +8329,9 @@ msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Atslēgt Kad"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1594,6 +1594,11 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lejupielādes (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4858,10 +4863,6 @@ msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6698,6 +6699,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6914,11 +6920,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2596,12 +2596,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4500,10 +4494,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Ports:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2664,14 +2664,6 @@ msgid "IP filter is ready"
 msgstr "IP-filter is klaar"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap van \n"
-"bekende clients"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nodes (%u)"
@@ -4595,10 +4587,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Poort:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bootstrap van bekende clients"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8539,6 +8527,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap van \n"
+#~ "bekende clients"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bootstrap van bekende clients"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Verbind met een server en/of Kad"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1623,6 +1623,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totaal gedownload: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4959,10 +4964,6 @@ msgid "Active Uploads"
 msgstr "Actieve uploads"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Procent van alle bestanden"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
@@ -6837,6 +6838,11 @@ msgstr "U heeft een Hoog ID nodig om een geldige bronlink te maken"
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totale grootte van gedeelde bestanden: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Bestandsnaam op afstand"
@@ -7054,11 +7060,6 @@ msgstr "Server-bezetting: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Aantal gedeelde bestanden: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totale grootte van gedeelde bestanden: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8526,6 +8527,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Procent van alle bestanden"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -4574,16 +4574,14 @@ msgid "Nodes stats"
 msgstr "Nodes stats"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bootstrap van bekende clients"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nieuwe node"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Voer hier het IP van de server in, gebuik het x.x.x.x formaat."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8529,6 +8527,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Nieuwe node"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Meer"
 
@@ -8538,9 +8545,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bootstrap van \n"
 #~ "bekende clients"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bootstrap van bekende clients"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Verbind met een server en/of Kad"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1395,7 +1395,8 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1622,11 +1623,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Totaal gedownload: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3014,7 +3010,7 @@ msgstr "Uploadgrens"
 msgid "Download limit"
 msgstr "Downloadgrens"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Verbreek"
 
@@ -3309,9 +3305,8 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Uitbreiding"
+msgid "More"
+msgstr "Meer"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3923,7 +3918,7 @@ msgstr "Max bronnen per bestand aan het downloaden:"
 msgid "Max simultaneous connections:"
 msgstr "Max gelijktijdige verbindingen:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4977,6 +4972,10 @@ msgid "Active Uploads"
 msgstr "Actieve uploads"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Procent van alle bestanden"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
@@ -5012,13 +5011,24 @@ msgstr "Verstuurt het opgegeven bericht."
 msgid "Close this chat-session."
 msgstr "Sluit deze chat-sessie."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Verbind met een server en/of Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Gedeelde bestanden"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Annuleren"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Verbreek"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Verbinden"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6840,11 +6850,6 @@ msgstr "U heeft een Hoog ID nodig om een geldige bronlink te maken"
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totale grootte van gedeelde bestanden: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Bestandsnaam op afstand"
@@ -7062,6 +7067,11 @@ msgstr "Server-bezetting: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Aantal gedeelde bestanden: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totale grootte van gedeelde bestanden: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8530,11 +8540,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Procent van alle bestanden"
-
-#~ msgid "More"
-#~ msgstr "Meer"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Verbind met een server en/of Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Verbreek verbinding met Kad"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3297,8 +3297,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Meer"
+#, fuzzy
+msgid "Extend"
+msgstr "Uitbreiding"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8527,6 +8528,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Meer"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1630,6 +1630,11 @@ msgstr "%y/%m/%d·%H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Nedlastingar (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totalt NL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4975,10 +4980,6 @@ msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
@@ -6880,6 +6881,11 @@ msgstr "Du treng ein HøgID for å lage ei gangbar kjeldelenkje"
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storleik på delte filer: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7098,11 +7104,6 @@ msgstr "Tenerlast: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Tal på delte filer: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storleik på delte filer: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3310,8 +3310,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Meir"
+#, fuzzy
+msgid "Extend"
+msgstr "Filetternamn"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8580,6 +8581,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Meir"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -4586,16 +4586,16 @@ msgid "Nodes stats"
 msgstr "Nodestatistikk"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Eigenoppstart"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Eigenoppstart frå \n"
+"kjende klientar"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Ny node"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8582,18 +8582,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Eigenoppstart"
+
+#~ msgid "New node"
+#~ msgstr "Ny node"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Meir"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Eigenoppstart frå \n"
-#~ "kjende klientar"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Eigenoppstart frå \n"
 #~ "kjende klientar"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2676,14 +2676,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Eigenoppstart frå \n"
-"kjende klientar"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Noder (%u)"
@@ -4607,13 +4599,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"Eigenoppstart frå \n"
-"kjende klientar"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8595,6 +8580,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Eigenoppstart frå \n"
+#~ "kjende klientar"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Eigenoppstart frå \n"
+#~ "kjende klientar"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Kople til vilkårleg tenar og/eller Kad"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1402,7 +1402,8 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1629,11 +1630,6 @@ msgstr "%y/%m/%d·%H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Nedlastingar (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Totalt NL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3028,7 +3024,7 @@ msgstr "Opplastingsgrense"
 msgid "Download limit"
 msgstr "Nedlastingsgrense"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Kople frå"
 
@@ -3322,9 +3318,8 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Filetternamn"
+msgid "More"
+msgstr "Meir"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3935,7 +3930,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2k"
 
@@ -4994,6 +4989,10 @@ msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
@@ -5034,13 +5033,24 @@ msgstr "Sender meldinga."
 msgid "Close this chat-session."
 msgstr "Stengje denne lynmeldingsøkta."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Kople til vilkårleg tenar og/eller Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Delte filer"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Avbryt"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Kople frå"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Kople til"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6884,11 +6894,6 @@ msgstr "Du treng ein HøgID for å lage ei gangbar kjeldelenkje"
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storleik på delte filer: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7107,6 +7112,11 @@ msgstr "Tenerlast: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Tal på delte filer: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storleik på delte filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8586,8 +8596,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Meir"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Kople til vilkårleg tenar og/eller Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kople frå Kad"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3307,8 +3307,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Więcej"
+#, fuzzy
+msgid "Extend"
+msgstr "Rozszerzenie"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8568,6 +8569,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Więcej"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2672,14 +2672,6 @@ msgid "IP filter is ready"
 msgstr "Filtr IP jest gotowy"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Rozruch od \n"
-"znanych klientów"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Węzły (%u)"
@@ -4607,10 +4599,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Rozruch od znanych klientów"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8580,6 +8568,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Rozruch od \n"
+#~ "znanych klientów"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Rozruch od znanych klientów"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Podłącz do dowolnego serwera i/lub Kad"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1401,7 +1401,8 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1628,11 +1629,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Pobieranie (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Razem DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3025,7 +3021,7 @@ msgstr "Limit wysyłania"
 msgid "Download limit"
 msgstr "Limit pobierania"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Rozłącz"
 
@@ -3319,9 +3315,8 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Rozszerzenie"
+msgid "More"
+msgstr "Więcej"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3933,7 +3928,7 @@ msgstr "Maks. ilość źródeł dla pobieranego pliku:"
 msgid "Max simultaneous connections:"
 msgstr "Maksymalne połączenia jednoczesne:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4991,6 +4986,11 @@ msgstr "Aktywne wysyłania"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
+msgid "Percent of total files"
+msgstr "procent wszystkich plików"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
@@ -5029,13 +5029,24 @@ msgstr "Wysyła wybraną wiadomość."
 msgid "Close this chat-session."
 msgstr "Zamknij tę sesję czata."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Podłącz do dowolnego serwera i/lub Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Udostępnione pliki"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Anuluj"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Rozłącz"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Podłącz"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6884,11 +6895,6 @@ msgstr "Potrzebujesz HighID, aby stworzyć poprawny link źródłowy"
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Łączny rozmiar udostępnianych plików: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7107,6 +7113,11 @@ msgstr "Zajętość serwera: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Liczba udostępnianych plików: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Łączny rozmiar udostępnianych plików: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8570,12 +8581,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#, fuzzy
-#~ msgid "Percent of total files"
-#~ msgstr "procent wszystkich plików"
-
-#~ msgid "More"
-#~ msgstr "Więcej"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Podłącz do dowolnego serwera i/lub Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Rozłącz z Kad"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1629,6 +1629,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Pobieranie (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Razem DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4973,11 +4978,6 @@ msgstr "Aktywne wysyłania"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "procent wszystkich plików"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
@@ -6882,6 +6882,11 @@ msgstr "Potrzebujesz HighID, aby stworzyć poprawny link źródłowy"
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Łączny rozmiar udostępnianych plików: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7100,11 +7105,6 @@ msgstr "Zajętość serwera: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Liczba udostępnianych plików: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Łączny rozmiar udostępnianych plików: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8567,6 +8567,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "procent wszystkich plików"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -4586,16 +4586,14 @@ msgid "Nodes stats"
 msgstr "Statystyki węzłów"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Rozruch od znanych klientów"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nowy węzeł"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8570,6 +8568,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Nowy węzeł"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Więcej"
 
@@ -8579,9 +8586,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Rozruch od \n"
 #~ "znanych klientów"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Rozruch od znanych klientów"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Podłącz do dowolnego serwera i/lub Kad"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2676,14 +2676,6 @@ msgid "IP filter is ready"
 msgstr "Filtro IP está pronto"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Inicializando com \n"
-"clientes conhecidos"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nós (%u)"
@@ -4575,10 +4567,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porta:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Inicializando de clientes conhecidos"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8519,6 +8507,16 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Inicializando com \n"
+#~ "clientes conhecidos"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Inicializando de clientes conhecidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectar a qualquer servidor e/ou Kad"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1631,6 +1631,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DL Total: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4946,10 +4951,6 @@ msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Porcentagem de total de arquivos"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
@@ -6803,6 +6804,11 @@ msgstr "Você precisa ter HighID para criar uma fonte ED2K válida"
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total de compartilhados: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do arquivo remoto"
@@ -7020,11 +7026,6 @@ msgstr "Ocupação do Servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de arquivos compartilhados: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total de compartilhados: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8506,6 +8507,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Porcentagem de total de arquivos"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Inicialização"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3297,8 +3297,9 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mais"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensão"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8507,6 +8508,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Mais"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -4554,16 +4554,14 @@ msgid "Nodes stats"
 msgstr "Estatísticas dos Nodes"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Inicialização"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Inicializando de clientes conhecidos"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Novo node"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Informe o IP do servidor no formato x.x.x.x nesse espaço."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8509,6 +8507,15 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
 
+#~ msgid "Bootstrap"
+#~ msgstr "Inicialização"
+
+#~ msgid "New node"
+#~ msgstr "Novo node"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Mais"
 
@@ -8518,9 +8525,6 @@ msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
 #~ msgstr ""
 #~ "Inicializando com \n"
 #~ "clientes conhecidos"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Inicializando de clientes conhecidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectar a qualquer servidor e/ou Kad"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1404,7 +1404,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1630,11 +1631,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "DL Total: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3017,7 +3013,7 @@ msgstr "Limite de envio"
 msgid "Download limit"
 msgstr "Limite de download"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Desconectar"
 
@@ -3309,9 +3305,8 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extensão"
+msgid "More"
+msgstr "Mais"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3913,7 +3908,7 @@ msgstr "Máximo de fontes para arquivos baixando:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de conexões simultâneas:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4964,6 +4959,10 @@ msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Porcentagem de total de arquivos"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
@@ -4999,13 +4998,24 @@ msgstr "Enviar a mensagem especificada."
 msgid "Close this chat-session."
 msgstr "Encerrar sessão de Chat."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Conectar a qualquer servidor e/ou Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Arquivos Compartilhados"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Cancelar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Desconectar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Conectar"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6806,11 +6816,6 @@ msgstr "Você precisa ter HighID para criar uma fonte ED2K válida"
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total de compartilhados: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do arquivo remoto"
@@ -7028,6 +7033,11 @@ msgstr "Ocupação do Servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de arquivos compartilhados: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total de compartilhados: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8510,11 +8520,8 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
 
-#~ msgid "Percent of total files"
-#~ msgstr "Porcentagem de total de arquivos"
-
-#~ msgid "More"
-#~ msgstr "Mais"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Conectar a qualquer servidor e/ou Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconectar da rede Kad"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1629,6 +1629,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4964,10 +4969,6 @@ msgid "Active Uploads"
 msgstr "Uploads Activos"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Percentagem dos ficheiros totais"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
@@ -6846,6 +6847,11 @@ msgstr "Necessita de HighID para criar uma ligação de fonte válida"
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total dos Ficheiros Partilhados: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do Ficheiro Remoto"
@@ -7063,11 +7069,6 @@ msgstr "Ocupação dos Servidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de Ficheiros Partilhados: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total dos Ficheiros Partilhados: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8529,6 +8530,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Percentagem dos ficheiros totais"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Inicialização"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3300,8 +3300,9 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mais"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensão"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8530,6 +8531,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Mais"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2668,14 +2668,6 @@ msgid "IP filter is ready"
 msgstr "O filtro de IPs está pronto"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Arrancar a partir de \n"
-"clientes conhecidos"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nós (%u)"
@@ -4599,10 +4591,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porto:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Arrancar a partir de clientes conhecidos"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8542,6 +8530,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Arrancar a partir de \n"
+#~ "clientes conhecidos"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Arrancar a partir de clientes conhecidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Ligar a qualquer servidor e/ou Kad"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1401,7 +1401,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1628,11 +1629,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3018,7 +3014,7 @@ msgstr "Limite de Upload"
 msgid "Download limit"
 msgstr "Limite de Download"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Desligar"
 
@@ -3312,9 +3308,8 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extensão"
+msgid "More"
+msgstr "Mais"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3926,7 +3921,7 @@ msgstr "Máximo de fontes por ficheiro:"
 msgid "Max simultaneous connections:"
 msgstr "Máximo de ligações simultâneas:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4982,6 +4977,10 @@ msgid "Active Uploads"
 msgstr "Uploads Activos"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Percentagem dos ficheiros totais"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
@@ -5017,13 +5016,24 @@ msgstr "Envia a mensagem especificada."
 msgid "Close this chat-session."
 msgstr "Fechar esta conversa."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Ligar a qualquer servidor e/ou Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Ficheiros Partilhados"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Cancelar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Desligar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Ligar"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6849,11 +6859,6 @@ msgstr "Necessita de HighID para criar uma ligação de fonte válida"
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total dos Ficheiros Partilhados: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do Ficheiro Remoto"
@@ -7071,6 +7076,11 @@ msgstr "Ocupação dos Servidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de Ficheiros Partilhados: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total dos Ficheiros Partilhados: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8533,11 +8543,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Percentagem dos ficheiros totais"
-
-#~ msgid "More"
-#~ msgstr "Mais"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Ligar a qualquer servidor e/ou Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desligar Kad"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -4578,16 +4578,14 @@ msgid "Nodes stats"
 msgstr "Estado dos nós"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Inicialização"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Arrancar a partir de clientes conhecidos"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Novo nó"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8532,6 +8530,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Inicialização"
+
+#~ msgid "New node"
+#~ msgstr "Novo nó"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Mais"
 
@@ -8541,9 +8548,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Arrancar a partir de \n"
 #~ "clientes conhecidos"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Arrancar a partir de clientes conhecidos"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Ligar a qualquer servidor e/ou Kad"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -4579,16 +4579,14 @@ msgid "Nodes stats"
 msgstr "Stare noduri"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bootstrap de la clienții cunoscuți"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nod nou"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8547,6 +8545,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Nod nou"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Mai mult"
 
@@ -8556,9 +8563,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bootstrap de la \n"
 #~ "clienți cunoscuți"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bootstrap de la clienții cunoscuți"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectare la orice server și/sau Kad"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1398,7 +1398,8 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1625,11 +1626,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descărcări (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3020,7 +3016,7 @@ msgstr "Limită încărcare"
 msgid "Download limit"
 msgstr "Limită descărcare"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Deconectează"
 
@@ -3314,9 +3310,8 @@ msgid "Start"
 msgstr "Începe"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Extensie"
+msgid "More"
+msgstr "Mai mult"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3928,7 +3923,7 @@ msgstr "Număr maxim de surse pe fișier descărcat:"
 msgid "Max simultaneous connections:"
 msgstr "Număr maxim de conexiuni simultane:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4982,6 +4977,10 @@ msgid "Active Uploads"
 msgstr "Încărcări active"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Procentul din totalul fișierelor"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
@@ -5017,13 +5016,24 @@ msgstr "Trimite mesajul specificat"
 msgid "Close this chat-session."
 msgstr "Închide această sesiune de chat."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Conectare la orice server și/sau Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Fișiere partajate"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Anulare"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Deconectează"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Conectează"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6862,11 +6872,6 @@ msgstr "Vă trebuie un HighID pentru a se crea o legătură sursă validă"
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensiunea totală a fișierelor partajate: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nume fișier distant"
@@ -7084,6 +7089,11 @@ msgstr "Ocupare server: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Număr de fișiere partajate: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensiunea totală a fișierelor partajate: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8548,11 +8558,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Procentul din totalul fișierelor"
-
-#~ msgid "More"
-#~ msgstr "Mai mult"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Conectare la orice server și/sau Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Deconectare Kad"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1626,6 +1626,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descărcări (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4964,10 +4969,6 @@ msgid "Active Uploads"
 msgstr "Încărcări active"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Procentul din totalul fișierelor"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
@@ -6859,6 +6860,11 @@ msgstr "Vă trebuie un HighID pentru a se crea o legătură sursă validă"
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensiunea totală a fișierelor partajate: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nume fișier distant"
@@ -7076,11 +7082,6 @@ msgstr "Ocupare server: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Număr de fișiere partajate: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensiunea totală a fișierelor partajate: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8544,6 +8545,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Procentul din totalul fișierelor"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2667,14 +2667,6 @@ msgid "IP filter is ready"
 msgstr "Filtrul IP este gata"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap de la \n"
-"clienți cunoscuți"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Noduri (%u)"
@@ -4600,10 +4592,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bootstrap de la clienții cunoscuți"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8557,6 +8545,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap de la \n"
+#~ "clienți cunoscuți"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bootstrap de la clienții cunoscuți"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Conectare la orice server și/sau Kad"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3302,8 +3302,9 @@ msgid "Start"
 msgstr "Începe"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mai mult"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensie"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8545,6 +8546,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Mai mult"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -4607,17 +4607,16 @@ msgstr "Ведите сюда URL к файлу nodes.dat и нажмите кн
 msgid "Nodes stats"
 msgstr "Статистика узлов"
 
+# Похоже, bootstrap в eMule перевели как инициализация
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Инициализация"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Инициализация от известных клиентов"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Новый узел"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Введите здесь IP-адрес сервера в формате: x.x.x.x"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8597,6 +8596,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Инициализация"
+
+#~ msgid "New node"
+#~ msgstr "Новый узел"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Дополнительно"
 
@@ -8607,10 +8615,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Инициализация от \n"
 #~ "известных клиентов"
-
-# Похоже, bootstrap в eMule перевели как инициализация
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Инициализация от известных клиентов"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Соединиться с произвольным сервером и/или Kad"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1639,6 +1639,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Загрузки (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Всего загружено: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4996,10 +5001,6 @@ msgid "Active Uploads"
 msgstr "Активные загрузки"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Процент от всех файлов"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
@@ -6907,6 +6908,11 @@ msgstr "Для создания ссылки на источник требуе�
 msgid "Shared Files (%i)"
 msgstr "Публикуемые файлы (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общий размер публикуемых файлов: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Удаленное имя файла"
@@ -7125,11 +7131,6 @@ msgstr "Загруженность сервера: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Число публикуемых файлов: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общий размер публикуемых файлов: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8595,6 +8596,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Процент от всех файлов"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Инициализация"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1410,7 +1410,8 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удаленный сервер"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1638,11 +1639,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Загрузки (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Всего загружено: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3039,7 +3035,7 @@ msgstr "Ограничение отдачи"
 msgid "Download limit"
 msgstr "Ограничение приема"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Отключиться"
 
@@ -3337,9 +3333,8 @@ msgid "Start"
 msgstr "Начать"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Расширение"
+msgid "More"
+msgstr "Дополнительно"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3953,7 +3948,7 @@ msgstr "Максимум источников на файл:"
 msgid "Max simultaneous connections:"
 msgstr "Максимум одновременных соединений:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -5015,6 +5010,10 @@ msgid "Active Uploads"
 msgstr "Активные загрузки"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Процент от всех файлов"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
@@ -5050,14 +5049,25 @@ msgstr "Отправить данное сообщение."
 msgid "Close this chat-session."
 msgstr "Закрыть данный чат."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Соединиться с произвольным сервером и/или Kad"
-
 # подпись в главном окне. длинная просто не влезет.
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Файлы"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Отменить"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Отключиться"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Подключиться"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6911,11 +6921,6 @@ msgstr "Для создания ссылки на источник требуе�
 msgid "Shared Files (%i)"
 msgstr "Публикуемые файлы (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общий размер публикуемых файлов: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Удаленное имя файла"
@@ -7134,6 +7139,11 @@ msgstr "Загруженность сервера: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Число публикуемых файлов: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общий размер публикуемых файлов: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8600,11 +8610,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Процент от всех файлов"
-
-#~ msgid "More"
-#~ msgstr "Дополнительно"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Соединиться с произвольным сервером и/или Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Отключить Kad"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3324,8 +3324,9 @@ msgid "Start"
 msgstr "Начать"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Дополнительно"
+#, fuzzy
+msgid "Extend"
+msgstr "Расширение"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8595,6 +8596,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Дополнительно"
 
 # Похоже, bootstrap в eMule перевели как инициализация
 #~ msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2683,15 +2683,6 @@ msgstr "Переименование нового файла %s неудачно
 msgid "IP filter is ready"
 msgstr "IP-фильтр готов"
 
-# Похоже, bootstrap в eMule перевели как инициализация
-#: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Инициализация от \n"
-"известных клиентов"
-
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -4630,11 +4621,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Порт:"
-
-# Похоже, bootstrap в eMule перевели как инициализация
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Инициализация от известных клиентов"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8609,6 +8595,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+# Похоже, bootstrap в eMule перевели как инициализация
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Инициализация от \n"
+#~ "известных клиентов"
+
+# Похоже, bootstrap в eMule перевели как инициализация
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Инициализация от известных клиентов"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Соединиться с произвольным сервером и/или Kad"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3321,8 +3321,9 @@ msgid "Start"
 msgstr "Začni"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Več"
+#, fuzzy
+msgid "Extend"
+msgstr "Končnica"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8579,6 +8580,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Več"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2683,14 +2683,6 @@ msgid "IP filter is ready"
 msgstr "Filter IP je pripravljen"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Naloži od znanih \n"
-"odjemalcev"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Vozlišča (%u)"
@@ -4620,12 +4612,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Vrata:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr ""
-"Naloži od znanih \n"
-"odjemalcev"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8593,6 +8579,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Naloži od znanih \n"
+#~ "odjemalcev"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Naloži od znanih \n"
+#~ "odjemalcev"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -4599,16 +4599,16 @@ msgid "Nodes stats"
 msgstr "Statistika vozlišč"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Začetno nalaganje"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Naloži od znanih \n"
+"odjemalcev"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Novo vozlišče"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8581,17 +8581,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Začetno nalaganje"
+
+#~ msgid "New node"
+#~ msgstr "Novo vozlišče"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Več"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Naloži od znanih \n"
-#~ "odjemalcev"
-
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Naloži od znanih \n"
 #~ "odjemalcev"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1635,6 +1635,11 @@ msgstr "%d.%m.%y %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Prejemanja (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Skupno dol: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4986,10 +4991,6 @@ msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Odstotek vseh datotek"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
@@ -6899,6 +6900,11 @@ msgstr "Potrebujete visok ID, da ustvarite povezavo z virom"
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Skupna velikost deljenih datotek: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Oddaljeno ime datoteke"
@@ -7116,11 +7122,6 @@ msgstr "Zasedenost strežnikov: %.2f %%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Število deljenih datotek: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Skupna velikost deljenih datotek: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8580,6 +8581,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Odstotek vseh datotek"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Začetno nalaganje"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1407,7 +1407,8 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1634,11 +1635,6 @@ msgstr "%d.%m.%y %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Prejemanja (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Skupno dol: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3039,7 +3035,7 @@ msgstr "Omejitev pošiljanja"
 msgid "Download limit"
 msgstr "Omejitev prejemanja"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Prekini povezave"
 
@@ -3333,9 +3329,8 @@ msgid "Start"
 msgstr "Začni"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Končnica"
+msgid "More"
+msgstr "Več"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3948,7 +3943,7 @@ msgstr "Največ virov na prejemanje:"
 msgid "Max simultaneous connections:"
 msgstr "Največ istočasnih povezav:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -5004,6 +4999,10 @@ msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Odstotek vseh datotek"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
@@ -5039,13 +5038,24 @@ msgstr "Pošlje navedeno sporočilo."
 msgid "Close this chat-session."
 msgstr "Zapri to pogovorno sejo."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Deljene datoteke"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Prekliči"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Prekini povezave"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Poveži se"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6902,11 +6912,6 @@ msgstr "Potrebujete visok ID, da ustvarite povezavo z virom"
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Skupna velikost deljenih datotek: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Oddaljeno ime datoteke"
@@ -7124,6 +7129,11 @@ msgstr "Zasedenost strežnikov: %.2f %%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Število deljenih datotek: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Skupna velikost deljenih datotek: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8584,11 +8594,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Odstotek vseh datotek"
-
-#~ msgid "More"
-#~ msgstr "Več"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Poveži se s poljubnim strežnikom in/ali s Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Prekini povezavo s Kad"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -4578,16 +4578,16 @@ msgid "Nodes stats"
 msgstr "Statistikat e Nyjeve"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Bootstrap nga \n"
+"kliente te njohur"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Nyje e re"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8553,18 +8553,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Nyje e re"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Me shume"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Bootstrap nga \n"
-#~ "kliente te njohur"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Bootstrap nga \n"
 #~ "kliente te njohur"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1625,6 +1625,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Shkarkimet (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totali i shkarkimit: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4967,10 +4972,6 @@ msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
@@ -6870,6 +6871,11 @@ msgstr "Ju keni nevoje per nje ID te larte per te krijuar nje sourcelink te vlef
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totali i madhesise se faileve te ndara: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7088,11 +7094,6 @@ msgstr "Zenia e Serverit: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numeri i faileve te ndara: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totali i madhesise se faileve te ndara: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2670,14 +2670,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap nga \n"
-"kliente te njohur"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Nyjet (%u)"
@@ -4599,13 +4591,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Porta:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"Bootstrap nga \n"
-"kliente te njohur"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8566,6 +8551,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap nga \n"
+#~ "kliente te njohur"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Bootstrap nga \n"
+#~ "kliente te njohur"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Lidhu me ndonje server dhe/ose Kad"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3303,8 +3303,9 @@ msgid "Start"
 msgstr "Fillo"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Me shume"
+#, fuzzy
+msgid "Extend"
+msgstr "Zgjerimi"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8551,6 +8552,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Me shume"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1399,7 +1399,8 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1624,11 +1625,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Shkarkimet (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Totali i shkarkimit: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3021,7 +3017,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Shkeputu"
 
@@ -3315,9 +3311,8 @@ msgid "Start"
 msgstr "Fillo"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Zgjerimi"
+msgid "More"
+msgstr "Me shume"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3928,7 +3923,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4986,6 +4981,10 @@ msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
@@ -5026,13 +5025,24 @@ msgstr "Dergo mesazhin e specifikuar."
 msgid "Close this chat-session."
 msgstr "Mbylle kete sesion chati."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Lidhu me ndonje server dhe/ose Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "File te ndara"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Fshij"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Shkeputu"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Lidhu"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6874,11 +6884,6 @@ msgstr "Ju keni nevoje per nje ID te larte per te krijuar nje sourcelink te vlef
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totali i madhesise se faileve te ndara: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7097,6 +7102,11 @@ msgstr "Zenia e Serverit: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numeri i faileve te ndara: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totali i madhesise se faileve te ndara: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8557,8 +8567,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Me shume"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Lidhu me ndonje server dhe/ose Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Shkeput Kad"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3292,8 +3292,9 @@ msgid "Start"
 msgstr "Starta"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mer"
+#, fuzzy
+msgid "Extend"
+msgstr "Filändelse"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8518,6 +8519,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Mer"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1621,6 +1621,11 @@ msgstr "%y/%m/%d %H.%M.%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Hämtningar (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totalt DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4954,10 +4959,6 @@ msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Procent av den totala filer"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
@@ -6832,6 +6833,11 @@ msgstr "Du behöver en HighID att skapa en giltig sourcelink"
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storlek på Delade filer: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Fjärrfilnamn"
@@ -7049,11 +7055,6 @@ msgstr "Serveranvändade: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Antal Delade filer: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storlek på Delade filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8517,6 +8518,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Procent av den totala filer"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Bootstrap"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -4569,16 +4569,14 @@ msgid "Nodes stats"
 msgstr "Nodstatistik"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Bootstrap"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bootstrap från kända klienter"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Ny nod"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Ange IP på servern här, med hjälp av xxxx format."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8520,6 +8518,15 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Bootstrap"
+
+#~ msgid "New node"
+#~ msgstr "Ny nod"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Mer"
 
@@ -8529,9 +8536,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Bootstrap från \n"
 #~ "kända klienter"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bootstrap från kända klienter"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Anslut till någon server och/eller Kad"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2660,14 +2660,6 @@ msgid "IP filter is ready"
 msgstr "IP-filter är redo"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bootstrap från \n"
-"kända klienter"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Noder (%u)"
@@ -4590,10 +4582,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bootstrap från kända klienter"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8530,6 +8518,16 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bootstrap från \n"
+#~ "kända klienter"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bootstrap från kända klienter"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Anslut till någon server och/eller Kad"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1393,7 +1393,8 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1620,11 +1621,6 @@ msgstr "%y/%m/%d %H.%M.%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Hämtningar (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Totalt DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3010,7 +3006,7 @@ msgstr "Uppladdningsbegränsning"
 msgid "Download limit"
 msgstr "Nerladdningsbegränsning"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Koppla från"
 
@@ -3304,9 +3300,8 @@ msgid "Start"
 msgstr "Starta"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Filändelse"
+msgid "More"
+msgstr "Mer"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3918,7 +3913,7 @@ msgstr "Max källor per hämtad fil:"
 msgid "Max simultaneous connections:"
 msgstr "Max samtidiga anslutningar:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4972,6 +4967,10 @@ msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Procent av den totala filer"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
@@ -5007,13 +5006,24 @@ msgstr "Skickar det specificerade meddelandet."
 msgid "Close this chat-session."
 msgstr "Stäng denna chat-session."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Anslut till någon server och/eller Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Utdelade filer"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Avbryt"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Koppla från"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Anslut"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6835,11 +6845,6 @@ msgstr "Du behöver en HighID att skapa en giltig sourcelink"
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storlek på Delade filer: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Fjärrfilnamn"
@@ -7057,6 +7062,11 @@ msgstr "Serveranvändade: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Antal Delade filer: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storlek på Delade filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8521,11 +8531,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "Procent av den totala filer"
-
-#~ msgid "More"
-#~ msgstr "Mer"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Anslut till någon server och/eller Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Koppla från Kad"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2581,12 +2581,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4473,10 +4467,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3202,7 +3202,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1357,7 +1357,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "காட்"
 
@@ -1580,11 +1581,6 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, c-format
-msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2920,7 +2916,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr ""
 
@@ -3212,7 +3208,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Extend"
+msgid "More"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3813,7 +3809,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4849,6 +4845,10 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -4884,12 +4884,23 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Cancel %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Disconnect %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Connect %s"
 msgstr ""
 
 #: src/OScopeCtrl.cpp
@@ -6660,11 +6671,6 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr ""
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6881,6 +6887,11 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
+msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1581,6 +1581,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4831,10 +4836,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6657,6 +6658,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6873,11 +6879,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4454,15 +4454,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1396,7 +1396,8 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1622,11 +1623,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "İndirmeler (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Toplam İND: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3000,7 +2996,7 @@ msgstr "Gönderim sınırı"
 msgid "Download limit"
 msgstr "Aktarım sınırı"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Bağlantıyı Kes"
 
@@ -3292,9 +3288,8 @@ msgid "Start"
 msgstr "Başlat"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Uzantı"
+msgid "More"
+msgstr "Daha Fazla"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3897,7 +3892,7 @@ msgstr "İndirilen dosya başına en fazla kaynak sayısı:"
 msgid "Max simultaneous connections:"
 msgstr "En cazla eş bağlantı sayısı:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4951,6 +4946,10 @@ msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "Toplam dosyaların yüzdesi"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
@@ -4986,13 +4985,24 @@ msgstr "Belirlenen iletiyi gönderir."
 msgid "Close this chat-session."
 msgstr "Bu sohbet oturumunu kapatır."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Paylaşılan Dosyalar"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "İptal"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Bağlantıyı Kes"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "Bağlan"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6797,11 +6807,6 @@ msgstr "Geçerli bir kaynak bağlantısı oluşturmak için YüksekID almanız g
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Dosya Adı"
@@ -7019,6 +7024,11 @@ msgstr "Sunucu Bağlantısı: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Paylaşılmış Dosya Sayısı: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8501,11 +8511,8 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
 
-#~ msgid "Percent of total files"
-#~ msgstr "Toplam dosyaların yüzdesi"
-
-#~ msgid "More"
-#~ msgstr "Daha Fazla"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad Bağlantısını Kes"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3280,8 +3280,9 @@ msgid "Start"
 msgstr "Başlat"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Daha Fazla"
+#, fuzzy
+msgid "Extend"
+msgstr "Uzantı"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8498,6 +8499,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "More"
+#~ msgstr "Daha Fazla"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -4541,16 +4541,14 @@ msgid "Nodes stats"
 msgstr "Düğüm istatistikleri"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Ön Yükleme"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Yeni düğüm"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Yeni sunucun IP numarasını x.x.x.x biçiminde buraya giriniz."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8500,6 +8498,15 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
 
+#~ msgid "Bootstrap"
+#~ msgstr "Ön Yükleme"
+
+#~ msgid "New node"
+#~ msgstr "Yeni düğüm"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Daha Fazla"
 
@@ -8509,9 +8516,6 @@ msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
 #~ msgstr ""
 #~ "Bilinen kullanıcılardan\n"
 #~ "Ön Yükleme"
-
-#~ msgid "Bootstrap from known clients"
-#~ msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1623,6 +1623,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "İndirmeler (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Toplam İND: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4933,10 +4938,6 @@ msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Toplam dosyaların yüzdesi"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
@@ -6794,6 +6795,11 @@ msgstr "Geçerli bir kaynak bağlantısı oluşturmak için YüksekID almanız g
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Dosya Adı"
@@ -7011,11 +7017,6 @@ msgstr "Sunucu Bağlantısı: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Paylaşılmış Dosya Sayısı: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8497,6 +8498,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Percent of total files"
+#~ msgstr "Toplam dosyaların yüzdesi"
 
 #~ msgid "Bootstrap"
 #~ msgstr "Ön Yükleme"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2659,14 +2659,6 @@ msgid "IP filter is ready"
 msgstr "IP süzgeci hazır"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Bilinen kullanıcılardan\n"
-"Ön Yükleme"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Düğümler (%u)"
@@ -4562,10 +4554,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Port:"
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8510,6 +8498,16 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Bilinen kullanıcılardan\n"
+#~ "Ön Yükleme"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "Bilinen kullanıcılardan Ön Yükleme"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "Herhangi bir sunucuya ve/veya Kad'a bağlan."

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2683,14 +2683,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-"Початковий запуск\n"
-"відомого клієнта"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "Вузли (%u)"
@@ -4623,13 +4615,6 @@ msgstr "IP:"
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "Порт:"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Bootstrap from known clients"
-msgstr ""
-"Початковий запуск\n"
-"відомого клієнта"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8628,6 +8613,19 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr ""
+#~ "Початковий запуск\n"
+#~ "відомого клієнта"
+
+#, fuzzy
+#~ msgid "Bootstrap from known clients"
+#~ msgstr ""
+#~ "Початковий запуск\n"
+#~ "відомого клієнта"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "З'єднатися з будь-яким сервером та/чи Kad"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3321,8 +3321,9 @@ msgid "Start"
 msgstr "Почати"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Більше"
+#, fuzzy
+msgid "Extend"
+msgstr "Розширення"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8613,6 +8614,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Більше"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1632,6 +1632,11 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Звантаження (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Всього звантажень: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4991,10 +4996,6 @@ msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
@@ -6910,6 +6911,11 @@ msgstr "Вам потрібно мати HighID щоб створити поси
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Загальний розмір спільних файлів: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7129,11 +7135,6 @@ msgstr "Навантаження на сервер: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Кількість спільних файлів: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Загальний розмір спільних файлів: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -4602,16 +4602,16 @@ msgid "Nodes stats"
 msgstr "Статистика вузлів"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "Початковий запуск"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr ""
+"Початковий запуск\n"
+"відомого клієнта"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "Новий вузол"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP:"
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8615,18 +8615,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "Початковий запуск"
+
+#~ msgid "New node"
+#~ msgstr "Новий вузол"
+
+#~ msgid "IP:"
+#~ msgstr "IP:"
+
 #~ msgid "More"
 #~ msgstr "Більше"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr ""
-#~ "Початковий запуск\n"
-#~ "відомого клієнта"
-
-#, fuzzy
-#~ msgid "Bootstrap from known clients"
 #~ msgstr ""
 #~ "Початковий запуск\n"
 #~ "відомого клієнта"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1404,7 +1404,8 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1631,11 +1632,6 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Звантаження (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "Всього звантажень: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3039,7 +3035,7 @@ msgstr "Обмеження вивантаження"
 msgid "Download limit"
 msgstr "Обмеження звантаження"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "Від'єднатися"
 
@@ -3333,9 +3329,8 @@ msgid "Start"
 msgstr "Почати"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "Розширення"
+msgid "More"
+msgstr "Більше"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3949,7 +3944,7 @@ msgstr "Найбільше джерел на звантажуваний файл
 msgid "Max simultaneous connections:"
 msgstr "Найбільше одночасних з'єднань:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "eD2k"
 
@@ -5010,6 +5005,10 @@ msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
@@ -5050,13 +5049,24 @@ msgstr "Надіслати вказане повідомлення."
 msgid "Close this chat-session."
 msgstr "Закрити цю розмову."
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "З'єднатися з будь-яким сервером та/чи Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "Спільні файли"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "Скасувати"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "Від'єднатися"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "З'єднатися"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6914,11 +6924,6 @@ msgstr "Вам потрібно мати HighID щоб створити поси
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Загальний розмір спільних файлів: %s"
-
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7138,6 +7143,11 @@ msgstr "Навантаження на сервер: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Кількість спільних файлів: %s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Загальний розмір спільних файлів: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8619,8 +8629,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "More"
-#~ msgstr "Більше"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "З'єднатися з будь-яким сервером та/чи Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Від'єднатися від Kad"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4454,15 +4454,11 @@ msgid "Nodes stats"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
+msgid "Bootstrap from node: IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
+msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1357,7 +1357,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1580,11 +1581,6 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, c-format
-msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2920,7 +2916,7 @@ msgstr ""
 msgid "Download limit"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr ""
 
@@ -3212,7 +3208,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Extend"
+msgid "More"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3813,7 +3809,7 @@ msgstr ""
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr ""
 
@@ -4849,6 +4845,10 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -4884,12 +4884,23 @@ msgstr ""
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Cancel %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Disconnect %s"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, c-format
+msgid "Connect %s"
 msgstr ""
 
 #: src/OScopeCtrl.cpp
@@ -6660,11 +6671,6 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr ""
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6881,6 +6887,11 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
+msgstr ""
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1581,6 +1581,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4831,10 +4836,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6657,6 +6658,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6873,11 +6879,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3202,7 +3202,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2581,12 +2581,6 @@ msgid "IP filter is ready"
 msgstr ""
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr ""
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr ""
@@ -4473,10 +4467,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1400,7 +1400,8 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1626,11 +1627,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下载 (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "总下载: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -2997,7 +2993,7 @@ msgstr "上传限制"
 msgid "Download limit"
 msgstr "下载限制"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "断开连接"
 
@@ -3289,9 +3285,8 @@ msgid "Start"
 msgstr "开始"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "扩展名"
+msgid "More"
+msgstr "更多"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3894,7 +3889,7 @@ msgstr "每个下载文件的最大的源数量:"
 msgid "Max simultaneous connections:"
 msgstr "最大同时连接数:"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4948,6 +4943,10 @@ msgid "Active Uploads"
 msgstr "活跃上传"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "全部文件的百分比"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "显示客户端"
 
@@ -4983,13 +4982,24 @@ msgstr "发送指定消息。"
 msgid "Close this chat-session."
 msgstr "结束本次聊天。"
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "连接至任何服务器和/或 Kad"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "共享文件"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "取消"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "断开连接"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "连接"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6794,11 +6804,6 @@ msgstr "你需要高ID来产生源链接"
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共享文件大小总和：%s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "远程文件名"
@@ -7016,6 +7021,11 @@ msgstr "服务器开销：%.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共享文件数：%s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共享文件大小总和：%s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8495,11 +8505,8 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
 
-#~ msgid "Percent of total files"
-#~ msgstr "全部文件的百分比"
-
-#~ msgid "More"
-#~ msgstr "更多"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "连接至任何服务器和/或 Kad"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "断开 Kad"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -4540,16 +4540,14 @@ msgid "Nodes stats"
 msgstr "节点状态"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "启动"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "从已知用户启动"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "新节点"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP："
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "输入新服务器的 IP 地址 (x.x.x.x格式)。"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8496,15 +8494,21 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
 
+#~ msgid "Bootstrap"
+#~ msgstr "启动"
+
+#~ msgid "New node"
+#~ msgstr "新节点"
+
+#~ msgid "IP:"
+#~ msgstr "IP："
+
 #~ msgid "More"
 #~ msgstr "更多"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr "从已知用户启动"
-
-#~ msgid "Bootstrap from known clients"
 #~ msgstr "从已知用户启动"
 
 #~ msgid "Connect to any server and/or Kad"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1627,6 +1627,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下载 (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "总下载: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4932,10 +4937,6 @@ msgid "Active Uploads"
 msgstr "活跃上传"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "全部文件的百分比"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "显示客户端"
 
@@ -6793,6 +6794,11 @@ msgstr "你需要高ID来产生源链接"
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共享文件大小总和：%s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "远程文件名"
@@ -7010,11 +7016,6 @@ msgstr "服务器开销：%.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共享文件数：%s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共享文件大小总和：%s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8493,6 +8494,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "全部文件的百分比"
 
 #~ msgid "Bootstrap"
 #~ msgstr "启动"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3279,8 +3279,9 @@ msgid "Start"
 msgstr "开始"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "更多"
+#, fuzzy
+msgid "Extend"
+msgstr "扩展名"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8494,6 +8495,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "More"
+#~ msgstr "更多"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2658,12 +2658,6 @@ msgid "IP filter is ready"
 msgstr "IP过滤器已准备好"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr "从已知用户启动"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "节点（%u）"
@@ -4559,10 +4553,6 @@ msgstr "IP："
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "端口："
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "从已知用户启动"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8504,6 +8494,14 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr "从已知用户启动"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "从已知用户启动"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "连接至任何服务器和/或 Kad"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 07:10+0200\n"
+"POT-Creation-Date: 2026-07-29 11:17+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3286,8 +3286,9 @@ msgid "Start"
 msgstr "開始"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "其他"
+#, fuzzy
+msgid "Extend"
+msgstr "副檔名"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8496,6 +8497,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "其他"
 
 #~ msgid ""
 #~ "Bootstrap from \n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:17+0200\n"
+"POT-Creation-Date: 2026-07-29 11:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -4563,16 +4563,14 @@ msgid "Nodes stats"
 msgstr "節點狀態"
 
 #: src/muuli_wdr.cpp
-msgid "Bootstrap"
-msgstr "啓動"
+#, fuzzy
+msgid "Bootstrap from node: IP"
+msgstr "從已知客戶端啓動"
 
 #: src/muuli_wdr.cpp
-msgid "New node"
-msgstr "新節點"
-
-#: src/muuli_wdr.cpp
-msgid "IP:"
-msgstr "IP："
+#, fuzzy
+msgid "Enter the IP of the node here, using the x.x.x.x format."
+msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
 
 #: src/muuli_wdr.cpp
 msgid "Port:"
@@ -8498,15 +8496,21 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
+#~ msgid "Bootstrap"
+#~ msgstr "啓動"
+
+#~ msgid "New node"
+#~ msgstr "新節點"
+
+#~ msgid "IP:"
+#~ msgstr "IP："
+
 #~ msgid "More"
 #~ msgstr "其他"
 
 #~ msgid ""
 #~ "Bootstrap from \n"
 #~ "known clients"
-#~ msgstr "從已知客戶端啓動"
-
-#~ msgid "Bootstrap from known clients"
 #~ msgstr "從已知客戶端啓動"
 
 #~ msgid "Connect to any server and/or Kad"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:47+0200\n"
+"POT-Creation-Date: 2026-07-29 00:53+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1394,7 +1394,8 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1621,11 +1622,6 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下載 (%i)"
-
-#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
-#, fuzzy, c-format
-msgid "Total queue size: %s"
-msgstr "總下載：%s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -3002,7 +2998,7 @@ msgstr "上傳限制"
 msgid "Download limit"
 msgstr "下載限制"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
+#: src/MuleTrayIcon.cpp
 msgid "Disconnect"
 msgstr "中斷連線"
 
@@ -3296,9 +3292,8 @@ msgid "Start"
 msgstr "開始"
 
 #: src/muuli_wdr.cpp
-#, fuzzy
-msgid "Extend"
-msgstr "副檔名"
+msgid "More"
+msgstr "其他"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -3910,7 +3905,7 @@ msgstr "每個檔案最大來源數："
 msgid "Max simultaneous connections:"
 msgstr "最大同時連線數："
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/ServerWnd.cpp
 msgid "ED2K"
 msgstr "ED2K"
 
@@ -4965,6 +4960,10 @@ msgid "Active Uploads"
 msgstr "目前上傳數"
 
 #: src/muuli_wdr.cpp
+msgid "Percent of total files"
+msgstr "% (所有檔案中)"
+
+#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
@@ -5000,13 +4999,24 @@ msgstr "傳送訊息。"
 msgid "Close this chat-session."
 msgstr "結束本次交談。"
 
-#: src/muuli_wdr.cpp
-msgid "Connect to any server and/or Kad"
-msgstr "連線到任何伺服器 和/或 Kad 網路"
-
 #: src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/Statistics.cpp
 msgid "Shared Files"
 msgstr "分享檔案"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Cancel %s"
+msgstr "取消"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Disconnect %s"
+msgstr "中斷連線"
+
+#: src/muuli_wdr.cpp
+#, fuzzy, c-format
+msgid "Connect %s"
+msgstr "連線"
 
 #: src/OScopeCtrl.cpp
 #, c-format
@@ -6815,11 +6825,6 @@ msgstr "您需要一個 HighID 才能建立有效來源連結"
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
 
-#: src/SharedFilesCtrl.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "檔案總容量：%s"
-
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "遠端檔案名稱"
@@ -7037,6 +7042,11 @@ msgstr "伺服器使用率：%.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "檔案數：%s"
+
+#: src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "檔案總容量：%s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8497,11 +8507,8 @@ msgstr ""
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
 
-#~ msgid "Percent of total files"
-#~ msgstr "% (所有檔案中)"
-
-#~ msgid "More"
-#~ msgstr "其他"
+#~ msgid "Connect to any server and/or Kad"
+#~ msgstr "連線到任何伺服器 和/或 Kad 網路"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "中斷 Kad 連線"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 11:49+0200\n"
+"POT-Creation-Date: 2026-07-29 12:49+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1622,6 +1622,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下載 (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "總下載：%s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4949,10 +4954,6 @@ msgid "Active Uploads"
 msgstr "目前上傳數"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "% (所有檔案中)"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
@@ -6814,6 +6815,11 @@ msgstr "您需要一個 HighID 才能建立有效來源連結"
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "檔案總容量：%s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "遠端檔案名稱"
@@ -7031,11 +7037,6 @@ msgstr "伺服器使用率：%.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "檔案數：%s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "檔案總容量：%s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8495,6 +8496,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "% (所有檔案中)"
 
 #~ msgid "Bootstrap"
 #~ msgstr "啓動"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 00:53+0200\n"
+"POT-Creation-Date: 2026-07-29 07:10+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2657,12 +2657,6 @@ msgid "IP filter is ready"
 msgstr "IP 過濾表已備妥"
 
 #: src/KadDlg.cpp
-msgid ""
-"Bootstrap from \n"
-"known clients"
-msgstr "從已知客戶端啓動"
-
-#: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
 msgstr "節點 (%u)"
@@ -4582,10 +4576,6 @@ msgstr "IP："
 #: src/muuli_wdr.cpp
 msgid "Port:"
 msgstr "埠："
-
-#: src/muuli_wdr.cpp
-msgid "Bootstrap from known clients"
-msgstr "從已知客戶端啓動"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -8506,6 +8496,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid ""
+#~ "Bootstrap from \n"
+#~ "known clients"
+#~ msgstr "從已知客戶端啓動"
+
+#~ msgid "Bootstrap from known clients"
+#~ msgstr "從已知客戶端啓動"
 
 #~ msgid "Connect to any server and/or Kad"
 #~ msgstr "連線到任何伺服器 和/或 Kad 網路"

--- a/src/KadDlg.cpp
+++ b/src/KadDlg.cpp
@@ -51,7 +51,6 @@ wxBEGIN_EVENT_TABLE(CKadDlg, wxPanel)
 	EVT_TEXT_ENTER(IDC_NODESLISTURL, CKadDlg::OnBnClickedUpdateNodeList)
 
 	EVT_BUTTON(ID_NODECONNECT, CKadDlg::OnBnClickedBootstrapClient)
-	EVT_BUTTON(ID_KNOWNNODECONNECT, CKadDlg::OnBnClickedBootstrapKnown)
 	EVT_BUTTON(ID_KADDISCONNECT, CKadDlg::OnBnClickedDisconnectKad)
 	EVT_BUTTON(ID_UPDATEKADLIST, CKadDlg::OnBnClickedUpdateNodeList)
 wxEND_EVENT_TABLE()
@@ -67,20 +66,6 @@ void CKadDlg::Init()
 	m_kad_scope = CastChild("kadScope", COScopeCtrl);
 	m_kad_scope->SetRanges(0.0, thePrefs::GetStatsMax());
 	m_kad_scope->SetYUnits("Nodes");
-
-#ifndef __WINDOWS__
-	//
-	// Get label with line breaks out of muuli.wdr, because generated code fails
-	// to compile in Windows.
-	//
-	// In Windows, setting a button label with a newline fails (the newline is ignored).
-	// Creating a button with such a label works however. :-/
-	// So leave the label from the muuli (without line breaks) here,
-	// so it can still be fixed in the translation.
-	//
-	wxButton *bootstrap = CastChild(ID_KNOWNNODECONNECT, wxButton);
-	bootstrap->SetLabel(_("Bootstrap from \nknown clients"));
-#endif
 
 	SetUpdatePeriod(thePrefs::GetTrafficOMeterInterval());
 	SetGraphColors();
@@ -212,11 +197,6 @@ void CKadDlg::OnBnClickedBootstrapClient(wxCommandEvent &WXUNUSED(evt))
 		wxMessageBox(
 			_("Please fill all fields required"), _("Message"), wxOK | wxICON_INFORMATION, this);
 	}
-}
-
-void CKadDlg::OnBnClickedBootstrapKnown(wxCommandEvent &WXUNUSED(evt))
-{
-	theApp->StartKad();
 }
 
 void CKadDlg::OnBnClickedDisconnectKad(wxCommandEvent &WXUNUSED(evt))

--- a/src/KadDlg.cpp
+++ b/src/KadDlg.cpp
@@ -102,7 +102,9 @@ void CKadDlg::UpdateConnectButton()
 		state = ConnButtonOff;
 	}
 
-	SetConnectButtonState(button, state, thePrefs::GetNetworkKademlia());
+	// _("Kad") matches the translatable tab label (muuli_wdr.cpp's
+	// NetDialog); see CServerWnd::UpdateED2KConnectButton's ED2K equivalent.
+	SetConnectButtonState(button, state, thePrefs::GetNetworkKademlia(), _("Kad"));
 }
 
 void CKadDlg::SetUpdatePeriod(int step)

--- a/src/KadDlg.cpp
+++ b/src/KadDlg.cpp
@@ -42,10 +42,7 @@
 #endif
 
 wxBEGIN_EVENT_TABLE(CKadDlg, wxPanel)
-	EVT_TEXT(ID_NODE_IP1, CKadDlg::OnFieldsChange)
-	EVT_TEXT(ID_NODE_IP2, CKadDlg::OnFieldsChange)
-	EVT_TEXT(ID_NODE_IP3, CKadDlg::OnFieldsChange)
-	EVT_TEXT(ID_NODE_IP4, CKadDlg::OnFieldsChange)
+	EVT_TEXT(ID_NODE_IP, CKadDlg::OnFieldsChange)
 	EVT_TEXT(ID_NODE_PORT, CKadDlg::OnFieldsChange)
 
 	EVT_TEXT_ENTER(IDC_NODESLISTURL, CKadDlg::OnBnClickedUpdateNodeList)
@@ -156,7 +153,7 @@ void CKadDlg::UpdateNodeCount(unsigned nodeCount)
 void CKadDlg::OnFieldsChange(wxCommandEvent &WXUNUSED(evt))
 {
 	// These are the IDs of the search-fields
-	int textfields[] = { ID_NODE_IP1, ID_NODE_IP2, ID_NODE_IP3, ID_NODE_IP4, ID_NODE_PORT };
+	int textfields[] = { ID_NODE_IP, ID_NODE_PORT };
 
 	bool enable = true;
 	for (int textfield : textfields) {
@@ -170,12 +167,18 @@ void CKadDlg::OnFieldsChange(wxCommandEvent &WXUNUSED(evt))
 void CKadDlg::OnBnClickedBootstrapClient(wxCommandEvent &WXUNUSED(evt))
 {
 	if (FindWindowById(ID_NODECONNECT)->IsEnabled()) {
-		// Ip is reversed since StringIPtoUint32 returns anti-host and kad expects host order
-		uint32 ip = StringIPtoUint32(
-			dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP4))->GetValue() + "." +
-			dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP3))->GetValue() + "." +
-			dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP2))->GetValue() + "." +
-			dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP1))->GetValue());
+		// Single "x.x.x.x" field (issue #402 review, matches the eD2k tab's
+		// IDC_IPADDRESS). Octets are reversed before StringIPtoUint32
+		// because that function returns anti-host order and Kad expects
+		// host order -- same trick the old four-separate-fields version
+		// used, just built from one string instead of four controls.
+		wxArrayString octets =
+			wxSplit(dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP))->GetValue(), '.');
+		uint32 ip = 0;
+		if (octets.GetCount() == 4) {
+			ip = StringIPtoUint32(
+				octets[3] + "." + octets[2] + "." + octets[1] + "." + octets[0]);
+		}
 
 		if (ip == 0) {
 			wxMessageBox(

--- a/src/KadDlg.cpp
+++ b/src/KadDlg.cpp
@@ -168,12 +168,19 @@ void CKadDlg::OnBnClickedBootstrapClient(wxCommandEvent &WXUNUSED(evt))
 {
 	if (FindWindowById(ID_NODECONNECT)->IsEnabled()) {
 		// Single "x.x.x.x" field (issue #402 review, matches the eD2k tab's
-		// IDC_IPADDRESS). Octets are reversed before StringIPtoUint32
-		// because that function returns anti-host order and Kad expects
-		// host order -- same trick the old four-separate-fields version
-		// used, just built from one string instead of four controls.
-		wxArrayString octets =
-			wxSplit(dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP))->GetValue(), '.');
+		// IDC_IPADDRESS). Trim first: the field's whole point is easier
+		// copy-paste, and a paste commonly carries a leading/trailing space
+		// that would otherwise fail as "Invalid ip to bootstrap". Octets are
+		// reversed before StringIPtoUint32 because that function returns
+		// anti-host order and Kad expects host order -- same trick the old
+		// four-separate-fields version used, just built from one string
+		// instead of four controls. wxSplit's third parameter (default '\\')
+		// is an escape character, not meaningful for IPs; left at default.
+		wxArrayString octets = wxSplit(dynamic_cast<wxTextCtrl *>(FindWindowById(ID_NODE_IP))
+						       ->GetValue()
+						       .Trim(true)
+						       .Trim(false),
+			'.');
 		uint32 ip = 0;
 		if (octets.GetCount() == 4) {
 			ip = StringIPtoUint32(

--- a/src/KadDlg.h
+++ b/src/KadDlg.h
@@ -38,7 +38,7 @@ class CKadDlg : public wxPanel
 {
 public:
 	CKadDlg(wxWindow *pParent);
-	~CKadDlg() {};
+	~CKadDlg(){};
 
 	void Init();
 	void SetUpdatePeriod(int step);
@@ -56,7 +56,6 @@ private:
 
 	// Event handlers
 	void OnBnClickedBootstrapClient(wxCommandEvent &evt);
-	void OnBnClickedBootstrapKnown(wxCommandEvent &evt);
 	void OnBnClickedDisconnectKad(wxCommandEvent &evt);
 	void OnBnClickedUpdateNodeList(wxCommandEvent &evt);
 	void OnFieldsChange(wxCommandEvent &evt);

--- a/src/KadDlg.h
+++ b/src/KadDlg.h
@@ -38,7 +38,7 @@ class CKadDlg : public wxPanel
 {
 public:
 	CKadDlg(wxWindow *pParent);
-	~CKadDlg(){};
+	~CKadDlg() = default;
 
 	void Init();
 	void SetUpdatePeriod(int step);

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -519,6 +519,10 @@ void CServerWnd::UpdateED2KConnectButton()
 		state = ConnButtonOff;
 	}
 
-	SetConnectButtonState(button, state, thePrefs::GetNetworkED2K() && theApp->ipfilter->IsReady());
+	// _("ED2K") matches the translatable tab label (muuli_wdr.cpp's
+	// NetDialog), so a translation that localizes the network name stays
+	// consistent between the tab and this button.
+	SetConnectButtonState(
+		button, state, thePrefs::GetNetworkED2K() && theApp->ipfilter->IsReady(), _("ED2K"));
 }
 // File_checked_for_headers

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2590,10 +2590,13 @@ wxSizer *KadDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     // "too close to the borders of the tab container").
     item0->Add( item3, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
 
-    wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
-    item1->AddGrowableCol( 0 );
-    item1->AddGrowableRow( 0 );
-
+    // Graph, full width -- mirrors serverListDlgUp's shape (top row, then a
+    // full-width primary area, then a manual-entry row below) rather than
+    // splitting the tab into two side-by-side columns (issue #402 review:
+    // "use more horizontal space for the graph"). item2 keeps the same
+    // wrapping depth around the graph box as the original two-column
+    // layout had (just added straight to item0 now, instead of via the
+    // dropped wxFlexGridSizer's first column).
     wxBoxSizer *item2 = new wxBoxSizer( wxVERTICAL );
 
     wxStaticBox *item8 = new wxStaticBox( parent, -1, _("Nodes stats") );
@@ -2636,52 +2639,28 @@ item9->SetName("kadScope");
     item10->Add( item17, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     item7->Add( item10, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT|wxTOP, 5) );
     item2->Add( item7, wxSizerFlags(1).Expand() );
-    item1->Add( item2, 0, wxGROW, 0 );
+    item0->Add( item2, wxSizerFlags(1).Expand() );
 
-    wxStaticBox *item21 = new wxStaticBox( parent, -1, _("Bootstrap") );
-    wxStaticBoxSizer *item20 = new wxStaticBoxSizer( item21, wxVERTICAL );
-
-    wxStaticBox *item23 = new wxStaticBox( parent, -1, _("New node") );
-    wxStaticBoxSizer *item22 = new wxStaticBoxSizer( item23, wxVERTICAL );
-
+    // Bootstrap-from-node row, full width below the graph -- mirrors
+    // serverListDlgUp's "Add server manually" row: a single IP field (not
+    // eD2k's ID_NODE_IP1..4 four-octet split -- issue #402 review: "have
+    // the IP address in just one field, it's easier to copy") plus a port
+    // field and the Connect button.
     wxBoxSizer *item24 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item25 = new wxStaticText( parent, -1, _("IP:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-    item24->Add( item25, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 10) );
-    CMuleTextCtrl *item26 = new CMuleTextCtrl( parent, ID_NODE_IP1, "", wxDefaultPosition, wxSize(30,-1), 0 );
-    item24->Add( item26, wxSizerFlags().Center().Border(wxTOP|wxBOTTOM, 5) );
-    wxStaticText *item27 = new wxStaticText( parent, -1, ".", wxDefaultPosition, wxDefaultSize, 0 );
-    item24->Add( item27, wxSizerFlags().Center().Border(wxTOP, 5) );
-    CMuleTextCtrl *item28 = new CMuleTextCtrl( parent, ID_NODE_IP2, "", wxDefaultPosition, wxSize(30,-1), 0 );
-    item24->Add( item28, wxSizerFlags().Center().Border(wxTOP|wxBOTTOM, 5) );
-    wxStaticText *item29 = new wxStaticText( parent, -1, ".", wxDefaultPosition, wxDefaultSize, 0 );
-    item24->Add( item29, wxSizerFlags().Center().Border(wxTOP, 5) );
-    CMuleTextCtrl *item30 = new CMuleTextCtrl( parent, ID_NODE_IP3, "", wxDefaultPosition, wxSize(30,-1), 0 );
-    item24->Add( item30, wxSizerFlags().Center().Border(wxTOP|wxBOTTOM, 5) );
-    wxStaticText *item31 = new wxStaticText( parent, -1, ".", wxDefaultPosition, wxDefaultSize, 0 );
-    item24->Add( item31, wxSizerFlags().Center().Border(wxTOP, 5) );
-    CMuleTextCtrl *item32 = new CMuleTextCtrl( parent, ID_NODE_IP4, "", wxDefaultPosition, wxSize(30,-1), 0 );
-    item24->Add( item32, wxSizerFlags().Center().Border(wxTOP|wxBOTTOM, 5) );
-    item22->Add( item24, wxSizerFlags().Expand().CenterVertical() );
-    wxFlexGridSizer *item33 = new wxFlexGridSizer( 2, 0, 0 );
-    item33->AddGrowableCol( 1 );
-
+    wxStaticText *item25 = new wxStaticText( parent, -1, _("Bootstrap from node: IP"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
+    item24->Add( item25, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
+    CMuleTextCtrl *item26 = new CMuleTextCtrl( parent, ID_NODE_IP, "", wxDefaultPosition, wxDefaultSize, 0 );
+    item26->SetToolTip( _("Enter the IP of the node here, using the x.x.x.x format.") );
+    item24->Add( item26, wxSizerFlags(1).Center().Border(wxLEFT|wxRIGHT, 5) );
     wxStaticText *item34 = new wxStaticText( parent, -1, _("Port:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-    item33->Add( item34, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
+    item24->Add( item34, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     CMuleTextCtrl *item35 = new CMuleTextCtrl( parent, ID_NODE_PORT, "", wxDefaultPosition, wxSize(80,-1), 0 );
-    item33->Add( item35, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    item22->Add( item33, wxSizerFlags().Expand().CenterVertical() );
+    item24->Add( item35, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     wxButton *item36 = new wxButton( parent, ID_NODECONNECT, _("Connect"), wxDefaultPosition, wxDefaultSize, 0 );
     item36->Enable( false );
-    item22->Add( item36, wxSizerFlags().Center().Border(wxTOP|wxBOTTOM, 5) );
-    item20->Add( item22, wxSizerFlags().Expand().Border(wxALL, 5) );
-
-    // The "Bootstrap from known clients" button (formerly here, ID_KNOWNNODECONNECT)
-    // was dropped (issue #402 review): it called the same theApp->StartKad() as the
-    // Kad tab's own Connect/Cancel/Disconnect toggle, so it was a redundant second
-    // way to do the same thing rather than a distinct action.
-    item1->Add( item20, wxSizerFlags().Top() );
-    item0->Add( item1, wxSizerFlags(1).Expand() );
+    item24->Add( item36, wxSizerFlags().Center().Border(wxLEFT, 5) );
+    item0->Add( item24, wxSizerFlags().Expand().CenterVertical().Border(wxTOP|wxBOTTOM, 5) );
     if (set_sizer)
     {
         parent->SetSizer( item0 );
@@ -5983,40 +5962,61 @@ namespace
 // per-tab button sitting next to a one-line URL field (issue #402 review:
 // "the button and the icon are too big"). Scaled to a uniform, more modest
 // size here rather than reworking the XPM data connButImg still serves.
-wxBitmap ScaledConnButImg(size_t index)
+// Cached per state: SetConnectButtonState runs on every connection-state
+// update (i.e. often), and rescaling the same three source bitmaps every
+// single call is wasted work -- index 2 is already 16x16 physical pixels,
+// so without the cache it round-trips through ConvertToImage/Rescale for
+// nothing on every "connecting" tick. DPI is resolved from whichever
+// button first triggers the fill for a given index; the ED2K and Kad
+// buttons live on the same top-level window in practice, so this doesn't
+// need to be any more dynamic than that.
+wxBitmap ScaledConnButImg(size_t index, const wxWindow *dpiRef)
 {
-	wxImage image = connButImg(index).ConvertToImage();
-	image.Rescale(16, 16, wxIMAGE_QUALITY_HIGH);
-	return wxBitmap(image);
+	static wxBitmap cache[3];
+	if (!cache[index].IsOk()) {
+		wxImage image = connButImg(index).ConvertToImage();
+		const int size = wxWindow::FromDIP(16, dpiRef);
+		image.Rescale(size, size, wxIMAGE_QUALITY_HIGH);
+		cache[index] = wxBitmap(image);
+	}
+	return cache[index];
 }
 } // namespace
 
 void SetConnectButtonState(
 	wxButton *button, EConnButtonState state, bool enabled, const wxString &networkName)
 {
-	// The leading space (outside the translatable string, so no new msgid)
-	// is the portable way to put a gap between the icon and the label:
-	// wxButton::SetBitmapMargins() only does anything on wxOSX (see
-	// osx/anybutton.h) -- wxGTK inherits the base class's no-op, so using
-	// it here would fix macOS while silently doing nothing on Linux.
-	//
 	// networkName ("ED2K" / "Kad") is folded into the label itself, not
 	// concatenated after translation: the button sits in the same spot on
 	// both tabs, so without it there is nothing on the button telling you
 	// which network "Disconnect" affects (issue #402 review).
+	wxString label;
 	switch (state) {
 	case ConnButtonConnecting:
-		button->SetLabel(wxT(" ") + wxString(CFormat(_("Cancel %s")) % networkName));
-		button->SetBitmap(ScaledConnButImg(2));
+		label = wxString(CFormat(_("Cancel %s")) % networkName);
+		button->SetBitmap(ScaledConnButImg(2, button));
 		break;
 	case ConnButtonConnected:
-		button->SetLabel(wxT(" ") + wxString(CFormat(_("Disconnect %s")) % networkName));
-		button->SetBitmap(ScaledConnButImg(1));
+		label = wxString(CFormat(_("Disconnect %s")) % networkName);
+		button->SetBitmap(ScaledConnButImg(1, button));
 		break;
 	default:
-		button->SetLabel(wxT(" ") + wxString(CFormat(_("Connect %s")) % networkName));
-		button->SetBitmap(ScaledConnButImg(0));
+		label = wxString(CFormat(_("Connect %s")) % networkName);
+		button->SetBitmap(ScaledConnButImg(0, button));
 	}
+
+	// wxButton::SetBitmapMargins() is a real gap on wxMSW and wxOSX (both
+	// override DoSetBitmapMargins -- see msw/anybutton.h, osx/anybutton.h)
+	// but a silent no-op on wxGTK, which inherits the base class's empty
+	// implementation. So GTK falls back to the old trick: a leading space
+	// outside the translatable string (so no new msgid), which depends on
+	// no translator trimming leading whitespace but is otherwise harmless.
+#ifdef __WXGTK__
+	button->SetLabel(wxT(" ") + label);
+#else
+	button->SetBitmapMargins(button->FromDIP(4), 0);
+	button->SetLabel(label);
+#endif
 
 	button->Enable(enabled);
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2676,11 +2676,10 @@ item9->SetName("kadScope");
     item22->Add( item36, wxSizerFlags().Center().Border(wxTOP|wxBOTTOM, 5) );
     item20->Add( item22, wxSizerFlags().Expand().Border(wxALL, 5) );
 
-    // Bootstrap actions stacked directly under the New node box, with
-    // padding but no filler spacers -- the column is top-aligned so the
-    // graph column beside it takes all the freed vertical space.
-    wxButton *item37 = new wxButton( parent, ID_KNOWNNODECONNECT, _("Bootstrap from known clients"), wxDefaultPosition, wxDefaultSize, 0 );
-    item20->Add( item37, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT|wxTOP, 5) );
+    // The "Bootstrap from known clients" button (formerly here, ID_KNOWNNODECONNECT)
+    // was dropped (issue #402 review): it called the same theApp->StartKad() as the
+    // Kad tab's own Connect/Cancel/Disconnect toggle, so it was a redundant second
+    // way to do the same thing rather than a distinct action.
     item1->Add( item20, wxSizerFlags().Top() );
     item0->Add( item1, wxSizerFlags(1).Expand() );
     if (set_sizer)

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -59,6 +59,7 @@
 #endif
 
 // Custom source
+#include <map>              // Needed for std::map (ScaledConnButImg's per-size cache)
 #include <common/Format.h> // Needed for CFormat (SetConnectButtonState)
 #include "ServerListCtrl.h"
 #include "DownloadListCtrl.h"
@@ -5962,24 +5963,27 @@ namespace
 // per-tab button sitting next to a one-line URL field (issue #402 review:
 // "the button and the icon are too big"). Scaled to a uniform, more modest
 // size here rather than reworking the XPM data connButImg still serves.
-// Cached per state: SetConnectButtonState runs on every connection-state
-// update (i.e. often), and rescaling the same three source bitmaps every
-// single call is wasted work -- index 2 is already 16x16 physical pixels,
-// so without the cache it round-trips through ConvertToImage/Rescale for
-// nothing on every "connecting" tick. DPI is resolved from whichever
-// button first triggers the fill for a given index; the ED2K and Kad
-// buttons live on the same top-level window in practice, so this doesn't
-// need to be any more dynamic than that.
+// Cached per (state, physical size): SetConnectButtonState runs on every
+// connection-state update (i.e. often), and rescaling the same three source
+// bitmaps every single call is wasted work -- index 2 is already 16x16
+// physical pixels, so without the cache it round-trips through
+// ConvertToImage/Rescale for nothing on every "connecting" tick. Keyed by
+// the FromDIP-resolved pixel size, not just the state index, so a window
+// dragged to a differently-scaled monitor (per-monitor DPI v2) gets a
+// freshly-rescaled bitmap instead of a stale one left over from wherever it
+// was first computed -- there is no wxEVT_DPI_CHANGED invalidation here,
+// the size-keyed cache sidesteps needing one.
 wxBitmap ScaledConnButImg(size_t index, const wxWindow *dpiRef)
 {
-	static wxBitmap cache[3];
-	if (!cache[index].IsOk()) {
+	static std::map<int, wxBitmap> cache[3];
+	const int size = wxWindow::FromDIP(16, dpiRef);
+	wxBitmap &bmp = cache[index][size];
+	if (!bmp.IsOk()) {
 		wxImage image = connButImg(index).ConvertToImage();
-		const int size = wxWindow::FromDIP(16, dpiRef);
 		image.Rescale(size, size, wxIMAGE_QUALITY_HIGH);
-		cache[index] = wxBitmap(image);
+		bmp = wxBitmap(image);
 	}
-	return cache[index];
+	return bmp;
 }
 } // namespace
 
@@ -6005,16 +6009,26 @@ void SetConnectButtonState(
 		button->SetBitmap(ScaledConnButImg(0, button));
 	}
 
-	// wxButton::SetBitmapMargins() is a real gap on wxMSW and wxOSX (both
-	// override DoSetBitmapMargins -- see msw/anybutton.h, osx/anybutton.h)
-	// but a silent no-op on wxGTK, which inherits the base class's empty
-	// implementation. So GTK falls back to the old trick: a leading space
+	// wxButton::SetBitmapMargins() means different things per port that
+	// implement it (msw/anybutton.h, osx/anybutton.h -- wxGTK inherits the
+	// base class's no-op): wxOSX stores it as the margin AROUND the bitmap
+	// (both sides, including button edge), so overriding it there is a real
+	// gap fix. wxMSW applies it BETWEEN bitmap and label only, layered on
+	// top of a font-derived default (src/msw/anybutton.cpp:
+	// m_margin.x = GetCharWidth(); m_margin.y = GetCharHeight() / 2) that
+	// already matches native Windows button metrics -- overriding it with a
+	// fixed (4, 0) narrows the gap AND drops the vertical margin to zero,
+	// moving the button away from the platform convention instead of toward
+	// it. So this is wxOSX-only; wxMSW keeps its own native default
+	// untouched, and wxGTK falls back to the old trick: a leading space
 	// outside the translatable string (so no new msgid), which depends on
 	// no translator trimming leading whitespace but is otherwise harmless.
-#ifdef __WXGTK__
+#ifdef __WXOSX__
+	button->SetBitmapMargins(button->FromDIP(4), 0);
+	button->SetLabel(label);
+#elif defined(__WXGTK__)
 	button->SetLabel(wxT(" ") + label);
 #else
-	button->SetBitmapMargins(button->FromDIP(4), 0);
 	button->SetLabel(label);
 #endif
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -59,6 +59,7 @@
 #endif
 
 // Custom source
+#include <common/Format.h> // Needed for CFormat (SetConnectButtonState)
 #include "ServerListCtrl.h"
 #include "DownloadListCtrl.h"
 #include "SourceListCtrl.h"
@@ -2482,7 +2483,9 @@ wxSizer *serverListDlgUp( wxWindow *parent, bool call_fit, bool set_sizer )
     // mirrors the Kad tab's "primary control on top, manual form below" shape.
     wxButton *item14 = new wxButton( parent, IDC_ED2KDISCONNECT, _("Connect"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item14, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
-    item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
+    // Top border: without it this row sits flush against the tab strip
+    // (issue #402 review: "too close to the borders of the tab container").
+    item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
     CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxSize(200, 100), wxLC_REPORT|wxSUNKEN_BORDER );
     item0->Add( item15, wxSizerFlags(1).Expand().CenterVertical() );
     wxBoxSizer *item5 = new wxBoxSizer( wxHORIZONTAL );
@@ -2583,7 +2586,9 @@ wxSizer *KadDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     // after construction, which sets the real label/bitmap for the current state.
     wxButton *item38 = new wxButton( parent, ID_KADDISCONNECT, _("Connect"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item38, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
-    item0->Add( item3, wxSizerFlags().Expand().CenterVertical() );
+    // Top border: matches serverListDlgUp's top row (issue #402 review:
+    // "too close to the borders of the tab container").
+    item0->Add( item3, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
 
     wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
     item1->AddGrowableCol( 0 );
@@ -3476,9 +3481,12 @@ wxSizer *messagePageMessages( wxWindow *parent, bool call_fit, bool set_sizer )
 void muleToolbar( wxToolBar *parent )
 {
     parent->SetMargins( 0, 0 );
-    
-    parent->AddTool( ID_BUTTONCONNECT, _("Connect"), connButImg( 0 ), wxNullBitmap, wxITEM_NORMAL, _("Connect to any server and/or Kad") );
-    parent->AddSeparator();
+
+    // The global Connect/Disconnect toolbar button (formerly ID_BUTTONCONNECT)
+    // was dropped here (issue #402): each network tab now has its own live
+    // Connect/Cancel/Disconnect toggle (SetConnectButtonState, wired from
+    // CServerWnd/CKadDlg), and the combined both-networks action remains
+    // available from the tray icon (CMuleTrayIcon::DoConnectDisconnect).
     parent->AddTool( ID_BUTTONNETWORKS, _("Networks"), amuleDlgImages( 20 ), wxNullBitmap, wxITEM_CHECK, _("Networks Window") );
     parent->AddTool( ID_BUTTONSEARCH, _("Searches"), amuleDlgImages( 22 ), wxNullBitmap, wxITEM_CHECK, _("Searches Window") );
     parent->AddTool( ID_BUTTONDOWNLOADS, _("Downloads"), amuleDlgImages( 21 ), wxNullBitmap, wxITEM_CHECK, _("Downloads Window") );
@@ -5969,25 +5977,46 @@ wxBitmap connButImg( size_t index )
     return wxNullBitmap;
 }
 
-void SetConnectButtonState(wxButton *button, EConnButtonState state, bool enabled)
+namespace
+{
+// connButImg's source pixel data is 32x32 for the off/connected icons but
+// 16x16 for the connecting one -- both sizes are oversized for an inline
+// per-tab button sitting next to a one-line URL field (issue #402 review:
+// "the button and the icon are too big"). Scaled to a uniform, more modest
+// size here rather than reworking the XPM data connButImg still serves.
+wxBitmap ScaledConnButImg(size_t index)
+{
+	wxImage image = connButImg(index).ConvertToImage();
+	image.Rescale(16, 16, wxIMAGE_QUALITY_HIGH);
+	return wxBitmap(image);
+}
+} // namespace
+
+void SetConnectButtonState(
+	wxButton *button, EConnButtonState state, bool enabled, const wxString &networkName)
 {
 	// The leading space (outside the translatable string, so no new msgid)
 	// is the portable way to put a gap between the icon and the label:
 	// wxButton::SetBitmapMargins() only does anything on wxOSX (see
 	// osx/anybutton.h) -- wxGTK inherits the base class's no-op, so using
 	// it here would fix macOS while silently doing nothing on Linux.
+	//
+	// networkName ("ED2K" / "Kad") is folded into the label itself, not
+	// concatenated after translation: the button sits in the same spot on
+	// both tabs, so without it there is nothing on the button telling you
+	// which network "Disconnect" affects (issue #402 review).
 	switch (state) {
 	case ConnButtonConnecting:
-		button->SetLabel(wxT(" ") + _("Cancel"));
-		button->SetBitmap(connButImg(2));
+		button->SetLabel(wxT(" ") + wxString(CFormat(_("Cancel %s")) % networkName));
+		button->SetBitmap(ScaledConnButImg(2));
 		break;
 	case ConnButtonConnected:
-		button->SetLabel(wxT(" ") + _("Disconnect"));
-		button->SetBitmap(connButImg(1));
+		button->SetLabel(wxT(" ") + wxString(CFormat(_("Disconnect %s")) % networkName));
+		button->SetBitmap(ScaledConnButImg(1));
 		break;
 	default:
-		button->SetLabel(wxT(" ") + _("Connect"));
-		button->SetBitmap(connButImg(0));
+		button->SetLabel(wxT(" ") + wxString(CFormat(_("Connect %s")) % networkName));
+		button->SetBitmap(ScaledConnButImg(0));
 	}
 
 	button->Enable(enabled);

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -624,7 +624,6 @@ wxSizer *messagePageMessages(wxWindow *parent, bool call_fit = TRUE, bool set_si
 
 // Declare toolbar functions
 
-#define ID_BUTTONCONNECT 10345
 #define ID_BUTTONNETWORKS 10346
 #define ID_BUTTONSEARCH 10347
 #define ID_BUTTONDOWNLOADS 10348
@@ -657,7 +656,8 @@ enum EConnButtonState
 	ConnButtonConnecting,
 	ConnButtonConnected
 };
-void SetConnectButtonState(wxButton *button, EConnButtonState state, bool enabled);
+void SetConnectButtonState(
+	wxButton *button, EConnButtonState state, bool enabled, const wxString &networkName);
 
 #endif
 

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -510,7 +510,6 @@ wxSizer *serverListDlgDown(wxWindow *parent, bool call_fit = TRUE, bool set_size
 #define ID_NODE_IP4 10259
 #define ID_NODE_PORT 10260
 #define ID_NODECONNECT 10261
-#define ID_KNOWNNODECONNECT 10262
 #define ID_KADDISCONNECT 10263
 wxSizer *KadDlg(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -504,10 +504,7 @@ wxSizer *serverListDlgDown(wxWindow *parent, bool call_fit = TRUE, bool set_size
 #define ID_UPDATEKADLIST 10253
 #define IDC_NODESLISTURL 10254
 #define ID_KADSCOPE 10255
-#define ID_NODE_IP1 10256
-#define ID_NODE_IP2 10257
-#define ID_NODE_IP3 10258
-#define ID_NODE_IP4 10259
+#define ID_NODE_IP 10256
 #define ID_NODE_PORT 10260
 #define ID_NODECONNECT 10261
 #define ID_KADDISCONNECT 10263


### PR DESCRIPTION
Follow-up to the #663/#677 review feedback ngosang left on #402 after the per-tab connect/disconnect toggle landed:

> I think the button and the icon are too big and too close to the borders of the tab container. Just reduce the size and some padding.
> Since the button is in the same place in both tabs [...] for me it's not clear what I'm disconnecting. Could you change the text to make it "Disconnect/Connect ED2K" or "Disconnect/Connect Kad"?

## Changes

- **Icon size**: `connButImg`'s source pixel data is an inconsistent 32x32 (off/connected) vs 16x16 (connecting). `SetConnectButtonState` now scales all three to a uniform, `FromDIP`-aware size (so it stays crisp on HiDPI/Retina) rather than reworking the XPM data, and caches the three scaled bitmaps as statics instead of rescaling on every connection-state update.
- **Padding**: the ED2K/Kad tabs' top row (containing the button) had no border and sat flush against the tab strip. Added `Border(wxTOP, 5)`.
- **Label**: `SetConnectButtonState` gained a `networkName` parameter, so the label now reads "Connect ED2K" / "Disconnect Kad" / "Cancel ED2K" etc. instead of the bare, ambiguous "Connect"/"Disconnect"/"Cancel". `_("ED2K")` / `_("Kad")` reuse the same translatable strings as the tab labels, so a translation stays consistent between the two.
- **Icon-label gap**: `SetBitmapMargins()` is a real gap on wxMSW and wxOSX (both override `DoSetBitmapMargins`) but a silent no-op on wxGTK, which inherits the base class's empty implementation -- the previous comment here had this backwards (said only wxOSX implements it). Now calls `SetBitmapMargins()` on the ports that support it and keeps the old leading-space trick only for wxGTK.
- **Kad tab layout**: dropped the two-column `wxFlexGridSizer` (graph in one column, "Bootstrap"/"New node" boxes in the other) in favor of the same vertical shape `serverListDlgUp` already uses: top row, full-width primary area (the graph, now with the full tab width instead of half), then a full-width manual-entry row below. That row also collapses the four-octet `ID_NODE_IP1..4` fields into a single IP text field, matching the eD2k tab's `IDC_IPADDRESS` -- easier to read and paste. `OnBnClickedBootstrapClient` now splits that one field on `.` instead of reading four controls (still reverses the octets before `StringIPtoUint32`, same as before, since that function returns anti-host order and Kad wants host order).
- **Dead code removal**: two buttons turned out to be redundant --
  - the toolbar's global Connect/Disconnect button (`ID_BUTTONCONNECT`) has no `EVT_TOOL` binding anywhere in `amuleDlg.cpp` (confirmed there's no `EVT_MENU` alias either, which is the one thing that could have hidden a live binding here since wx maps `wxEVT_TOOL`/`wxEVT_MENU` together) -- it looks like the click handler was dropped somewhere across #663/#677 and the button has been inert (visible, does nothing on click) ever since. Removed it; the combined both-networks action is still reachable from the tray icon (`CMuleTrayIcon::DoConnectDisconnect`), consistent with what was agreed on #402.
  - the Kad tab's "Bootstrap from known clients" button (`ID_KNOWNNODECONNECT`) called the exact same `theApp->StartKad()` the tab's own Connect/Cancel/Disconnect toggle already calls when off -- a second control for the same action. Removed (ngosang, this thread).

`po/*.po` regenerated via `scripts/update-po.sh` each time a commit touched a translatable string.

## Testing

Built `amule` and `amulegui` clean on Windows (MSYS2/MinGW-w64). clang-format v18 applied via the exact CI image (`ghcr.io/jidicula/clang-format:18` -- a substitute image with the same version string but a different point release, `xianpengshen/clang-tools:18`, disagreed with CI on a destructor-spacing edge case in an earlier push; fixed and confirmed idempotent against the real image).

Fixes #402 (follow-up review comments).