### PR TITLE
feat(web-ui): add a per-file Clients tab to the detail panels

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -770,6 +770,12 @@ table.data.virtual td .name-cell .badge { flex-shrink: 0; }
   border-radius: 0 0 var(--radius) var(--radius); padding: 12px;
 }
 
+/* --- per-file clients tab --- */
+/* Fills the detail body so the table scrolls its own rows (the .split-view
+   .table-wrap.virtual rule above gives it flex:1) instead of stretching the
+   panel and adding a second scrollbar. */
+.detail-clients { display: flex; flex-direction: column; gap: 8px; height: 100%; }
+
 /* --- comments / ratings tab --- */
 .detail-comments { display: flex; flex-direction: column; gap: 16px; }
 .comment-editor { display: flex; flex-direction: column; gap: 8px; }

--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -239,6 +239,7 @@
   "downloads_detail_copy_failed": "Could not copy the link",
   "downloads_detail_eta": "Remaining",
   "detail_tab_details": "Details",
+  "detail_tab_clients": "Clients",
   "detail_tab_comments": "Comments",
   "detail_tab_filename": "Filename",
   "filename_none": "No source-reported names yet.",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -239,6 +239,7 @@
   "downloads_detail_copy_failed": "No se pudo copiar el enlace",
   "downloads_detail_eta": "Tiempo restante",
   "detail_tab_details": "Detalles",
+  "detail_tab_clients": "Clientes",
   "detail_tab_comments": "Comentarios",
   "detail_tab_filename": "Nombre",
   "filename_none": "Todavía no hay nombres reportados por las fuentes.",

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -1,0 +1,174 @@
+// Peer table shared by the Clients section and the per-file "Clients" tab in
+// the Downloads / Shared Files detail panels. Columns, formatting helpers and
+// the live `clients` store wiring live here once; each consumer decides which
+// columns it shows by default and which rows it feeds in.
+
+import { api } from "../api.js";
+import { data } from "../events.js";
+import { html, useState, useEffect, useStore } from "../dom.js";
+import { Badge, Placeholder } from "../components.js";
+import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
+import { formatBytes, formatSpeed } from "../format.js";
+import { Icon } from "../icons.js";
+import { t } from "../i18n.js";
+
+const ACTIVE = (s) => s && s !== "idle" && s !== "unknown";
+export const isDown = (c) => (c.download_speed_bps || 0) > 0 || ACTIVE(c.download_state);
+export const isUp = (c) => (c.upload_speed_bps || 0) > 0 || ACTIVE(c.upload_state);
+
+// Column set, declared once. Every consumer offers all of them in the column
+// picker and picks which ones start hidden (see ClientTable's defaultHidden),
+// so a column is always one click away instead of missing from a tab.
+const softLabel = (c) => [c.software ? t("downloads_peer_soft_" + c.software) : "", c.software === "unknown" ? "" : c.software_version].filter(Boolean).join(" ") || "—";
+const rankLabel = (c) => !c.remote_queue_rank ? "—" : c.remote_queue_rank >= 0xFFFF ? t("downloads_peer_queue_full") : c.remote_queue_rank;
+const bytesOf = (c, k) => formatBytes((c.xfer || {})[k]);
+// The "file" column is shared by both directions: download_file_name is the
+// peer-advertised name of what we're pulling FROM them; upload_file_name is
+// the partfile they're pulling FROM us. An upload-only peer has no
+// download_file_name, so falling back to upload_file_name is what actually
+// makes the column non-blank for uploads (previously always "—" there).
+export const fileNameOf = (c) => c.download_file_name || c.upload_file_name || "";
+
+// Default order when no column sort is chosen: busiest peers first.
+export const bySpeed = (a, b) =>
+  ((b.download_speed_bps || 0) + (b.upload_speed_bps || 0)) -
+  ((a.download_speed_bps || 0) + (a.upload_speed_bps || 0));
+
+// Each column carries key + sortVal so the header is clickable-to-sort (the
+// flags column has no key → stays non-sortable).
+export const COLS = [
+  { cls: "peer-flags", width: "60px", cell: (c) => peerFlags(c) },
+  { key: "name", always: true, th: "downloads_peer_col_name", width: "170px", sortable: true,
+    sortVal: (c) => (c.client_name || "").toLowerCase(),
+    cell: (c) => html`<span title=${c.client_name}>${c.client_name || "—"}</span>` },
+  { key: "software", th: "downloads_peer_col_software", width: "140px", sortable: true,
+    sortVal: (c) => softLabel(c).toLowerCase(), cell: (c) => softLabel(c) },
+  { key: "file", th: "downloads_peer_col_file", cls: "name", sortable: true,
+    sortVal: (c) => fileNameOf(c).toLowerCase(),
+    cell: (c) => html`<span title=${fileNameOf(c)}>${fileNameOf(c) || "—"}</span>` },
+
+  { key: "dl_state", th: "downloads_peer_col_dl_state", width: "120px", sortable: true,
+    sortVal: (c) => c.download_state || "", cell: (c) => stateBadge(c.download_state) },
+  { key: "dl_speed", th: "downloads_peer_col_dl_speed", num: true, width: "100px", sortable: true,
+    sortVal: (c) => c.download_speed_bps || 0, cell: (c) => formatSpeed(c.download_speed_bps) },
+  { key: "downloaded", th: "downloads_peer_col_downloaded", num: true, width: "100px", sortable: true,
+    sortVal: (c) => (c.xfer && c.xfer.down_total) || 0, cell: (c) => bytesOf(c, "down_total") },
+  { key: "dl_session", th: "downloads_peer_col_downloaded_session", num: true, width: "110px", sortable: true,
+    sortVal: (c) => (c.xfer && c.xfer.down_session) || 0, cell: (c) => bytesOf(c, "down_session") },
+  { key: "remote_rank", th: "downloads_peer_col_remote_rank", num: true, width: "90px", sortable: true,
+    sortVal: (c) => c.remote_queue_rank || 0, cell: (c) => rankLabel(c) },
+
+  { key: "ul_state", th: "downloads_peer_col_ul_state", width: "120px", sortable: true,
+    sortVal: (c) => c.upload_state || "", cell: (c) => stateBadge(c.upload_state) },
+  { key: "ul_speed", th: "downloads_peer_col_ul_speed", num: true, width: "100px", sortable: true,
+    sortVal: (c) => c.upload_speed_bps || 0, cell: (c) => formatSpeed(c.upload_speed_bps) },
+  { key: "uploaded", th: "downloads_peer_col_uploaded", num: true, width: "100px", sortable: true,
+    sortVal: (c) => (c.xfer && c.xfer.up_total) || 0, cell: (c) => bytesOf(c, "up_total") },
+  { key: "ul_session", th: "downloads_peer_col_uploaded_session", num: true, width: "110px", sortable: true,
+    sortVal: (c) => (c.xfer && c.xfer.up_session) || 0, cell: (c) => bytesOf(c, "up_session") },
+  { key: "queue_pos", th: "downloads_peer_col_queue_pos", num: true, width: "90px", sortable: true,
+    sortVal: (c) => c.queue_waiting_position || 0, cell: (c) => c.queue_waiting_position || "—" },
+  { key: "score", th: "downloads_peer_col_score", num: true, width: "80px", sortable: true,
+    sortVal: (c) => c.score || 0, cell: (c) => c.score || "—" },
+];
+
+export const IDENT_FILTERS = ["all", "identified", "not_identified"].map((v) => [v, t("downloads_peer_ident_" + v)]);
+
+// Live `clients` collection (GET /clients seed + SSE client_added/updated/
+// removed). register/ensure are idempotent, so every consumer can just call
+// this; the resource starts on the first mount and stays live from then on.
+export function useClients() {
+  useEffect(() => {
+    data.register({ key: "clients", eventPrefix: "client", id: "client_ecid",
+      list: () => api.get("clients").then((r) => r.clients || []) });
+    data.ensure("clients");
+  }, []);
+  return useStore("clients") || [];
+}
+
+// Compact status icons (replacing the ident/obfuscation/friend columns). Each
+// icon carries an explanatory tooltip; only meaningful states show an icon.
+export function peerFlags(c) {
+  const flags = [];
+  if (c.ident_state === "identified")
+    flags.push(["verified", t("downloads_peer_ident") + ": " + t("downloads_peer_identified")]);
+  else if (c.ident_state === "bad_guy")
+    flags.push(["warning", t("downloads_peer_ident") + ": " + t("downloads_peer_bad_guy")]);
+  if (c.obfuscation_status === "enabled")
+    flags.push(["lock", t("downloads_peer_obfuscation") + ": " + t("downloads_peer_enabled")]);
+  if (c.friend_slot)
+    flags.push(["star", t("downloads_peer_friend")]);
+  return flags.map(([name, tip]) => html`<${Icon} name=${name} size=${18} title=${tip} />`);
+}
+
+export function stateBadge(s) {
+  if (!s || s === "idle") return html`<${Badge}>${t("downloads_peer_state_" + (s || "idle"))}<//>`;
+  const kind = s === "downloading" || s === "uploading" ? "downloading"
+    : s === "banned" || s === "error" ? "paused" : "waiting";
+  return html`<${Badge} kind=${kind}>${t("downloads_peer_state_" + s)}<//>`;
+}
+
+// Toolbar + peer table, shared by every consumer. Always offers the full
+// column set in the picker; `defaultHidden` / `defaultSort` are only the
+// starting point, and `prefsKey` is where the user's choice (sort, hidden
+// columns, widths) is persisted. Every caller sorts descending by default
+// (biggest transfer first), so only the column key is a prop. `toolbar` is
+// whatever filter controls the caller wants left of the picker. Returns the
+// two siblings so the caller keeps owning the layout box around them.
+export function ClientTable({ rows, prefsKey, defaultHidden, defaultSort, toolbar, toolbarCls = "toolbar" }) {
+  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
+    useTablePrefs(prefsKey, { sortKey: defaultSort, sortDir: -1, hidden: defaultHidden });
+
+  const columns = COLS.map((col) => ({ ...col, label: col.th ? t(col.th) : "" }));
+  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
+  // Sort by the chosen column when set; otherwise keep the default "busiest
+  // peers first" order (combined dl+ul speed, descending).
+  const list = columns.some((c) => c.key === sortKey && c.sortVal)
+    ? sortRows(rows, columns, sortKey, sortDir)
+    : rows.slice().sort(bySpeed);
+
+  return html`
+    <div class=${toolbarCls}>
+      ${toolbar}
+      <div class="spacer"></div>
+      <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
+    </div>
+    <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.client_ecid}
+                     sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
+                     widths=${widths} onResize=${setWidth}
+                     maxHeight="none"
+                     empty=${html`<${Placeholder} kind="info">${t("downloads_peer_empty")}<//>`} />`;
+}
+
+// Per-file peer table for the detail panels. Rows are the live clients whose
+// download_file_hash (they serve us this file) or upload_file_hash (they pull
+// it from us) matches; both hashes come from the same m_files map that produced
+// the file's own hash, so a plain string compare is enough. Peers that are not
+// currently connected for this file (A4AF, offline sources) have neither hash
+// and therefore never show up here.
+export function FileClients({ hash, prefsKey, defaultHidden, defaultSort }) {
+  const clients = useClients();
+  const [ident, setIdent] = useState("all");
+  const [q, setQ] = useState("");
+
+  let rows = clients.filter((c) => c.download_file_hash === hash || c.upload_file_hash === hash);
+  if (ident === "identified") rows = rows.filter((c) => c.ident_state === "identified");
+  else if (ident === "not_identified") rows = rows.filter((c) => c.ident_state !== "identified");
+  if (q) { const match = textMatcher(q); rows = rows.filter((c) => match((c.client_name || "") + " " + fileNameOf(c))); }
+
+  return html`
+    <div class="detail-clients">
+      <${ClientTable} rows=${rows} prefsKey=${prefsKey} defaultHidden=${defaultHidden}
+                      defaultSort=${defaultSort}
+                      toolbar=${ClientFilters({ ident, setIdent, q, setQ })} />
+    </div>`;
+}
+
+// The identity <select> + free-text box, identical in both consumers.
+export function ClientFilters({ ident, setIdent, q, setQ }) {
+  return html`
+    <select class="input input-sm" value=${ident} onChange=${(e) => setIdent(e.target.value)}>
+      ${IDENT_FILTERS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
+    </select>
+    <input class="input input-sm" type="text" placeholder=${t("downloads_peer_filter")} value=${q} onInput=${(e) => setQ(e.target.value)} />`;
+}

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -2,91 +2,31 @@
 // Todos / Descargas / Subidas selector. Data comes from the live `clients`
 // store (api.get("clients") + SSE client_added/updated/removed) which already
 // carries all peers regardless of transfer direction, so filtering is purely
-// client-side. Renders every field GET /api/v0/clients exposes.
+// client-side. Columns and formatting live in client-table.js, shared with the
+// per-file Clients tab of the detail panels.
 
-import { api } from "../api.js";
-import { data } from "../events.js";
-import { html, useState, useEffect, useStore } from "../dom.js";
-import { Badge, Placeholder, Tabs } from "../components.js";
-import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
-import { formatBytes, formatSpeed } from "../format.js";
-import { Icon } from "../icons.js";
+import { html, useState } from "../dom.js";
+import { Tabs } from "../components.js";
+import { ClientFilters, ClientTable, fileNameOf, isDown, isUp, useClients } from "./client-table.js";
+import { textMatcher } from "../table.js";
 import { t } from "../i18n.js";
 
-const ACTIVE = (s) => s && s !== "idle" && s !== "unknown";
-const isDown = (c) => (c.download_speed_bps || 0) > 0 || ACTIVE(c.download_state);
-const isUp = (c) => (c.upload_speed_bps || 0) > 0 || ACTIVE(c.upload_state);
-
-// Column set, declared once with the tabs each column shows in. The "all" tab
-// keeps the shared columns plus a condensed state/speed/total per direction;
-// each single-direction tab adds that direction's extra detail columns.
-const ALL = ["all", "downloads", "uploads"];
-const DL = ["all", "downloads"];
-const UL = ["all", "uploads"];
-const softLabel = (c) => [c.software ? t("downloads_peer_soft_" + c.software) : "", c.software === "unknown" ? "" : c.software_version].filter(Boolean).join(" ") || "—";
-const rankLabel = (c) => !c.remote_queue_rank ? "—" : c.remote_queue_rank >= 0xFFFF ? t("downloads_peer_queue_full") : c.remote_queue_rank;
-const bytesOf = (c, k) => formatBytes((c.xfer || {})[k]);
-// The "file" column is shared by both directions: download_file_name is the
-// peer-advertised name of what we're pulling FROM them; upload_file_name is
-// the partfile they're pulling FROM us. An upload-only peer has no
-// download_file_name, so falling back to upload_file_name is what actually
-// makes the column non-blank for uploads (previously always "—" there).
-const fileNameOf = (c) => c.download_file_name || c.upload_file_name || "";
-
-// Each column carries key + sortVal so the header is clickable-to-sort (the
-// flags column has no key → stays non-sortable).
-const COLS = [
-  { cls: "peer-flags", width: "60px", show: ALL, cell: (c) => peerFlags(c) },
-  { key: "name", always: true, th: "downloads_peer_col_name", width: "170px", show: ALL, sortable: true,
-    sortVal: (c) => (c.client_name || "").toLowerCase(),
-    cell: (c) => html`<span title=${c.client_name}>${c.client_name || "—"}</span>` },
-  { key: "software", th: "downloads_peer_col_software", width: "140px", show: ALL, sortable: true,
-    sortVal: (c) => softLabel(c).toLowerCase(), cell: (c) => softLabel(c) },
-  { key: "file", th: "downloads_peer_col_file", cls: "name", show: ALL, sortable: true,
-    sortVal: (c) => fileNameOf(c).toLowerCase(),
-    cell: (c) => html`<span title=${fileNameOf(c)}>${fileNameOf(c) || "—"}</span>` },
-
-  { key: "dl_state", th: "downloads_peer_col_dl_state", width: "120px", show: DL, sortable: true,
-    sortVal: (c) => c.download_state || "", cell: (c) => stateBadge(c.download_state) },
-  { key: "dl_speed", th: "downloads_peer_col_dl_speed", num: true, width: "100px", show: DL, sortable: true,
-    sortVal: (c) => c.download_speed_bps || 0, cell: (c) => formatSpeed(c.download_speed_bps) },
-  { key: "downloaded", th: "downloads_peer_col_downloaded", num: true, width: "100px", show: DL, sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.down_total) || 0, cell: (c) => bytesOf(c, "down_total") },
-  { key: "dl_session", th: "downloads_peer_col_downloaded_session", num: true, width: "110px", show: ["downloads"], sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.down_session) || 0, cell: (c) => bytesOf(c, "down_session") },
-  { key: "remote_rank", th: "downloads_peer_col_remote_rank", num: true, width: "90px", show: ["downloads"], sortable: true,
-    sortVal: (c) => c.remote_queue_rank || 0, cell: (c) => rankLabel(c) },
-
-  { key: "ul_state", th: "downloads_peer_col_ul_state", width: "120px", show: UL, sortable: true,
-    sortVal: (c) => c.upload_state || "", cell: (c) => stateBadge(c.upload_state) },
-  { key: "ul_speed", th: "downloads_peer_col_ul_speed", num: true, width: "100px", show: UL, sortable: true,
-    sortVal: (c) => c.upload_speed_bps || 0, cell: (c) => formatSpeed(c.upload_speed_bps) },
-  { key: "uploaded", th: "downloads_peer_col_uploaded", num: true, width: "100px", show: UL, sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.up_total) || 0, cell: (c) => bytesOf(c, "up_total") },
-  { key: "ul_session", th: "downloads_peer_col_uploaded_session", num: true, width: "110px", show: ["uploads"], sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.up_session) || 0, cell: (c) => bytesOf(c, "up_session") },
-  { key: "queue_pos", th: "downloads_peer_col_queue_pos", num: true, width: "90px", show: ["uploads"], sortable: true,
-    sortVal: (c) => c.queue_waiting_position || 0, cell: (c) => c.queue_waiting_position || "—" },
-  { key: "score", th: "downloads_peer_col_score", num: true, width: "80px", show: ["uploads"], sortable: true,
-    sortVal: (c) => c.score || 0, cell: (c) => c.score || "—" },
-];
-
-const IDENT_FILTERS = ["all", "identified", "not_identified"].map((v) => [v, t("downloads_peer_ident_" + v)]);
+// Every tab lists the full column set in the picker; these are the ones that
+// start hidden in each, so the default view stays focused on that direction
+// while the rest is one click away.
+const TAB_HIDDEN = {
+  all: ["dl_session", "remote_rank", "ul_session", "queue_pos", "score"],
+  downloads: ["ul_state", "ul_speed", "uploaded", "ul_session", "queue_pos", "score"],
+  uploads: ["dl_state", "dl_speed", "downloaded", "dl_session", "remote_rank"],
+};
+// Default sort per tab: most transferred first, in the tab's own direction.
+const TAB_SORT = { all: "downloaded", downloads: "downloaded", uploads: "uploaded" };
 
 export default function ClientsPanel() {
-  const clients = useStore("clients") || [];
+  const clients = useClients();
   const [filter, setFilter] = useState("all"); // direction tab: all / downloads / uploads
   const [ident, setIdent] = useState("identified");
   const [q, setQ] = useState("");
-  // sortKey null → default sort (busiest first).
-  const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
-    useTablePrefs("clients", { sortKey: null, sortDir: 1, hidden: [] });
-
-  useEffect(() => {
-    data.register({ key: "clients", eventPrefix: "client", id: "client_ecid",
-      list: () => api.get("clients").then((r) => r.clients || []) });
-    data.ensure("clients");
-  }, []);
 
   const nDown = clients.filter(isDown).length;
   const nUp = clients.filter(isUp).length;
@@ -104,61 +44,19 @@ export default function ClientsPanel() {
     { key: "uploads", label: t("downloads_peer_upload"), badge: nUp },
   ];
 
-  const columns = COLS.filter((col) => col.show.includes(filter))
-    .map((col) => ({ ...col, label: col.th ? t(col.th) : "" }));
-  const shown = columns.filter((c) => !c.key || !hidden.has(c.key));
-
-  // Sort by the chosen column when set (and visible in this tab); otherwise keep
-  // the default "busiest peers first" order (combined dl+ul speed, descending).
-  if (columns.some((c) => c.key === sortKey && c.sortVal)) {
-    list = sortRows(list, columns, sortKey, sortDir);
-  } else {
-    list.sort((a, b) =>
-      ((b.download_speed_bps || 0) + (b.upload_speed_bps || 0)) -
-      ((a.download_speed_bps || 0) + (a.upload_speed_bps || 0)));
-  }
-
+  // key=${filter} remounts the table on a tab switch: useTablePrefs reads its
+  // storage key once, so each tab needs its own instance to keep its own
+  // hidden columns / sort / widths.
   return html`
     <div class="fill-view">
       <section class="net-pane pane-fill">
         <${Tabs} tabs=${tabs} active=${filter} onSelect=${setFilter} />
         <div class="net-pane-body">
-        <div class="toolbar pane-toolbar">
-          <select class="input input-sm" value=${ident} onChange=${(e) => setIdent(e.target.value)}>
-            ${IDENT_FILTERS.map(([v, l]) => html`<option value=${v}>${l}</option>`)}
-          </select>
-          <input class="input input-sm" type="text" placeholder=${t("downloads_peer_filter")} value=${q} onInput=${(e) => setQ(e.target.value)} />
-          <div class="spacer"></div>
-          <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
-        </div>
-        <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.client_ecid}
-                         sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
-                         widths=${widths} onResize=${setWidth}
-                         maxHeight="none"
-                         empty=${html`<${Placeholder} kind="info">${t("downloads_peer_empty")}<//>`} />
+          <${ClientTable} key=${filter} rows=${list} prefsKey=${"clients_" + filter}
+                          defaultHidden=${TAB_HIDDEN[filter]} defaultSort=${TAB_SORT[filter]}
+                          toolbarCls="toolbar pane-toolbar"
+                          toolbar=${ClientFilters({ ident, setIdent, q, setQ })} />
         </div>
       </section>
     </div>`;
-}
-
-// Compact status icons (replacing the ident/obfuscation/friend columns). Each
-// icon carries an explanatory tooltip; only meaningful states show an icon.
-function peerFlags(c) {
-  const flags = [];
-  if (c.ident_state === "identified")
-    flags.push(["verified", t("downloads_peer_ident") + ": " + t("downloads_peer_identified")]);
-  else if (c.ident_state === "bad_guy")
-    flags.push(["warning", t("downloads_peer_ident") + ": " + t("downloads_peer_bad_guy")]);
-  if (c.obfuscation_status === "enabled")
-    flags.push(["lock", t("downloads_peer_obfuscation") + ": " + t("downloads_peer_enabled")]);
-  if (c.friend_slot)
-    flags.push(["star", t("downloads_peer_friend")]);
-  return flags.map(([name, tip]) => html`<${Icon} name=${name} size=${18} title=${tip} />`);
-}
-
-function stateBadge(s) {
-  if (!s || s === "idle") return html`<${Badge}>${t("downloads_peer_state_" + (s || "idle"))}<//>`;
-  const kind = s === "downloading" || s === "uploading" ? "downloading"
-    : s === "banned" || s === "error" ? "paused" : "waiting";
-  return html`<${Badge} kind=${kind}>${t("downloads_peer_state_" + s)}<//>`;
 }

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -10,7 +10,12 @@ import { html, useState, useEffect, useRef, useStore } from "../dom.js";
 import { ProgressBar, Placeholder, toast, confirmDialog, Section, statRow, IdentityLine, copyText, Tabs, CommentEditor, RenameForm, ratingLabel, PRIORITIES, prioValue, prioLabel } from "../components.js";
 import { formatBytes, formatSpeed, formatDuration, formatInt, formatPercent } from "../format.js";
 import { Icon } from "../icons.js";
+import { FileClients } from "./client-table.js";
 import { t, tn, terr } from "../i18n.js";
+
+// Peers of a download: show the download-side columns, keep the upload ones
+// (and the redundant per-row file name) one click away in the column picker.
+const DL_HIDDEN = ["file", "ul_state", "ul_speed", "uploaded", "ul_session", "queue_pos", "score"];
 
 // The pieces bar mirrors the aMule GUI download bar, theme-tuned via CSS vars:
 // green (--ok) = have it, blue (--piece-avail-lo -> --piece-avail, faded by
@@ -90,12 +95,16 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
 
       <${Tabs} tabs=${[
         { key: "details", label: t("detail_tab_details") },
+        { key: "clients", label: t("detail_tab_clients") },
         { key: "filename", label: t("detail_tab_filename") },
         { key: "comments", label: t("detail_tab_comments") },
       ]} active=${tab} onSelect=${setTab} />
 
       <div class="detail-body">
-      ${tab === "comments" ? html`
+      ${tab === "clients" ? html`
+        <${FileClients} hash=${d.hash} prefsKey="download_clients" defaultHidden=${DL_HIDDEN}
+                        defaultSort="downloaded" />
+      ` : tab === "comments" ? html`
         <${DownloadComments} hash=${d.hash} comment=${d.comment} rating=${d.rating}
                              tick=${downloads} parts=${(d.progress && d.progress.parts) || []} />
       ` : tab === "filename" ? html`

--- a/src/webapi/static/js/views/shared-detail.js
+++ b/src/webapi/static/js/views/shared-detail.js
@@ -10,9 +10,14 @@ import { api } from "../api.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { Placeholder, toast, Section, statRow, IdentityLine, copyText, Tabs, CommentEditor, RenameForm } from "../components.js";
 import { formatBytes, formatInt, formatDuration, twin } from "../format.js";
+import { FileClients } from "./client-table.js";
 import { t } from "../i18n.js";
 
 const PRIORITIES = ["very_low", "low", "normal", "high", "release"];
+
+// Peers of a shared file: show the upload-side columns, keep the download ones
+// (and the redundant per-row file name) one click away in the column picker.
+const SH_HIDDEN = ["file", "dl_state", "dl_speed", "downloaded", "dl_session", "remote_rank"];
 
 // Human upload-priority label, matching the shared list (auto shows the
 // derived level in parentheses).
@@ -68,12 +73,16 @@ export function SharedDetail({ hash }) {
 
       <${Tabs} tabs=${[
         { key: "details", label: t("detail_tab_details") },
+        { key: "clients", label: t("detail_tab_clients") },
         { key: "filename", label: t("detail_tab_filename") },
         { key: "comments", label: t("detail_tab_comments") },
       ]} active=${tab} onSelect=${setTab} />
 
       <div class="detail-body">
-      ${tab === "comments" ? html`
+      ${tab === "clients" ? html`
+        <${FileClients} hash=${s.hash} prefsKey="shared_clients" defaultHidden=${SH_HIDDEN}
+                        defaultSort="uploaded" />
+      ` : tab === "comments" ? html`
         <div class="detail-comments">
           <${CommentEditor} key=${s.hash} hash=${s.hash} kind="shared" comment=${s.comment} rating=${s.rating} />
         </div>


### PR DESCRIPTION
Downloads and Shared Files detail panels now have a second tab listing the peers tied to the selected file, so the peer list is reachable without leaving the file. Rows are the live clients whose download_file_hash (they serve us the file) or upload_file_hash (they pull it from us) matches, both already exposed by GET /clients and resolved from the same m_files map that produces the file hash — no backend change.

- New views/client-table.js: the column set, formatting helpers, peerFlags/ stateBadge, the identity+text filters and the live clients store wiring, all extracted from views/clients.js. Adds ClientTable (toolbar + virtual table + column picker) and FileClients (per-file rows on top of it).
- Every table now offers the full column set in the picker; each consumer only picks which columns start hidden, replacing the per-tab 'show' lists that made a column unreachable outside its tab. Download-side columns are visible by default in the Downloads panel, upload-side ones in the Shared Files panel.
- Default sort is the direction's transferred total, descending: Downloaded for the Clients All/Download tabs and the Downloads panel, Uploaded for the Clients Upload tab and the Shared Files panel.
- Clients view keeps its behaviour but stores column prefs per direction tab (amule.table.clients_{all,downloads,uploads}), so hiding a column in one tab no longer affects the others.
- New detail_tab_clients string (en/es) and a .detail-clients rule so the table fills the detail body instead of adding a second scrollbar.

Known limitation: peers that are not currently connected for the file (A4AF or offline sources) carry neither hash and therefore never appear.