### PR TITLE
feat(gui): rename the search "More" button to "Extend"

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3208,7 +3208,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3247,8 +3247,9 @@ msgid "Start"
 msgstr "ابدء"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "إمتداد"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3309,8 +3309,9 @@ msgid "Start"
 msgstr "Entamar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Más"
+#, fuzzy
+msgid "Extend"
+msgstr "Estensión"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8576,6 +8577,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Más"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconeutar Kad"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3240,8 +3240,9 @@ msgid "Start"
 msgstr "Старт"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Разширение"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3207,7 +3207,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3299,8 +3299,9 @@ msgid "Start"
 msgstr "Inicia"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Més"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensió"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8518,6 +8519,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Més"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconnecta Kad"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3288,8 +3288,9 @@ msgid "Start"
 msgstr "Spustit"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Více"
+#, fuzzy
+msgid "Extend"
+msgstr "Přípona"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8504,6 +8505,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Více"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Odpojit Kad"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3257,8 +3257,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Endelse"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3297,8 +3297,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mehr"
+#, fuzzy
+msgid "Extend"
+msgstr "Dateiendung"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8532,6 +8533,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Mehr"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad trennen"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3320,8 +3320,9 @@ msgid "Start"
 msgstr "Εκκίνηση"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Περισσότερα"
+#, fuzzy
+msgid "Extend"
+msgstr "Κατάληξη"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8595,6 +8596,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Περισσότερα"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Αποσυνδεδεμένο Kad"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3208,7 +3208,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3296,8 +3296,9 @@ msgid "Start"
 msgstr "Comenzar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Más"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensión"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8513,6 +8514,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Más"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconectar Kad"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3300,8 +3300,9 @@ msgid "Start"
 msgstr "Alusta"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Rohkem"
+#, fuzzy
+msgid "Extend"
+msgstr "Laiend"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8521,6 +8522,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Rohkem"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Lõpeta Kad ühendus"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3301,8 +3301,9 @@ msgid "Start"
 msgstr "Hasi"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Gehiago"
+#, fuzzy
+msgid "Extend"
+msgstr "Hedapena"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8521,6 +8522,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Gehiago"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad deskonektatu"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3301,8 +3301,9 @@ msgid "Start"
 msgstr "Käynnistä haku"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Hae lisää"
+#, fuzzy
+msgid "Extend"
+msgstr "Pääte"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8521,6 +8522,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Hae lisää"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Katkaise Kad-yhteys"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3294,8 +3294,9 @@ msgid "Start"
 msgstr "Démarrer"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Plus"
+#, fuzzy
+msgid "Extend"
+msgstr "Extension"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8505,6 +8506,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "More"
+#~ msgstr "Plus"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Déconnecter Kad"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3310,8 +3310,9 @@ msgid "Start"
 msgstr "Comezar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Máis"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensión"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8542,6 +8543,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Máis"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconectar Kad"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3270,8 +3270,9 @@ msgid "Start"
 msgstr "התחל"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "עוד"
+#, fuzzy
+msgid "Extend"
+msgstr "סיומת"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8494,6 +8495,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "עוד"
 
 #~ msgid "Stop the current connection attempts"
 #~ msgstr "הפסק את ניסיונות ההתחברות הנוכחיים"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3267,8 +3267,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Ekstenzija"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3280,8 +3280,9 @@ msgid "Start"
 msgstr "Indít"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Több"
+#, fuzzy
+msgid "Extend"
+msgstr "Kiterjesztés"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8490,6 +8491,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Több"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Leválasztás a Kad-ról"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3308,8 +3308,9 @@ msgid "Start"
 msgstr "Cerca"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Ancora"
+#, fuzzy
+msgid "Extend"
+msgstr "Estensione"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8509,6 +8510,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Ancora"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Disconnetti rete Kad"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3298,8 +3298,9 @@ msgid "Start"
 msgstr "開始"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "もっと"
+#, fuzzy
+msgid "Extend"
+msgstr "拡張子"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8525,6 +8526,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "もっと"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kadを切断する"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3318,8 +3318,9 @@ msgid "Start"
 msgstr "시작"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "추가"
+#, fuzzy
+msgid "Extend"
+msgstr "확장자"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8575,6 +8576,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "추가"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad 끊김"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3332,8 +3332,9 @@ msgid "Start"
 msgstr "Pradėti"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Daugiau"
+#, fuzzy
+msgid "Extend"
+msgstr "Plėtinys"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8612,6 +8613,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Daugiau"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Atjungti Kademlia"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3223,8 +3223,9 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr ""
+#, fuzzy
+msgid "Extend"
+msgstr "Paplašinājums"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3304,8 +3304,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Meer"
+#, fuzzy
+msgid "Extend"
+msgstr "Uitbreiding"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8527,6 +8528,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Meer"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Verbreek verbinding met Kad"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3317,8 +3317,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Meir"
+#, fuzzy
+msgid "Extend"
+msgstr "Filetternamn"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8583,6 +8584,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Meir"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kople frå Kad"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3314,8 +3314,9 @@ msgid "Start"
 msgstr "Start"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Więcej"
+#, fuzzy
+msgid "Extend"
+msgstr "Rozszerzenie"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8568,6 +8569,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Więcej"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Rozłącz z Kad"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3304,8 +3304,9 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mais"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensão"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8507,6 +8508,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "More"
+#~ msgstr "Mais"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desconectar da rede Kad"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3307,8 +3307,9 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mais"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensão"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8530,6 +8531,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Mais"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Desligar Kad"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3309,8 +3309,9 @@ msgid "Start"
 msgstr "Începe"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mai mult"
+#, fuzzy
+msgid "Extend"
+msgstr "Extensie"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8545,6 +8546,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Mai mult"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Deconectare Kad"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3332,8 +3332,9 @@ msgid "Start"
 msgstr "Начать"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Дополнительно"
+#, fuzzy
+msgid "Extend"
+msgstr "Расширение"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8597,6 +8598,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Дополнительно"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Отключить Kad"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3328,8 +3328,9 @@ msgid "Start"
 msgstr "Začni"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Več"
+#, fuzzy
+msgid "Extend"
+msgstr "Končnica"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8581,6 +8582,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Več"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Prekini povezavo s Kad"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3310,8 +3310,9 @@ msgid "Start"
 msgstr "Fillo"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Me shume"
+#, fuzzy
+msgid "Extend"
+msgstr "Zgjerimi"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8554,6 +8555,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Me shume"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Shkeput Kad"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3299,8 +3299,9 @@ msgid "Start"
 msgstr "Starta"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Mer"
+#, fuzzy
+msgid "Extend"
+msgstr "Filändelse"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8518,6 +8519,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Mer"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Koppla från Kad"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3207,7 +3207,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3287,8 +3287,9 @@ msgid "Start"
 msgstr "Başlat"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Daha Fazla"
+#, fuzzy
+msgid "Extend"
+msgstr "Uzantı"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8498,6 +8499,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "More"
+#~ msgstr "Daha Fazla"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Kad Bağlantısını Kes"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3328,8 +3328,9 @@ msgid "Start"
 msgstr "Почати"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "Більше"
+#, fuzzy
+msgid "Extend"
+msgstr "Розширення"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8616,6 +8617,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "Більше"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "Від'єднатися від Kad"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3207,7 +3207,7 @@ msgid "Start"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "More"
+msgid "Extend"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3284,8 +3284,9 @@ msgid "Start"
 msgstr "开始"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "更多"
+#, fuzzy
+msgid "Extend"
+msgstr "扩展名"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8492,6 +8493,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "More"
+#~ msgstr "更多"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "断开 Kad"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-28 21:43+0200\n"
+"POT-Creation-Date: 2026-07-29 10:26+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3291,8 +3291,9 @@ msgid "Start"
 msgstr "開始"
 
 #: src/muuli_wdr.cpp
-msgid "More"
-msgstr "其他"
+#, fuzzy
+msgid "Extend"
+msgstr "副檔名"
 
 #: src/muuli_wdr.cpp
 msgid "Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed."
@@ -8494,6 +8495,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "More"
+#~ msgstr "其他"
 
 #~ msgid "Disconnect Kad"
 #~ msgstr "中斷 Kad 連線"

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -334,7 +334,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item43->Add( item44, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticLine *item45 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item43->Add( item45, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxButton *item46 = new wxButton( parent, IDC_SEARCHMORE, _("More"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxButton *item46 = new wxButton( parent, IDC_SEARCHMORE, _("Extend"), wxDefaultPosition, wxDefaultSize, 0 );
     item46->SetToolTip( _("Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed.") );
     item46->Enable( false );
     item43->Add( item46, wxSizerFlags().Center().Border(wxALL, 5) );


### PR DESCRIPTION
The Kad search-widen button was labelled **"More"**, which implies it produces more results — but a wider re-ask only *might* surface extra matches, and only *while* a Kad search is running (never after it finishes). **"Extend"** describes what it actually does — extend the running search to more peers — and reads correctly in its default greyed-out state, where there's no live search to extend.

Raised by @ghysler in #571.

Renames `IDC_SEARCHMORE`'s label and regenerates the `po/` catalogs. The button's tooltip already explains the mechanics, so it's unchanged. "Extend" is a new string, so it lands untranslated (Weblate will pick it up); msgmerge's `#, fuzzy` matches to the unrelated "Extension" (file-suffix) strings are the usual regen artifact and fall back to English until translated.
