### PR TITLE
feat(gui): show total size in the Downloads and Shared panels

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1581,6 +1581,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4845,10 +4850,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6660,6 +6661,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6876,11 +6882,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1605,6 +1605,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "تحميل (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4902,11 +4907,6 @@ msgstr "رفع نشط :"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "مجموع الملفات"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "منفذ العميل"
 
@@ -6769,6 +6769,11 @@ msgstr "يجب ان تكون ذا هوية مرتفعة لتتمكن من انش
 msgid "Shared Files (%i)"
 msgstr "ملفات مشاركة (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "مجموع حجم ملفات المشاركة : %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -6987,11 +6992,6 @@ msgstr "إحتلال الخادم: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8399,6 +8399,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "مجموع الملفات"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1623,6 +1623,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargues (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4986,10 +4991,6 @@ msgid "Active Uploads"
 msgstr "Xubes aceutaes :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Amosar Veceros"
@@ -6875,6 +6876,11 @@ msgstr "Necesites IDAlta pa criar un enllaz fonte válidu"
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamañu total de ficheros compartíos: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7093,11 +7099,6 @@ msgstr "Ocupación de Sirvidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Númberu de ficheros compartíos: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamañu total de ficheros compartíos: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1600,6 +1600,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Файлове за сваляне (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Общ размер на споределните файлове : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4890,11 +4895,6 @@ msgstr "Активни качвания: %i"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "Общо файлове"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Клиенти"
 
@@ -6743,6 +6743,11 @@ msgstr "Трябва да имате HighID, за да създадете вал
 msgid "Shared Files (%i)"
 msgstr "Споделени файлове (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общ размер на споределните файлове : %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -6961,11 +6966,6 @@ msgstr ""
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общ размер на споределните файлове : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8371,6 +8371,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "Общо файлове"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1580,6 +1580,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4844,10 +4849,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6659,6 +6660,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6875,11 +6881,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1620,6 +1620,11 @@ msgstr "%d/%m/%y %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Baixades (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total BA: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4967,10 +4972,6 @@ msgid "Active Uploads"
 msgstr "Pujades actives"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Percentatge del total de fitxers"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra els clients per"
 
@@ -6834,6 +6835,11 @@ msgstr "Necessiteu ID Alta per crear un enllaç font vàlid"
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Mida total dels fitxers compartits: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom de fitxer remot"
@@ -7051,11 +7057,6 @@ msgstr "Càrrega del servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Fitxers compartits: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Mida total dels fitxers compartits: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8519,6 +8520,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Percentatge del total de fitxers"
 
 #~ msgid "More"
 #~ msgstr "Més"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1616,6 +1616,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Stahování (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Celkem DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4956,10 +4961,6 @@ msgid "Active Uploads"
 msgstr "Aktivní odesílání"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Zobrazit klienty"
@@ -6846,6 +6847,11 @@ msgstr "K vytvoření platného odkazu potřebujete HighID"
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Celková velikost sdílených souborů: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7064,11 +7070,6 @@ msgstr "Zaplnění serveru: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Počet sdílených souborů: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Celková velikost sdílených souborů: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1608,6 +1608,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4917,11 +4922,6 @@ msgstr "Aktive Uploads"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "Antal Filer Total"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Vis Liste"
 
@@ -6786,6 +6786,11 @@ msgstr "Du skal have et HighID for at lave et godkendt kildelink"
 msgid "Shared Files (%i)"
 msgstr "Delte Filer (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total Størrelse Af Delte Filer: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7004,11 +7009,6 @@ msgstr ""
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8426,6 +8426,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "Antal Filer Total"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1628,6 +1628,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Gesamt-DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4963,10 +4968,6 @@ msgid "Active Uploads"
 msgstr "Aktive Uploads"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Prozent aller Dateien"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Clients anzeigen für"
 
@@ -6829,6 +6830,11 @@ msgstr "Du brauchst eine hohe ID, um einen gültigen Quellenverweis zu erstellen
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Gesamtgröße der freigegebenen Dateien: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Ferndateiname"
@@ -7046,11 +7052,6 @@ msgstr "Server-Auslastung: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Anzahl freigegebener Dateien: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Gesamtgröße der freigegebenen Dateien: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8533,6 +8534,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Prozent aller Dateien"
 
 #~ msgid "More"
 #~ msgstr "Mehr"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1631,6 +1631,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Κατεβασμένα (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Συνολικό Κατέβασμα: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4997,10 +5002,6 @@ msgid "Active Uploads"
 msgstr "Ενεργά ανεβάσματα :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Δείξε τους πελάτες"
@@ -6892,6 +6893,11 @@ msgstr "Χρειάζεται Υψηλή Προτεραιότητα για τη �
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7110,11 +7116,6 @@ msgstr "Κατοχή διακομιστών: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Αριθμός κοινόχρηστων αρχείων: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1581,6 +1581,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4845,10 +4850,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6660,6 +6661,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6876,11 +6882,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1631,6 +1631,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DES: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4959,10 +4964,6 @@ msgid "Active Uploads"
 msgstr "Subidas activas"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Porcentaje del total de archivos"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar los clientes para"
 
@@ -6811,6 +6812,11 @@ msgstr "Necesita Id Alta para crear un enlace fuente válido"
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total de los archivos compartidos: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nombre del archivo remoto"
@@ -7028,11 +7034,6 @@ msgstr "Ocupación de servidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de archivos compartidos: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total de los archivos compartidos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8514,6 +8515,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Porcentaje del total de archivos"
 
 #~ msgid "More"
 #~ msgstr "Más"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1621,6 +1621,11 @@ msgstr "%H:%M:%S %d/%m/%y"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Tõmbamised (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Kokku AL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4970,10 +4975,6 @@ msgid "Active Uploads"
 msgstr "Aktiivsed saatmised"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Protsenti kogufailidest"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näita Kliente"
 
@@ -6844,6 +6845,11 @@ msgstr "Allika lingi loomiseks pead omama HighID'd."
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jagatud failide suurus kokku: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Kaugfaili nimi"
@@ -7061,11 +7067,6 @@ msgstr "Serveri hõivatus: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jagatud failide arv: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jagatud failide suurus kokku: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8522,6 +8523,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Protsenti kogufailidest"
 
 #~ msgid "More"
 #~ msgstr "Rohkem"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1622,6 +1622,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Deskargak (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DE guztira: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4970,10 +4975,6 @@ msgid "Active Uploads"
 msgstr "Igoera aktiboak"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "fitxategi guztien ehunekoa"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Erakutsi bezeroak:"
 
@@ -6840,6 +6841,11 @@ msgstr "ID altua behar duzu baliozko jatorri lotura bat sortzeko"
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Guztira partekatutako fitxategi tamaina: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Urruneko fitxategiaren izena"
@@ -7057,11 +7063,6 @@ msgstr "Zerbitzari lan karga %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Partekatutako fitxategi kopurua: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Guztira partekatutako fitxategi tamaina: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8522,6 +8523,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "fitxategi guztien ehunekoa"
 
 #~ msgid "More"
 #~ msgstr "Gehiago"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1622,6 +1622,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lataukset (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Yht alas: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4970,10 +4975,6 @@ msgid "Active Uploads"
 msgstr "Aktiiviset lähetykset"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Prosenttia kaikista tiedostoista"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Näytä asiakkaat"
 
@@ -6840,6 +6841,11 @@ msgstr "Tarvitset HighID:een luodaksesi voimassa olevan lähdelinkin"
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Tiedoston nimi etäpäässä"
@@ -7057,11 +7063,6 @@ msgstr "Palvelimien käyttö: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Jaettuja tiedostoja: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8522,6 +8523,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Prosenttia kaikista tiedostoista"
 
 #~ msgid "More"
 #~ msgstr "Hae lisää"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1629,6 +1629,11 @@ msgstr "%y/%m/%d %H : %M : %S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Téléchargements (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Reçu au total : %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4953,10 +4958,6 @@ msgid "Active Uploads"
 msgstr "Envois Actifs"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Pourcentage du total de fichiers"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Afficher les clients pour"
 
@@ -6803,6 +6804,11 @@ msgstr "Vous devez être en HighID pour créer un lien valide"
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Taille totale des Fichiers Partagés : %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom du fichier à distance"
@@ -7020,11 +7026,6 @@ msgstr "Occupation du Serveur : %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Nombre de Fichiers Partagés : %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Taille totale des Fichiers Partagés : %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8506,6 +8507,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Percent of total files"
+#~ msgstr "Pourcentage du total de fichiers"
 
 #~ msgid "More"
 #~ msgstr "Plus"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1641,6 +1641,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descargas (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4977,10 +4982,6 @@ msgid "Active Uploads"
 msgstr "Envíos activos"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Porcentaxe de todos os ficheiros"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Amosar clientes para"
 
@@ -6844,6 +6845,11 @@ msgstr "Precísase ter IDAlta para crear unha ligazón á fonte válido"
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total dos ficheiros compartidos: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome remoto do ficheiro"
@@ -7061,11 +7067,6 @@ msgstr "Ocupación do servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de ficheiros compartidos: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total dos ficheiros compartidos: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8543,6 +8544,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Porcentaxe de todos os ficheiros"
 
 #~ msgid "More"
 #~ msgstr "Máis"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1610,6 +1610,11 @@ msgstr "%y/%m/%d·%H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "הורדות (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "סכום כולל: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4930,10 +4935,6 @@ msgid "Active Uploads"
 msgstr "העלאות פעילים :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "לקוחות"
@@ -6816,6 +6817,11 @@ msgstr "אתה צריך מ\"ז גבוה (HighID) כדי לחןר קישור-מק
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "גודל כולל של קבצים משותפים: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7034,11 +7040,6 @@ msgstr "תעסוקת שרתים: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "מספר קבצים משותפים: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "גודל כולל של קבצים משותפים: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1614,6 +1614,11 @@ msgstr ""
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4927,11 +4932,6 @@ msgstr "Aktivni uploadovi :"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "Ukupni fajlovi"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Pokazi liste"
 
@@ -6815,6 +6815,11 @@ msgstr "Za ispravan izvorni link, potrebna je HIGH ID"
 msgid "Shared Files (%i)"
 msgstr "Dijeljeni fajlovi (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7033,11 +7038,6 @@ msgstr "Zauzetost servera: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8445,6 +8445,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "Ukupni fajlovi"
 
 #, fuzzy
 #~ msgid "Stop the current connection attempts"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1618,6 +1618,11 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Letöltések (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Összes letöltés: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4955,10 +4960,6 @@ msgid "Active Uploads"
 msgstr "Aktív feltöltések"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Összes fájl százalékaként"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kliensek megjelenítése ehhez:"
 
@@ -6804,6 +6805,11 @@ msgstr "Érvényes forráshivatkozáshoz magas azonosító (HighID) szükséges"
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Megosztott fájlok teljes mérete: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Távoli fájlnév"
@@ -7021,11 +7027,6 @@ msgstr "Kiszolgáló leterheltség: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Megosztott fájlok száma: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Megosztott fájlok teljes mérete: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8491,6 +8492,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Összes fájl százalékaként"
 
 #~ msgid "More"
 #~ msgstr "Több"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1634,6 +1634,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Download (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DL totale: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4963,10 +4968,6 @@ msgid "Active Uploads"
 msgstr "Upload attivi"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Percentuale di file totali"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostra client per"
 
@@ -6808,6 +6809,11 @@ msgstr "Hai bisogno di un ID alto per creare un sourcelink valido"
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensione totale file condivisi: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome file remoto"
@@ -7025,11 +7031,6 @@ msgstr "Occupazione server: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numero di file condivisi: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensione totale file condivisi: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8510,6 +8511,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Percentuale di file totali"
 
 #~ msgid "More"
 #~ msgstr "Ancora"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1622,6 +1622,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "ダウンロード数（%i）"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DLの合計：%s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4969,10 +4974,6 @@ msgid "Active Uploads"
 msgstr "アクティブなアップロード数："
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "クライアントを表示する"
@@ -6842,6 +6843,11 @@ msgstr "有効なソースリンクを作るにはHighIDが必要です"
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共有ファイルの合計サイズ： %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7060,11 +7066,6 @@ msgstr "サーバ占有： %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共有ファイル数： %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共有ファイルの合計サイズ： %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1629,6 +1629,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "내려받기 (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "전체 내려받기: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4988,10 +4993,6 @@ msgid "Active Uploads"
 msgstr "활성화된 올려주기 :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "클라이언트 보기"
@@ -6890,6 +6891,11 @@ msgstr "유효한 자료 링크를 만들기 위해서 높은아이디가 필요
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "공유파일의 전체 크기: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7108,11 +7114,6 @@ msgstr "서버 할당: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "공유된 파일의 수: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "공유파일의 전체 크기: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1635,6 +1635,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Atsiuntimai (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Iš viso atsiųsta: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -5004,10 +5009,6 @@ msgid "Active Uploads"
 msgstr "Aktyvūs išsiuntimai:"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Rodyti klientus"
@@ -6914,6 +6915,11 @@ msgstr "Norėdami sukurti šaltinio nuorodą, privalote turėti aukštą ID"
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Bendras dalinamų failų dydis: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7132,11 +7138,6 @@ msgstr "Serverių užimtumas: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Dalinamų failų kiekis: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Bendras dalinamų failų dydis: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1593,6 +1593,11 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Lejupielādes (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4871,10 +4876,6 @@ msgid "Active Uploads"
 msgstr "Aktīvas augšupielādes"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6700,6 +6701,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6916,11 +6922,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1622,6 +1622,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totaal gedownload: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4972,10 +4977,6 @@ msgid "Active Uploads"
 msgstr "Actieve uploads"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Procent van alle bestanden"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Toon clients voor"
 
@@ -6839,6 +6840,11 @@ msgstr "U heeft een Hoog ID nodig om een geldige bronlink te maken"
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totale grootte van gedeelde bestanden: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Bestandsnaam op afstand"
@@ -7056,11 +7062,6 @@ msgstr "Server-bezetting: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Aantal gedeelde bestanden: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totale grootte van gedeelde bestanden: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8528,6 +8529,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Procent van alle bestanden"
 
 #~ msgid "More"
 #~ msgstr "Meer"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1629,6 +1629,11 @@ msgstr "%y/%m/%d·%H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Nedlastingar (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totalt NL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4989,10 +4994,6 @@ msgid "Active Uploads"
 msgstr "Aktive opplastingar :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Syne klientar"
@@ -6883,6 +6884,11 @@ msgstr "Du treng ein HøgID for å lage ei gangbar kjeldelenkje"
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storleik på delte filer: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7101,11 +7107,6 @@ msgstr "Tenerlast: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Tal på delte filer: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storleik på delte filer: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:12+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1628,6 +1628,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Pobieranie (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Razem DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4986,11 +4991,6 @@ msgstr "Aktywne wysyłania"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Percent of total files"
-msgstr "procent wszystkich plików"
-
-#: src/muuli_wdr.cpp
-#, fuzzy
 msgid "Show Clients for"
 msgstr "Pokaż klientów"
 
@@ -6884,6 +6884,11 @@ msgstr "Potrzebujesz HighID, aby stworzyć poprawny link źródłowy"
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Łączny rozmiar udostępnianych plików: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7102,11 +7107,6 @@ msgstr "Zajętość serwera: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Liczba udostępnianych plików: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Łączny rozmiar udostępnianych plików: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8569,6 +8569,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Percent of total files"
+#~ msgstr "procent wszystkich plików"
 
 #~ msgid "More"
 #~ msgstr "Więcej"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1630,6 +1630,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "DL Total: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4959,10 +4964,6 @@ msgid "Active Uploads"
 msgstr "Uploads Ativos"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Porcentagem de total de arquivos"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Exibir Clientes para"
 
@@ -6805,6 +6806,11 @@ msgstr "Você precisa ter HighID para criar uma fonte ED2K válida"
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total de compartilhados: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do arquivo remoto"
@@ -7022,11 +7028,6 @@ msgstr "Ocupação do Servidor: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de arquivos compartilhados: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total de compartilhados: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8508,6 +8509,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "Porcentagem de total de arquivos"
 
 #~ msgid "More"
 #~ msgstr "Mais"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:13+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1628,6 +1628,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Downloads (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4977,10 +4982,6 @@ msgid "Active Uploads"
 msgstr "Uploads Activos"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Percentagem dos ficheiros totais"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Mostrar Clientes para"
 
@@ -6848,6 +6849,11 @@ msgstr "Necessita de HighID para criar uma ligação de fonte válida"
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total dos Ficheiros Partilhados: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do Ficheiro Remoto"
@@ -7065,11 +7071,6 @@ msgstr "Ocupação dos Servidores: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Número de Ficheiros Partilhados: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total dos Ficheiros Partilhados: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8531,6 +8532,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Percentagem dos ficheiros totais"
 
 #~ msgid "More"
 #~ msgstr "Mais"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1625,6 +1625,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Descărcări (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Total DE: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4977,10 +4982,6 @@ msgid "Active Uploads"
 msgstr "Încărcări active"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Procentul din totalul fișierelor"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Arată clienții pentru"
 
@@ -6861,6 +6862,11 @@ msgstr "Vă trebuie un HighID pentru a se crea o legătură sursă validă"
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensiunea totală a fișierelor partajate: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nume fișier distant"
@@ -7078,11 +7084,6 @@ msgstr "Ocupare server: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Număr de fișiere partajate: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensiunea totală a fișierelor partajate: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8546,6 +8547,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Procentul din totalul fișierelor"
 
 #~ msgid "More"
 #~ msgstr "Mai mult"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:14+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1638,6 +1638,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Загрузки (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Всего загружено: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -5010,10 +5015,6 @@ msgid "Active Uploads"
 msgstr "Активные загрузки"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Процент от всех файлов"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Показать клиентов для"
 
@@ -6910,6 +6911,11 @@ msgstr "Для создания ссылки на источник требуе�
 msgid "Shared Files (%i)"
 msgstr "Публикуемые файлы (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общий размер публикуемых файлов: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Удаленное имя файла"
@@ -7128,11 +7134,6 @@ msgstr "Загруженность сервера: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Число публикуемых файлов: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общий размер публикуемых файлов: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8598,6 +8599,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Процент от всех файлов"
 
 #~ msgid "More"
 #~ msgstr "Дополнительно"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1634,6 +1634,11 @@ msgstr "%d.%m.%y %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Prejemanja (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Skupno dol: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4999,10 +5004,6 @@ msgid "Active Uploads"
 msgstr "Dejavna pošiljanja"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Odstotek vseh datotek"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Prikaži odjemalce za"
 
@@ -6901,6 +6902,11 @@ msgstr "Potrebujete visok ID, da ustvarite povezavo z virom"
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Skupna velikost deljenih datotek: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Oddaljeno ime datoteke"
@@ -7118,11 +7124,6 @@ msgstr "Zasedenost strežnikov: %.2f %%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Število deljenih datotek: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Skupna velikost deljenih datotek: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8582,6 +8583,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Odstotek vseh datotek"
 
 #~ msgid "More"
 #~ msgstr "Več"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:15+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1624,6 +1624,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Shkarkimet (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totali i shkarkimit: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4981,10 +4986,6 @@ msgid "Active Uploads"
 msgstr "Ngarkime Aktive :"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Trego klientet"
@@ -6873,6 +6874,11 @@ msgstr "Ju keni nevoje per nje ID te larte per te krijuar nje sourcelink te vlef
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totali i madhesise se faileve te ndara: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7091,11 +7097,6 @@ msgstr "Zenia e Serverit: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Numeri i faileve te ndara: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totali i madhesise se faileve te ndara: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1620,6 +1620,11 @@ msgstr "%y/%m/%d %H.%M.%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Hämtningar (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Totalt DL: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4967,10 +4972,6 @@ msgid "Active Uploads"
 msgstr "Aktiva uppladdningar"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Procent av den totala filer"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Visa klienter för"
 
@@ -6834,6 +6835,11 @@ msgstr "Du behöver en HighID att skapa en giltig sourcelink"
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storlek på Delade filer: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Fjärrfilnamn"
@@ -7051,11 +7057,6 @@ msgstr "Serveranvändade: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Antal Delade filer: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storlek på Delade filer: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8519,6 +8520,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "Procent av den totala filer"
 
 #~ msgid "More"
 #~ msgstr "Mer"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1580,6 +1580,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4844,10 +4849,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6659,6 +6660,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6875,11 +6881,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1622,6 +1622,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "İndirmeler (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Toplam İND: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4946,10 +4951,6 @@ msgid "Active Uploads"
 msgstr "Etkin Göndermeler"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "Toplam dosyaların yüzdesi"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "Kullanıcıları Göster"
 
@@ -6796,6 +6797,11 @@ msgstr "Geçerli bir kaynak bağlantısı oluşturmak için YüksekID almanız g
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Dosya Adı"
@@ -7013,11 +7019,6 @@ msgstr "Sunucu Bağlantısı: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Paylaşılmış Dosya Sayısı: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8499,6 +8500,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Percent of total files"
+#~ msgstr "Toplam dosyaların yüzdesi"
 
 #~ msgid "More"
 #~ msgstr "Daha Fazla"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1631,6 +1631,11 @@ msgstr "%y.%m.%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "Звантаження (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "Всього звантажень: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -5005,10 +5010,6 @@ msgid "Active Uploads"
 msgstr "Чинні вивантаження:"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Show Clients for"
 msgstr "Показати клієнтів"
@@ -6913,6 +6914,11 @@ msgstr "Вам потрібно мати HighID щоб створити поси
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Загальний розмір спільних файлів: %s"
+
 #: src/SourceListCtrl.cpp
 #, fuzzy
 msgid "Remote File Name"
@@ -7132,11 +7138,6 @@ msgstr "Навантаження на сервер: %.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "Кількість спільних файлів: %s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Загальний розмір спільних файлів: %s"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1580,6 +1580,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp
 #, c-format
 msgid "Downloads (%i)"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, c-format
+msgid "Total queue size: %s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -4844,10 +4849,6 @@ msgid "Active Uploads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr ""
 
@@ -6659,6 +6660,11 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
@@ -6875,11 +6881,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Number of Shared Files: %s"
-msgstr ""
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:17+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1626,6 +1626,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下载 (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "总下载: %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4943,10 +4948,6 @@ msgid "Active Uploads"
 msgstr "活跃上传"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "全部文件的百分比"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "显示客户端"
 
@@ -6793,6 +6794,11 @@ msgstr "你需要高ID来产生源链接"
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共享文件大小总和：%s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "远程文件名"
@@ -7010,11 +7016,6 @@ msgstr "服务器开销：%.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "共享文件数：%s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共享文件大小总和：%s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8493,6 +8494,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Percent of total files"
+#~ msgstr "全部文件的百分比"
 
 #~ msgid "More"
 #~ msgstr "更多"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-29 10:26+0200\n"
+"POT-Creation-Date: 2026-07-29 11:47+0200\n"
 "PO-Revision-Date: 2026-07-28 20:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1621,6 +1621,11 @@ msgstr "%y/%m/%d %H:%M:%S"
 #, c-format
 msgid "Downloads (%i)"
 msgstr "下載 (%i)"
+
+#: src/DownloadListCtrl.cpp src/TransferWnd.cpp
+#, fuzzy, c-format
+msgid "Total queue size: %s"
+msgstr "總下載：%s"
 
 #: src/DownloadListCtrl.cpp
 msgid "the default Windows shell handler"
@@ -4960,10 +4965,6 @@ msgid "Active Uploads"
 msgstr "目前上傳數"
 
 #: src/muuli_wdr.cpp
-msgid "Percent of total files"
-msgstr "% (所有檔案中)"
-
-#: src/muuli_wdr.cpp
 msgid "Show Clients for"
 msgstr "顯示客戶端："
 
@@ -6814,6 +6815,11 @@ msgstr "您需要一個 HighID 才能建立有效來源連結"
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
 
+#: src/SharedFilesCtrl.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "檔案總容量：%s"
+
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "遠端檔案名稱"
@@ -7031,11 +7037,6 @@ msgstr "伺服器使用率：%.2f%%"
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr "檔案數：%s"
-
-#: src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "檔案總容量：%s"
 
 #: src/Statistics.cpp
 #, c-format
@@ -8495,6 +8496,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Percent of total files"
+#~ msgstr "% (所有檔案中)"
 
 #~ msgid "More"
 #~ msgstr "其他"

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -186,6 +186,7 @@ CDownloadListCtrl::CDownloadListCtrl(wxWindow *parent,
 
 	m_category = 0;
 	m_filecount = 0;
+	m_shownSize = 0;
 	m_ItemSelectionChangePending = false;
 	LoadSettings();
 
@@ -309,6 +310,7 @@ void CDownloadListCtrl::RebuildVisibleList()
 
 	bool hasCompletedDownloads = false;
 	int shown = 0;
+	uint64 totalSize = 0;
 
 	for (const auto &entry : m_ListItems) {
 		CPartFile *file = entry.second->GetFile();
@@ -317,6 +319,7 @@ void CDownloadListCtrl::RebuildVisibleList()
 		}
 		AppendItemData(reinterpret_cast<wxUIntPtr>(entry.second));
 		++shown;
+		totalSize += file->GetFileSize();
 		if (file->IsCompleted()) {
 			hasCompletedDownloads = true;
 		}
@@ -327,6 +330,7 @@ void CDownloadListCtrl::RebuildVisibleList()
 
 	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(hasCompletedDownloads);
 	SetFilesCount(shown);
+	SetTotalSize(totalSize);
 
 	Thaw();
 }
@@ -412,12 +416,14 @@ void CDownloadListCtrl::ShowFile(CPartFile *file, bool show)
 			if (RowOfData(data) == -1) {
 				AppendItemDataNow(data);
 				ShowFilesCount(1);
+				SetTotalSize(m_shownSize + file->GetFileSize());
 			}
 		} else {
 			// Remove the row if present.
 			if (RowOfData(data) != -1) {
 				RemoveItemData(data);
 				ShowFilesCount(-1);
+				SetTotalSize(m_shownSize - file->GetFileSize());
 			}
 		}
 	}
@@ -1339,6 +1345,24 @@ void CDownloadListCtrl::SetFilesCount(int count)
 
 	label->SetLabel(CFormat(_("Downloads (%i)")) % m_filecount);
 	label->GetParent()->Layout();
+}
+
+void CDownloadListCtrl::SetTotalSize(uint64 total)
+{
+	m_shownSize = total;
+
+	// This label lives in the sources pane (the bottom of the transfer
+	// splitter), a different window from the download list, so reach it via
+	// the transfer window rather than GetParent(). Guard the early calls
+	// before the transfer window is fully constructed.
+	if (!theApp->amuledlg || !theApp->amuledlg->m_transferwnd) {
+		return;
+	}
+	wxStaticText *label = CastByName("downloadsTotalSize", theApp->amuledlg->m_transferwnd, wxStaticText);
+	if (label) {
+		label->SetLabel(CFormat(_("Total queue size: %s")) % CastItoXBytes(m_shownSize));
+		label->GetParent()->Layout();
+	}
 }
 
 static const CMuleColour crHave(104, 104, 104);

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -178,6 +178,14 @@ private:
 	void SetFilesCount(int count);
 
 	/**
+	 * Sets the "Total size:" label to the combined size of the currently
+	 * shown files (category + text filter). Kept in step with the visible
+	 * set the same way as the file count: reset in bulk by RebuildVisibleList
+	 * and adjusted by GetFileSize() as ShowFile() adds/removes a row.
+	 */
+	void SetTotalSize(uint64 total);
+
+	/**
 	 * Rebuilds the visible rows from the model in a single pass, keeping the
 	 * files that pass the current category + text filter. Used whenever the
 	 * visible set changes wholesale (category switch, filter edit).
@@ -291,6 +299,9 @@ private:
 
 	//! The number of displayed files
 	int m_filecount;
+
+	//! Combined size of the displayed files (drives the "Total size:" label)
+	uint64 m_shownSize;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -97,6 +97,7 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 : CMuleVirtualListCtrl(parent, id, pos, size, flags | wxLC_OWNERDRAW)
 , m_inBulkUpdate(false)
 , m_batchUpdate(false)
+, m_shownSize(0)
 {
 	// Setting the sorter function.
 	SetSortFunc(SortProc);
@@ -314,11 +315,14 @@ void CSharedFilesCtrl::ShowFileList()
 
 	std::vector<CKnownFile *> files;
 	theApp->sharedfiles->CopyFileList(files);
+	uint64 totalSize = 0;
 	for (CKnownFile *file : files) {
 		if (MatchesFilter(file->GetFileName().GetPrintable())) {
 			AppendItemData(reinterpret_cast<wxUIntPtr>(file));
+			totalSize += file->GetFileSize();
 		}
 	}
+	m_shownSize = totalSize;
 	FinishBulkLoad();
 	RestoreSelection(selected, focused);
 	ShowFilesCount();
@@ -360,6 +364,7 @@ void CSharedFilesCtrl::RemoveFile(CKnownFile *toRemove)
 		return;
 	}
 	RemoveItemData(reinterpret_cast<wxUIntPtr>(toRemove));
+	m_shownSize -= toRemove->GetFileSize();
 	ShowFilesCount();
 }
 
@@ -387,6 +392,7 @@ void CSharedFilesCtrl::ShowFile(CKnownFile *file)
 		const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(file);
 		if (RowOfData(data) == -1) {
 			AppendItemDataNow(data);
+			m_shownSize += file->GetFileSize();
 			ShowFilesCount();
 		}
 		return;
@@ -404,6 +410,9 @@ void CSharedFilesCtrl::DoShowFile(CKnownFile *file, bool batch)
 	}
 
 	// AddItemData() dedupes internally.
+	if (RowOfData(reinterpret_cast<wxUIntPtr>(file)) == -1) {
+		m_shownSize += file->GetFileSize();
+	}
 	AddItemData(reinterpret_cast<wxUIntPtr>(file));
 	ShowFilesCount();
 }
@@ -660,6 +669,20 @@ void CSharedFilesCtrl::ShowFilesCount()
 	wxStaticText *label = CastByName("sharedFilesLabel", GetParent(), wxStaticText);
 
 	label->SetLabel(CFormat(_("Shared Files (%i)")) % GetItemCount());
+
+	// Combined size of the shown files. The label lives in the statistics box
+	// (the bottom pane of the shared splitter), a different window from this
+	// list, so reach it through the shared-files window rather than GetParent().
+	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd) {
+		wxStaticText *totalLabel =
+			CastByName("sharedFilesTotalSize", theApp->amuledlg->m_sharedfileswnd, wxStaticText);
+		if (totalLabel) {
+			totalLabel->SetLabel(
+				CFormat(_("Total size of Shared Files: %s")) % CastItoXBytes(m_shownSize));
+			totalLabel->GetParent()->Layout();
+		}
+	}
+
 	label->GetParent()->Layout();
 	// If file list was updated, the "selection" is involved too, if we chose to show clients for all
 	// files. So update client list here too.

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -257,6 +257,9 @@ private:
 	//! the row without sorting; EndBatchUpdate() does the single SortList().
 	bool m_batchUpdate;
 
+	//! Combined size of the displayed files (drives the "Total size:" label)
+	uint64 m_shownSize;
+
 	// The virtual-list model, sorting, live auto-sort and selection
 	// preservation all live in CMuleVirtualListCtrl now.
 

--- a/src/SharedFilesWnd.cpp
+++ b/src/SharedFilesWnd.cpp
@@ -67,6 +67,15 @@ CSharedFilesWnd::CSharedFilesWnd(wxWindow *pParent)
 	peerslistctrl = CastChild(ID_SHAREDCLIENTLIST, CSharedFilePeersListCtrl);
 	wxASSERT(sharedfilesctrl);
 	wxASSERT(peerslistctrl);
+
+	// Render the initial "Total size: 0 bytes" for an empty share.
+	// CSharedFilesCtrl::ShowFilesCount() can't do it yet: it reaches the label
+	// through theApp->amuledlg->m_sharedfileswnd, which isn't assigned until
+	// this constructor returns. The widget lives under this window.
+	if (wxStaticText *totalSize = CastChild("sharedFilesTotalSize", wxStaticText)) {
+		totalSize->SetLabel(CFormat(_("Total size of Shared Files: %s")) % CastItoXBytes(0));
+	}
+
 	m_prepared = false;
 
 	m_splitter = 0;

--- a/src/TransferWnd.cpp
+++ b/src/TransferWnd.cpp
@@ -43,6 +43,7 @@
 #include "SourceListCtrl.h"   // Needed for CSourceListCtrl
 #include "amule.h"            // Needed for theApp
 #include "muuli_wdr.h"        // Needed for ID_CATEGORIES
+#include "OtherFunctions.h"   // Needed for CastItoXBytes
 #include "SearchDlg.h"        // Needed for CSearchDlg->UpdateCatChoice()
 #include "MuleNotebook.h"
 #include "Preferences.h"
@@ -84,6 +85,15 @@ CTransferWnd::CTransferWnd(wxWindow *pParent)
 	downloadlistctrl = CastChild("downloadList", CDownloadListCtrl);
 	clientlistctrl = CastChild(ID_CLIENTLIST, CSourceListCtrl);
 	m_dlTab = CastChild(ID_CATEGORIES, CMuleNotebook);
+
+	// Render the initial "Total size: 0 bytes" so the field is visible for an
+	// empty queue. CDownloadListCtrl::SetTotalSize() can't do it yet: it reaches
+	// the label through theApp->amuledlg->m_transferwnd, which isn't assigned
+	// until this constructor returns. The widget lives under this window, so
+	// CastChild finds it directly.
+	if (wxStaticText *totalSize = CastChild("downloadsTotalSize", wxStaticText)) {
+		totalSize->SetLabel(CFormat(_("Total queue size: %s")) % CastItoXBytes(0));
+	}
 
 	// Set disabled image for clear complete button
 	const wxBitmapBundle clrDisabled =

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -437,6 +437,14 @@ wxSizer *transferBottomPane( wxWindow *parent, bool call_fit, bool set_sizer )
     item3->Add( item5, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
     item1->Add( item3, 0, wxALIGN_CENTER, 5 );
 
+    // Combined size of the downloads currently visible (category + text
+    // filter), right-aligned in the growable header's third column. Set by
+    // CDownloadListCtrl::SetTotalSize(). No wxST_NO_AUTORESIZE: the label must
+    // grow to fit its text (it starts empty, so the flag would pin it 0-wide).
+    wxStaticText *item5b = new wxStaticText( parent, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
+    item5b->SetName( "downloadsTotalSize" );
+    item1->Add( item5b, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
+
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
     CSourceListCtrl *item6 = new CSourceListCtrl( parent, ID_CLIENTLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
     item0->Add( item6, 1, wxGROW, 5 );
@@ -3301,8 +3309,14 @@ wxSizer *sharedfilesBottomDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item12->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item12, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
     item2->Add( item10, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxStaticText *item13 = new wxStaticText( parent, -1, _("Percent of total files"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item13, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
+    // Combined size of the shared files currently visible (text filter),
+    // occupying the row that used to hold the misleading "Percent of total
+    // files" label (the gauges beside it show session/all-time, not a file
+    // percentage). Set by CSharedFilesCtrl::ShowFilesCount(). No
+    // wxST_NO_AUTORESIZE: the label must grow to fit its text.
+    wxStaticText *item13 = new wxStaticText( parent, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    item13->SetName( "sharedFilesTotalSize" );
+    item2->Add( item13, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
     wxGauge *item14 = new wxGauge( parent, -1, 100, wxDefaultPosition, wxSize(200,18), 0 );
     item14->SetName( "popbar" );
     item2->Add( item14, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );


### PR DESCRIPTION
Closes #617.

Adds a running total of file sizes to both panels.

**Downloads** — a **"Total queue size: X"** field, right-aligned in the *File sources* row, summing the files currently visible (selected category **+** text filter, so it matches exactly what's in the table). Kept live like the existing file count: reset in bulk by `RebuildVisibleList()`, adjusted by `GetFileSize()` as `ShowFile()` adds/removes a row — no per-tick cost.

**Shared** — the combined size of the visible shared files, shown as **"Total size of Shared Files: X"** in the statistics box, replacing the **"Percent of total files"** label. That label was misleading: the three gauges beside it show a *session / all-time ratio* for the selected file (`sharePerMille`), not any percentage of files. The gauges stay; only the mislabel goes.

Both auto-scale units via `CastItoXBytes` and work in **amuleGUI** too — file sizes are already EC-streamed, so **no core/protocol change**. One new string (`"Total queue size: %s"`); the shared side reuses an existing string. Catalogs regenerated.

Built and visually verified on macOS (monolithic + amuleGUI); Windows + Linux builds green.
