### PR TITLE
feat(gui): show the server host country as a flag icon

### DIFF
--- a/src/CountryDisplay.h
+++ b/src/CountryDisplay.h
@@ -1,0 +1,91 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef COUNTRYDISPLAY_H
+#define COUNTRYDISPLAY_H
+
+//
+// Which country code a list should display for one entry -- the rule shared by
+// the peer list and the server list, so the two cannot drift apart.
+//
+// This is a header, and the body below is deliberately NOT in a .cpp: the
+// answer depends on ENABLE_IP2COUNTRY / CLIENT_GUI, and those are per-target
+// compile definitions. CountryFlags.cpp -- the obvious neighbour -- lives in
+// muleappgui, one static library built once and linked into both aMule and
+// amulegui, so it is compiled with neither define and could only ever produce
+// the amulegui answer. Compiling per includer is what makes the monolithic
+// build take the local-resolver path at all.
+//
+// The corollary: only include this from sources that are built once per
+// variant (the list controls are), never from a shared library like
+// muleappgui, or one binary would end up linking two different definitions.
+//
+
+#include "amule.h" // Needed for theApp and GEOIP_GUI
+#if defined(GEOIP_GUI) && !defined(CLIENT_GUI)
+#include "IP2Country.h" // Needed for CIP2Country (monolithic local lookup)
+#endif
+
+#include <wx/string.h>
+
+/**
+ * The country code to display for one list entry.
+ *
+ * The core emits its country tag whenever its resolver is enabled -- even as
+ * an empty string for an address that resolved to nothing -- so a tag that
+ * arrived over EC is authoritative: @a fromCore true means the core knows, and
+ * an empty @a coreCode then means "unknown", not "GeoIP is off". Only a build
+ * with no such feed (monolithic aMule) falls back to its own resolver, which
+ * carries its enabled state itself.
+ *
+ * Deliberately no thePrefs::IsGeoIPEnabled() on top: on amulegui that pref is
+ * only a mirror of the core's, refreshed at prefs-sync time, so consulting it
+ * could never do more than disagree with the tag we were handed.
+ *
+ * @param fromCore Whether the core sent a country tag for this entry.
+ * @param coreCode The code it sent (meaningful only when @a fromCore).
+ * @param ip       Dotted address, for the monolithic local lookup.
+ * @param code     Receives the ISO 3166-1 alpha-2 code; may come back empty
+ *                 for an address that did not resolve.
+ * @return false when no country is known at all -- render neither icon nor
+ *         text.
+ */
+inline bool GetDisplayCountryCode(bool fromCore, const wxString &coreCode, const wxString &ip, wxString &code)
+{
+	if (fromCore) {
+		code = coreCode;
+		return true;
+	}
+#if defined(GEOIP_GUI) && !defined(CLIENT_GUI)
+	// Monolithic aMule resolves locally. amulegui only ever takes the EC path
+	// above, and compiling this branch out of it keeps it link-clean of
+	// CIP2Country.
+	if (theApp->GetIP2Country() && theApp->GetIP2Country()->IsEnabled()) {
+		code = theApp->GetIP2Country()->GetCountryCode(ip);
+		return true;
+	}
+#else
+	wxUnusedVar(ip);
+#endif
+	code.Clear();
+	return false;
+}
+
+#endif // COUNTRYDISPLAY_H

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -40,8 +40,8 @@
 #include "GetTickCount.h"       // Needed for GetTickCount64
 #include "GuiEvents.h"          // Needed for CoreNotify_*
 #ifdef GEOIP_GUI
-#include "IP2Country.h"   // Needed for CIP2Country
-#include "CountryFlags.h" // Needed for CCountryFlags (flag bitmaps)
+#include "CountryFlags.h"   // Needed for CCountryFlags (flag bitmaps)
+#include "CountryDisplay.h" // Needed for GetDisplayCountryCode
 #endif
 #include "muuli_wdr.h" // Needed for ID_DLOADLIST
 #include "PartFile.h"  // Needed for CPartFile
@@ -921,26 +921,14 @@ void CGenericClientListCtrl::DrawClientItem(wxDC *dc,
 
 		wxString userName;
 #ifdef GEOIP_GUI
-		// Country flag. Prefer the code the core resolved and sent over EC
-		// (#439): it is authoritative, so amulegui renders it regardless of its
-		// own (synced) GeoIP-enabled pref — the core only emits a code when its
-		// GeoIP is on. Monolithic amule has no EC feed and resolves locally,
-		// gated on its own IsGeoIPEnabled. The flag cache turns code -> bitmap.
+		// Country flag; GetDisplayCountryCode() holds the shared gate (see
+		// CountryDisplay.h) so this list and the server list stay in step. The
+		// flag cache then turns the code into a bitmap.
 		wxString code;
-		bool haveCountry = false;
-		if (client.GetClient()->IsCountryFromCore()) {
-			code = client.GetClient()->GetCountryCode();
-			haveCountry = true;
-		}
-#ifndef CLIENT_GUI
-		// Monolithic-only local lookup (keeps amulegui free of CIP2Country link
-		// symbols; amulegui only ever takes the EC-provided path above).
-		else if (thePrefs::IsGeoIPEnabled() && theApp->GetIP2Country() &&
-			 theApp->GetIP2Country()->IsEnabled()) {
-			code = theApp->GetIP2Country()->GetCountryCode(client.GetFullIP());
-			haveCountry = true;
-		}
-#endif
+		const bool haveCountry = GetDisplayCountryCode(client.GetClient()->IsCountryFromCore(),
+			client.GetClient()->GetCountryCode(),
+			client.GetFullIP(),
+			code);
 		// Draw the country flag only — no textual code. An unknown / unresolved
 		// peer (empty code) gets neither flag nor prefix.
 		if (haveCountry && !code.IsEmpty()) {

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -63,6 +63,16 @@ wxEND_EVENT_TABLE()
 //! Shared list of arrow-pixmaps
 static wxImageList imgList(16, 16, true, 0);
 
+void CMuleListCtrl::AddSortArrows(wxImageList &list)
+{
+	// Order is the contract SetSorting() indexes into: 0/1 are the plain
+	// descending / ascending arrows, 2/3 their alt-sort variants.
+	list.Add(wxArtProvider::GetBitmap("amule:sort_dn"));
+	list.Add(wxArtProvider::GetBitmap("amule:sort_up"));
+	list.Add(wxArtProvider::GetBitmap("amule:sort_dnx2"));
+	list.Add(wxArtProvider::GetBitmap("amule:sort_upx2"));
+}
+
 CMuleListCtrl::CMuleListCtrl(wxWindow *parent,
 	wxWindowID winid,
 	const wxPoint &pos,
@@ -78,10 +88,7 @@ CMuleListCtrl::CMuleListCtrl(wxWindow *parent,
 	m_isSorting = false;
 
 	if (imgList.GetImageCount() == 0) {
-		imgList.Add(wxArtProvider::GetBitmap("amule:sort_dn"));
-		imgList.Add(wxArtProvider::GetBitmap("amule:sort_up"));
-		imgList.Add(wxArtProvider::GetBitmap("amule:sort_dnx2"));
-		imgList.Add(wxArtProvider::GetBitmap("amule:sort_upx2"));
+		AddSortArrows(imgList);
 	}
 
 	// Default sort-order is to sort by the first column (asc).

--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -169,8 +169,12 @@ public:
 	 * This function will return the user-data for each selected item in a
 	 * vector, which can then be manipulated with regards to changes made
 	 * in the current order of the listctrl items.
+	 *
+	 * Virtual: this implementation reads the native items, which a virtual
+	 * list does not have -- CMuleVirtualListCtrl overrides it to read its
+	 * own model instead.
 	 */
-	ItemDataList GetSelectedItems() const;
+	virtual ItemDataList GetSelectedItems() const;
 
 	/**
 	 * Sets the sorter function.
@@ -257,6 +261,18 @@ protected:
 	// SortList() (owning its own row storage) can hold the same re-entrancy /
 	// IsSorting() guard the base sort does.
 	bool m_isSorting;
+
+	/**
+	 * Appends the four header sort arrows to @a list, at the indices
+	 * SetSorting() addresses them by (descending, ascending, and their
+	 * alt-sort variants).
+	 *
+	 * Every CMuleListCtrl shares one small image list holding just these.
+	 * A subclass that needs per-item icons has to attach a small image list
+	 * of its own instead -- it seeds it through here so the arrows keep
+	 * working and the index contract stays in one place.
+	 */
+	static void AddSortArrows(wxImageList &list);
 
 	/**
 	 * Must be overwritten to enable alternate sorting.

--- a/src/MuleVirtualListCtrl.cpp
+++ b/src/MuleVirtualListCtrl.cpp
@@ -214,6 +214,20 @@ bool CMuleVirtualListCtrl::MatchesFilter(const wxString &name) const
 	return name.Lower().Contains(m_filterText);
 }
 
+bool CMuleVirtualListCtrl::DeleteAllItems()
+{
+	ClearItemData();
+	return true;
+}
+
+CMuleVirtualListCtrl::ItemDataList CMuleVirtualListCtrl::GetSelectedItems() const
+{
+	// Same walk as SaveSelection(), which the sort path uses; the focused item
+	// is of no interest here.
+	wxUIntPtr focused = 0;
+	return SaveSelection(focused);
+}
+
 std::vector<wxUIntPtr> CMuleVirtualListCtrl::SaveSelection(wxUIntPtr &focused) const
 {
 	std::vector<wxUIntPtr> selected;

--- a/src/MuleVirtualListCtrl.h
+++ b/src/MuleVirtualListCtrl.h
@@ -86,6 +86,15 @@ public:
 	 *  preserving selection + focus by item identity. */
 	virtual void SortList();
 
+	/** The user-data of every selected item. Overrides the base, which reads
+	 *  the native items a virtual list does not have. */
+	virtual ItemDataList GetSelectedItems() const;
+
+	/** Empty the list. Shadows the (non-virtual) wxListCtrl method, which
+	 *  only drops native items and would leave this control's model holding
+	 *  rows -- pointers to objects the caller is most likely about to free. */
+	bool DeleteAllItems();
+
 	/** Set the live, case-insensitive substring filter; an empty string clears
 	 *  it. Calls RebuildFilteredView() when the text actually changes. */
 	void SetFilterText(const wxString &text);

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -26,30 +26,34 @@
 #include "ServerListCtrl.h" // Interface declarations
 
 #include <algorithm> // Needed for std::max
+#include <vector>    // Needed for std::vector
 
 #include <common/MenuIDs.h>
 
 #include <wx/menu.h>
 #include <wx/stattext.h>
 #include <wx/msgdlg.h>
-#include <wx/settings.h>
 
 #include "amule.h"         // Needed for theApp
 #include "DownloadQueue.h" // Needed for CDownloadQueue
 #ifdef GEOIP_GUI
-#include "IP2Country.h" // Needed for IP2Country
-#include "amuleDlg.h"   // Needed for IP2Country
+#include "CountryFlags.h"   // Needed for CCountryFlags (flag bitmaps)
+#include "CountryDisplay.h" // Needed for GetDisplayCountryCode
 #endif
 #include "ServerList.h"    // Needed for CServerList
 #include "ServerConnect.h" // Needed for CServerConnect
 #include "Server.h"        // Needed for CServer and SRV_PR_*
 #include "Logger.h"
 #include <common/Format.h> // Needed for CFormat
-#include "Preferences.h"   // Needed for thePrefs
 
-#define CMuleColour(x) (wxSystemSettings::GetColour(x))
+#include <wx/dcclient.h> // Needed for wxClientDC
 
-wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleListCtrl)
+// One fixed size for everything in the control's small image list. Set by the
+// 16x16 header sort arrows; the bundled country flags are 16x11 and get padded
+// onto a transparent cell of this size (see FlagImage).
+static const int LIST_IMAGE_SIZE = 16;
+
+wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleVirtualListCtrl)
 	EVT_LIST_ITEM_RIGHT_CLICK(-1, CServerListCtrl::OnItemRightClicked)
 	EVT_LIST_ITEM_ACTIVATED(-1, CServerListCtrl::OnItemActivated)
 
@@ -77,7 +81,8 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 	long style,
 	const wxValidator &validator,
 	const wxString &name)
-: CMuleListCtrl(parent, winid, pos, size, style, validator, name)
+: CMuleVirtualListCtrl(parent, winid, pos, size, style, validator, name)
+, m_images(LIST_IMAGE_SIZE, LIST_IMAGE_SIZE, true, 0)
 {
 	// Setting the sorter function.
 	SetSortFunc(SortProc);
@@ -86,6 +91,17 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 	SetTableName("Server");
 
 	m_connected = 0;
+
+	// Take over the small image list from the one every CMuleListCtrl shares:
+	// the country flags are added to it on demand and have no business showing
+	// up in the other lists' indices. The sort arrows have to come first, at
+	// the indices SetSorting() uses.
+	AddSortArrows(m_images);
+	SetImageList(&m_images, wxIMAGE_LIST_SMALL);
+
+	wxFont bold = GetFont();
+	bold.SetWeight(wxFONTWEIGHT_BOLD);
+	m_boldAttr.SetFont(bold);
 
 	InsertColumn(COLUMN_SERVER_NAME, _("Server Name"), wxLIST_FORMAT_LEFT, 150, "N");
 	InsertColumn(COLUMN_SERVER_ADDR, _("Address"), wxLIST_FORMAT_LEFT, 140, "A");
@@ -131,20 +147,36 @@ void CServerListCtrl::AddServer(CServer *toadd)
 
 void CServerListCtrl::RemoveServer(CServer *server)
 {
-	long result = FindItem(-1, reinterpret_cast<wxUIntPtr>(server));
-	if (result != -1) {
-		DeleteItem(result);
-		ShowServerCount();
+	const wxUIntPtr ptr = reinterpret_cast<wxUIntPtr>(server);
+	if (!HasItemData(ptr)) {
+		return;
 	}
+	if (server == m_connected) {
+		m_connected = nullptr;
+	}
+	RemoveItemData(ptr);
+	ShowServerCount();
 }
 
 void CServerListCtrl::RemoveAllServers(int state)
 {
-	int pos = GetNextItem(-1, wxLIST_NEXT_ALL, state);
-	bool connected = theApp->IsConnectedED2K() || theApp->serverconnect->IsConnecting();
+	// Collect first, delete second: the rows are a view onto the model, so
+	// removing one renumbers every row below it -- and the confirmations below
+	// run a nested event loop, during which the list can be updated underneath
+	// a row index but never underneath a server pointer.
+	std::vector<CServer *> candidates;
+	for (long pos = GetNextItem(-1, wxLIST_NEXT_ALL, state); pos != -1;
+		pos = GetNextItem(pos, wxLIST_NEXT_ALL, state)) {
+		candidates.push_back(reinterpret_cast<CServer *>(ItemAt(pos)));
+	}
 
-	while (pos != -1) {
-		CServer *server = reinterpret_cast<CServer *>(GetItemData(pos));
+	const bool connected = theApp->IsConnectedED2K() || theApp->serverconnect->IsConnecting();
+
+	for (CServer *server : candidates) {
+		// May have gone away while a message box was up.
+		if (!HasItemData(reinterpret_cast<wxUIntPtr>(server))) {
+			continue;
+		}
 
 		if (server == m_connected && connected) {
 			wxMessageBox(_("You are connected to a server you are trying to delete. Please "
@@ -152,8 +184,10 @@ void CServerListCtrl::RemoveAllServers(int state)
 				_("Info"),
 				wxOK,
 				this);
-			++pos;
-		} else if (server->IsStaticMember()) {
+			continue;
+		}
+
+		if (server->IsStaticMember()) {
 			const wxString name = (!server->GetListName() ? wxString(_("(Unknown name)"))
 								      : server->GetListName());
 
@@ -161,19 +195,19 @@ void CServerListCtrl::RemoveAllServers(int state)
 				    CFormat(_("Are you sure you want to delete the static server %s")) % name,
 				    _("Cancel"),
 				    wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT,
-				    this) == wxYES) {
-				theApp->serverlist->SetStaticServer(server, false);
-				DeleteItem(pos);
-				theApp->serverlist->RemoveServer(server);
-			} else {
-				++pos;
+				    this) != wxYES) {
+				continue;
 			}
-		} else {
-			DeleteItem(pos);
-			theApp->serverlist->RemoveServer(server);
+			theApp->serverlist->SetStaticServer(server, false);
 		}
 
-		pos = GetNextItem(pos - 1, wxLIST_NEXT_ALL, state);
+		// Drop the row before asking for the removal, not as a result of it:
+		// amulegui's CServerListRem::RemoveServer() only sends an EC command,
+		// so the row would otherwise linger until the core's next update. In
+		// the monolithic build the resulting Notify_ServerRemove() comes back
+		// here and finds the row already gone.
+		RemoveServer(server);
+		theApp->serverlist->RemoveServer(server);
 	}
 
 	ShowServerCount();
@@ -186,188 +220,231 @@ void CServerListCtrl::RefreshServer(CServer *server)
 		return;
 	}
 
-	wxUIntPtr ptr = reinterpret_cast<wxUIntPtr>(server);
-	long itemnr = FindItem(-1, ptr);
-	if (itemnr == -1) {
-		// We are not at the sure that the server isn't in the list, so we can re-add
-		itemnr = InsertItem(GetInsertPos(ptr), server->GetListName());
-		SetItemPtrData(itemnr, ptr);
-
-		wxListItem item;
-		item.SetId(itemnr);
-		item.SetBackgroundColour(CMuleColour(wxSYS_COLOUR_LISTBOX));
-		SetItem(item);
+	const wxUIntPtr ptr = reinterpret_cast<wxUIntPtr>(server);
+	if (HasItemData(ptr)) {
+		// The cells are rendered from the server on demand, so a refresh is
+		// just a repaint -- plus, when sorted by a column whose value just
+		// changed, the re-sort the base class coalesces for us.
+		RefreshItemData(ptr);
+	} else {
+		// We are not sure that the server isn't in the list, so we can re-add
+		AddItemData(ptr);
 	}
+}
 
-	wxString serverName;
-#ifdef GEOIP_GUI
-	// Prepend the ISO country code. Prefer the code the daemon resolved and
-	// sent over EC (remote GUI, #440) — authoritative even when empty; only
-	// fall back to a local lookup for monolithic amule / an old daemon. The
-	// server list is a plain text wxListCtrl, so — unlike the client list — it
-	// shows the code as text rather than a flag bitmap.
-	if (thePrefs::IsGeoIPEnabled()) {
-		wxString code;
-		bool haveCountry = false;
-		if (server->IsCountryFromCore()) {
-			code = server->GetCountryCode();
-			haveCountry = true;
+wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, long column) const
+{
+	const CServer *server = reinterpret_cast<const CServer *>(item);
+
+	switch (column) {
+	case COLUMN_SERVER_NAME:
+		// The host country is the flag icon on this column, not a text
+		// prefix -- see OnGetItemColumnImage().
+		return server->GetListName();
+
+	case COLUMN_SERVER_ADDR:
+		return server->GetAddress();
+
+	case COLUMN_SERVER_PORT:
+		if (server->GetAuxPortsList().IsEmpty()) {
+			return CFormat("%u") % server->GetPort();
 		}
-#ifndef CLIENT_GUI
-		// Monolithic amule resolves locally; amulegui takes only the EC path
-		// above (guarding the local branch out keeps amulegui link-clean).
-		else if (theApp->GetIP2Country() && theApp->GetIP2Country()->IsEnabled()) {
-			code = theApp->GetIP2Country()->GetCountryCode(server->GetFullIP());
-			haveCountry = true;
+		return CFormat("%u (%s)") % server->GetPort() % server->GetAuxPortsList();
+
+	case COLUMN_SERVER_DESC:
+		return server->GetDescription();
+
+	case COLUMN_SERVER_PING:
+		if (!server->GetPing()) {
+			return wxEmptyString;
 		}
-#endif
-		if (haveCountry) {
-			serverName << (code.IsEmpty() ? wxString("?") : code) << " - ";
+		return CastSecondsToHM(server->GetPing() / 1000, server->GetPing() % 1000);
+
+	case COLUMN_SERVER_USERS:
+		if (!server->GetUsers()) {
+			return wxEmptyString;
 		}
-	}
-#endif // GEOIP_GUI
-	serverName << server->GetListName();
-	SetItem(itemnr, COLUMN_SERVER_NAME, serverName);
-	SetItem(itemnr, COLUMN_SERVER_ADDR, server->GetAddress());
-	if (server->GetAuxPortsList().IsEmpty()) {
-		SetItem(itemnr, COLUMN_SERVER_PORT, CFormat("%u") % server->GetPort());
-	} else {
-		SetItem(itemnr,
-			COLUMN_SERVER_PORT,
-			CFormat("%u (%s)") % server->GetPort() % server->GetAuxPortsList());
-	}
-	SetItem(itemnr, COLUMN_SERVER_DESC, server->GetDescription());
+		return CFormat("%u") % server->GetUsers();
 
-	if (server->GetPing()) {
-		SetItem(itemnr,
-			COLUMN_SERVER_PING,
-			CastSecondsToHM(server->GetPing() / 1000, server->GetPing() % 1000));
-	} else {
-		SetItem(itemnr, COLUMN_SERVER_PING, "");
-	}
+	case COLUMN_SERVER_FILES:
+		if (!server->GetFiles()) {
+			return wxEmptyString;
+		}
+		return CFormat("%u") % server->GetFiles();
 
-	if (server->GetUsers()) {
-		SetItem(itemnr, COLUMN_SERVER_USERS, CFormat("%u") % server->GetUsers());
-	} else {
-		SetItem(itemnr, COLUMN_SERVER_USERS, "");
-	}
+	case COLUMN_SERVER_PRIO:
+		switch (server->GetPreferences()) {
+		case SRV_PR_LOW:
+			return _("Low");
+		case SRV_PR_NORMAL:
+			return _("Normal");
+		case SRV_PR_HIGH:
+			return _("High");
+		default:
+			return "---"; // this should never happen
+		}
 
-	if (server->GetFiles()) {
-		SetItem(itemnr, COLUMN_SERVER_FILES, CFormat("%u") % server->GetFiles());
-	} else {
-		SetItem(itemnr, COLUMN_SERVER_FILES, "");
-	}
+	case COLUMN_SERVER_FAILS:
+		return CFormat("%u") % server->GetFailedCount();
 
-	switch (server->GetPreferences()) {
-	case SRV_PR_LOW:
-		SetItem(itemnr, COLUMN_SERVER_PRIO, _("Low"));
-		break;
-	case SRV_PR_NORMAL:
-		SetItem(itemnr, COLUMN_SERVER_PRIO, _("Normal"));
-		break;
-	case SRV_PR_HIGH:
-		SetItem(itemnr, COLUMN_SERVER_PRIO, _("High"));
-		break;
-	default:
-		SetItem(itemnr, COLUMN_SERVER_PRIO, "---"); // this should never happen
-	}
+	case COLUMN_SERVER_STATIC:
+		return server->IsStaticMember() ? _("Yes") : _("No");
 
-	SetItem(itemnr, COLUMN_SERVER_FAILS, CFormat("%u") % server->GetFailedCount());
-	SetItem(itemnr, COLUMN_SERVER_STATIC, (server->IsStaticMember() ? _("Yes") : _("No")));
-	SetItem(itemnr, COLUMN_SERVER_VERSION, server->GetVersion());
+	case COLUMN_SERVER_VERSION:
+		return server->GetVersion();
 
 #if !defined(CLIENT_GUI)
-	wxString flags;
-	/* TCP */
-	if (server->GetTCPFlags() & SRV_TCPFLG_COMPRESSION) {
-		flags += "c";
-	}
-	if (server->GetTCPFlags() & SRV_TCPFLG_NEWTAGS) {
-		flags += "n";
-	}
-	if (server->GetTCPFlags() & SRV_TCPFLG_UNICODE) {
-		flags += "u";
-	}
-	if (server->GetTCPFlags() & SRV_TCPFLG_RELATEDSEARCH) {
-		flags += "r";
-	}
-	if (server->GetTCPFlags() & SRV_TCPFLG_TYPETAGINTEGER) {
-		flags += "t";
-	}
-	if (server->GetTCPFlags() & SRV_TCPFLG_LARGEFILES) {
-		flags += "l";
-	}
-	if (server->GetTCPFlags() & SRV_TCPFLG_TCPOBFUSCATION) {
-		flags += "o";
+	case COLUMN_SERVER_TCPFLAGS: {
+		wxString flags;
+		if (server->GetTCPFlags() & SRV_TCPFLG_COMPRESSION) {
+			flags += "c";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_NEWTAGS) {
+			flags += "n";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_UNICODE) {
+			flags += "u";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_RELATEDSEARCH) {
+			flags += "r";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_TYPETAGINTEGER) {
+			flags += "t";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_LARGEFILES) {
+			flags += "l";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_TCPOBFUSCATION) {
+			flags += "o";
+		}
+		return flags;
 	}
 
-	SetItem(itemnr, COLUMN_SERVER_TCPFLAGS, flags);
-
-	/* UDP */
-	flags.Clear();
-	if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES) {
-		flags += "g";
+	case COLUMN_SERVER_UDPFLAGS: {
+		wxString flags;
+		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES) {
+			flags += "g";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETFILES) {
+			flags += "f";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_NEWTAGS) {
+			flags += "n";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_UNICODE) {
+			flags += "u";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES2) {
+			flags += "G";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_LARGEFILES) {
+			flags += "l";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_UDPOBFUSCATION) {
+			flags += "o";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_TCPOBFUSCATION) {
+			flags += "O";
+		}
+		return flags;
 	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETFILES) {
-		flags += "f";
-	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_NEWTAGS) {
-		flags += "n";
-	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_UNICODE) {
-		flags += "u";
-	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES2) {
-		flags += "G";
-	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_LARGEFILES) {
-		flags += "l";
-	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_UDPOBFUSCATION) {
-		flags += "o";
-	}
-	if (server->GetUDPFlags() & SRV_UDPFLG_TCPOBFUSCATION) {
-		flags += "O";
-	}
-	SetItem(itemnr, COLUMN_SERVER_UDPFLAGS, flags);
-
 #endif
 
-	// Deletions of items causes rather large amount of flicker, so to
-	// avoid this, we resort the list to ensure correct ordering.
-	if (!IsItemSorted(itemnr)) {
-		SortList();
+	default:
+		return wxEmptyString;
+	}
+}
+
+int CServerListCtrl::FlagImage(const wxString &code) const
+{
+	const auto it = m_flagImages.find(code);
+	if (it != m_flagImages.end()) {
+		return it->second;
+	}
+
+	const wxImage &flag = theApp->GetCountryFlags()->GetFlag(code);
+	if (!flag.IsOk()) {
+		m_flagImages[code] = -1;
+		return -1;
+	}
+
+	// Centre the 16x11 flag on the image list's square cell. Adding it at its
+	// own size instead would leave wxImageList to stretch it to the cell.
+	wxImage cell = flag;
+	if (!cell.HasAlpha()) {
+		// Size() only pads with transparent pixels when there is an alpha
+		// channel to be transparent in; without one it would pad with black.
+		cell.InitAlpha();
+	}
+	cell = cell.Size(wxSize(LIST_IMAGE_SIZE, LIST_IMAGE_SIZE),
+		wxPoint((LIST_IMAGE_SIZE - cell.GetWidth()) / 2, (LIST_IMAGE_SIZE - cell.GetHeight()) / 2));
+
+	const int index = m_images.Add(wxBitmap(cell));
+	m_flagImages[code] = index;
+	return index;
+}
+
+int CServerListCtrl::OnGetItemColumnImage(long item, long column) const
+{
+	if (column != COLUMN_SERVER_NAME) {
+		return -1;
+	}
+#ifdef GEOIP_GUI
+	// Host country as a flag icon, matching the peer list: no icon at all for
+	// an unresolved server, rather than the "? - " prefix this used to show.
+	const CServer *server = reinterpret_cast<const CServer *>(ItemAt(item));
+	wxString code;
+	if (GetDisplayCountryCode(
+		    server->IsCountryFromCore(), server->GetCountryCode(), server->GetFullIP(), code) &&
+		!code.IsEmpty()) {
+		return FlagImage(code);
+	}
+#else
+	wxUnusedVar(item);
+#endif // GEOIP_GUI
+	return -1;
+}
+
+wxListItemAttr *CServerListCtrl::OnGetItemAttr(long item) const
+{
+	if (m_connected && reinterpret_cast<const CServer *>(ItemAt(item)) == m_connected) {
+		return &m_boldAttr;
+	}
+	return nullptr;
+}
+
+bool CServerListCtrl::IsLiveSortColumn() const
+{
+	switch (static_cast<int>(GetSortColumn())) {
+	case COLUMN_SERVER_PING:
+	case COLUMN_SERVER_USERS:
+	case COLUMN_SERVER_FILES:
+		return true;
+	default:
+		return false;
 	}
 }
 
 void CServerListCtrl::HighlightServer(const CServer *server, bool highlight)
 {
-	// Unset the old highlighted server if we are going to set a new one
-	if (m_connected && highlight) {
-		// A recursive call to do the real work.
-		HighlightServer(m_connected, false);
+	// The bold font is handed out by OnGetItemAttr(), so all this has to do is
+	// move m_connected and repaint the rows either side of the change.
+	const CServer *previous = m_connected;
 
-		m_connected = 0;
+	if (highlight) {
+		m_connected = server;
+	} else if (m_connected == server) {
+		m_connected = nullptr;
 	}
 
-	long itemnr = FindItem(-1, reinterpret_cast<wxUIntPtr>(server));
-	if (itemnr > -1) {
-		wxListItem item;
-		item.SetId(itemnr);
-
-		if (GetItem(item)) {
-			wxFont font = GetFont();
-
-			if (highlight) {
-				font.SetWeight(wxFONTWEIGHT_BOLD);
-
-				m_connected = server;
-			}
-
-			item.SetFont(font);
-
-			SetItem(item);
-		}
+	if (previous == m_connected) {
+		return;
+	}
+	if (previous) {
+		RefreshItemData(reinterpret_cast<wxUIntPtr>(previous));
+	}
+	if (m_connected) {
+		RefreshItemData(reinterpret_cast<wxUIntPtr>(m_connected));
 	}
 }
 
@@ -388,6 +465,25 @@ void CServerListCtrl::FitColumnsToContent()
 	// the column out. The other columns hold short, bounded values.
 	const int descMaxWidth = 300;
 
+	// wxLIST_AUTOSIZE is a no-op on a virtual control -- it has no native items
+	// to measure and just hands back a default width -- so the content side is
+	// measured here against the model. wxLIST_AUTOSIZE_USEHEADER measures the
+	// header text and works either way, so that half is left to it.
+	//
+	// The two constants and the arithmetic below reproduce what the non-virtual
+	// wxLIST_AUTOSIZE did, so column widths come out where they used to: the
+	// margin is the starting floor and is added once to the finished column
+	// (NOT per cell), and a cell carrying an image counts the image plus the
+	// narrower in-row image margin. Both live in listctrl.cpp as file-statics,
+	// hence the copies.
+	const int autosizeMargin = 10; // AUTOSIZE_COL_MARGIN
+	const int imageMargin = 5;     // IMAGE_MARGIN_IN_REPORT_MODE
+
+	wxClientDC dc(this);
+	dc.SetFont(GetFont());
+
+	const long rows = ItemDataCount();
+
 	Freeze();
 	for (int col = 0; col < GetColumnCount(); ++col) {
 		// Leave hidden columns (width 0, e.g. the TCP/UDP flag columns or
@@ -396,8 +492,20 @@ void CServerListCtrl::FitColumnsToContent()
 			continue;
 		}
 
-		SetColumnWidth(col, wxLIST_AUTOSIZE);
-		const int contentWidth = GetColumnWidth(col);
+		int contentWidth = autosizeMargin;
+		for (long row = 0; row < rows; ++row) {
+			wxCoord textWidth = 0;
+			dc.GetTextExtent(GetItemColumnText(ItemAt(row), col), &textWidth, nullptr);
+			int cellWidth = textWidth;
+			if (OnGetItemColumnImage(row, col) != -1) {
+				cellWidth += LIST_IMAGE_SIZE + imageMargin;
+			}
+			if (cellWidth > contentWidth) {
+				contentWidth = cellWidth;
+			}
+		}
+		contentWidth += autosizeMargin;
+
 		SetColumnWidth(col, wxLIST_AUTOSIZE_USEHEADER);
 		const int headerWidth = GetColumnWidth(col);
 
@@ -437,7 +545,7 @@ void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
 
 	// Gather information on the selected items
 	while (index > -1) {
-		CServer *server = reinterpret_cast<CServer *>(GetItemData(index));
+		CServer *server = reinterpret_cast<CServer *>(ItemAt(index));
 
 		// The current server is selected, so we might display the reconnect option
 		if (server == m_connected) {
@@ -552,7 +660,7 @@ void CServerListCtrl::OnConnectToServer(wxCommandEvent &WXUNUSED(event))
 			theApp->serverconnect->Disconnect();
 		}
 
-		theApp->serverconnect->ConnectToServer(reinterpret_cast<CServer *>(GetItemData(item)));
+		theApp->serverconnect->ConnectToServer(reinterpret_cast<CServer *>(ItemAt(item)));
 	}
 }
 
@@ -563,7 +671,7 @@ void CServerListCtrl::OnGetED2kURL(wxCommandEvent &WXUNUSED(event))
 	wxString URL;
 
 	while (pos != -1) {
-		CServer *server = reinterpret_cast<CServer *>(GetItemData(pos));
+		CServer *server = reinterpret_cast<CServer *>(ItemAt(pos));
 
 		URL += CFormat("ed2k://|server|%s|%d|/\n") % server->GetFullIP() % server->GetPort();
 

--- a/src/ServerListCtrl.h
+++ b/src/ServerListCtrl.h
@@ -26,7 +26,9 @@
 #ifndef SERVERLISTCTRL_H
 #define SERVERLISTCTRL_H
 
-#include "MuleListCtrl.h" // Needed for CMuleListCtrl
+#include "MuleVirtualListCtrl.h" // Needed for CMuleVirtualListCtrl (and wxListItemAttr)
+
+#include <map>
 
 #define COLUMN_SERVER_NAME 0
 #define COLUMN_SERVER_ADDR 1
@@ -51,8 +53,12 @@ class wxCommandEvent;
  * The CServerListCtrl is used to display the list of servers which the user
  * can connect to and which we request sources from. It is a permanently sorted
  * list in that it always ensure that the items are sorted in the correct order.
+ *
+ * The rows are text-rendered from the model (GetItemColumnText), not
+ * owner-drawn: the only graphic is the country flag in the Server Name column,
+ * which a virtual list can supply through OnGetItemColumnImage.
  */
-class CServerListCtrl : public CMuleListCtrl
+class CServerListCtrl : public CMuleVirtualListCtrl
 {
 public:
 	/**
@@ -139,6 +145,24 @@ protected:
 	/// Return old column order.
 	wxString GetOldColumnOrder() const;
 
+	/// Text of one cell, rendered on demand by the virtual control.
+	virtual wxString GetItemColumnText(wxUIntPtr item, long column) const;
+
+	/**
+	 * Image index for one cell: the host-country flag on the Server Name
+	 * column, none anywhere else.
+	 */
+	virtual int OnGetItemColumnImage(long item, long column) const;
+
+	/// Bold attribute for the server we are connected to, none for the rest.
+	virtual wxListItemAttr *OnGetItemAttr(long item) const;
+
+	/**
+	 * Ping, Users and Files change while the list is up, so sorting by one of
+	 * them enables the inherited live auto-sort.
+	 */
+	virtual bool IsLiveSortColumn() const;
+
 private:
 	/**
 	 * Event-handler for handling item activation (connect).
@@ -187,8 +211,33 @@ private:
 	 */
 	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
+	/**
+	 * Index of @a code's flag in m_images, adding the bitmap on first use.
+	 * Returns -1 for a code with no bundled flag.
+	 */
+	int FlagImage(const wxString &code) const;
+
 	//! Used to keep track of the last high-lighted item.
 	const CServer *m_connected;
+
+	/**
+	 * This control's own small image list: the header sort arrows first (the
+	 * indices CMuleListCtrl::SetSorting() uses), then one entry per country
+	 * flag actually seen. It replaces the list shared by every CMuleListCtrl
+	 * so the flags stay out of every other list in the app.
+	 *
+	 * Mutable because the flags are filled in lazily from
+	 * OnGetItemColumnImage(), which the virtual control calls to paint a row
+	 * and is therefore const. Loading all ~250 flags up front instead would
+	 * decode a PNG for every country nobody is connected to.
+	 */
+	mutable wxImageList m_images;
+
+	//! ISO code -> index into m_images.
+	mutable std::map<wxString, int> m_flagImages;
+
+	//! Returned by OnGetItemAttr() for the connected server; see HighlightServer().
+	mutable wxListItemAttr m_boldAttr;
 
 	wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
Closes #686.

Since #440 the core resolves each ed2k server's host country and hands it to the GUI, but the two lists rendered the same piece of data two different ways: the peer list drew a flag bitmap, while the server list prefixed the *Server Name* column with the ISO code (`de - ServerName`, or `? - ` when unresolved). The prefix ate horizontal space in a column that is often too narrow already, and broke up the name itself.

The server list now draws the same flag the peer list does, with the same rule for the unresolved case: no icon rather than a placeholder.

## Finishing the virtual-list migration

Getting an icon into that column meant finishing a migration that was started when the virtual lists landed and deliberately left out — the server list was the last report-mode `CMuleListCtrl` of the pair, and only a virtual list can answer `OnGetItemColumnImage` per row.

`CServerListCtrl` now derives from `CMuleVirtualListCtrl` and renders its cells on demand from the model via `GetItemColumnText`. That also buys what the other virtual lists already have: O(1) row lookup instead of the linear `FindItem` that `RefreshServer`, `RemoveServer` and `HighlightServer` each ran; a `std::sort` over the model instead of moving native rows; and one coalesced re-sort per update batch instead of an inline `SortList` per refreshed server. Ping, Users and Files are declared live-sort columns, so sorting by one of them now follows the data — which matters most right after a server-list refresh, when UDP replies arrive in bursts.

Three things had to be rebuilt against the model rather than the native items:

- The connected server's bold font moves from a per-item `wxListItem` to `OnGetItemAttr`; `HighlightServer` just moves `m_connected` and repaints the two affected rows.
- `FitColumnsToContent` measures the model itself. `wxLIST_AUTOSIZE` is a no-op on a virtual control — it has no native items to measure and hands back a default width — so only the header half can still be left to `wxLIST_AUTOSIZE_USEHEADER`.
- `RemoveAllServers` collects its victims before deleting any, instead of deleting while walking row indices. The confirmations it raises run a nested event loop, and a row index does not survive that; a server pointer does.

The flags live in a small image list owned by this one control, seeded with the header sort arrows so those keep their indices, rather than in the list every `CMuleListCtrl` shares. Each flag is padded onto a transparent 16×16 cell — `wxImageList` has one fixed size and the bundled flags are 16×11, so adding them as-is would stretch them vertically.

## One gate for both lists

The rule deciding which country code to show was duplicated between the two lists, and the server list's copy carried an extra `thePrefs::IsGeoIPEnabled()` check the peer list deliberately does not have. It is redundant on both paths: the core only emits its country tag when its resolver is on, so a tag received over EC already implies it, and the monolithic local lookup is guarded by the resolver's own `IsEnabled()`. On amulegui that pref is merely a mirror of the core's, refreshed at prefs-sync time, so consulting it could only ever disagree with the tag we were handed. Both lists now share `GetDisplayCountryCode()`.

That helper is a header rather than a `.cpp` on purpose: the answer depends on `ENABLE_IP2COUNTRY` / `CLIENT_GUI`, and those are per-target compile definitions. `CountryFlags.cpp` — the obvious neighbour — is built into `muleappgui`, one static library linked into both binaries with neither define set, where it could only ever produce the amulegui answer.

## Drive-by

Two `CMuleListCtrl` methods assumed native items and were dead against a virtual model: `GetSelectedItems` returned nothing, and `DeleteAllItems` left the model holding pointers to objects the caller was about to free. Both are now handled in `CMuleVirtualListCtrl`, which is where the other virtual lists get them from too.

No new translatable strings, so no catalog changes.

## Testing

Built and run on macOS (monolithic aMule and amulegui). Verified in the running app: flags render undistorted for resolved servers and are absent for unresolved ones, header sort arrows still work, the connected server renders bold and clears on disconnect, columns fit their content on load, and server removal (including the static-server confirmation) behaves as before.

Object-level check that both build variants compile the intended branch: `amule.dir/ServerListCtrl.cpp.o` references `CIP2Country::GetCountryCode`/`IsEnabled`, while `amulegui.dir/ServerListCtrl.cpp.o` references only `CCountryFlags::GetFlag` — amulegui stays link-clean of the resolver.
