### PR TITLE
feat(amuleapi): serve country-flag artwork at GET /flags/{code}.png

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -98,6 +98,9 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/search/results/{hash}/comments`](#get-apiv0searchresultshashcomments) — Kad ratings/comments for a result
 - [`POST /api/v0/search/results/{hash}/comments`](#post-apiv0searchresultshashcomments) — trigger a Kad notes lookup for a result
 
+**Assets**
+- [`GET /flags/{code}.png`](#get-flagscodepng) — country-flag artwork for a `country_code`
+
 ## Base URL and transport
 
 `amuleapi` serves HTTP on the address declared in `amuleapi.conf[Server]/Port` (default `4713`). The server is HTTP-only by design — terminate TLS in a reverse proxy (nginx, Caddy, etc.) for any non-loopback deployment. The cookie is deliberately NOT marked `Secure` so the same Set-Cookie works whether the operator runs amuleapi behind TLS or directly. See QUICKSTART for the full bind-vs-listen story.
@@ -1008,7 +1011,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 `software` and `software_version` are locale-independent, per the API's English-only contract. A peer the daemon could not identify reports `"software": "unknown"` and `"software_version": "unknown"` — a lowercase sentinel, never a daemon-localized string (the daemon's own version formatting is gettext-translated and is deliberately not surfaced here). `os_info` is the peer's *own* self-reported OS string (raw external data, not normalized by amuled) and is frequently empty, since most clients don't send it.
 
-`country_code` is the peer's ISO 3166-1 alpha-2 country code (lowercase, e.g. `"de"`), resolved server-side from the peer IP by the daemon's GeoIP database. It is an empty string when GeoIP is disabled or unsupported by the build, or when the IP does not resolve — render the flag and localized country name client-side from the code.
+`country_code` is the peer's ISO 3166-1 alpha-2 country code (lowercase, e.g. `"de"`), resolved server-side from the peer IP by the daemon's GeoIP database. It is an empty string when GeoIP is disabled or unsupported by the build, or when the IP does not resolve — render the flag and localized country name client-side from the code. The flag image is served by [`GET /flags/{code}.png`](#get-flagscodepng); the localized name has no endpoint because the browser already has it (`Intl.DisplayNames` with `{ type: "region" }`).
 
 **Errors:** `400 bad_request` (unknown filter token), `503 ec_unavailable`.
 
@@ -1387,7 +1390,7 @@ Send a bare priority level to pin it (the file's `priority_auto` becomes `false`
 }
 ```
 
-`country_code` is the ISO 3166-1 alpha-2 code (lowercase, e.g. `"de"`) of the server host, resolved server-side from the server IP by the daemon's GeoIP database — same semantics and empty-string fallback as the peer `country_code` on `/clients`.
+`country_code` is the ISO 3166-1 alpha-2 code (lowercase, e.g. `"de"`) of the server host, resolved server-side from the server IP by the daemon's GeoIP database — same semantics and empty-string fallback as the peer `country_code` on `/clients`, and the same artwork route, [`GET /flags/{code}.png`](#get-flagscodepng).
 
 **Errors:** `503 ec_unavailable`.
 
@@ -2044,6 +2047,35 @@ Trigger an on-demand Kad notes lookup for a search result you have not downloade
 **Response:** `202 Accepted` → `{ "status": "kad_search_started" }`.
 
 **Errors:** `400 bad_request` (malformed hash), `404 not_found` (no current search result with that hash), `400 amuled_rejected` (Kad down, or a search is already using this hash — retry shortly), `503 ec_unavailable`.
+
+---
+
+### Assets
+
+#### `GET /flags/{code}.png`
+
+**Auth:** `NONE` — public artwork, no per-installation data. `HEAD` is accepted too; any other method is `405 method_not_allowed`.
+
+The country-flag image for a `country_code`. `/clients`, `/servers` and their SSE diffs carry the ISO 3166-1 alpha-2 code (see [`GET /api/v0/clients`](#get-apiv0clients)); this is where the matching artwork comes from, so a frontend does not have to ship its own flag set.
+
+Note the path is deliberately **outside** `/api/v0/` — it is an image an `<img src>` points at, not a JSON resource, and it is versioned by the daemon build rather than by the API contract.
+
+`{code}` must be exactly two **lowercase** ASCII letters, or the literal `unknown` for the "??" placeholder the desktop GUI falls back to when a code is empty or unrecognised. The bytes are the 16×11 famfamfam PNGs compiled into the daemon binary — the same artwork the desktop draws — so the route behaves identically whether or not `[Server]/StaticRoot` is set, and never touches the file system.
+
+```sh
+curl -s http://$HOST/flags/de.png -o de.png
+curl -s http://$HOST/flags/unknown.png -o unknown.png
+```
+
+**Response:** `200 OK`, `Content-Type: image/png`, `Cache-Control: public, max-age=86400`.
+
+Responses carry an `ETag` and honour `If-None-Match` with `304 Not Modified` like every other `GET` (see [ETag and conditional GET](#etag-and-conditional-get)). The `max-age` is what keeps a peer list full of `<img>` tags from issuing one conditional request per country on every reload; the artwork can only change with a new daemon build, and a day bounds how long an upgraded daemon keeps serving the old image.
+
+The response is never `Content-Encoding: gzip` — a PNG is already entropy-coded, so the server skips compression for it.
+
+**Errors:** `404 not_found` for anything that is neither two lowercase letters nor `unknown` (uppercase, wrong length, digits, another extension), and for a well-formed code the famfamfam set has no artwork for — it covers 248 of the assignable alpha-2 codes, so a resolvable country can legitimately have no flag. Render the code as text, or fall back to `unknown.png`, in that case. `400 bad_request` for paths carrying traversal tokens, per [Path validation](#path-validation).
+
+Peers whose country could not be resolved — GeoIP disabled, unsupported by the build, or a private/unmatched address — come back with `country_code: ""`. There is no per-country image to request in that case; draw nothing, or `unknown.png` for parity with the desktop list.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -42,6 +42,7 @@
 #include "Constants.h"
 #include "OtherFunctions.h" // GetFiletypeByName for the shared file_type token
 #include <common/Path.h>    // CPath
+#include <icon_data.h>      // amule_find_icon — country flags for GET /flags/{code}.png
 
 #include <ec/cpp/ECPacket.h>
 #include <ec/cpp/ECCodes.h>
@@ -1183,6 +1184,19 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
+	// Country-flag artwork. Sits ahead of the static fallthrough so the
+	// route answers identically whether or not StaticRoot is set — the
+	// bytes are compiled in, not read from disk. Deliberately outside
+	// /api/v0/: it is an image an <img src> points at, not a JSON
+	// resource, and it carries no per-installation data.
+	if (path.compare(0, 7, "/flags/") == 0) {
+		if (req.method != "GET" && req.method != "HEAD") {
+			return ErrorResponse(
+				405, "method_not_allowed", "only GET / HEAD on /flags/{code}.png");
+		}
+		return ServeCountryFlag(req, path);
+	}
+
 	// Static-frontend fallthrough. Anything that didn't match an
 	// /api/v0/* route and is a safe-method request for a non-API path
 	// is a candidate. ServeStaticFile is a no-op (404) when StaticRoot
@@ -1266,6 +1280,61 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	r.content_type = StaticContentType(rel);
 	r.body = (req.method == "HEAD") ? std::string() : std::move(body);
 	r.headers["ETag"] = etag;
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::ServeCountryFlag(
+	const CHttpServer::Request &, const std::string &url_path)
+{
+	// Exact shape only: "/flags/" + name + ".png".
+	static const std::string kPrefix = "/flags/";
+	static const std::string kSuffix = ".png";
+	if (url_path.size() <= kPrefix.size() + kSuffix.size() ||
+		url_path.compare(0, kPrefix.size(), kPrefix) != 0 ||
+		url_path.compare(url_path.size() - kSuffix.size(), kSuffix.size(), kSuffix) != 0) {
+		return ErrorResponse(404, "not_found", "no such flag");
+	}
+	const std::string code =
+		url_path.substr(kPrefix.size(), url_path.size() - kPrefix.size() - kSuffix.size());
+
+	// Two lowercase ASCII letters — the shape `country_code` arrives in
+	// — plus the one literal name the set ships alongside the alpha-2
+	// files: "unknown", the "??" placeholder CCountryFlags falls back
+	// to for an empty or unrecognised code, offered here so a frontend
+	// can match the desktop instead of inventing its own.
+	//
+	// The art id is built by concatenation, so this whitelist is what
+	// stops a crafted code from naming a non-flag entry in the shared
+	// icon table ("/flags/../amule.png" and friends — LooksMalicious
+	// already rejects those upstream, but the lookup must not depend
+	// on that).
+	const bool is_alpha2 =
+		code.size() == 2 && code[0] >= 'a' && code[0] <= 'z' && code[1] >= 'a' && code[1] <= 'z';
+	if (!is_alpha2 && code != "unknown") {
+		return ErrorResponse(404, "not_found", "no such flag");
+	}
+
+	// The famfamfam set covers 248 of the ~300 assignable alpha-2
+	// codes, and GeoIP can resolve one it has no artwork for, so a
+	// well-formed miss is a normal 404 rather than an error.
+	const struct AMuleIconEntry *icon = amule_find_icon(("flag_" + code).c_str());
+	if (!icon || icon->png_data == nullptr || icon->png_len == 0) {
+		return ErrorResponse(404, "not_found", "no such flag");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "image/png";
+	// HEAD body-stripping and the ETag / If-None-Match → 304 swap are
+	// applied to every 200 GET/HEAD by Dispatch(), so this handler only
+	// has to produce the bytes.
+	r.body.assign(reinterpret_cast<const char *>(icon->png_data), icon->png_len);
+	// The artwork is compiled in: it can only change with a new build,
+	// and a peer list is a page full of <img> tags pointing here. A day
+	// of freshness turns those into cache hits instead of one
+	// conditional request per distinct country per reload, while still
+	// bounding how long an upgraded daemon keeps serving stale art.
+	r.headers["Cache-Control"] = "public, max-age=86400";
 	return r;
 }
 

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -186,6 +186,17 @@ private:
 	// Never requires auth — the shell is public; the API calls it
 	// makes still hit the per-handler role gates.
 	CHttpServer::Response ServeStaticFile(const CHttpServer::Request &, const std::string &url_path);
+	// Country-flag artwork for `country_code` (/clients, /servers and
+	// their SSE diffs carry the code; the flag image is what a frontend
+	// still needs to draw it). `url_path` is the full request path and
+	// must be "/flags/<cc>.png" with two lowercase ASCII letters, or
+	// "/flags/unknown.png" for the "??" placeholder; the bytes come
+	// from the embedded icon table's "flag_<cc>" entry, so nothing
+	// touches the file system. Returns 404 for any other shape and for
+	// codes the famfamfam set has no artwork for. Never requires auth
+	// — same rationale as ServeStaticFile, and the artwork is public
+	// either way.
+	CHttpServer::Response ServeCountryFlag(const CHttpServer::Request &, const std::string &url_path);
 	// Rescan shared directories — amuled re-walks the configured share
 	// roots and re-publishes whatever's there. Parameterless EC op
 	// (EC_OP_SHAREDFILES_RELOAD).

--- a/src/webapi/CMakeLists.txt
+++ b/src/webapi/CMakeLists.txt
@@ -8,6 +8,16 @@ add_executable (amuleapi
 	${CMAKE_SOURCE_DIR}/src/RLE.cpp
 	${CMAKE_SOURCE_DIR}/src/NetworkFunctions.cpp
 	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+	# Same embedded icon table the desktop GUI links (build-generated
+	# by src/icons/embed_icons.py, or the checked-in fallback when the
+	# host has no Python3 — see src/CMakeLists.txt for the resolution).
+	# GET /flags/{code}.png serves the flag_<cc> entries straight out
+	# of .rodata, which is what keeps the country artwork a single
+	# committed copy instead of a duplicate under static/. Plain C byte
+	# arrays, so it compiles fine under wxUSE_GUI=0; the top-level
+	# icons amuleapi never asks for are pages that simply never fault
+	# in.
+	${AMULE_ICON_DATA_C}
 	AmuleApiConfig.cpp
 	Api.cpp
 	App.cpp
@@ -37,8 +47,20 @@ target_include_directories (amuleapi
 	PRIVATE ${CMAKE_BINARY_DIR}
 	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 	PRIVATE ${SRC_DIR}
+	# icon_data.c #includes "icon_data.h" unqualified, and Api.cpp does
+	# the same to reach amule_find_icon() — same reason muleappgui puts
+	# src/icons on its include path.
+	PRIVATE ${SRC_DIR}/icons
 	PRIVATE ${Boost_INCLUDE_DIR}
 )
+
+# ${AMULE_ICON_DATA_C} is generated into the build tree when Python3 was
+# found at configure time; without it the variable already points at the
+# checked-in source copy and no ordering dependency is needed. Mirrors
+# what muleappgui does in src/CMakeLists.txt.
+if (Python3_FOUND)
+	add_dependencies (amuleapi generate_icon_data)
+endif()
 
 target_link_libraries (amuleapi
 	PRIVATE ec

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -45,6 +45,7 @@
 #include <cassert>
 #include <cctype>
 #include <chrono>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -92,6 +93,30 @@ std::atomic<int> g_streaming_session_count{ 0 };
 // framing eats most of any ratio gain, and error/heartbeat payloads
 // are common in that size range.
 constexpr size_t kGzipMinBodyBytes = 256;
+
+// Media types whose payload is already entropy-coded. Running deflate
+// over a PNG / JPEG / WebP / GIF / woff2 buys a percent at best and
+// routinely grows the body, so the flag artwork and any future binary
+// asset ship as-is. Prefix match on the type token — the check runs
+// before any "; charset=" parameter would matter, and none of these
+// carry one.
+bool IsPrecompressedType(const std::string &content_type)
+{
+	static const char *const kTypes[] = { "image/png",
+		"image/jpeg",
+		"image/gif",
+		"image/webp",
+		"font/woff",
+		"font/woff2",
+		"application/zip",
+		"application/gzip" };
+	for (const char *type : kTypes) {
+		if (content_type.compare(0, std::strlen(type), type) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
 
 // Case-insensitive token search for "gzip" in an Accept-Encoding header
 // value. Real clients (curl, browsers) send "gzip, deflate, br" or
@@ -809,7 +834,9 @@ private:
 		//  * body is above kGzipMinBodyBytes (header overhead is a
 		//    significant fraction below that),
 		//  * handler didn't already set Content-Encoding (a future
-		//    pre-gzipped static asset path would use that hook).
+		//    pre-gzipped static asset path would use that hook),
+		//  * body isn't already entropy-coded (PNG flags, images and
+		//    fonts out of the static tree).
 		// deflate() fallback: on any zlib error we ship the original
 		// uncompressed body rather than 500 — better degraded than
 		// broken. Content-Length is set correctly by
@@ -820,7 +847,8 @@ private:
 		// entry correctly across clients that do / don't send the
 		// header.
 		if (m_accepts_gzip && resp.body.size() >= kGzipMinBodyBytes &&
-			resp.headers.find("Content-Encoding") == resp.headers.end()) {
+			resp.headers.find("Content-Encoding") == resp.headers.end() &&
+			!IsPrecompressedType(resp.content_type)) {
 			std::string compressed;
 			if (GzipOnce(resp.body, compressed)) {
 				resp.body = std::move(compressed);

--- a/unittests/curl-tests/amuleapi/32-country-flags.sh
+++ b/unittests/curl-tests/amuleapi/32-country-flags.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+#
+# amuleapi 32-country-flags — GET /flags/{code}.png.
+#
+# The peer / server `country_code` on /clients and /servers is only half
+# the story; this route is where a frontend gets the matching artwork.
+# The bytes come from the icon table compiled into the binary (the same
+# famfamfam set the desktop GUI draws), so the assertions here are about
+# the route's shape rather than any file on disk:
+#
+#   * a known code returns a PNG with the right Content-Type,
+#   * the response is cacheable — ETag + Cache-Control — and honours
+#     If-None-Match with a 304,
+#   * HEAD returns the headers with no body,
+#   * the artwork is served verbatim, NOT gzip-encoded (it is already
+#     entropy-coded; deflate over a PNG is pure waste),
+#   * the "unknown" placeholder (the "??" flag the desktop falls back
+#     to for an unresolved code) is reachable under the same route,
+#   * anything else that is not exactly two lowercase ASCII letters +
+#     .png is a 404, including uppercase, wrong length, traversal
+#     attempts and a well-formed code the set has no artwork for,
+#   * non-safe methods are 405,
+#   * it works with `[Server]/StaticRoot` unset — nothing here reads
+#     the file system.
+#
+# Usage:
+#   amuleapi --config-dir=/tmp/amuleapi-regtest &
+#   ./32-country-flags.sh
+#
+# Exits 0 on success, 1 on any failed assertion, 2 on bring-up error.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_32_country_flags_body.XXXXXX)
+CURL_HEAD_FILE=$(mktemp -t amuleapi_32_country_flags_head.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE" "$CURL_HEAD_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+# Binary-safe: the body lands in a file and stays there. $CURL_BODY is
+# deliberately NOT populated (a PNG through a shell variable loses the
+# NUL bytes); assertions read $CURL_BODY_FILE instead.
+#
+# Body *length* comes from curl's own %{size_download}, never from the
+# file: curl leaves the previous response's file untouched when a reply
+# carries no body (304), and `-I` writes the response headers into it,
+# so file size answers a different question than "how many body bytes
+# came back". The file is truncated up front anyway so a signature
+# check can't read stale bytes.
+_curl() {
+	local resp
+	: > "$CURL_BODY_FILE"
+	resp=$(curl -s --max-time 10 \
+		-D "$CURL_HEAD_FILE" \
+		-o "$CURL_BODY_FILE" -w '%{http_code} %{size_download}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=${resp%% *}
+	CURL_SIZE=${resp##* }
+	CURL_HEAD=$(cat "$CURL_HEAD_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS"
+	fi
+}
+
+_header() { echo "$CURL_HEAD" | awk -F': ' -v k="$1" 'tolower($1) == k {gsub(/\r/,""); print $2}'; }
+
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
+fi
+
+echo "amuleapi 32-country-flags @ $HOST"
+
+# --- 1. A known code returns a PNG. -------------------------------
+_curl "$HOST/flags/de.png"
+_assert_status 200 "GET /flags/de.png"
+
+CT=$(_header content-type)
+case "$CT" in
+	image/png*) _pass "Content-Type is image/png" ;;
+	*) _fail "/flags/de.png Content-Type" "expected image/png, got: ${CT:-<none>}" ;;
+esac
+
+# The famfamfam flags are 16x11 8-bit colormap PNGs, a few hundred bytes
+# each. Check the 8-byte PNG signature so a future refactor that returns
+# the wrong table entry (or an empty body) fails loudly here.
+SIG=$(od -An -tx1 -N8 "$CURL_BODY_FILE" | tr -d ' \n')
+if [ "$SIG" = "89504e470d0a1a0a" ]; then
+	_pass "body starts with the PNG signature"
+else
+	_fail "/flags/de.png body" "expected PNG magic 89504e470d0a1a0a, got ${SIG:-<empty>}"
+fi
+
+if [ "$CURL_SIZE" -gt 100 ] && [ "$CURL_SIZE" -lt 8192 ]; then
+	_pass "body is a plausible flag size ($CURL_SIZE bytes)"
+else
+	_fail "/flags/de.png size" "expected 100..8192 bytes, got $CURL_SIZE"
+fi
+
+# --- 2. Cacheable: ETag + Cache-Control. --------------------------
+ETAG=$(_header etag)
+if [ -n "$ETAG" ]; then
+	_pass "GET /flags/de.png emits an ETag ($ETAG)"
+else
+	_fail "/flags/de.png ETag" "no ETag header found"
+fi
+
+CC=$(_header cache-control)
+case "$CC" in
+	*max-age=*) _pass "Cache-Control carries a max-age ($CC)" ;;
+	*) _fail "/flags/de.png Cache-Control" "expected a max-age directive, got: ${CC:-<none>}" ;;
+esac
+
+# --- 3. If-None-Match → 304. --------------------------------------
+_curl -H "If-None-Match: $ETAG" "$HOST/flags/de.png"
+_assert_status 304 "If-None-Match matching ETag → 304"
+if [ "$CURL_SIZE" = "0" ]; then
+	_pass "304 carries no body"
+else
+	_fail "304 body" "expected 0 body bytes, got $CURL_SIZE"
+fi
+
+# --- 4. HEAD returns headers, no body. ----------------------------
+_curl -I "$HOST/flags/de.png"
+_assert_status 200 "HEAD /flags/de.png"
+if [ "$CURL_SIZE" = "0" ]; then
+	_pass "HEAD carries no body"
+else
+	_fail "HEAD body" "expected 0 body bytes, got $CURL_SIZE"
+fi
+# Note: like every other amuleapi endpoint, HEAD comes back with
+# `Content-Length: 0` rather than the length the GET would return —
+# Dispatch() strips the body before Beast sizes the payload. That is
+# daemon-wide existing behaviour, not specific to this route, so it is
+# deliberately not asserted here.
+
+# --- 5. Already-compressed payload is not gzip-encoded. -----------
+# curl offers gzip in Accept-Encoding here. deflate over a PNG buys
+# nothing and routinely grows the body, so the server must skip it.
+_curl --compressed "$HOST/flags/us.png"
+_assert_status 200 "GET /flags/us.png (Accept-Encoding: gzip)"
+ENC=$(_header content-encoding)
+if [ -z "$ENC" ]; then
+	_pass "PNG is served unencoded even when gzip is offered"
+else
+	_fail "/flags/us.png Content-Encoding" "expected none, got: $ENC"
+fi
+
+# --- 6. The "unknown" placeholder is reachable. -------------------
+# CCountryFlags::GetFlag() falls back to flags/unknown.png ("??") for
+# an empty or unrecognised code; the same artwork has to be available
+# here or a frontend can't match the desktop.
+_curl "$HOST/flags/unknown.png"
+_assert_status 200 "GET /flags/unknown.png (the \"??\" placeholder)"
+SIG=$(od -An -tx1 -N8 "$CURL_BODY_FILE" | tr -d ' \n')
+if [ "$SIG" = "89504e470d0a1a0a" ]; then
+	_pass "placeholder body starts with the PNG signature"
+else
+	_fail "/flags/unknown.png body" "expected PNG magic, got ${SIG:-<empty>}"
+fi
+
+# --- 7. Malformed codes are 404, not 500 / not a wrong icon. ------
+# The art id is built by concatenating "flag_" with the code, so the
+# charset check is load-bearing: without it a crafted code could name a
+# non-flag entry in the shared icon table.
+while read -r target label; do
+	[ -z "$target" ] && continue
+	_curl "$HOST$target"
+	_assert_status 404 "$label"
+done <<-'EOF'
+	/flags/DE.png	uppercase code → 404
+	/flags/d.png	one-letter code → 404
+	/flags/deu.png	three-letter code → 404
+	/flags/de.jpg	wrong extension → 404
+	/flags/de	no extension → 404
+	/flags/	empty code → 404
+	/flags/d1.png	digit in code → 404
+	/flags/zz.png	well-formed code with no artwork → 404
+EOF
+
+# Traversal attempts. `..` is rejected upstream by the shared
+# LooksMalicious gate (400), and the exact-shape check would 404 them
+# anyway — either way, no icon comes back.
+for target in "/flags/../amule.png" "/flags/%2e%2e/amule.png" "/flags/amule.png"; do
+	_curl "$HOST$target"
+	case "$CURL_STATUS" in
+		400|404) _pass "traversal $target is refused (HTTP $CURL_STATUS)" ;;
+		*) _fail "traversal $target" "expected 400 or 404, got $CURL_STATUS" ;;
+	esac
+	SIG=$(od -An -tx1 -N8 "$CURL_BODY_FILE" | tr -d ' \n')
+	if [ "$SIG" = "89504e470d0a1a0a" ]; then
+		_fail "traversal $target body" "response leaked a PNG from the icon table"
+	fi
+done
+
+# --- 8. Non-safe methods are 405. ---------------------------------
+for method in POST PATCH DELETE; do
+	_curl -X "$method" "$HOST/flags/de.png"
+	_assert_status 405 "$method /flags/de.png → 405"
+done
+
+# --- 9. No auth required. -----------------------------------------
+# Every assertion above ran without a token, so reaching this line at
+# all proves it. Assert explicitly with a deliberately bogus bearer so
+# a future auth gate on the route can't slip through unnoticed.
+_curl -H "Authorization: Bearer not-a-real-token" "$HOST/flags/fr.png"
+_assert_status 200 "GET /flags/fr.png with a bogus bearer is still served"
+
+# --- Summary. -----------------------------------------------------
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -204,6 +204,7 @@ PHASES=(
 	29-bulk-mutations.sh
 	30-shared-verify.sh
 	31-shared-directories.sh
+	32-country-flags.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
## Summary

Implements option **B** from https://github.com/amule-org/amule/issues/687 — the country-flag artwork is served from the icon table already compiled into the binary, so no second copy of the flag set enters the repo, the static tree, or the build.

`country_code` (added core-side in `5b7cdf131`, https://github.com/amule-org/amule/issues/439 / https://github.com/amule-org/amule/issues/440) reaches the Web UI on `/clients`, `/servers` and their SSE diffs, but the flag image had nowhere to come from — which is why https://github.com/amule-org/amule/pull/690 could only paint the bare two-letter code. This is the missing half. It is backend-only and changes nothing in `src/webapi/static/`: whether and how the flags get drawn stays a frontend decision.

**How it works.** `src/icons/embed_icons.py` already turns every `flags/<code>.png` into a byte array under the art id `flag_<cc>`, exposed through the plain-C `amule_find_icon()`. That TU was linked only into `muleappgui`; `amuleapi` now links the same `${AMULE_ICON_DATA_C}` (it is pure C byte arrays, so it compiles fine under `wxUSE_GUI=0`) and `GET /flags/{code}.png` returns the bytes straight out of `.rodata`.

Nothing touches the file system, so the route behaves identically in a source-tree dev run, an installed layout, and an API-only deployment with `StaticRoot` unset — and there is no path-traversal surface to guard beyond the code itself.

**Accepted codes.** Two lowercase ASCII letters, or the literal `unknown` — the "??" placeholder `CCountryFlags::GetFlag()` falls back to for an empty or unrecognised code, offered here so a frontend can match what the desktop list draws instead of inventing its own. Everything else is a `404`, including a well-formed code the famfamfam set has no artwork for (it covers 248 of the ~300 assignable alpha-2 codes, so a resolvable country can legitimately have no flag). The art id is built by concatenating `"flag_"` with the code, so that whitelist — not the upstream `LooksMalicious` gate — is what keeps a crafted code from naming a non-flag entry in the shared icon table.

**Caching.** `ETag`, `If-None-Match` → `304` and `HEAD` body-stripping come for free from the existing response post-processing. The handler only adds `Cache-Control: public, max-age=86400`, so a peer list full of `<img>` tags does not issue one conditional request per country on every reload; a day also bounds how long an upgraded daemon keeps serving the old artwork.

**One adjacent fix.** Responses whose media type is already entropy-coded (PNG, JPEG, GIF, WebP, woff/woff2, zip, gzip) now skip the gzip encoder. Deflate over a PNG buys nothing and routinely grows the body — before this the 700-900 byte flags cleared the 256-byte compression threshold and got encoded for no gain. The only other responses in that set today are images out of the static tree.

**Cost.** ~320 KB of read-only data in the `amuleapi` binary (308 KB `__TEXT,__const` + a 12 KB pointer table), which is the whole icon table even though only the flags are ever requested. Trimming it to flags-only would need a second `embed_icons.py` invocation and its own generated TU with duplicate symbol names; the unused entries are pages that never fault in, so a parallel asset pipeline did not seem worth ~110 KB. Easy to add later if the size matters more than the simplicity.

The endpoint is documented under a new **Assets** section in `docs/api/REFERENCE.md`, and the `country_code` prose on both `/clients` and `/servers` now points at it.

## Test plan

Built and verified on macOS (ARM64, clang, Boost 1.90, wx 3.3).

**New regtest** — `unittests/curl-tests/amuleapi/32-country-flags.sh`, registered in `run-all.sh`, **29/29 passing**. Covers: `200` + `Content-Type: image/png`, the PNG signature and a plausible body size, `ETag` + `Cache-Control`, `If-None-Match` → `304` with no body, `HEAD` with no body, the no-gzip guarantee under `Accept-Encoding: gzip`, the `unknown` placeholder, `404` for uppercase / one-letter / three-letter / wrong-extension / no-extension / empty / digit-bearing codes and for a well-formed code with no artwork, `400`-or-`404` on three traversal shapes with an explicit check that no PNG leaks, `405` on POST/PATCH/DELETE, and that a bogus bearer is still served (no auth required).

**Exhaustive artwork check** — every one of the 249 files under `src/icons/flags/` fetched over the route and byte-compared against the source file: 249 identical, 0 mismatched, 0 non-200.

**No regression from the gzip guard** — `27-static-frontend` 12/12, `25-cors` 21/21, `20-etag-conditional-get` 30/30, `01-version-and-errors` 19/19.

**Build and unit tests** — full CI-aligned configure (`BUILD_MONOLITHIC` + `DAEMON` + `REMOTEGUI` + `AMULECMD` + `WEBSERVER` + `TESTING` + `AMULEAPI`) builds with 0 errors, confirming `muleappgui` and `amuleapi` can both consume the shared generated `icon_data.c`. An `amuleapi`-only configure (`-DBUILD_MONOLITHIC=NO`) also builds, which is the case where nothing else pulls the icon table in. `ctest` 28/28.

**Lint gates** — `git clang-format origin/master` clean (clang-format 18, matching CI), and diff-scoped clang-tidy clean against both `.clang-tidy-new-code` and `.clang-tidy`, each verified to report 0 compiler errors so no check was silently skipped on a truncated AST.

Not covered locally: the curl phases that need a network-connected amuled (server connect, `networks/connect`, Kad bootstrap, global search and the SSE search-progress frames) were run against a deliberately offline daemon and fail there for that reason. None of them exercise code this PR touches.
