### PR TITLE
feat(amuleapi): server priority/static PATCH and Kad node-list update endpoints (#692, #693)

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -62,6 +62,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`POST /api/v0/servers`](#post-apiv0servers) — add server
 - [`POST /api/v0/servers/{ecid}/connect`](#post-apiv0serversecidconnect--post-apiv0serversipportconnect) — connect to specific server (ECID or `ip:port`)
 - [`DELETE /api/v0/servers/{ecid}`](#delete-apiv0serversecid--delete-apiv0serversipport) — remove server (ECID or `ip:port`)
+- [`PATCH /api/v0/servers/{ecid}`](#patch-apiv0serversecid--patch-apiv0serversipport) — set server priority / static flag (ECID or `ip:port`)
 - [`POST /api/v0/servers/update`](#post-apiv0serversupdate) — refresh from `server.met` URL
 
 **Categories**
@@ -1436,6 +1437,31 @@ Removes the server from amuled's list.
 **Response:** `200 OK` → `{ "ok": true, "ecid": 1 }`.
 
 **Errors:** `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
+
+#### `PATCH /api/v0/servers/{ecid}` / `PATCH /api/v0/servers/{ip}:{port}`
+
+**Auth:** `ADMIN`
+
+Sets an ed2k server's priority, its static flag, or both — the same operation the desktop server list offers from its context menu.
+
+**Body:** both fields are optional, and only the ones present are applied; a body with neither is a `400`.
+
+```json
+{ "priority": "high", "static": true }
+```
+
+`priority` is one of `"low"` / `"normal"` / `"high"` — the same values `GET /servers` reports. `static` marks the server as one amuled keeps across list updates.
+
+```sh
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"priority":"high","static":true}' \
+  "http://$HOST/api/v0/servers/1"
+```
+
+**Response:** `200 OK` → `{ "ok": true, "ecid": 1 }`.
+
+**Errors:** `400 bad_request` (unknown `priority`, non-bool `static`, or neither field present), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
 
 #### `POST /api/v0/servers/update`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -79,6 +79,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`POST /api/v0/networks/connect`](#post-apiv0networksconnect) — connect ed2k / kad / both
 - [`POST /api/v0/networks/disconnect`](#post-apiv0networksdisconnect) — disconnect ed2k / kad / both
 - [`POST /api/v0/kad/bootstrap`](#post-apiv0kadbootstrap) — single-contact Kad bootstrap
+- [`POST /api/v0/kad/update`](#post-apiv0kadupdate) — refresh the Kad node list from a `nodes.dat` URL
 - [`GET /api/v0/kad`](#get-apiv0kad) — Kad-only status subtree
 
 **Logs**
@@ -1744,6 +1745,31 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 **Response:** `202 Accepted` → `{ "ok": true, "ip": <uint32>, "port": <uint16> }`. The Kad probe itself is fire-and-forget UDP; the `202` confirms amuled accepted the request, not that the contact was reachable.
 
 **Errors:** `400 bad_request` (missing/non-string-or-number `ip`, missing/non-numeric `port`, port outside `[0, 65535]`, malformed dotted-quad), `400 amuled_rejected`, `503 ec_unavailable`.
+
+#### `POST /api/v0/kad/update`
+
+**Auth:** `ADMIN`
+
+Downloads a `nodes.dat` from the supplied URL and rebuilds the Kad node list from it — the Kad counterpart of [`POST /api/v0/servers/update`](#post-apiv0serversupdate), and the same operation the desktop GUI's "Update node list from URL" button drives.
+
+**Body:**
+
+```json
+{ "nodes_url": "https://upd.emule-security.org/nodes.dat" }
+```
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"nodes_url":"https://upd.emule-security.org/nodes.dat"}' \
+  "http://$HOST/api/v0/kad/update"
+```
+
+Two side effects are worth planning for. The URL is **persisted** into the `kademlia.update_url` preference, so a subsequent `GET /preferences` reflects it — there is no need to PATCH it separately. And once the download completes, amuled **stops Kad, swaps in the new `nodes.dat`, and starts Kad again**; expect a brief Kad outage and a `kad_state` transition on the SSE stream. The desktop GUI prompts before doing this; the API does not.
+
+**Response:** `202 Accepted` → `{ "ok": true, "nodes_url": "..." }`. The download is asynchronous, so the `202` confirms amuled accepted the request, not that the node list was replaced.
+
+**Errors:** `400 bad_request` (missing/non-string/empty `nodes_url`, or a scheme other than `http://` / `https://`), `400 amuled_rejected`, `503 ec_unavailable`.
 
 #### `GET /api/v0/kad`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -928,6 +928,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// favour of /networks/{connect,disconnect} with `{"network":"kad"}`
 	// — the two were strict aliases and the granular-selector form on
 	// /networks/* makes the dedicated shortcut redundant.
+	if (path == "/api/v0/kad/update") {
+		if (req.method != "POST") {
+			return ErrorResponse(405, "method_not_allowed", "only POST on /kad/update");
+		}
+		return HandleKadUpdateFromUrl(req);
+	}
+
 	if (path == "/api/v0/kad/bootstrap") {
 		if (req.method != "POST") {
 			return ErrorResponse(405, "method_not_allowed", "only POST on /kad/bootstrap");
@@ -6236,6 +6243,73 @@ CHttpServer::Response CApiDispatcher::HandleNetworksDisconnect(const CHttpServer
 // `{"network":"kad"}`. The Kad bootstrap handler below is genuinely
 // distinct (single-contact bootstrap from an explicit IP+port) and
 // stays.
+
+// POST /kad/update — refresh the Kad node list from a nodes.dat URL (#693).
+//
+// Strict mirror of HandleServerUpdateFromUrl: same validation, same 202. The
+// EC handler (EC_OP_KAD_UPDATE_FROM_URL) persists the URL into preferences
+// itself via SetKadNodesUrl(), so this deliberately does NOT also patch
+// kademlia.update_url — doing both would diverge from the ed2k path and could
+// race it.
+//
+// Side effect worth knowing: once the download completes amuled stops Kad,
+// swaps nodes.dat in, and starts Kad again. The desktop GUI warns before
+// firing this; API callers get the same behaviour without the prompt.
+CHttpServer::Response CApiDispatcher::HandleKadUpdateFromUrl(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+	const auto it = obj.find("nodes_url");
+	if (it == obj.end() || !it->second.is<std::string>()) {
+		return ErrorResponse(400, "bad_request", "required string field `nodes_url` is missing");
+	}
+	const std::string &url = it->second.get<std::string>();
+	if (url.empty()) {
+		return ErrorResponse(400, "bad_request", "`nodes_url` must not be empty");
+	}
+	// Same scheme gate as the ed2k path: amuled hands the string to
+	// libcurl, so anything that is not http(s) is rejected here rather
+	// than failing asynchronously with no way to report it back.
+	if (url.compare(0, 7, "http://") != 0 && url.compare(0, 8, "https://") != 0) {
+		return ErrorResponse(400, "bad_request", "`nodes_url` must be an http:// or https:// URL");
+	}
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_KAD_UPDATE_FROM_URL));
+	ec_req->AddTag(CECTag(EC_TAG_KADEMLIA_UPDATE_URL, wxString::FromUTF8(url.c_str())));
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for KAD_UPDATE_FROM_URL");
+	}
+	std::string ec_err;
+	if (IsEcFailedResponse(ec_resp, ec_err)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err.c_str());
+	}
+	delete ec_resp;
+
+	CHttpServer::Response r;
+	r.status = 202;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.Key("nodes_url");
+	w.ValueString(wxString::FromUTF8(url.c_str()));
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
 
 CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Request &req)
 {

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -888,11 +888,16 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return HandleServerConnect(req, caps["ecid"]);
 		}
 		if (web_api_path::Match(server_one, path_segs, caps)) {
-			if (req.method != "DELETE") {
+			if (req.method != "DELETE" && req.method != "PATCH") {
 				return ErrorResponse(
-					405, "method_not_allowed", "only DELETE on /servers/{ecid}");
+					405, "method_not_allowed", "only DELETE / PATCH on /servers/{ecid}");
 			}
-			if (caps["ecid"].find(':') != std::string::npos) {
+			const bool by_address = caps["ecid"].find(':') != std::string::npos;
+			if (req.method == "PATCH") {
+				return by_address ? HandleServerPatchByAddress(req, caps["ecid"])
+						  : HandleServerPatch(req, caps["ecid"]);
+			}
+			if (by_address) {
 				return HandleServerDeleteByAddress(req, caps["ecid"]);
 			}
 			return HandleServerDelete(req, caps["ecid"]);
@@ -4575,6 +4580,135 @@ CHttpServer::Response CApiDispatcher::HandleServerConnectByAddress(
 	std::ostringstream os;
 	os << ecid;
 	return HandleServerConnect(req, os.str());
+}
+
+// PATCH /servers/{ecid} — priority and/or static flag (#692).
+//
+// EC_OP_SERVER_SET_STATIC_PRIO carries EC_TAG_SERVER as a plain ECID integer,
+// unlike EC_OP_SERVER_REMOVE next door which carries an EC_IPv4_t. It also
+// applies each of EC_TAG_SERVER_PRIO / EC_TAG_SERVER_STATIC only when present,
+// so a partial update is native to the wire and this handler simply forwards
+// whichever fields the body carried.
+//
+// amuled answers EC_OP_NOOP whether or not the ECID resolved, so an unknown
+// server is indistinguishable from success at the EC layer — the 404 has to
+// come from checking the snapshot here.
+CHttpServer::Response CApiDispatcher::HandleServerPatch(
+	const CHttpServer::Request &req, const std::string &ecid_str)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	std::uint32_t ecid = 0;
+	if (!ParseEcidPath(ecid_str, ecid)) {
+		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
+	}
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+
+	std::uint32_t prio_code = 0;
+	bool has_prio = false;
+	if (const auto it = obj.find("priority"); it != obj.end()) {
+		if (!it->second.is<std::string>()) {
+			return ErrorResponse(400, "bad_request", "`priority` must be a string");
+		}
+		if (!webapi::ServerPriorityCode(it->second.get<std::string>(), prio_code)) {
+			return ErrorResponse(
+				400, "bad_request", "`priority` must be one of low, normal, high");
+		}
+		has_prio = true;
+	}
+
+	bool is_static = false;
+	bool has_static = false;
+	if (const auto it = obj.find("static"); it != obj.end()) {
+		if (!it->second.is<bool>()) {
+			return ErrorResponse(400, "bad_request", "`static` must be a bool");
+		}
+		is_static = it->second.get<bool>();
+		has_static = true;
+	}
+
+	if (!has_prio && !has_static) {
+		return ErrorResponse(
+			400, "bad_request", "body must include at least one of `priority`, `static`");
+	}
+
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+	webapi::ServerSnapshot srv;
+	if (!FindServerByEcid(m_state, ecid, srv)) {
+		return ErrorResponse(404, "not_found", "no server with that ECID in the current snapshot");
+	}
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SERVER_SET_STATIC_PRIO));
+	ec_req->AddTag(CECTag(EC_TAG_SERVER, ecid));
+	if (has_prio) {
+		ec_req->AddTag(CECTag(EC_TAG_SERVER_PRIO, static_cast<std::uint8_t>(prio_code)));
+	}
+	if (has_static) {
+		ec_req->AddTag(CECTag(EC_TAG_SERVER_STATIC, static_cast<std::uint8_t>(is_static ? 1 : 0)));
+	}
+
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for SERVER_SET_STATIC_PRIO");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	// Inline refresh so the next GET /servers and the SSE stream both show
+	// the new values, matching the sibling server mutations.
+	(void)RefresherTick(m_app, m_state);
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.Key("ecid");
+	w.ValueInt(static_cast<int64_t>(ecid));
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+// Address-keyed alias for the above, mirroring the connect / delete pair.
+CHttpServer::Response CApiDispatcher::HandleServerPatchByAddress(
+	const CHttpServer::Request &req, const std::string &ip_port)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+	const std::uint32_t ecid = ResolveServerEcidByAddress(m_state, ip_port);
+	if (ecid == 0) {
+		return ErrorResponse(404, "not_found", "no server matches that ip:port");
+	}
+	std::ostringstream os;
+	os << ecid;
+	return HandleServerPatch(req, os.str());
 }
 
 CHttpServer::Response CApiDispatcher::HandleServerDeleteByAddress(

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -168,6 +168,7 @@ private:
 	CHttpServer::Response HandleNetworksConnect(const CHttpServer::Request &);
 	CHttpServer::Response HandleNetworksDisconnect(const CHttpServer::Request &);
 	CHttpServer::Response HandleKadBootstrap(const CHttpServer::Request &);
+	CHttpServer::Response HandleKadUpdateFromUrl(const CHttpServer::Request &);
 	// single shared-file detail (GET / HEAD). `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleSharedDetail(const CHttpServer::Request &, const std::string &key);
 	// shared file priority PATCH. `key` = hash OR ECID.

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -147,6 +147,7 @@ private:
 	CHttpServer::Response HandleServerAdd(const CHttpServer::Request &);
 	CHttpServer::Response HandleServerConnect(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleServerDelete(const CHttpServer::Request &, const std::string &ecid_str);
+	CHttpServer::Response HandleServerPatch(const CHttpServer::Request &, const std::string &ecid_str);
 	// Refresh the server list from a `server.met` URL — operator-
 	// curated server-list update, same EC op the desktop GUI's "Update
 	// from URL" button uses.
@@ -156,6 +157,8 @@ private:
 	// clients work without first having to GET /servers to learn the
 	// ECID for a known address.
 	CHttpServer::Response HandleServerConnectByAddress(
+		const CHttpServer::Request &, const std::string &ip_port);
+	CHttpServer::Response HandleServerPatchByAddress(
 		const CHttpServer::Request &, const std::string &ip_port);
 	CHttpServer::Response HandleServerDeleteByAddress(
 		const CHttpServer::Request &, const std::string &ip_port);

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1431,15 +1431,14 @@ void ParseAmuleLogFromPacket(const CECPacket *resp, std::vector<std::string> &ou
 
 // --- /servers (rides on GET_UPDATE response) ---------------------------
 
-namespace
-{
-
+// SRV_PR_* constants live in `Server.h`. Note the values aren't monotone with
+// priority (NORMAL=0, HIGH=1, LOW=2) — using the named macros instead of
+// literal 0/1/2 saves anyone reading this from re-checking Server.h to
+// remember the order. The two directions are kept adjacent, and covered by a
+// round-trip test, because that non-monotone order is exactly the kind of
+// thing a second implementation elsewhere would get wrong.
 const char *ServerPriorityName(std::uint32_t prio_code)
 {
-	// SRV_PR_* constants live in `Server.h`. Note the values aren't
-	// monotone with priority (NORMAL=0, HIGH=1, LOW=2) — using the
-	// named macros instead of literal 0/1/2 saves anyone reading
-	// this from re-checking Server.h to remember the order.
 	switch (prio_code) {
 	case SRV_PR_NORMAL:
 		return "normal";
@@ -1451,6 +1450,23 @@ const char *ServerPriorityName(std::uint32_t prio_code)
 		return "normal";
 	}
 }
+
+bool ServerPriorityCode(const std::string &name, std::uint32_t &out_code)
+{
+	if (name == "normal") {
+		out_code = SRV_PR_NORMAL;
+	} else if (name == "high") {
+		out_code = SRV_PR_HIGH;
+	} else if (name == "low") {
+		out_code = SRV_PR_LOW;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+namespace
+{
 
 // Build (or merge into) a ServerSnapshot from one per-server tag.
 // Identity-only tags (name/description/version/IPv4) are subject to

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -150,6 +150,13 @@ void ApplyGetUpdateToShared(const CECPacket *resp, FileMap &cache);
 
 void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, ServerSnapshot> &cache);
 
+// ed2k server priority, both directions. The SRV_PR_* wire values are not
+// monotone (NORMAL=0, HIGH=1, LOW=2), so callers must never assume a name's
+// position in a list is its code. ServerPriorityCode returns false for an
+// unknown name, leaving out_code untouched.
+const char *ServerPriorityName(std::uint32_t prio_code);
+bool ServerPriorityCode(const std::string &name, std::uint32_t &out_code);
+
 // /stats/tree (EC_OP_GET_STATSTREE response). Recursive walk —
 // every EC_TAG_STATTREE_NODE that contains children becomes a
 // branch; leaves get `children.empty()`. The top-level `root` is

--- a/unittests/curl-tests/amuleapi/14-servers-mutations.sh
+++ b/unittests/curl-tests/amuleapi/14-servers-mutations.sh
@@ -5,6 +5,7 @@
 # Endpoints:
 #   POST   /api/v0/servers                   — add by {address, name?}
 #   POST   /api/v0/servers/{ecid}/connect    — connect to one server
+#   PATCH  /api/v0/servers/{ecid}            — set priority / static flag
 #   DELETE /api/v0/servers/{ecid}            — remove from the list
 #
 # All keyed by ECID on the URL — the EC ops (CONNECT/REMOVE) actually
@@ -229,6 +230,85 @@ _assert_status 400 "POST /servers/not-a-number/connect → 400"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/servers/4294967295/connect"
 _assert_status 404 "POST /servers/{unknown ecid}/connect → 404"
+
+# --- 5b. PATCH /servers/{ecid} — priority + static (#692). ---------
+# The SRV_PR_* wire values are not monotone (NORMAL=0, HIGH=1, LOW=2),
+# so round-tripping every name through the API is what actually proves
+# the reverse mapping, not just that a 200 came back.
+for PRIO in high low normal; do
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"priority\":\"$PRIO\"}" "$HOST/api/v0/servers/$ECID"
+	_assert_status 200 "PATCH /servers/{ecid} priority=$PRIO → 200"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/servers"
+	GOT=$(printf '%s' "$CURL_BODY" | jq -r --argjson e "$ECID" \
+		'.servers[] | select(.ecid == $e) | .priority')
+	if [ "$GOT" = "$PRIO" ]; then
+		_pass "priority=$PRIO round-trips through GET /servers"
+	else
+		_fail "priority round-trip" "set $PRIO, GET returned $GOT"
+	fi
+done
+
+# static flag, both directions.
+for FLAG in true false; do
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"static\":$FLAG}" "$HOST/api/v0/servers/$ECID"
+	_assert_status 200 "PATCH /servers/{ecid} static=$FLAG → 200"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/servers"
+	GOT=$(printf '%s' "$CURL_BODY" | jq -r --argjson e "$ECID" \
+		'.servers[] | select(.ecid == $e) | .static')
+	if [ "$GOT" = "$FLAG" ]; then
+		_pass "static=$FLAG round-trips through GET /servers"
+	else
+		_fail "static round-trip" "set $FLAG, GET returned $GOT"
+	fi
+done
+
+# Both fields in one body.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"priority":"high","static":true}' "$HOST/api/v0/servers/$ECID"
+_assert_status 200 "PATCH /servers/{ecid} priority+static together → 200"
+_assert_json_eq '.ok' true 'PATCH response carries ok:true'
+_assert_json_eq '.ecid' "$ECID" 'PATCH response echoes the ecid'
+
+# --- 5c. PATCH error paths. ----------------------------------------
+_curl -X PATCH -H "Content-Type: application/json" \
+	-d '{"priority":"high"}' "$HOST/api/v0/servers/$ECID"
+_assert_status 401 "PATCH /servers/{ecid} (no token) → 401"
+
+if [ "$HAVE_GUEST" = "1" ]; then
+	_curl -X PATCH -H "Authorization: Bearer $GUEST_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"priority":"high"}' "$HOST/api/v0/servers/$ECID"
+	_assert_status 403 "PATCH /servers/{ecid} (guest) → 403"
+fi
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" -d '{}' "$HOST/api/v0/servers/$ECID"
+_assert_status 400 "PATCH /servers/{ecid} empty body → 400"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"priority":"urgent"}' "$HOST/api/v0/servers/$ECID"
+_assert_status 400 "PATCH /servers/{ecid} unknown priority → 400"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"static":"yes"}' "$HOST/api/v0/servers/$ECID"
+_assert_status 400 "PATCH /servers/{ecid} non-bool static → 400"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"priority":"high"}' "$HOST/api/v0/servers/not-a-number"
+_assert_status 400 "PATCH /servers/not-a-number → 400"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"priority":"high"}' "$HOST/api/v0/servers/999999"
+_assert_status 404 "PATCH /servers/{unknown ecid} → 404 (EC no-ops silently, #692)"
 
 # --- 6. DELETE /servers/{ecid} happy path + no-stale invariant. ---
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/curl-tests/amuleapi/16-networks-connect.sh
+++ b/unittests/curl-tests/amuleapi/16-networks-connect.sh
@@ -12,6 +12,8 @@
 #   favour of the network-selector form on /networks/*.)
 #   POST /api/v0/kad/bootstrap          — EC_OP_KAD_BOOTSTRAP_FROM_IP
 #       body: {ip: "1.2.3.4" | uint32, port: uint16}
+#   POST /api/v0/kad/update             — EC_OP_KAD_UPDATE_FROM_URL
+#       body: {nodes_url: "https://.../nodes.dat"}
 #
 # amuled's CONNECT/DISCONNECT return EC_OP_STRINGS with status
 # messages — the handler relays those into `response.message`.
@@ -186,6 +188,52 @@ _assert_status 405 "GET /networks/connect → 405"
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/kad/bootstrap"
 _assert_status 405 "DELETE /kad/bootstrap → 405"
+
+# --- 6. kad/update validation + auth (#693). ----------------------
+#
+# Deliberately NO happy-path call here. A successful POST makes amuled
+# download a nodes.dat and then STOP AND RESTART Kad, which would tear
+# down the connection state every later phase depends on and leave the
+# operator's node re-bootstrapping. The 202 path is exercised by hand
+# instead; what is pinned here is everything that must be rejected
+# before any of that can happen.
+_curl -X POST -H "Content-Type: application/json" \
+	-d '{"nodes_url":"https://example.com/nodes.dat"}' "$HOST/api/v0/kad/update"
+_assert_status 401 "POST /kad/update (no token) → 401"
+
+if [ "$HAVE_GUEST" = "1" ]; then
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"nodes_url":"https://example.com/nodes.dat"}' "$HOST/api/v0/kad/update"
+	_assert_status 403 "POST /kad/update (guest) → 403"
+fi
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" -d '{}' "$HOST/api/v0/kad/update"
+_assert_status 400 "POST /kad/update missing nodes_url → 400"
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"nodes_url":""}' "$HOST/api/v0/kad/update"
+_assert_status 400 "POST /kad/update empty nodes_url → 400"
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"nodes_url":123}' "$HOST/api/v0/kad/update"
+_assert_status 400 "POST /kad/update non-string nodes_url → 400"
+
+# Scheme gate: amuled hands the string to libcurl, so a non-http(s)
+# scheme has to be rejected here or it fails asynchronously with no
+# way to report back.
+for BAD in "ftp://example.com/nodes.dat" "file:///etc/passwd" "example.com/nodes.dat"; do
+	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"nodes_url\":\"$BAD\"}" "$HOST/api/v0/kad/update"
+	_assert_status 400 "POST /kad/update rejects scheme: $BAD → 400"
+done
+
+_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/kad/update"
+_assert_status 405 "GET /kad/update → 405"
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -27,6 +27,7 @@
 #include <set>
 
 #include "PrefsSchema.h"
+#include "Server.h" // SRV_PR_*
 #include "Refresher.h"
 #include "State.h"
 
@@ -1628,4 +1629,41 @@ TEST(Refresher, PrefsSchemaIrregularitiesStayContained)
 	ASSERT_EQUALS(static_cast<std::size_t>(2), inverted);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), foreign_group);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), bespoke);
+}
+
+// --- #692: ed2k server priority maps both ways -------------------------
+//
+// The SRV_PR_* wire values are not monotone (NORMAL=0, HIGH=1, LOW=2), so a
+// name->code mapping that assumed a name's position in a list was its code --
+// which is exactly what the generic enum helper on the preferences path does
+// -- would be wrong for every value. Pin both directions and the round trip.
+TEST(Refresher, ServerPriorityMapsBothWays)
+{
+	ASSERT_EQUALS(std::string("normal"), std::string(ServerPriorityName(SRV_PR_NORMAL)));
+	ASSERT_EQUALS(std::string("high"), std::string(ServerPriorityName(SRV_PR_HIGH)));
+	ASSERT_EQUALS(std::string("low"), std::string(ServerPriorityName(SRV_PR_LOW)));
+
+	std::uint32_t code = 0xFFFFFFFFu;
+	ASSERT_TRUE(ServerPriorityCode("normal", code));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_PR_NORMAL), code);
+	ASSERT_TRUE(ServerPriorityCode("high", code));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_PR_HIGH), code);
+	ASSERT_TRUE(ServerPriorityCode("low", code));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_PR_LOW), code);
+
+	// name -> code -> name is the identity for every accepted name.
+	for (const char *name : { "low", "normal", "high" }) {
+		std::uint32_t c = 0;
+		ASSERT_TRUE(ServerPriorityCode(name, c));
+		ASSERT_EQUALS(std::string(name), std::string(ServerPriorityName(c)));
+	}
+
+	// An unknown name is rejected and leaves the out-param untouched, so a
+	// caller that ignores the return value cannot silently write a priority.
+	std::uint32_t untouched = 4242;
+	ASSERT_TRUE(!ServerPriorityCode("urgent", untouched));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(4242), untouched);
+	ASSERT_TRUE(!ServerPriorityCode("", untouched));
+	ASSERT_TRUE(!ServerPriorityCode("HIGH", untouched)); // case-sensitive by design
+	ASSERT_EQUALS(static_cast<std::uint32_t>(4242), untouched);
 }


### PR DESCRIPTION
Closes [#692](https://github.com/amule-org/amule/issues/692). Closes [#693](https://github.com/amule-org/amule/issues/693).

Two endpoints amuleapi was missing, both wrapping EC operations that already exist — no core changes. Web UI for either is out of scope here; ngosang is doing that separately once this lands.

## `PATCH /api/v0/servers/{ecid}` — priority and static flag

Priority and the static flag were readable through `GET /servers` but not settable, though the desktop server list has offered both from its context menu all along. The new endpoint takes either or both fields, applies only what the body carried, and rejects a body with neither. The `{ip}:{port}` alias works as it does for `connect` and `DELETE`.

Two properties of `EC_OP_SERVER_SET_STATIC_PRIO` are worth knowing, because both differ from the sibling handler this would naturally be copied from:

- It identifies the server by a **plain ECID integer** in `EC_TAG_SERVER`, whereas `EC_OP_SERVER_REMOVE` next door passes an `EC_IPv4_t`. Copying that line yields a well-formed packet the daemon reads as the wrong server.
- It answers `EC_OP_NOOP` **whether or not the ECID resolved**, so an unknown server is indistinguishable from success on the wire. The `404` therefore comes from checking the snapshot before sending, not from the EC response — a handler that trusted the reply would return `200` for a server that does not exist.

Priority needs a name→code mapping, and the `SRV_PR_*` values are not monotone: `NORMAL=0`, `HIGH=1`, `LOW=2`. The generic enum helper on the preferences path encodes a name's *index*, which would map every value wrongly here, so this adds `ServerPriorityCode()` alongside the existing `ServerPriorityName()`. Both directions now live in one place and are covered by a round-trip test. An unknown name is rejected without touching the out-param, so a caller that ignores the return value cannot silently write a priority.

## `POST /api/v0/kad/update` — refresh the node list from a URL

The Kad counterpart of `POST /servers/update`, and the same operation the desktop's "Update node list from URL" button drives. Kad could previously only be bootstrapped from a single contact; the nodes URL was reachable only as the `kademlia.update_url` preference, where writing it stored a string without fetching anything.

A strict mirror of `HandleServerUpdateFromUrl`: non-empty string required, `http://` or `https://` only, `202 Accepted`. The scheme gate matters because amuled hands the string straight to libcurl, so anything else fails asynchronously with no way to report back.

The handler deliberately does **not** touch preferences. `EC_OP_KAD_UPDATE_FROM_URL` persists the URL itself via `SetKadNodesUrl()` before starting the download, so patching `kademlia.update_url` here as well would diverge from the ed2k path and race the EC handler for the same field.

Both side effects are documented, since neither is visible from the request: the URL is persisted, and on download completion amuled stops Kad, swaps in the new `nodes.dat` and starts Kad again. The desktop prompts before that; API callers do not, so a brief Kad outage and a `kad_state` transition on the SSE stream are expected.

## Verification

Exercised live against a throwaway daemon. All three priorities round-trip through `GET /servers` — which is what actually proves the reverse mapping, since an index-based encoding would have returned `normal` for `low`:

| Set | HTTP | `GET /servers` reports |
| --- | --- | --- |
| `high` / `low` / `normal` | 200 | `high` / `low` / `normal` |
| `static: true` / `false` | 200 | `true` / `false` |
| both fields together | 200 | `{ok:true, ecid}` |

Error paths return 400/404/405 as documented, the `ip:port` alias resolves, and an unknown alias gives 404. For `/kad/update`, every rejected body shape and all three bad schemes return 400, and the `202` path was confirmed by hand: posting a fresh URL left `kademlia.update_url` updated on the next `GET /preferences` without the handler ever patching it.

`ctest` 28/28 including the new priority round-trip test. 27 new curl assertions across phases 14 and 16, all passing. clang-format 18 and both clang-tidy tiers clean on the diff, with 0 compiler errors so the checks genuinely ran.

The curl phase for `/kad/update` deliberately stops short of the `202`: a success restarts Kad on the operator's node mid-run and would strand every later phase.
