### PR TITLE
fix(build): drop redundant WXDLLEXPORT on wxDropTarget forward decl

### DIFF
--- a/src/extern/wxWidgets/listctrl.h
+++ b/src/extern/wxWidgets/listctrl.h
@@ -20,7 +20,7 @@
 #include <wx/imaglist.h>
 
 #if wxUSE_DRAG_AND_DROP
-class WXDLLEXPORT wxDropTarget;
+class wxDropTarget;
 #endif
 
 // Fix for bug in wx's implementation, which uses longs for item*


### PR DESCRIPTION
## Summary
- Full clean rebuild (no ccache) surfaced exactly one recurring warning across the whole tree: `-Wattributes: type attributes ignored after type is already defined`, coming from `src/extern/wxWidgets/listctrl.h:23`.
- `wxDropTarget` is already forward-declared by wx's own headers before this point, so redeclaring it here with `WXDLLEXPORT` is a no-op that GCC flags.
- Dropped the redundant attribute on the forward declaration; behavior is unchanged since the pointer-only usages later in the file don't need the full definition.

Fixes #701

## Test plan
- [x] `cmake --build build -j"$(nproc)"` — clean build, 0 warnings
- [x] `ctest` — 28/28 tests passed