### PR TITLE
fix(gui): give the log panes a text margin so text isn't flush to the frame

### DIFF
--- a/src/MuleLogCtrl.cpp
+++ b/src/MuleLogCtrl.cpp
@@ -67,6 +67,28 @@ CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
 	for (int margin = 0; margin < 3; ++margin) {
 		SetMarginWidth(margin, 0);
 	}
+	// Zeroing the numbered margins above also removes the only inset Scintilla
+	// had, so text rendered hard against the control's frame -- most visible
+	// where the theme draws a tight, high-contrast border (issue #702). These
+	// are the text-area margins, a separate concept from the numbered margins,
+	// so they restore the padding without bringing the code-editor gutters
+	// back. Scintilla draws its own text area, so this is not theme- or
+	// platform-specific; DIP-scaled so the gap keeps its size on HiDPI.
+	// Scintilla's own default here is 1px (ViewStyle::Init), which is what
+	// made the text look flush -- so this has to be visibly larger than the
+	// default to be worth anything, not a nudge above it.
+	const int textMargin = FromDIP(5);
+	SetMarginLeft(textMargin);
+	SetMarginRight(textMargin);
+
+	// Scintilla has no vertical counterpart to the text-area margins, so the
+	// first line otherwise sits directly on the frame. extraAscent feeds
+	// lineHeight (ViewStyle::Refresh: maxAscent += extraAscent), so this is
+	// line spacing rather than a one-off top gap -- which is what we want
+	// here: the log tails to the bottom, so a fixed band at the viewport top
+	// would only show above a partially scrolled line.
+	SetExtraAscent(FromDIP(2));
+
 	// Word-wrap long lines, as the old wxTE_RICH2 pane did, so nothing is clipped
 	// off the right edge; with wrapping on there is no horizontal scrollbar to
 	// show. (Wrapping is why AtBottom() and the tail-scroll reason in display


### PR DESCRIPTION
## Summary

Addresses #702. The log and Server Info panes render their text hard against the control's frame, with no padding at all — most obvious on themes that draw a tight, high-contrast border, which is how it was reported on Debian/MATE.

## Root cause

Not a theme issue, and not Linux-specific. `CMuleLogCtrl` is a `wxStyledTextCtrl`, and its constructor zeroes Scintilla's three numbered margins so the pane reads as a plain log rather than a code editor:

```cpp
for (int margin = 0; margin < 3; ++margin) {
    SetMarginWidth(margin, 0);
}
```

Those gutters were the only inset the control had, so removing them left the text starting at x=0. Scintilla draws its own text area, so this happens identically on every platform — it just reads as fine on Adwaita, macOS and Windows, where the frame is softer or slightly inset, and jumps out on a tighter border.

## Fix

**Horizontally**, set the text-area margins, which are a distinct concept from the numbered margins, so the code-editor gutters stay gone:

```cpp
const int textMargin = FromDIP(5);
SetMarginLeft(textMargin);
SetMarginRight(textMargin);
```

Scintilla's own default here is 1px (`ViewStyle::Init`), which is what made the text look flush — so the value has to be visibly above the default rather than a nudge past it.

**Vertically**, Scintilla has no counterpart to those margins, so the first line otherwise sits directly on the frame. `extraAscent` is the only vertical knob, and it feeds `lineHeight` (`ViewStyle::Refresh`: `maxAscent += extraAscent`), so it is line spacing rather than a one-off top gap:

```cpp
SetExtraAscent(FromDIP(2));
```

That is the better fit here rather than a limitation worked around: the log tails to the bottom, so a fixed band at the viewport top would only ever appear above a partially scrolled line, whereas uniform spacing reads correctly both when the content scrolls and when it is short enough not to.

Both values are DIP-scaled so the gaps hold their size on HiDPI.

## Tail-scroll is unaffected

Worth stating explicitly, since `extraAscent` changes `lineHeight`: the auto-scroll path reasons in display lines and never in pixels. `AtBottom()` compares `GetFirstVisibleLine() + LinesOnScreen()` against the display-line count, and `OnInternalIdle()` only compares `GetFirstVisibleLine()` values. Scintilla derives `LinesOnScreen()` from the same `lineHeight` it lays out with, so both sides of the comparison move together, and the existing `- 1` slack in `AtBottom()` already absorbs partial-row rounding. The batch replay path (`m_batchTailing`) inherits the same reasoning.

## Scope

Covers all three `CMuleLogCtrl` panes: aMule Log, Server Info, and amulegui's aMuleGUI Log.

The **ED2K Info** and **Kad Info** panes in the same notebook are native two-column `wxListCtrl`s, not Scintilla, so they're untouched by this. Their cell padding comes from the platform theme and `wxListCtrl` offers no portable equivalent, so if they need the same treatment it's a separate change — either a GTK-only style tweak or converting those panes to `CMuleLogCtrl` like the other two already are. Deliberately not using a closing keyword for #702 so the issue stays open pending @mifritscher2's word on whether the Info lists still look wrong.

## Testing

Built monolithic clean on macOS ARM64 and Ubuntu ARM64 (wxGTK3), and checked visually on both. `git clang-format origin/master` reports no deviation, and the diff-scoped Tier-2 clang-tidy run is clean with zero compiler errors. The previous horizontal-only revision passed all 14 CI checks.
