### PR TITLE
fix(gui): stop Reset Fields wiping the search history, gate the history UI

### DIFF
--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -66,6 +66,7 @@
 #include "CamuleArtProvider.h" // CamuleArtProvider::MakeId for the page-icon bundles
 #include "MuleColour.h"
 #include "EditServerListDlg.h"
+#include "SearchDlg.h"      // Needed for CSearchDlg::ApplySearchHistoryPref
 #include "SharedFileList.h" // Needed for CSharedFileList
 #include "StatisticsDlg.h"  // Needed for graph parameters, colors
 #include "IPFilter.h"       // Needed for CIPFilter
@@ -1397,6 +1398,14 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 
 	if (CfgChanged(IDC_EXTCATINFO)) {
 		theApp->amuledlg->m_transferwnd->UpdateCatTabTitles();
+	}
+
+	// Applied live rather than listed as restart-needed: the search panel swaps
+	// the Name field between a history dropdown and a plain text field, hides
+	// or shows its Clear button, and (re)loads the stored terms -- all of which
+	// it can do in place (issue #697).
+	if (CfgChanged(IDC_SEARCHHISTORYENABLED) && theApp->amuledlg->m_searchwnd != nullptr) {
+		theApp->amuledlg->m_searchwnd->ApplySearchHistoryPref();
 	}
 
 	// Changes related to the statistics-dlg

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -136,11 +136,125 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	s_search_sizer->Show(s_extended_sizer, false);
 	s_search_sizer->Show(s_filter_sizer, false);
 
-	LoadSearchHistory();
-	CastChild(IDC_SEARCHNAME, wxComboBox)
-		->Bind(wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
+	// Clear-history button, sitting between the search-type choice and the
+	// Extended Parameters checkbox. Two reasons it is built here instead of in
+	// muuli_wdr: the right-click route it backs up is unreachable on wxMSW
+	// (the native combobox's child EDIT window never forwards WM_CONTEXTMENU
+	// to wx -- ShouldForwardFromEditToCombo in src/msw/combobox.cpp forwards
+	// only key, focus and clipboard messages), and keeping the existing
+	// _("Clear search history") msgid in this file preserves its position in
+	// the catalogs, whereas adding the same string to muuli_wdr.cpp would move
+	// the pot entry (xgettext orders entries by file scan order) and trip the
+	// pot-sync gate for no benefit. Bound directly on the instance, so no new
+	// window id is needed. (issue #697)
+	if (wxWindow *typeChoice = FindWindow(ID_SEARCHTYPE)) {
+		if (wxSizer *row = typeChoice->GetContainingSizer()) {
+			size_t at = row->GetItemCount();
+			size_t index = 0;
+			for (const wxSizerItem *item : row->GetChildren()) {
+				if (item->GetWindow() == typeChoice) {
+					at = index + 1;
+					break;
+				}
+				++index;
+			}
+			m_clearHistoryBtn = new wxButton(this, wxID_ANY, _("Clear search history"));
+			row->Insert(at, m_clearHistoryBtn, wxSizerFlags().Center().Border(wxALL, 5));
+			m_clearHistoryBtn->Bind(wxEVT_BUTTON, &CSearchDlg::OnBnClickedClearHistory, this);
+		}
+	}
+
+	ApplySearchHistoryPref();
 
 	Layout();
+}
+
+void CSearchDlg::ApplySearchHistoryPref()
+{
+	const bool wantHistory = CPreferences::RememberSearchHistory();
+
+	RebuildSearchNameField(wantHistory);
+
+	if (m_clearHistoryBtn) {
+		m_clearHistoryBtn->Show(wantHistory);
+	}
+
+	// Only populate when the preference allows it. searchhistory.dat is left
+	// untouched either way, so turning the preference back on restores the
+	// previous terms instead of starting from an empty list.
+	if (wantHistory) {
+		LoadSearchHistory();
+	}
+
+	Layout();
+}
+
+wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
+{
+	wxWindow *current = FindWindow(IDC_SEARCHNAME);
+	if (current == nullptr) {
+		return nullptr;
+	}
+
+	// wxComboBox is not a wxTextCtrl (it is wxWindowWithItems<wxControl,
+	// wxComboBoxBase>), so which one is in place decides whether a dropdown
+	// and its history exist at all.
+	const bool haveCombo = (dynamic_cast<wxComboBox *>(current) != nullptr);
+	if (haveCombo == wantHistory) {
+		return dynamic_cast<wxTextEntry *>(current);
+	}
+
+	wxSizer *slot = current->GetContainingSizer();
+	if (slot == nullptr) {
+		return dynamic_cast<wxTextEntry *>(current);
+	}
+
+	// Carry the typed value across; the swap is a UI change, not a reason to
+	// lose what the user was in the middle of typing.
+	const wxString typed = dynamic_cast<wxTextEntry *>(current)->GetValue();
+
+	wxWindow *replacement = nullptr;
+	if (wantHistory) {
+		wxComboBox *combo = new wxComboBox(this,
+			IDC_SEARCHNAME,
+			wxEmptyString,
+			wxDefaultPosition,
+			wxSize(80, -1),
+			0,
+			nullptr,
+			wxTE_PROCESS_ENTER);
+		// The context menu is bound per instance, so a freshly created combo
+		// needs it re-attached -- unlike the id-keyed event-table entries
+		// (EVT_TEXT_ENTER / wxEVT_TEXT), which survive the swap by themselves.
+		combo->Bind(wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
+		replacement = combo;
+	} else {
+		// wxTE_PROCESS_ENTER kept so Enter still starts the search through the
+		// existing EVT_TEXT_ENTER(IDC_SEARCHNAME) entry.
+		replacement = new wxTextCtrl(this,
+			IDC_SEARCHNAME,
+			wxEmptyString,
+			wxDefaultPosition,
+			wxSize(80, -1),
+			wxTE_PROCESS_ENTER);
+	}
+
+	// Replace() swaps the window inside the existing sizer item, so the slot
+	// keeps its proportion and border flags; the detached window is ours to
+	// destroy.
+	slot->Replace(current, replacement);
+	current->Destroy();
+
+	wxTextEntry *entry = dynamic_cast<wxTextEntry *>(replacement);
+	if (entry != nullptr) {
+		entry->SetValue(typed);
+	}
+	return entry;
+}
+
+void CSearchDlg::OnBnClickedClearHistory(wxCommandEvent &WXUNUSED(evt))
+{
+	ClearSearchHistory();
 }
 
 CSearchDlg::~CSearchDlg() {}
@@ -165,7 +279,16 @@ wxString SearchHistoryFilePath()
 
 void CSearchDlg::LoadSearchHistory()
 {
+	// With the preference off the Name field is a plain wxTextCtrl, so there is
+	// no dropdown to fill and the cast below would be null. Guarding here (as
+	// well as at the ApplySearchHistoryPref call site) keeps every future
+	// caller safe rather than relying on each one to check first.
 	wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox);
+	if (combo == nullptr || !CPreferences::RememberSearchHistory()) {
+		UpdateClearHistoryButton();
+		return;
+	}
+
 	combo->Clear(); // item list, not the (empty at startup) text value
 
 	CTextFile file;
@@ -196,6 +319,8 @@ void CSearchDlg::LoadSearchHistory()
 	// re-armed here and after every RecordSearchHistory/ClearSearchHistory
 	// call so it always reflects the current entry set.
 	combo->AutoComplete(entries);
+
+	UpdateClearHistoryButton();
 }
 
 void CSearchDlg::RecordSearchHistory(const wxString &term)
@@ -204,7 +329,13 @@ void CSearchDlg::RecordSearchHistory(const wxString &term)
 		return;
 	}
 
+	// Null when the preference was turned off (plain wxTextCtrl in place). The
+	// check above already covers that, but this stays defensive because the
+	// two states have to agree for the cast to be safe.
 	wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox);
+	if (combo == nullptr) {
+		return;
+	}
 
 	wxArrayString current;
 	for (unsigned int i = 0; i < combo->GetCount(); ++i) {
@@ -227,6 +358,8 @@ void CSearchDlg::RecordSearchHistory(const wxString &term)
 		file.WriteLines(entries);
 		file.Close();
 	}
+
+	UpdateClearHistoryButton();
 }
 
 void CSearchDlg::ClearSearchHistory()
@@ -235,9 +368,27 @@ void CSearchDlg::ClearSearchHistory()
 		wxRemoveFile(SearchHistoryFilePath());
 	}
 
-	wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox);
-	combo->Clear();
-	combo->AutoComplete(wxArrayString());
+	// Reached from the context menu and from the Clear button, both of which
+	// only exist alongside a combo -- but the cast is checked so a future
+	// caller cannot turn a disabled-history state into a null dereference.
+	if (wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox)) {
+		combo->Clear();
+		// Empty array is how wx disables completion (wxMSW routes it to
+		// DisableCompletion()), so the last term stops being suggested too.
+		combo->AutoComplete(wxArrayString());
+	}
+
+	UpdateClearHistoryButton();
+}
+
+void CSearchDlg::UpdateClearHistoryButton()
+{
+	if (m_clearHistoryBtn == nullptr) {
+		return;
+	}
+
+	const wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox);
+	m_clearHistoryBtn->Enable(combo != nullptr && combo->GetCount() > 0);
 }
 
 void CSearchDlg::OnSearchNameContextMenu(wxContextMenuEvent &WXUNUSED(evt))
@@ -1211,9 +1362,13 @@ void CSearchDlg::UpdateHitCount(CSearchListCtrl *page)
 
 void CSearchDlg::OnBnClickedReset(wxCommandEvent &WXUNUSED(evt))
 {
-	// wxTextEntry::Clear(), not wxComboBox's own Clear() -- the latter empties
-	// the dropdown's item list (the history), not the typed value.
-	CastChild(IDC_SEARCHNAME, wxTextEntry)->Clear();
+	// SetValue(""), not Clear(). Casting to wxTextEntry does NOT get you
+	// wxTextEntry::Clear() here: that method is virtual and wxComboBoxBase
+	// overrides it as { wxItemContainer::Clear(); wxTextEntry::Clear(); }, so
+	// the call dispatches to the override and wipes the dropdown's item list
+	// -- i.e. the whole search history -- along with the typed value. That is
+	// what issue #697 reported. SetValue() only touches the text.
+	CastChild(IDC_SEARCHNAME, wxTextEntry)->SetValue(wxEmptyString);
 	CastChild(IDC_EDITSEARCHEXTENSION, wxTextCtrl)->Clear();
 	CastChild(IDC_SPINSEARCHMIN, wxSpinCtrl)->SetValue(0);
 	CastChild(IDC_SEARCHMINSIZE, wxChoice)->SetSelection(2);

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -40,6 +40,8 @@ class wxListEvent;
 class wxSpinEvent;
 class wxGauge;
 class wxContextMenuEvent;
+class wxButton;
+class wxTextEntry;
 class CSearchFile;
 
 /**
@@ -236,6 +238,32 @@ private:
 	void RecordSearchHistory(const wxString &term);
 	void ClearSearchHistory();
 	void OnSearchNameContextMenu(wxContextMenuEvent &evt);
+
+public:
+	// Brings the whole search-history UI in line with the "Remember search
+	// history" preference: with it off the Name field is a plain wxTextCtrl
+	// (no dropdown), the Clear button is hidden and no stored terms are
+	// loaded. searchhistory.dat is deliberately left on disk, so re-enabling
+	// the preference restores the previous history rather than starting over.
+	// Called at construction and live from PrefsUnifiedDlg::OnOk when the
+	// checkbox changes, so no restart is needed (issue #697).
+	void ApplySearchHistoryPref();
+
+private:
+	// Replaces the Name field in its sizer slot with the control type the
+	// preference calls for, carrying the typed value across. Returns the
+	// control now in place. A no-op when the right type is already there.
+	wxTextEntry *RebuildSearchNameField(bool wantHistory);
+
+	// Clear-history button, inserted next to the search-type choice at
+	// construction. Held rather than looked up by id so show/hide stays
+	// cheap and cannot silently miss.
+	wxButton *m_clearHistoryBtn = nullptr;
+	void OnBnClickedClearHistory(wxCommandEvent &evt);
+
+	// Greys the button out when there is nothing stored to clear, mirroring
+	// what the context-menu item already does with its own Enable() call.
+	void UpdateClearHistoryButton();
 
 	// Persists the chosen search type so it survives a restart (amule-org/amule#608).
 	void OnSearchTypeChanged(wxCommandEvent &evt);

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -848,7 +848,14 @@ void CSearchListCtrl::OnRelatedSearch(wxCommandEvent &WXUNUSED(event))
 			keyword << "::" << file->GetFileHash().Encode();
 			item = GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 		} while (item > -1);
-		CastByID(IDC_SEARCHNAME, theApp->amuledlg->m_searchwnd, wxTextCtrl)->SetValue(keyword);
+		// wxTextEntry, not wxTextCtrl: the Name field became a wxComboBox in
+		// #643 (search history), and wxComboBox does not derive from
+		// wxTextCtrl -- it is wxWindowWithItems<wxControl, wxComboBoxBase>.
+		// CastByID is a dynamic_cast, so casting to wxTextCtrl yielded
+		// nullptr here and this line dereferenced it. wxTextEntry is the
+		// common base of both, so it keeps working whichever control the
+		// search-history preference has put in place.
+		CastByID(IDC_SEARCHNAME, theApp->amuledlg->m_searchwnd, wxTextEntry)->SetValue(keyword);
 		wxChoice *searchtype = CastByID(ID_SEARCHTYPE, theApp->amuledlg->m_searchwnd, wxChoice);
 		searchtype->SetSelection(searchtype->FindString(_("Local")));
 		theApp->amuledlg->m_searchwnd->StartNewSearch();


### PR DESCRIPTION
## Summary

Closes #697. Four fixes around the search Name field, addressing all three of @ghysler's proposals plus a crash found while auditing the call sites.

## 1. "Reset Fields" wiped the whole search history

The reported bug, and the cause is a subtle one. The call already cast to `wxTextEntry` specifically to avoid this, with a comment saying so — but the cast doesn't help:

```cpp
// wxComboBoxBase, include/wx/combobox.h
virtual void Clear() override
{
    wxItemContainer::Clear();   // ← the dropdown's item list
    wxTextEntry::Clear();
}
```

`wxTextEntry::Clear()` is **virtual**, so calling it through a `wxTextEntry*` dispatches to the combo override and empties the item list too. Now uses `SetValue("")`, which only touches the text.

This also explains the second half of the report — the last term still being offered as a completion after the pull-down looked empty. The item list was being cleared while the autocomplete set stayed armed, so proposal (3) resolves with the same fix rather than needing its own.

## 2. Crash in "search related files"

`SearchListCtrl.cpp` did `CastByID(IDC_SEARCHNAME, …, wxTextCtrl)->SetValue(keyword)`. The field became a `wxComboBox` in #643, and `wxComboBox` doesn't derive from `wxTextCtrl` — it's `wxWindowWithItems<wxControl, wxComboBoxBase>`. `CastByID` is a `dynamic_cast`, so that yielded `nullptr` and the `SetValue()` dereferenced it. Reachable whenever you're connected to an ed2k server. Cast to `wxTextEntry`, the common base.

## 3. "Clear search history" as a visible button

Proposal (2). The action already existed in the field's right-click menu, but **that menu is unreachable on Windows**: the editable part of a `wxComboBox` is a native child `EDIT` window, and per `ShouldForwardFromEditToCombo()` in `src/msw/combobox.cpp` wx forwards only `WM_KEYUP/KEYDOWN/CHAR/SYSCHAR/SYSKEYDOWN/SYSKEYUP/SETFOCUS/KILLFOCUS/CUT/COPY/PASTE` from it. `WM_CONTEXTMENU` isn't among them, so the native menu appears and our handler never runs — matching @ghysler's screenshot exactly.

The button sits after the search-type choice and greys out when there's nothing stored. Built in `SearchDlg.cpp` rather than `muuli_wdr.cpp` so the existing msgid keeps its catalog position — adding the same string to `muuli_wdr.cpp` would move the pot entry, since xgettext orders entries by file scan order, and that trips pot-sync. **No catalog changes in this PR.**

## 4. The preference now gates the whole history UI

"Remember search history" previously only stopped *new* terms being recorded: existing terms stayed in the dropdown, kept being offered as completions, and the field kept its dropdown regardless. Now, with it off, the Name field is a plain `wxTextCtrl`, the Clear button is hidden, and no stored terms are loaded. `searchhistory.dat` is deliberately left on disk, so re-enabling restores the previous history rather than starting over.

Applied live from `PrefsUnifiedDlg::OnOk` via `CfgChanged(IDC_SEARCHHISTORYENABLED)`, following the same idiom as the existing `IDC_EXTCATINFO` / `IDC_SLIDER` branches, so no restart is needed. The swap uses `wxSizer::Replace`, carries the typed value across, keeps `wxTE_PROCESS_ENTER` so Enter still searches, and re-binds the context menu when a combo is created.

## Testing

Built monolithic + amulegui clean on macOS ARM64, Ubuntu ARM64 (wxGTK3) and Windows ARM64. `git clang-format origin/master` clean; diff-scoped Tier-2 clang-tidy clean. Verified on the Windows portable: the crash is gone, Reset Fields keeps the dropdown, and the preference toggle swaps the field and the button live in both directions.
