### PR TITLE
feat(search): show searches started by other clients in the monolithic GUI (#703)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1715,23 +1715,6 @@ constexpr std::size_t kMaxEcSearches = 20;
 class CEcSearchRegistry
 {
 public:
-	// Allocate a fresh ed2k search ID in the LOW quarter (& 0x3fffffff), never 0
-	// (our "none"). This keeps ed2k IDs provably disjoint from the two other id
-	// spaces they share the wire with: Kad's top-half IDs (>= 0x80000000) and
-	// the remote GUI's optimistic placeholder tab IDs, which reserve the
-	// 0x40000000-0x7fffffff sub-range (see CSearchDlg::StartNewSearch). Without
-	// that separation a placeholder could numerically equal a live ed2k ID and
-	// the GUI's tab-rekey would hit the wrong tab. IDs are ephemeral (a 20-entry
-	// LRU ring), so the wrap back to 1 after ~1.07e9 searches only ever reuses
-	// IDs whose search was evicted long before — no live collision.
-	uint32 AllocateEd2kId()
-	{
-		do {
-			m_nextEd2kId = (m_nextEd2kId + 1) & 0x3fffffff;
-		} while (m_nextEd2kId == 0);
-		return m_nextEd2kId;
-	}
-
 	// Register a just-started search as most-recently-used and current,
 	// evicting the least-recently-used if over capacity.
 	void Register(uint32 id)
@@ -1779,7 +1762,6 @@ public:
 
 private:
 	std::list<uint32> m_lru; // front = most-recently-used
-	uint32 m_nextEd2kId = 0;
 	uint32 m_current = 0;
 };
 
@@ -1788,7 +1770,7 @@ CEcSearchRegistry s_ecSearches;
 
 static uint32 AllocateBrowseSearchId()
 {
-	uint32 id = s_ecSearches.AllocateEd2kId();
+	uint32 id = theApp->searchlist->AllocateEd2kId();
 	s_ecSearches.Register(id);
 	return id;
 }
@@ -2137,7 +2119,7 @@ static CECPacket *Get_EC_Response_Search(const CECPacket *request, bool multiSea
 			// bottom-half ID; a Kad search self-allocates a top-half ID
 			// inside StartNewSearch, which overwrites this seed and we read
 			// the real ID back.
-			search_id = s_ecSearches.AllocateEd2kId();
+			search_id = theApp->searchlist->AllocateEd2kId();
 		} else {
 			// Legacy single-search sentinel path (unchanged): wipe the one
 			// bucket and reuse 0xffffffff.

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -708,6 +708,18 @@ void Search_Removed(wxUIntPtr NOT_ON_DAEMON(searchID))
 #endif
 }
 
+// MuleNotify stores the notify args by value, so `name` is by value here like
+// every other notify handler taking a string.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void Search_Added(wxUIntPtr NOT_ON_DAEMON(searchID), wxString NOT_ON_DAEMON(name), uint32 NOT_ON_DAEMON(kind))
+{
+#ifndef AMULE_DAEMON
+	if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+		theApp->amuledlg->m_searchwnd->OnSearchAdded(searchID, name, kind);
+	}
+#endif
+}
+
 void Browse_Started(uint32 NOT_ON_DAEMON(ecid), wxString NOT_ON_DAEMON(name), uint64 NOT_ON_DAEMON(searchID))
 {
 #ifndef AMULE_DAEMON

--- a/src/GuiEvents.h
+++ b/src/GuiEvents.h
@@ -137,6 +137,19 @@ void SearchFileBeingDestroyed(CSearchFile *file);
 // close, rather than two mechanisms for one idea.
 void Search_Removed(wxUIntPtr searchID);
 
+// Fired from CSearchList::StartNewSearch, once per search the core begins,
+// whoever asked for it. The mirror of Search_Removed: it lets the monolithic
+// GUI show a tab for a search started by an EC client (amulegui, amulecmd,
+// amuleapi), which until now it could not see at all -- amulegui and amuleapi
+// already discover each other's searches over EC_OP_SEARCH_LIST, so this is
+// the last direction left (amule-org/amule#703).
+//
+// The tab is created unselected: it appears on its own, so it must not pull
+// the selection away from whatever the local user is doing, possibly
+// mid-typing. `kind` is the CSearchList::SearchType of the new search, used
+// only to seed the Kad "!" marker the way a locally-started tab does.
+void Search_Added(wxUIntPtr searchID, wxString name, uint32 kind);
+
 void ServerAdd(CServer *server);
 void ServerRemove(CServer *server);
 void ServerRemoveDead();
@@ -534,6 +547,10 @@ typedef void (wxEvtHandler::*MuleNotifyEventFunction)(CMuleGUIEvent &);
 // A search's result bucket was freed — see MuleNotify::Search_Removed
 // doc-comment in this header.
 #define Notify_Search_Removed(id) MuleNotify::DoNotify(&MuleNotify::Search_Removed, id)
+
+// The core started a search — see MuleNotify::Search_Added doc-comment in
+// this header.
+#define Notify_Search_Added(id, name, kind) MuleNotify::DoNotify(&MuleNotify::Search_Added, id, name, kind)
 
 // server
 #define Notify_ServerAdd(ptr) MuleNotify::DoNotify(&MuleNotify::ServerAdd, ptr)

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -96,6 +96,7 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	m_last_search_time = 0;
 	m_expiringSearchID = 0;
 	m_inSearchClosing = false;
+	m_startingLocalSearch = false;
 
 	wxSizer *content = searchDlg(this, true);
 	content->Show(this, true);
@@ -783,6 +784,28 @@ void CSearchDlg::OnStartRejected(wxUIntPtr searchID, const wxString &error)
 	}
 }
 
+void CSearchDlg::OnSearchAdded(wxUIntPtr searchID, const wxString &name, uint32 kind)
+{
+	if (m_startingLocalSearch) {
+		// The local user's own search: OnBnClickedStart creates its tab
+		// itself, selected, as soon as StartNewSearch returns.
+		return;
+	}
+
+	if (GetSearchList(searchID)) {
+		return; // already have a tab for it
+	}
+	// Labelled like any other tab -- "(0)" hit count, "!" for a Kad search --
+	// since it is the same kind of thing and needs no separate vocabulary
+	// (got3nks, amule-org/amule#703). Unselected: it appears unprompted, so it
+	// must not pull the selection away from what the user is doing.
+	//
+	// Synchronous, matching its mirror Search_Removed -> CloseSearchTab: both
+	// run from wherever the core changed the search set, including inside EC
+	// packet handling.
+	CreateNewTab(((kind == KadSearch) ? "!" : "") + name + " (0)", searchID, false);
+}
+
 void CSearchDlg::CloseSearchTab(wxUIntPtr searchID)
 {
 	if (m_inSearchClosing) {
@@ -976,11 +999,11 @@ bool CSearchDlg::CheckTabNameExists(const wxString &searchString)
 	return false;
 }
 
-void CSearchDlg::CreateNewTab(const wxString &searchString, wxUIntPtr nSearchID)
+void CSearchDlg::CreateNewTab(const wxString &searchString, wxUIntPtr nSearchID, bool select)
 {
 	CSearchListCtrl *list = new CSearchListCtrl(
 		m_notebook, ID_SEARCHLISTCTRL, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxNO_BORDER);
-	m_notebook->AddPage(list, searchString, true, 0);
+	m_notebook->AddPage(list, searchString, select, 0);
 
 	// Ensure that new results are filtered
 	bool enable = CastChild(IDC_FILTERCHECK, wxCheckBox)->GetValue();
@@ -995,10 +1018,15 @@ void CSearchDlg::CreateNewTab(const wxString &searchString, wxUIntPtr nSearchID)
 	Layout();
 	FindWindow(IDC_CLEAR_RESULTS)->Enable(true);
 
-	// AddPage above made the new tab the selected one; defer to
-	// IsKadSearch on its searchID so a freshly-created ED2K tab leaves
-	// the button disabled.
-	FindWindow(IDC_SEARCHMORE)->Enable(theApp->searchlist->IsKadSearch((uint32_t)nSearchID));
+	// "More" tracks the *visible* tab. Only touch it when this tab actually
+	// became the visible one: an unselected tab (a discovered search) must
+	// leave the button reflecting whatever the user is still looking at.
+	if (select) {
+		// AddPage above made the new tab the selected one; defer to
+		// IsKadSearch on its searchID so a freshly-created ED2K tab leaves
+		// the button disabled.
+		FindWindow(IDC_SEARCHMORE)->Enable(theApp->searchlist->IsKadSearch((uint32_t)nSearchID));
+	}
 }
 
 uint32 CSearchDlg::s_optimisticIdCounter = 0;
@@ -1307,12 +1335,28 @@ void CSearchDlg::StartNewSearch()
 	// definition for why the range (bit 30) matters.
 	uint32 real_id = static_cast<uint32>(AllocateOptimisticId());
 #else
-	// Monolithic: the id is used directly (no remap). Stay in the bottom half of
-	// the uint32 space so it can never collide with Kad ids (>= 0x80000000).
-	s_optimisticIdCounter = (s_optimisticIdCounter + 1) & 0x7fffffff;
-	uint32 real_id = s_optimisticIdCounter;
+	// Monolithic: the id is used directly (no remap). Use the single core-search
+	// ID counter in CSearchList::AllocateEd2kId, shared with the EC daemon path
+	// (s_ecSearches), so every ed2k search -- started locally or by an EC
+	// client (amulegui, amulecmd, amuleapi) -- draws from one counter in
+	// the range [1, 0x3fffffff]. This range is provably disjoint from Kad's
+	// top-half IDs (>= 0x80000000) and from the remote GUI's optimistic
+	// placeholder tab IDs (0x40000000-0x7fffffff, see AllocateOptimisticId).
+	// Before this fix the monolithic path reused AllocateOptimisticId, whose
+	// bit-30 reservation collides with every amulegui placeholder -- the
+	// two started at the same counter value and the GUI's tab-rekey would
+	// remap results to the wrong tab
+	// (amule-org/amule#703 review by got3nks).
+	uint32 real_id = theApp->searchlist->AllocateEd2kId();
 #endif
-	wxString error = theApp->searchlist->StartNewSearch(&real_id, search_type, params);
+	wxString error;
+	{
+		// StartNewSearch fires MuleNotify::Search_Added before returning; the
+		// tab for this search is created just below, selected. Suppress the
+		// notification-driven one for the duration (see m_startingLocalSearch).
+		CScopedFlag localStartGuard(m_startingLocalSearch);
+		error = theApp->searchlist->StartNewSearch(&real_id, search_type, params);
+	}
 	if (!error.IsEmpty()) {
 		// Search failed / Remote in progress. Shared with amuleGUI's
 		// EC_OP_FAILED path so both builds report a rejected start the same

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -95,8 +95,14 @@ public:
 	 *
 	 * @param searchString This will be the heading of the new page.
 	 * @param nSearchID The results with this searchId will be displayed.
+	 * @param select Whether to bring the new tab to the front. True for a tab
+	 *   the local user just asked for (a search they started, a peer they
+	 *   chose to browse). False for one that appears on its own -- a search
+	 *   discovered from another client -- which must not steal the selection
+	 *   from whatever the user is currently looking at, possibly mid-typing
+	 *   (got3nks, amule-org/amule#703).
 	 */
-	void CreateNewTab(const wxString &searchString, wxUIntPtr nSearchID);
+	void CreateNewTab(const wxString &searchString, wxUIntPtr nSearchID, bool select = true);
 
 	/**
 	 * Call this function to signify that the local search is over.
@@ -152,6 +158,13 @@ public:
 	// browse -- the user never pressed Search, so it would wrongly disable
 	// Download/Stop for whichever search tab is visible.
 	void OnStartRejected(wxUIntPtr searchID, const wxString &error);
+
+	// The core started a search (MuleNotify::Search_Added). Creates a tab for
+	// it unless this GUI already has one, or unless it is the local user's own
+	// search still inside OnBnClickedStart -- that path creates its own tab,
+	// selected, right after StartNewSearch returns, and would otherwise end up
+	// with two (amule-org/amule#703).
+	void OnSearchAdded(wxUIntPtr searchID, const wxString &name, uint32 kind);
 
 	// This search's results are gone -- close its tab, since a tab left open
 	// on a freed search can only mislead (in amuleGUI "Download" would
@@ -312,6 +325,12 @@ private:
 	// last-tab button disabling), so that cleanup exists in exactly one
 	// place (got3nks, PR #680 review). 0 the rest of the time.
 	wxUIntPtr m_expiringSearchID;
+
+	// True while OnBnClickedStart is inside StartNewSearch. That call fires
+	// MuleNotify::Search_Added before it returns, and this dialog creates the
+	// tab for its own search only afterwards -- so without this the local
+	// user's every search would get two tabs (amule-org/amule#703).
+	bool m_startingLocalSearch;
 
 	// True while OnSearchClosing is on the stack. In the monolithic build
 	// that handler calls CSearchList::RemoveResults, which now fires

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -291,6 +291,14 @@ CSearchList::~CSearchList()
 	}
 }
 
+uint32 CSearchList::AllocateEd2kId()
+{
+	do {
+		m_nextEd2kId = (m_nextEd2kId + 1) & 0x3fffffff;
+	} while (m_nextEd2kId == 0);
+	return m_nextEd2kId;
+}
+
 void CSearchList::RemoveResults(wxUIntPtr searchID)
 {
 	// A non-existent search id will just be ignored
@@ -463,6 +471,17 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 	// anchor bookkeeping.
 	m_searchKinds[static_cast<uint32_t>(*searchID)] = type;
 	m_searchStrings[static_cast<uint32_t>(*searchID)] = params.searchString;
+
+	// Tell the GUI a search now exists. Every producer funnels through here --
+	// the monolithic dialog and the EC_OP_SEARCH_START handler alike -- so
+	// this one call covers a search started by any client. The monolithic
+	// GUI's own searches already have a tab by this point and are filtered
+	// out on the handler side; what this adds is the tab for a search some
+	// *other* client started, the last direction of the reachability work
+	// amulegui and amuleapi already had over EC_OP_SEARCH_LIST
+	// (amule-org/amule#703).
+	Notify_Search_Added(
+		static_cast<wxUIntPtr>(*searchID), params.searchString, static_cast<uint32>(type));
 
 	return "";
 }

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -117,6 +117,15 @@ public:
 	 */
 	void StopInFlightEd2kSearch();
 
+	/**
+	 * Allocates a fresh ed2k search ID from the single core counter shared by
+	 * the monolithic GUI and the EC daemon path. Returns IDs in the range
+	 * [1, 0x3fffffff] (never 0), provably disjoint from Kad's top-half IDs
+	 * (>= 0x80000000) and from the remote GUI's optimistic placeholder tab IDs
+	 * (0x40000000-0x7fffffff, see CSearchDlg::AllocateOptimisticId).
+	 */
+	uint32 AllocateEd2kId();
+
 	/** True if the given searchID corresponds to an active Kad search. */
 	bool IsKadSearch(uint32_t searchID) const;
 
@@ -397,6 +406,11 @@ private:
 
 	//! The ID of the current search.
 	wxUIntPtr m_currentSearch;
+
+	//! Monotonic counter for ed2k search IDs, shared by the monolithic GUI and
+	//! the EC daemon path. Its range [1, 0x3fffffff] keeps IDs provably disjoint
+	//! from Kad's top-half IDs and the remote GUI's optimistic placeholder range.
+	uint32 m_nextEd2kId = 0;
 
 	//! The current packet used for searches.
 	CPacket *m_searchPacket;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3285,8 +3285,14 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 				// in m_activeSearches is what lets that live path take over
 				// from here -- the "!" appears on the next progress poll if
 				// this is in fact a running Kad search, same as any other tab.
+				// Unselected: this tab appears on its own, driven by another
+				// client, so it must not pull the selection away from whatever
+				// the local user is looking at -- possibly mid-typing in the
+				// search box (got3nks, amule-org/amule#703).
 				theApp->amuledlg->m_searchwnd->CreateNewTab(
-					(nameTag ? nameTag->GetStringData() : wxString()) + " (0)", sid);
+					(nameTag ? nameTag->GetStringData() : wxString()) + " (0)",
+					sid,
+					false);
 				// Reachability fix (#641): without this, a discovered tab never
 				// gets polled for progress at all (Phase1Done only loops over
 				// m_activeSearches), so its hit count, progress bar and "!"


### PR DESCRIPTION
Closes #703. Implements the three answers you gave there, plus the last direction of the #641 reachability work.

## The gap

`amulegui` and `amuleapi` already discover each other's searches over `EC_OP_SEARCH_LIST`. The monolithic GUI was the last surface that could not see a search started elsewhere — its own core was running it and holding the results, with no tab for it.

`MuleNotify::Search_Added` fires from `CSearchList::StartNewSearch`, the single place every producer funnels through (monolithic dialog and the `EC_OP_SEARCH_START` handler alike), so one call covers every client. `CSearchDlg::OnSearchAdded` builds the tab, mirroring `Search_Removed` from #680 so "the search set changed" stays one mechanism in both directions.

## Your three points

1. **Selection.** Tabs that appear on their own are added unselected — `CreateNewTab` gained a `select` parameter. This also covers the `amulegui` half you flagged: a search started by another client was being pulled to the foreground there, introduced by #680. "More" is left untouched for an unselected tab, since it tracks the visible one.
2. **Labelling.** No separate vocabulary: a foreign search gets the same `query (0)` (and `!` for Kad) as any other.
3. **Filter state.** Non-issue once (1) is in, as you expected — a tab that never takes the selection inherits the current filter the same way a local one does.

Shared ownership recorded as the model, per your note.

One thing that needed a guard: `StartNewSearch` fires the notification *before* returning, and `OnBnClickedStart` creates the tab for its own search just *after* — so without `m_startingLocalSearch` every local search would have ended up with two tabs.

## An unrelated, pre-existing id collision this exposed

Keeping this in the PR per your note.

The monolithic GUI drew its search ids from a bare counter (1, 2, 3...) — the same range `CEcSearchRegistry::AllocateEd2kId` handed an EC client from its own independent counter. With any EC client attached, the first search on each side collided: both then shared one `CSearchList::m_results` bucket, and each tab showed the other's results. Present since 10b4efac0, invisible until this PR because the monolithic never displayed another client's search before.

My first fix reused `AllocateOptimisticId`, which you caught: that range (`0x40000000-0x7fffffff`) is the client-side placeholder range amulegui hands out pre-remap, not a core id range. An ed2k search in the monolithic is never remapped, so it landed at `0x40000001` right next to amulegui's own first placeholder tab — the collision moved, it didn't go away.

Fixed properly now: `AllocateEd2kId` is hoisted out of `CEcSearchRegistry`'s anonymous namespace in `ExternalConn.cpp` and into `CSearchList`, so every core ed2k search — monolithic or `EC_OP_SEARCH_START` — draws from one counter (`CSearchList::m_nextEd2kId`), range `[1, 0x3fffffff]`, disjoint from both Kad (`>= 0x80000000`) and amulegui's placeholder range by construction.

## Testing

Monolithic aMule on live ed2k/Kad with an `amuleapi` client against the same core:

- A search started over EC appears in the monolithic as an unselected tab and fills with its own results, while the local user stays on the panel and tab they were on.
- A local search started afterwards gets exactly one tab, selected, showing its own results, drawing from the shared core counter.
- `amulegui` side of point 1 checked separately: with a search tab open and the cursor in the name field, a search started by another client adds its tab without taking the selection or disturbing what was being typed.

`clang-format` v18 applied, `git diff -- po/` empty. The four touched files (`SearchList.h/.cpp`, `ExternalConn.cpp`, `SearchDlg.cpp`) compile cleanly against every relevant preprocessor configuration (`AMULE_DAEMON`, monolithic, `CLIENT_GUI`), checked directly against the project's own compile flags. A full local link is blocked right now by an unrelated Homebrew boost 1.90 / CMake 4 environment issue on my machine — leaning on CI for the full build/link this round.

Not covered by an automated test: this is GUI behaviour in the monolithic build, which neither the unit tests nor the curl suite can drive. Verified by hand as above.
