### PR TITLE
fix(gui): bind the search field's context menu at startup, not only on a swap

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -201,6 +201,17 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 	// and its history exist at all.
 	const bool haveCombo = (dynamic_cast<wxComboBox *>(current) != nullptr);
 	if (haveCombo == wantHistory) {
+		// Right control already in place, so nothing to rebuild -- but it may
+		// still need the context menu. At construction the combo here is the
+		// one muuli_wdr built, which this class never created and therefore
+		// never bound; leaving the binding to the creation path below meant
+		// the "Clear search history" item was missing until the preference
+		// was toggled off and on, since only then was a combo created here.
+		if (wantHistory && !m_searchNameCtxBound) {
+			dynamic_cast<wxComboBox *>(current)->Bind(
+				wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
+			m_searchNameCtxBound = true;
+		}
 		return dynamic_cast<wxTextEntry *>(current);
 	}
 
@@ -227,10 +238,13 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 		// needs it re-attached -- unlike the id-keyed event-table entries
 		// (EVT_TEXT_ENTER / wxEVT_TEXT), which survive the swap by themselves.
 		combo->Bind(wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
+		m_searchNameCtxBound = true;
 		replacement = combo;
 	} else {
 		// wxTE_PROCESS_ENTER kept so Enter still starts the search through the
-		// existing EVT_TEXT_ENTER(IDC_SEARCHNAME) entry.
+		// existing EVT_TEXT_ENTER(IDC_SEARCHNAME) entry. A plain text control
+		// carries no history menu, so the binding is gone with the old combo.
+		m_searchNameCtxBound = false;
 		replacement = new wxTextCtrl(this,
 			IDC_SEARCHNAME,
 			wxEmptyString,

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -255,6 +255,13 @@ private:
 	// control now in place. A no-op when the right type is already there.
 	wxTextEntry *RebuildSearchNameField(bool wantHistory);
 
+	// Whether the combo currently in the Name slot has had the context-menu
+	// handler attached. The handler is bound per instance, and the combo built
+	// by muuli_wdr is one this class never created, so binding cannot be left
+	// to the creation path alone -- that is what made the "Clear search
+	// history" item missing until the preference was toggled.
+	bool m_searchNameCtxBound = false;
+
 	// Clear-history button, inserted next to the search-type choice at
 	// construction. Held rather than looked up by id so show/hide stays
 	// cheap and cannot silently miss.


### PR DESCRIPTION
## Summary

Regression from #709. The Name field's right-click menu — and with it the **Clear search history** item — was missing after startup. Toggling *Remember search history* off and on made it appear, which is what pointed at the cause.

## Root cause

#709 replaced the constructor's explicit bind

```cpp
CastChild(IDC_SEARCHNAME, wxComboBox)->Bind(wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
```

with a call to `ApplySearchHistoryPref()` → `RebuildSearchNameField()`. That function binds the handler only on combos **it creates**, and it returns early when the control is already the type the preference calls for:

```cpp
const bool haveCombo = (dynamic_cast<wxComboBox *>(current) != nullptr);
if (haveCombo == wantHistory) {
	return dynamic_cast<wxTextEntry *>(current);   // ← no bind
}
```

At construction that early return always fires: the preference defaults on, and the combo in the slot is the one `muuli_wdr` built — an instance this class never created and therefore never bound. Only a preference toggle went down the creation path, which is why cycling the setting appeared to fix it.

## Fix

Bind on the early-return path as well, tracked by a new `m_searchNameCtxBound` so the handler is attached exactly once per control:

- **early return** — bind if the current combo hasn't been bound (the startup case)
- **combo created** — bind and set the flag, as before
- **text control created** — clear the flag; the binding died with the old combo, and that state has no history menu at all

The invariant is now "a combo in the Name slot always has the context menu", holding from construction rather than only after a swap.

## Notes

Not platform-specific, despite being reported on macOS — the same code runs on wxGTK and would behave identically. It surfaced on macOS because that is a platform where the menu is reachable at all; on Windows the native `EDIT` child of a `wxComboBox` never forwards `WM_CONTEXTMENU` to wx, so the item is unreachable there regardless (which is what the visible **Clear search history** button added in #709 exists to cover).

## Testing

Built `amule` and `amulegui` clean on macOS ARM64 and verified by hand: right-clicking the Name field immediately after startup now offers **Clear search history**, correctly greyed when no history is stored, and toggling the preference behaves identically instead of being required first. With the preference off the field is a plain text control and shows the native menu with no history item, as intended.

`clang-format` 18.1.8 (CI's exact version) reports no violations; diff-scoped Tier-2 clang-tidy is clean with 0 compiler errors.
