### PR TITLE
feat(web-ui): draw the country flag next to the code in both lists (#687)

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -486,6 +486,8 @@ table.data.virtual td .name-cell .name-text { min-width: 0; overflow: hidden; te
 .row-actions .btn + .btn { margin-left: 4px; }
 .row-actions select + .btn { margin-left: 6px; }
 .color-swatch { display: inline-block; width: 14px; height: 14px; border-radius: 3px; border: 1px solid var(--border); vertical-align: middle; }
+.country-cell { white-space: nowrap; }
+.flag { display: inline-block; width: 16px; height: 11px; vertical-align: middle; margin-right: 5px; }
 
 /* --- search --- */
 .search-grid {

--- a/src/webapi/static/js/components.js
+++ b/src/webapi/static/js/components.js
@@ -4,7 +4,7 @@
 
 import { html, render, useState } from "./dom.js";
 import { formatPercent } from "./format.js";
-import { t, terr } from "./i18n.js";
+import { t, terr, getLang } from "./i18n.js";
 import { api } from "./api.js";
 import { Icon } from "./icons.js";
 
@@ -30,6 +30,24 @@ export function Badge({ kind = "", title, children }) {
 // Empty / loading / error placeholder for view bodies.
 export function Placeholder({ kind, children }) {
   return html`<div class=${"placeholder placeholder-" + kind}>${children}</div>`;
+}
+
+// Relative, like BASE in api.js: it has to survive a reverse-proxy subpath.
+const FLAG_BASE = window.location.pathname.replace(/\/?$/, "/") + "flags/";
+const REGIONS = (() => {
+  try { return new Intl.DisplayNames([getLang()], { type: "region" }); } catch (_) { return null; }
+})();
+
+// Flag from GET /flags/{code}.png (#694) next to the code, as the desktop lists
+// draw it. Empty code (GeoIP off / unresolved IP) -> dash, no image; onError
+// hides the image for a well-formed code the flag set has no artwork for.
+export function CountryCell({ code }) {
+  const cc = (code || "").toLowerCase();
+  if (!cc) return "—";
+  const CC = cc.toUpperCase();
+  return html`<span class="country-cell" title=${(REGIONS && REGIONS.of(CC)) || CC}
+    ><img class="flag" src=${FLAG_BASE + cc + ".png"} alt="" width="16" height="11"
+          onError=${(e) => { e.target.style.visibility = "hidden"; }} />${CC}</span>`;
 }
 
 // --- download priority --------------------------------------------------

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -6,7 +6,7 @@
 import { api } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { Badge, Placeholder } from "../components.js";
+import { Badge, Placeholder, CountryCell } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker, ipNum } from "../table.js";
 import { formatBytes, formatSpeed } from "../format.js";
 import { Icon } from "../icons.js";
@@ -40,11 +40,9 @@ export const COLS = [
   { cls: "peer-flags", width: "60px", cell: (c) => peerFlags(c) },
   // Identity block, each field next to the one it qualifies: where the peer is
   // (country, address), who it claims (name, user_hash), what it runs (software, os).
-  // country_code is "" when the daemon's GeoIP is off or the IP doesn't resolve
-  // (#439) -- an empty cell like any other. Abbreviated header: a spelled-out
-  // "Country" would need ~80px for a 2-char cell.
-  { key: "country", th: "downloads_peer_col_country", width: "52px", sortable: true,
-    sortVal: (c) => c.country_code || "", cell: (c) => (c.country_code || "").toUpperCase() || "—" },
+  // Abbreviated header: a spelled-out "Country" would still be wider than the cell.
+  { key: "country", th: "downloads_peer_col_country", width: "70px", sortable: true,
+    sortVal: (c) => c.country_code || "", cell: (c) => html`<${CountryCell} code=${c.country_code} />` },
   // Empty ip: a peer we never connected to directly (LowID).
   { key: "address", th: "downloads_peer_col_address", num: true, width: "180px", sortable: true,
     sortVal: (c) => ipNum(c.ip), cell: (c) => c.ip ? c.ip + ":" + c.port : "—" },

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -10,7 +10,7 @@ import { api } from "../api.js";
 import { data } from "../events.js";
 import { store } from "../store.js";
 import { html, useState, useEffect, useRef, useStore } from "../dom.js";
-import { Tabs, Placeholder, toast, confirmDialog } from "../components.js";
+import { Tabs, Placeholder, toast, confirmDialog, CountryCell } from "../components.js";
 import { VirtualTable, sortRows, useTablePrefs, ColumnPicker, ipNum } from "../table.js";
 import { Chart } from "../charts.js";
 import { formatInt } from "../format.js";
@@ -159,8 +159,8 @@ function ServersPanel({ isGuest }) {
 
   const columns = [
     // Server host country (#440): same cell and header as the peer table's.
-    { key: "country", label: t("networks_server_country"), width: "52px", sortable: true,
-      sortVal: (s) => s.country_code || "", cell: (s) => (s.country_code || "").toUpperCase() || "—" },
+    { key: "country", label: t("networks_server_country"), width: "70px", sortable: true,
+      sortVal: (s) => s.country_code || "", cell: (s) => html`<${CountryCell} code=${s.country_code} />` },
     { key: "address", label: t("networks_server_address"), num: true, width: "180px", sortable: true,
       sortVal: (s) => ipNum(s.address),
       cell: (s) => s.address && s.address.includes(":") ? s.address : (s.address + ":" + s.port) },


### PR DESCRIPTION
1bc9d6e7 (#694) added GET /flags/{code}.png, but nothing consumed it: the country column of the peer list and of the ed2k server list still painted only the bare uppercase code, duplicating the same one-liner cell in two views.

Both now render through a single new CountryCell in components.js: the 16x11 famfamfam flag from the route followed by the code, the layout the desktop lists already use. The image URL is built relative to window.location.pathname like BASE in api.js, so it survives a reverse-proxy subpath, and the route's one-day Cache-Control means a peer list full of <img> tags doesn't re-fetch a flag per country on reload.

country_code is an empty string when the daemon's GeoIP is off or the IP doesn't resolve (#439, #440), so an empty code short-circuits to the dash the cell already showed -- no <img>, and in particular no request for the "/flags/.png" the route would 404. A well-formed code the flag set has no artwork for (zz, GeoIP pseudo-codes like ap/eu) also 404s, so onError hides the image and leaves the code readable instead of a broken-image icon.

The cell gains a title with the localized country name via Intl.DisplayNames ({ type: "region" }) in the UI language, as docs/api/REFERENCE.md prescribes: no endpoint and no new translation keys, since the browser already has the data. The formatter is built once per module load, not once per row.

Column width goes 52px -> 70px to fit flag + code + sort arrow; sortVal is unchanged, so the column still sorts by code.

Verified against a live daemon: flags render in the Networks server list and the Clients list, an empty country_code shows the dash alone, /flags/zz.png falls back to the hidden image, the tooltip follows the EN/ES switch (France/Francia), sorting works both directions, and the console stays clean.