### PR TITLE
fix(gui): request Flatpak background permission so aMule isn't killed on close

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,10 @@ list (FIND wxWidgets_DEFINITIONS "__WXGTK__" _amule_wxgtk_idx)
 if (_amule_wxgtk_idx GREATER -1 AND NOT APPLE)
 	find_package (PkgConfig QUIET)
 	if (PkgConfig_FOUND)
-		pkg_check_modules (GLIB QUIET glib-2.0)
+		# gio-2.0 (ships with glib) provides GDBus, used by the monolithic /
+		# amulegui GUI to ask xdg-desktop-portal for background permission
+		# under Flatpak (see RequestFlatpakBackgroundPermission in amuleDlg.cpp).
+		pkg_check_modules (GLIB QUIET glib-2.0 gio-2.0)
 	endif()
 
 	if ((BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI) AND NOT GLIB_FOUND)

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -142,6 +142,62 @@ wxEND_EVENT_TABLE()
 #define wxCLOSE_BOX 0
 #endif
 
+#if defined(__WXGTK__) && !defined(__APPLE__)
+#include <gio/gio.h> // GDBus, for the Flatpak background-portal request below
+
+// Inside a Flatpak sandbox, a client configured to run without a visible window
+// (hide-to-tray on close, or start minimized) maps no window, and
+// xdg-desktop-portal's background monitor then kills it unless the "background"
+// permission was granted. aMule never asked for it, so on backends that default
+// to deny (KDE) the app was killed on close (amule-org/amule#535). Requesting it
+// registers aMule as a legitimate background app, so the permission is granted
+// (or, on KDE, prompted once and remembered). Native, non-sandboxed builds are
+// not background-monitored -- hence the FLATPAK_ID gate -- and this is a no-op
+// wherever there is no Background portal (the call just fails silently).
+static void RequestFlatpakBackgroundPermission()
+{
+	if (g_getenv("FLATPAK_ID") == nullptr) {
+		return;
+	}
+
+	GError *error = nullptr;
+	GDBusConnection *conn = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, &error);
+	if (conn == nullptr) {
+		if (error != nullptr) {
+			g_error_free(error);
+		}
+		return;
+	}
+
+	GVariantBuilder options;
+	g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+	g_variant_builder_add(&options,
+		"{sv}",
+		"reason",
+		g_variant_new_string("aMule keeps running in the background to continue your transfers."));
+	g_variant_builder_add(&options, "{sv}", "autostart", g_variant_new_boolean(FALSE));
+
+	// Fire-and-forget: the portal grants (or on KDE prompts once) and records the
+	// permission for next launch. We don't need the returned request handle, and
+	// must not block the GUI waiting on a possible prompt -- the shared GTK main
+	// loop flushes this async call.
+	g_dbus_connection_call(conn,
+		"org.freedesktop.portal.Desktop",
+		"/org/freedesktop/portal/desktop",
+		"org.freedesktop.portal.Background",
+		"RequestBackground",
+		g_variant_new("(sa{sv})", "", &options),
+		nullptr,
+		G_DBUS_CALL_FLAGS_NONE,
+		-1,
+		nullptr,
+		nullptr,
+		nullptr);
+
+	g_object_unref(conn);
+}
+#endif // defined(__WXGTK__) && !defined(__APPLE__)
+
 CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wxSize dlg_size)
 : wxFrame(pParent,
 	  -1,
@@ -338,6 +394,15 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	if (thePrefs::GetStartMinimized()) {
 		Iconize(true);
 	}
+
+#if defined(__WXGTK__) && !defined(__APPLE__)
+	// If we're set up to run without a visible window (hide-to-tray on close, or
+	// start minimized), ask the desktop portal for background permission so a
+	// Flatpak build isn't killed on close. No-op outside Flatpak. See the helper.
+	if (thePrefs::HideOnClose() || thePrefs::GetStartMinimized()) {
+		RequestFlatpakBackgroundPermission();
+	}
+#endif
 
 	// Set shortcut keys
 #ifdef __WXMAC__


### PR DESCRIPTION
## Problem

Reported in #535: the Flatpak build of aMule gets **killed the moment its window is hidden** — hide-to-tray on close, or start-minimized — on KDE/Plasma. The only workaround is granting the permission by hand (`flatpak permission-set background background org.amule.aMule yes`).

## Cause

Inside a Flatpak sandbox, an app that maps no window is watched by `xdg-desktop-portal`'s background monitor and killed unless it holds the `background` permission. aMule has no portal integration, so it never *requests* that permission — and on backends that default the unrequested state to **deny** (KDE's `xdg-desktop-portal-kde`) the app is killed as soon as it goes to the tray. GNOME's backend auto-grants running apps, which is why GNOME users never hit this.

## Fix

On GTK builds inside a Flatpak sandbox (gated on `FLATPAK_ID`) and only when the app is configured to run without a visible window (`HideOnClose` or `StartMinimized`), call the Background portal's `RequestBackground` via GDBus (`amuleDlg.cpp`). That registers aMule as a legitimate background app, so the portal grants it (or, on KDE, prompts once and remembers). Fire-and-forget, so it never blocks startup; a no-op outside Flatpak and wherever there's no Background portal (the call just fails silently).

`GDBus` comes from **gio-2.0**, which ships with the glib package aMule already requires (`glib-2.0`) — **not a new dependency**; the GUI targets just link `libgio-2.0` alongside `libglib-2.0`.

## Testing

Builds and links both natively (Ubuntu ARM64) and inside the Flatpak sandbox. On a GNOME VM the pre-fix build already ends up with `background: yes` because GNOME's backend **auto-grants** it — so the fix is a no-op there; its effect is specific to KDE, where the same unrequested state is denied. The reporter's KDE environment is where the deny→grant flip prevents the kill.
