### PR TITLE
perf(ec): skip unchanged search results on the multi-search union poll

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -310,6 +310,15 @@ private:
 	// unchanged files so old clients (which infer deletion from absence)
 	// keep working unchanged — see `Get_EC_Response_GetUpdate`.
 	bool m_partialUpdateActive;
+
+	// Client negotiated `EC_TAG_CAN_PARTIAL_SEARCH`: the multi-search results
+	// union may skip results whose exported fields are unchanged and report
+	// removals with explicit `EC_TAG_FILE_REMOVED` tombstones. Separate from
+	// `m_partialUpdateActive` on purpose -- see EC_TAG_CAN_PARTIAL_SEARCH in
+	// RemoteConnect.cpp for why reusing that flag would break an older
+	// amuleGUI, which advertises it but still deletes any result absent from
+	// the reply.
+	bool m_partialSearchActive;
 	// Client opted in to the multi-search protocol at auth time (advertised
 	// `EC_TAG_CAN_MULTI_SEARCH`). When set, the EC search handlers allocate a
 	// distinct daemon-side search ID per `EC_OP_SEARCH_START` (returned via
@@ -339,10 +348,21 @@ private:
 	std::set<uint32> m_lastSentSharedFileIds;
 	std::set<uint32> m_lastSentPartFileIds;
 	// `EC_OP_SEARCH_RESULTS` at `EC_DETAIL_UPDATE` (amuleweb's polling
-	// path). amulegui takes the `EC_DETAIL_INC_UPDATE` overload which
-	// uses the always-bulk-delete `CRemoteContainer::ProcessUpdate` and
-	// needs no tombstones, so search-results tracking is amuleweb-only.
+	// path), which addresses one search at a time.
 	std::set<uint32> m_lastSentSearchIds;
+
+	// Result ECIDs last sent on the `EC_DETAIL_INC_UPDATE` union poll
+	// (amulegui), so `Get_EC_Response_Search_Results_Union` can emit
+	// `EC_TAG_FILE_REMOVED` for results that are gone instead of relying on
+	// absence. Separate from `m_lastSentSearchIds` above: that one belongs
+	// to amuleweb's per-search `EC_DETAIL_UPDATE` path and tracks a
+	// different set on a different schedule.
+	//
+	// Only populated for clients that negotiated `EC_TAG_CAN_PARTIAL_UPDATE`.
+	// A legacy client keeps the bulk "anything missing == deleted" rule, so
+	// the union must keep re-sending every result to it and there is nothing
+	// to track.
+	std::set<uint32> m_lastSentSearchResultIds;
 
 	// Set of file ECIDs already sent to the client with full detail
 	// (EC_DETAIL_INC_UPDATE / EC_DETAIL_UPDATE payload, not the legacy
@@ -370,6 +390,7 @@ CECServerSocket::CECServerSocket(ECNotifier *notifier)
 , m_lastEcGenSeenShared(0)
 , m_lastEcGenSeenPart(0)
 , m_partialUpdateActive(false)
+, m_partialSearchActive(false)
 , m_multiSearchActive(false)
 , m_chatActive(false)
 {
@@ -782,6 +803,12 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// them — see `Get_EC_Response_GetUpdate`.
 					m_partialUpdateActive = true;
 				}
+				if (request->GetTagByName(EC_TAG_CAN_PARTIAL_SEARCH)) {
+					// Client applies the same rule to search results. Old
+					// clients omit this tag and the union keeps re-sending
+					// every result of every open search on every poll.
+					m_partialSearchActive = true;
+				}
 				if (request->GetTagByName(EC_TAG_CAN_MULTI_SEARCH)) {
 					// Client understands the multi-search protocol: EC
 					// searches are addressed by a daemon-allocated
@@ -872,6 +899,13 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// off its bulk "missing == deleted" fallback and
 					// expects explicit `EC_TAG_FILE_REMOVED` markers.
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
+				}
+				if (m_partialSearchActive) {
+					// Confirm the search half too. The client must not stop
+					// deleting on absence until it knows the daemon actually
+					// skips unchanged results -- against an older daemon that
+					// never skips, absence still means the result is gone.
+					response->AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_SEARCH));
 				}
 				if (m_chatActive) {
 					// Confirm chat relay so the client starts polling
@@ -2020,24 +2054,53 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // eviction only -- folding monolithic searches into that 20-entry LRU would
 // let unrelated EC traffic evict, and so stop, a local user's own
 // still-running Kad search.
-static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
+static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap,
+	bool partial_update_active,
+	std::set<uint32> &io_lastSentResultIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_RESULTS);
 	// Incremental: unchanged fields are diffed out via the per-connection
 	// valuemap (keyed by the globally-unique ECID). Safe now that amulegui's
 	// container retains its items across searches (it no longer flushes on a
 	// new search), so a result is never re-created from a diffed tag — no
-	// ghosts — while re-sending unchanged results every poll stays cheap.
+	// ghosts.
+	//
+	// Every result the client is currently believed to hold, so the
+	// partial-update path below can synthesize removals by diffing against
+	// the previous cycle instead of relying on absence.
+	std::set<uint32> current_ids;
+
+	auto emitOne = [&](CSearchFile *sf, uint32 sid) {
+		const uint32 ecid = sf->ECID();
+		current_ids.insert(ecid);
+		const bool known = io_lastSentResultIds.count(ecid) != 0;
+		CValueMap &valuemap = tagmap.GetValueMap(ecid);
+		// The owning search ID never changes for a result, so it only has to
+		// travel once per connection -- but only once removal is explicit.
+		// A legacy client deletes anything missing from the reply and would
+		// then re-create the item from a later diffed tag, which must still
+		// carry the ID to be attributable to a tab.
+		const uint32 attribute_sid = (partial_update_active && known) ? 0 : sid;
+		CEC_SearchFile_Tag tag(sf, EC_DETAIL_INC_UPDATE, &valuemap, attribute_sid);
+		if (partial_update_active && known && !tag.HasChildTags()) {
+			// Nothing about this result changed since the client's last view.
+			// Absence no longer implies deletion for this client (it deletes
+			// only on an explicit EC_TAG_FILE_REMOVED emitted below), so the
+			// whole tag can go. This is what makes an idle search cost
+			// nothing: previously every result re-sent its envelope plus its
+			// search ID on every poll, forever.
+			return;
+		}
+		response->AddTag(tag);
+	};
+
 	auto emitResultsFor = [&](uint32 sid) {
 		const CSearchResultList &list = theApp->searchlist->GetSearchResults(sid);
 		for (CSearchFile *sf : list) {
-			CValueMap &valuemap = tagmap.GetValueMap(sf->ECID());
-			response->AddTag(CEC_SearchFile_Tag(sf, EC_DETAIL_INC_UPDATE, &valuemap, sid));
+			emitOne(sf, sid);
 			if (sf->HasChildren()) {
 				for (CSearchFile *sfc : sf->GetChildren()) {
-					CValueMap &valuemap1 = tagmap.GetValueMap(sfc->ECID());
-					response->AddTag(CEC_SearchFile_Tag(
-						sfc, EC_DETAIL_INC_UPDATE, &valuemap1, sid));
+					emitOne(sfc, sid);
 				}
 			}
 		}
@@ -2047,6 +2110,27 @@ static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap)
 	}
 	for (const auto &entry : theApp->searchlist->GetBrowseSearchIds()) {
 		emitResultsFor(static_cast<uint32>(entry.first));
+	}
+
+	if (partial_update_active) {
+		// One EC_TAG_FILE_REMOVED per result the client was told about that
+		// the core no longer holds -- a closed or evicted search, or a
+		// results list replaced by a new search on the same ID. Reuses the
+		// knownfile tombstone rather than inventing a second one: the
+		// meaning ("this ECID is gone") and the payload (the ECID) are
+		// identical, and the search container reads it the same way.
+		for (uint32 id : io_lastSentResultIds) {
+			if (!current_ids.count(id)) {
+				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, id));
+				// Drop the diff state with the result. ECIDs are handed out
+				// monotonically so reuse is not expected, but a stale
+				// valuemap would diff away the very fields a re-created
+				// result needs, leaving the client a tag it cannot use --
+				// the same hazard `freshEcids` guards on the file path.
+				tagmap.EraseValueMap(id);
+			}
+		}
+		io_lastSentResultIds.swap(current_ids);
 	}
 	return response;
 }
@@ -2936,7 +3020,8 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		// amulegui (multi + INC_UPDATE) polls all its searches at once: return
 		// the union, each result tagged with its search ID (see the handler).
 		if (m_multiSearchActive && incUpdate) {
-			response = Get_EC_Response_Search_Results_Union(m_obj_tagmap);
+			response = Get_EC_Response_Search_Results_Union(
+				m_obj_tagmap, m_partialSearchActive, m_lastSentSearchResultIds);
 			break;
 		}
 		// Otherwise address a specific search by EC_TAG_SEARCH_ID (no ID =>

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2054,9 +2054,8 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // eviction only -- folding monolithic searches into that 20-entry LRU would
 // let unrelated EC traffic evict, and so stop, a local user's own
 // still-running Kad search.
-static CECPacket *Get_EC_Response_Search_Results_Union(CObjTagMap &tagmap,
-	bool partial_update_active,
-	std::set<uint32> &io_lastSentResultIds)
+static CECPacket *Get_EC_Response_Search_Results_Union(
+	CObjTagMap &tagmap, bool partial_update_active, std::set<uint32> &io_lastSentResultIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_RESULTS);
 	// Incremental: unchanged fields are diffed out via the per-connection

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3144,6 +3144,48 @@ void CSearchListRem::RequestSearchList()
 	m_conn->SendRequest(this, &req);
 }
 
+void CSearchListRem::ProcessUpdate(const CECTag *reply, CECPacket *full_req, int req_type)
+{
+	if (!m_conn->ServerSupportsPartialSearch()) {
+		// Legacy daemon: it still re-sends every live result each poll and
+		// expects absence to mean deletion.
+		CRemoteContainer<CSearchFile, uint32, CEC_SearchFile_Tag>::ProcessUpdate(
+			reply, full_req, req_type);
+		return;
+	}
+	for (CECPacket::const_iterator it = reply->begin(); it != reply->end(); ++it) {
+		const CECTag *curTag = &*it;
+		if (curTag->GetTagName() == EC_TAG_FILE_REMOVED) {
+			// The one path that deletes now. Same tombstone the shared-file
+			// list uses; the payload is the result's ECID.
+			const uint32 ecid = static_cast<uint32>(curTag->GetInt());
+			std::map<uint32, CSearchFile *>::iterator hit = m_items_hash.find(ecid);
+			if (hit == m_items_hash.end()) {
+				continue;
+			}
+			for (iterator lit = begin(); lit != end(); ++lit) {
+				if (GetItemID(*lit) == ecid) {
+					RemoveItem(lit);
+					break;
+				}
+			}
+			continue;
+		}
+		if (curTag->GetTagName() != req_type) {
+			continue;
+		}
+		const CEC_SearchFile_Tag *tag = static_cast<const CEC_SearchFile_Tag *>(curTag);
+		if (m_items_hash.count(tag->ID())) {
+			ProcessItemUpdate(tag, m_items_hash[tag->ID()]);
+		} else {
+			// A result new to this client always arrives with its owning
+			// EC_TAG_SEARCH_ID (the daemon omits that tag only for results it
+			// has already attributed), so CreateItem can route it to a tab.
+			AddItem(CreateItem(tag));
+		}
+	}
+}
+
 void CSearchListRem::HandlePacket(const CECPacket *packet)
 {
 	if (packet->GetOpCode() == EC_OP_SEARCH_PROGRESS) {

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3153,8 +3153,8 @@ void CSearchListRem::ProcessUpdate(const CECTag *reply, CECPacket *full_req, int
 			reply, full_req, req_type);
 		return;
 	}
-	for (CECPacket::const_iterator it = reply->begin(); it != reply->end(); ++it) {
-		const CECTag *curTag = &*it;
+	for (const CECTag &entry : *reply) {
+		const CECTag *curTag = &entry;
 		if (curTag->GetTagName() == EC_TAG_FILE_REMOVED) {
 			// The one path that deletes now. Same tombstone the shared-file
 			// list uses; the payload is the result's ECID.

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -633,6 +633,21 @@ class CSearchListRem : public CRemoteContainer<CSearchFile, uint32, CEC_SearchFi
 {
 	virtual void HandlePacket(const CECPacket *);
 
+	// Partial-update union poll: delete a result only when the daemon says
+	// so (EC_TAG_FILE_REMOVED), instead of the base class's "anything
+	// missing from this reply is gone" sweep.
+	//
+	// Absence-implies-deletion forced the daemon to re-send every result of
+	// every open search on every poll just to say "still here" -- with two
+	// finished searches and ~900 results that measured 12 KB every 3 s, of
+	// which none carried a single changed field. With removal made explicit
+	// the daemon can skip an unchanged result entirely, and an idle search
+	// costs nothing.
+	//
+	// Falls back to the base implementation against a daemon that did not
+	// echo EC_TAG_CAN_PARTIAL_UPDATE, which still relies on absence.
+	virtual void ProcessUpdate(const CECTag *reply, CECPacket *full_req, int req_type);
+
 public:
 	CSearchListRem(CRemoteConnect *);
 

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -211,6 +211,7 @@ EC_TAG_CAN_AEAD                           0x001B
 EC_TAG_AEAD_CIPHER                        0x001C
 EC_TAG_AEAD_CLIENT_NONCE                  0x001D
 EC_TAG_AEAD_SERVER_NONCE                  0x001E
+EC_TAG_CAN_PARTIAL_SEARCH                 0x001F
 
 
 EC_TAG_CLIENT_NAME                        0x0100

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -99,6 +99,12 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	// the unknown tag and the server falls back to emitting alive-
 	// marker tags for unchanged files (still backward-compatible).
 	AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
+	// Client applies the same skip-unchanged / explicit-removal rule to the
+	// multi-search results union. Advertised separately from
+	// EC_TAG_CAN_PARTIAL_UPDATE because only a client that implements it on
+	// the *search* container may be sent skipped results; older clients omit
+	// this tag and keep getting every result on every poll.
+	AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_SEARCH));
 	// Client can read and write the daemon's shared-directory configuration
 	// over EC (EC_OP_GET/SET_SHARED_DIRS). Always advertised; old daemons
 	// ignore the unknown tag and simply never echo it back.
@@ -176,6 +182,7 @@ m_req_fifo_thr(20)
 , m_preferNoZlib(false)
 , m_forceZlib(false)
 , m_serverPartialUpdate(false)
+, m_serverPartialSearch(false)
 , m_canMultiSearch(false)
 , m_serverMultiSearch(false)
 , m_canChat(false)
@@ -556,6 +563,9 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			// tags for unchanged files (#713).
 			if (reply->GetTagByName(EC_TAG_CAN_PARTIAL_UPDATE)) {
 				m_serverPartialUpdate = true;
+			}
+			if (reply->GetTagByName(EC_TAG_CAN_PARTIAL_SEARCH)) {
+				m_serverPartialSearch = true;
 			}
 			// Server confirmed multi-search: it will allocate a distinct
 			// `EC_TAG_SEARCH_ID` per search. Old daemons omit the echo and

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -170,6 +170,19 @@ private:
 	// path (server emits alive-marker tags so it still works).
 	bool m_serverPartialUpdate;
 
+	// Set when the server echoed `EC_TAG_CAN_PARTIAL_SEARCH` in AUTH_OK,
+	// confirming it may skip unchanged *search results* on the multi-search
+	// union poll and signal their removal with `EC_TAG_FILE_REMOVED`.
+	//
+	// Deliberately separate from `m_serverPartialUpdate`: that one is about
+	// the shared-file / download INC_UPDATE stream and is advertised by every
+	// client built since it landed, including ones with no idea that search
+	// results could be skipped too. Reusing it here would make an older
+	// amuleGUI -- which advertises it, speaks multi-search, and still deletes
+	// any result missing from the reply -- silently drop its search results
+	// against a newer daemon.
+	bool m_serverPartialSearch;
+
 	// Client opts into the multi-search protocol (advertise
 	// `EC_TAG_CAN_MULTI_SEARCH`). Off by default; a client sets it via
 	// SetCanMultiSearch() only once it addresses searches by
@@ -243,6 +256,7 @@ public:
 	void SetCanChat(bool can) noexcept { m_canChat = can; }
 
 	bool ServerSupportsPartialUpdate() const { return m_serverPartialUpdate; }
+	bool ServerSupportsPartialSearch() const { return m_serverPartialSearch; }
 
 	bool ServerSupportsMultiSearch() const { return m_serverMultiSearch; }
 


### PR DESCRIPTION
An idle amuleGUI sitting on the Search panel spends roughly **14 KB per poll for every 1000 search results it holds**, purely to tell the daemon that nothing has changed. At the 3 s cadence that is about 17 MB/hour per 1000 results, per connected client — and it scales with how much the user has open, not with how much changed.

Every figure below was measured with [amule-ec-profiler](https://github.com/got3nks/amule-ec-profiler), a pass-through EC proxy that sizes each packet and breaks it down per tag, so the costs here are observed on the wire rather than reasoned from the source.

## What it costs today

Measured against a daemon holding two finished searches and ~900 results, with the search tab open and nothing running:

| tag | per poll | per result | share |
|---|---|---|---|
| `EC_TAG_SEARCHFILE` | 7.0 KB | ~7.8 B | 57% |
| `EC_TAG_SEARCH_ID` | 5.3 KB | ~5.9 B | 43% |
| **total** | **12.3 KB** | **~13.7 B** | |

Nothing else — every mutable field diffs away correctly through the per-connection valuemap. What remains is a fixed ~14 bytes per result, per poll, forever, for results nobody is looking at.

## Why both halves were there

The envelope was load-bearing. `CRemoteContainer::ProcessUpdate` deletes any item absent from the reply, so omitting an unchanged result made the client drop it from the tab. Absence *was* the deletion protocol.

`EC_TAG_SEARCH_ID` was then emitted unconditionally, outside the valuemap, so a result re-created after such a deletion could still be attributed to a tab. It was guarding against a case the first half caused.

Both fall away once removal is explicit.

## The change

The union now skips a result whose valuemap diff is empty and that the client already has, emits `EC_TAG_FILE_REMOVED` for results the core no longer holds, and sends `EC_TAG_SEARCH_ID` only on a result's first appearance. `CSearchListRem::ProcessUpdate` deletes only on those tombstones instead of sweeping by absence. A tombstone also clears that ECID's valuemap, so a re-created result cannot inherit a diff that would strip the fields it needs — the same hazard `freshEcids` guards on the file path.

This reuses the existing knownfile tombstone rather than inventing a second one: the meaning ("this ECID is gone") and the payload are identical.

## Compatibility

Negotiated as its own capability, `EC_TAG_CAN_PARTIAL_SEARCH`, **not** by reusing `EC_TAG_CAN_PARTIAL_UPDATE`. That existing flag is advertised unconditionally by every `RemoteConnect` client and means the *file* INC_UPDATE stream. An already-released amuleGUI advertises it, speaks multi-search, and still deletes any result missing from the reply — so reusing it would make such a client silently lose its search results against a newer daemon.

| daemon | client | behaviour |
|---|---|---|
| new | new amuleGUI | skips unchanged, explicit tombstones |
| new | older amuleGUI | tag absent → union re-sends everything, exactly as today |
| old | new amuleGUI | no `AUTH_OK` echo → client keeps the absence sweep |
| any | amuleweb / amuleapi / amulecmd | never reach the union |

amuleweb never sets `EC_TAG_CAN_MULTI_SEARCH`, so it stays on the per-search `EC_DETAIL_UPDATE` branch; amuleapi addresses searches by id at `EC_DETAIL_FULL`.

## Measured

Same daemon, same searches, before and after:

| | master | this branch |
|---|---|---|
| results held | 827 | 1491 |
| envelope + search id per poll | 11,616 B | **0 B** |
| **per result per poll** | **~14 B** | **0 B** |
| total per poll (idle) | ~11.6 KB | **10 B** |
| projected at 1000 results | ~14 KB/poll | **10 B/poll** |
| `EC_TAG_SEARCH_ID` | every result, every poll | first appearance only |

The two runs held different amounts, which is the point: master's cost is per result, so it has to be compared per result. This branch's 10 bytes is a bare envelope with a zero tag count — a constant, unchanged whether the client holds 800 results or 1500. The cost is now proportional to what changed, not to what is open.

Mechanism confirmed on the wire rather than inferred: closing two tabs produced 1223 `EC_TAG_FILE_REMOVED` tombstones once each; a subsequent search delivered 313 `EC_TAG_SEARCHFILE` against 269 `EC_TAG_SEARCH_ID`, the 44-tag gap being updates to already-known results correctly omitting the id.

## Testing

- amuleGUI against a live daemon on ed2k + Kad: four searches started, two tabs closed, a fourth search run. Results stay put, close removes them, new results land in the right tab.
- The same daemon with an amuleGUI built from `70c1ec09a` (this branch's base, so the only difference is this change): 11,616 B per poll of envelope + id, zero tombstones, results intact. The fallback is per connection, not global.
- amuleapi curl suite 32/32 phases, `19-search.sh` 108/108.
- clang-format v18 and Tier-2 clang-tidy on changed lines, both clean.

Two things stated rather than measured, so they can be challenged cheaply:

- **Old daemon, new client** is argued, not run. `m_serverPartialSearch` has exactly two writes — `false` in the constructor and `true` only when the daemon echoes the capability in `AUTH_OK` — so against an old daemon the client falls through to the unmodified base `ProcessUpdate`. The premise that an old daemon ignores an unknown `AUTH_REQ` tag is the same mechanism ten existing capability tags already rely on.
- Kad comments are unaffected by construction: that block bypasses the valuemap, so whenever there is anything to report the tag has children and the skip cannot fire. The one case it does not cover — a Kad comment search that finishes finding nothing never telling the client it ended — behaves identically on master, since the client only acts on a tag that is present.

Results carrying Kad comments are still re-sent in full every poll, because that block has no valuemap. That is unchanged here, but it will now be the only remaining per-poll cost and is worth a separate look.
