### PR TITLE
fix(gui): one answer for a peer's ident state, and never a blank field

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1121,6 +1121,10 @@ msgstr ""
 
 #: src/ClientRef.cpp
 msgid "Verified - OK"
+msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
 msgstr ""
 
 #: src/ClientRef.cpp
@@ -3254,10 +3258,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "File sources:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 19:56+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1142,6 +1142,10 @@ msgstr "شخص سيئ"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "تأكيد - صحيح"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "غير متوفر"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3297,10 +3301,6 @@ msgstr ""
 #, fuzzy
 msgid "File sources:"
 msgstr "ايجاد المصدر :"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "غير متوفر"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 19:57+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1159,6 +1159,10 @@ msgstr "Veceru sospechosu"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificáu - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3357,10 +3361,6 @@ msgstr "Llimpiar descargues completaes"
 #, fuzzy
 msgid "File sources:"
 msgstr "Fontes completes"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 19:59+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1137,6 +1137,10 @@ msgstr ""
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Няма"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3290,10 +3294,6 @@ msgstr ""
 #, fuzzy
 msgid "File sources:"
 msgstr "Намерени източници: %i"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Няма"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1120,6 +1120,10 @@ msgstr ""
 
 #: src/ClientRef.cpp
 msgid "Verified - OK"
+msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
 msgstr ""
 
 #: src/ClientRef.cpp
@@ -3253,10 +3257,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "File sources:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 19:59+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1156,6 +1156,10 @@ msgstr "Dolent"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificat - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/D"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3346,10 +3350,6 @@ msgstr "Neteja les baixades completades"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fonts del fitxer:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/D"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:00+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1154,6 +1154,10 @@ msgstr "Zloduch"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Ověřeno - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3338,10 +3342,6 @@ msgstr "Vyčistí dokončená stahování"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Zdroje souboru:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:01+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1145,6 +1145,10 @@ msgstr ""
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3307,10 +3311,6 @@ msgstr ""
 #, fuzzy
 msgid "File sources:"
 msgstr "Fundne Kilder :"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1165,6 +1165,10 @@ msgstr "Böser Bube"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verifiziert - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Nicht verfügbar"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3344,10 +3348,6 @@ msgstr "Vollständige Downloads entfernen"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Dateiquellen:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Nicht verfügbar"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:03+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1168,6 +1168,10 @@ msgstr "Κακό παιδί"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Επιβεβαιώθηκε - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Δεν υπάρχει"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3368,10 +3372,6 @@ msgstr "Καθάρισμα των ολοκληρωμένων κατεβασμά�
 #, fuzzy
 msgid "File sources:"
 msgstr "Ολοκλήρωση πηγών"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Δεν υπάρχει"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1121,6 +1121,10 @@ msgstr ""
 
 #: src/ClientRef.cpp
 msgid "Verified - OK"
+msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
 msgstr ""
 
 #: src/ClientRef.cpp
@@ -3254,10 +3258,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "File sources:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1169,6 +1169,10 @@ msgstr "Cliente sospechoso"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - Correcto"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/D"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3343,10 +3347,6 @@ msgstr "Quita de la lista las descargas completadas"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fuentes del archivo:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/D"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1157,6 +1157,10 @@ msgstr "Paha Poiss"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Kontrollitud - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3347,10 +3351,6 @@ msgstr "Puhastab lõpetatud tõmbamised"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Faili allikad:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:05+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1158,6 +1158,10 @@ msgstr "Tipo gaiztoa"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Egiaztaturik: Ondo"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "E/G"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3348,10 +3352,6 @@ msgstr "Garbitu amaituriko deskargak"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fitxategiaren iturburua:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "E/G"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1158,6 +1158,10 @@ msgstr "Pahis"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Vahvistettu - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Ei saatavilla"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3348,10 +3352,6 @@ msgstr "Siivoaa valmistuneet lataukset pois näkyvistä"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Tiedostolähteet:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Ei saatavilla"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:06+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1167,6 +1167,10 @@ msgstr "Mauvais garçon"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Vérification - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3341,10 +3345,6 @@ msgstr "Effacer les téléchargements terminés"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Sources du fichier :"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:07+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1178,6 +1178,10 @@ msgstr "Rapaz malo"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3357,10 +3361,6 @@ msgstr "Limpar descargas completadas"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes do ficheiro:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:08+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1149,6 +1149,10 @@ msgstr ""
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "ל\"ת"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3320,10 +3324,6 @@ msgstr "מנקה הורדות שהושלמו"
 #, fuzzy
 msgid "File sources:"
 msgstr "מקורות שנמצאו :"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "ל\"ת"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1150,6 +1150,10 @@ msgstr "Los decko"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Priznat - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3317,10 +3321,6 @@ msgstr ""
 #, fuzzy
 msgid "File sources:"
 msgstr "Nadjeni izvori :"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1156,6 +1156,10 @@ msgstr "Rossz fiú"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Hitelesítés - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3327,10 +3331,6 @@ msgstr "Befejeződött letöltések törlése"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fájl források:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1172,6 +1172,10 @@ msgstr "Cattivo"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificata - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/D"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3353,10 +3357,6 @@ msgstr "Rimuovi download completati"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fonti del file:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/D"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1160,6 +1160,10 @@ msgstr "悪意の相手"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "検証されています"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "非適用"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3346,10 +3350,6 @@ msgstr "完成したダウンロードをクリアします"
 #, fuzzy
 msgid "File sources:"
 msgstr "ソース完了"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "非適用"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:12+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1167,6 +1167,10 @@ msgstr "나쁜 사람"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "인증됨"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "없음"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3366,10 +3370,6 @@ msgstr "완료된 내려받기 정리"
 #, fuzzy
 msgid "File sources:"
 msgstr "자료 유지"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "없음"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:13+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1171,6 +1171,10 @@ msgstr "Kenkėjas"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Praėjo patikrinimą"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Nežinoma"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3380,10 +3384,6 @@ msgstr "Pašalinti iš sąrašo jau atsiųstus failus"
 #, fuzzy
 msgid "File sources:"
 msgstr "Pilni šaltiniai"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Nežinoma"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1131,6 +1131,10 @@ msgstr "Sliktais čalis"
 
 #: src/ClientRef.cpp
 msgid "Verified - OK"
+msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
 msgstr ""
 
 #: src/ClientRef.cpp
@@ -3270,10 +3274,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "File sources:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:13+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1158,6 +1158,10 @@ msgstr "Slechterik"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Gecontroleerd - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/B"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3351,10 +3355,6 @@ msgstr "Verwijdert complete downloads"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Bestandsbronnen:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/B"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:14+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1166,6 +1166,10 @@ msgstr "Kjeltring"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Granska - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "I/T"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3365,10 +3369,6 @@ msgstr "Ryddar bort ferdige nedlastingar"
 #, fuzzy
 msgid "File sources:"
 msgstr "Komplette kjelder"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "I/T"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:15+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1163,6 +1163,10 @@ msgstr "Zły człowiek"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Weryfikacja - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Brak"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3361,10 +3365,6 @@ msgstr "Wyczyść skończone pobierania"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Źródła pliku:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Brak"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:16+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1168,6 +1168,10 @@ msgstr "Cara Mau"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3349,10 +3353,6 @@ msgstr "Limpar downloads completados"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes de arquivos:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:16+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1164,6 +1164,10 @@ msgstr "Pessoa Maldosa"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificado - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/D"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3354,10 +3358,6 @@ msgstr "Limpa os downloads concluídos"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes de ficheiros:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/D"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:17+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1160,6 +1160,10 @@ msgstr "Utilizator rău"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verificat - ok"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "NU SE APLICĂ"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3356,10 +3360,6 @@ msgstr "Curăță descărcările terminate"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Surse fișier:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "NU SE APLICĂ"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:18+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1171,6 +1171,10 @@ msgstr "Нарушитель"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Проверено - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3378,10 +3382,6 @@ msgstr "Очистить результаты"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Источников:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1168,6 +1168,10 @@ msgstr "Baraba"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Preverjeno – v redu"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "Ni na voljo"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3375,10 +3379,6 @@ msgstr "Počisti zaključena prejemanja"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Viri datoteke:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "Ni na voljo"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1163,6 +1163,10 @@ msgstr "Djale i keq"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "E verifikuar - Ne rregull"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3358,10 +3362,6 @@ msgstr "Pastro shkarkimet e perfunduara"
 #, fuzzy
 msgid "File sources:"
 msgstr "Burime te gjetura :"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1156,6 +1156,10 @@ msgstr "Bad Guy"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Verifierad - OK"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3346,10 +3350,6 @@ msgstr "Rensar färdiga nedladdningar"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Filkällor:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1120,6 +1120,10 @@ msgstr ""
 
 #: src/ClientRef.cpp
 msgid "Verified - OK"
+msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
 msgstr ""
 
 #: src/ClientRef.cpp
@@ -3253,10 +3257,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "File sources:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1160,6 +1160,10 @@ msgstr "Kötü Çocuk"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "İncelendi - Tamam"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3334,10 +3338,6 @@ msgstr "Tamamlanan aktarımları temizler."
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Dosya kaynakları:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:20+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1162,6 +1162,10 @@ msgstr "Поганий хлопець"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "Перевірено - добре"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "недоступні"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3376,10 +3380,6 @@ msgstr "Очистити завершені звантаження"
 #, fuzzy
 msgid "File sources:"
 msgstr "Завершених джерел"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "недоступні"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1120,6 +1120,10 @@ msgstr ""
 
 #: src/ClientRef.cpp
 msgid "Verified - OK"
+msgstr ""
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
 msgstr ""
 
 #: src/ClientRef.cpp
@@ -3253,10 +3257,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "File sources:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:21+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1164,6 +1164,10 @@ msgstr "坏蛋"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "验证 - 通过"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3347,10 +3351,6 @@ msgstr "清除已完成的下载"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "文件源:"
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-30 17:42+0200\n"
+"POT-Creation-Date: 2026-07-31 00:41+0200\n"
 "PO-Revision-Date: 2026-07-30 20:21+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1158,6 +1158,10 @@ msgstr "壞蛋"
 #: src/ClientRef.cpp
 msgid "Verified - OK"
 msgstr "驗證通過"
+
+#: src/ClientRef.cpp src/muuli_wdr.cpp
+msgid "N/A"
+msgstr "N/A"
 
 #: src/ClientRef.cpp
 msgid "Not Available"
@@ -3340,10 +3344,6 @@ msgstr "清除已完成的檔案"
 #: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "檔案來源："
-
-#: src/muuli_wdr.cpp
-msgid "N/A"
-msgstr "N/A"
 
 #: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 msgid "General"

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2667,29 +2667,40 @@ void CUpDownClient::UpdateStats()
 	}
 }
 
+// All five go through GetCurrentIdentState(), which is the one place that
+// decides what a missing credits object means (IS_NOTAVAILABLE). Testing
+// `credits &&` here instead made the boolean set unable to express that
+// state: with credits still NULL -- its value from construction until the
+// peer's user hash resolves -- every predicate answered false, including
+// SUINotSupported(), while the accessor on the same object was reporting
+// exactly IS_NOTAVAILABLE.
+//
+// Only SUINotSupported() changes behaviour. For the other four the guard
+// was redundant: a NULL credits yields IS_NOTAVAILABLE, which already
+// compares unequal to the state each of them asks about.
 bool CUpDownClient::IsIdentified() const
 {
-	return (credits && credits->GetCurrentIdentState(GetIP()) == IS_IDENTIFIED);
+	return GetCurrentIdentState() == IS_IDENTIFIED;
 }
 
 bool CUpDownClient::IsBadGuy() const
 {
-	return (credits && credits->GetCurrentIdentState(GetIP()) == IS_IDBADGUY);
+	return GetCurrentIdentState() == IS_IDBADGUY;
 }
 
 bool CUpDownClient::SUIFailed() const
 {
-	return (credits && credits->GetCurrentIdentState(GetIP()) == IS_IDFAILED);
+	return GetCurrentIdentState() == IS_IDFAILED;
 }
 
 bool CUpDownClient::SUINeeded() const
 {
-	return (credits && credits->GetCurrentIdentState(GetIP()) == IS_IDNEEDED);
+	return GetCurrentIdentState() == IS_IDNEEDED;
 }
 
 bool CUpDownClient::SUINotSupported() const
 {
-	return (credits && credits->GetCurrentIdentState(GetIP()) == IS_NOTAVAILABLE);
+	return GetCurrentIdentState() == IS_NOTAVAILABLE;
 }
 
 uint64 CUpDownClient::GetDownloadedTotal() const

--- a/src/ClientRef.cpp
+++ b/src/ClientRef.cpp
@@ -184,6 +184,13 @@ wxString CClientRef::GetSecureIdentTextStatus() const
 			ret = _("Bad Guy");
 		} else if (m_client->IsIdentified()) {
 			ret = _("Verified - OK");
+		} else {
+			// Unreachable while the five predicates cover every EIdentState,
+			// but the only caller assigns this straight into the Client
+			// Details label, so an unmatched state would blank the field
+			// instead of leaving its _("N/A") placeholder. Keep the chain
+			// total, and reuse that same placeholder text.
+			ret = _("N/A");
 		}
 	} else {
 		ret = _("Not Available");


### PR DESCRIPTION
## Summary

Fixes https://github.com/amule-org/amule/issues/727.

`CUpDownClient` had two accessors disagreeing about what a missing credits object means. `GetCurrentIdentState()` treats it as `IS_NOTAVAILABLE`; the five boolean predicates tested `credits &&` instead, so with `credits` still `NULL` every one of them returned `false` — including `SUINotSupported()`, which is exactly the state the accessor was reporting. `credits` is `NULL` from construction until the peer's user hash resolves, so this is reachable rather than theoretical.

The visible effect was in the Client Details dialog. `CClientRef::GetSecureIdentTextStatus()` is an `if / else if` chain over those five predicates with no final `else`, and its result is assigned straight into the label. All five false left the string empty, blanking the **Secure ident:** field and overwriting the `_("N/A")` placeholder it was built with. The same dialog reads "Not supported" in `amulegui`, whose predicates compare `m_identState` directly and whose credits object is always allocated — so the monolithic GUI was the odd one out, disagreeing with both `amulegui` and the EC / Web API view, all of which go through `GetCurrentIdentState()`.

**The fix** defines the predicates in terms of that accessor. The contradiction then cannot recur: they are the accessor's answer rather than a second opinion about it.

The chain also gets a final `else`. It is unreachable while the five predicates cover every `EIdentState`, but a sixth state would otherwise silently blank the field again instead of failing visibly.

### Blast radius is smaller than it looks

Only `SUINotSupported()` changes behaviour, and it has **exactly one caller in the tree** — the chain being fixed. For the other four the guard was redundant: a `NULL` credits yields `IS_NOTAVAILABLE`, which already compares unequal to the state each of them asks about, so their 6 / 4 / 1 / 1 call sites are unaffected.

### On the catalogs

No new translatable string — the fallback reuses the `_("N/A")` the field is already built with. The catalogs still move, because since #673 they record locations by file and that msgid's reference list gains `src/ClientRef.cpp`. Existing translations are preserved.

## Test plan

Built on macOS 15 ARM64 with `MONOLITHIC` + `DAEMON` + `REMOTEGUI` + `AMULECMD` + `AMULEAPI` + `TESTING`: 0 errors, `ctest` 29/29. Both divergent implementations compile — the monolithic `aMule.app` and `aMuleGUI.app` now report the same thing for the same peer.

`git clang-format origin/master` reports nothing to format. Diff-scoped clang-tidy is clean against both `.clang-tidy-new-code` and `.clang-tidy`, each analysing 5 TUs with 0 truncated ASTs.

**Not unit-tested, deliberately.** Nothing currently links `BaseClient` / `ClientRef`; `CUpDownClient`'s construction pulls a 49-include closure with five app-singleton headers, and the chain needs `theApp` for `CryptoAvailable()`. A harness for that would dwarf the fix. Routing the predicates through the accessor makes the disagreement unrepresentable instead, which is a stronger guarantee than a test could give — a test could only sample states, whereas the definition covers all of them.

The reproduction in the issue (a source added from a server response, opened before it completes the eD2k handshake) has a short window and depends on live peers, so it has not been reproduced end to end here; the fix is derived from the code paths rather than from a captured repro.

## Left out

The issue's "Related, same area" note — that `GenericClientListCtrl` draws an overlay for `IsIdentified()` and `IsBadGuy()` but nothing for `SUIFailed()`, so a peer whose signature actually failed looks identical to one that never supported SecIdent. That is a real gap, but it needs a decision on which icon to use, so it belongs in its own change.
