### PR TITLE
perf(web-ui): drive the comments tab off SSE instead of polling

### DIFF
--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -141,6 +141,14 @@ function openSse() {
     try { store.set("search:progress", JSON.parse(ev.data)); } catch (_) {}
   });
 
+  // Comments ride their own event (EVENTS.md §comments_updated) instead of
+  // download_updated, so the per-tick download frame stays lean. The payload is
+  // byte-for-byte the GET downloads/{hash}/comments body — the detail view
+  // applies it directly rather than re-fetching.
+  es.addEventListener("comments_updated", (ev) => {
+    try { store.set("comments:updated", JSON.parse(ev.data)); } catch (_) {}
+  });
+
   es.addEventListener("resync", () => {
     if (statusActive) refreshStatus();
     for (const k of active) seed(k);

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -6,6 +6,7 @@
 // frames short-circuit to a 304 + the cached body).
 
 import { api } from "../api.js";
+import { store } from "../store.js";
 import { html, useState, useEffect, useRef, useStore } from "../dom.js";
 import { ProgressBar, Placeholder, toast, confirmDialog, Section, statRow, IdentityLine, copyText, Tabs, CommentEditor, RenameForm, ratingLabel, PRIORITIES, prioValue, prioLabel } from "../components.js";
 import { formatBytes, formatSpeed, formatDuration, formatInt, formatPercent, formatTimestamp } from "../format.js";
@@ -105,7 +106,8 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
                         defaultSort="downloaded" />
       ` : tab === "comments" ? html`
         <${DownloadComments} hash=${d.hash} comment=${d.comment} rating=${d.rating}
-                             tick=${downloads} parts=${(d.progress && d.progress.parts) || []} />
+                             running=${!!(downloads.find((x) => x.hash === d.hash) || {}).kad_comment_search_running}
+                             parts=${(d.progress && d.progress.parts) || []} />
       ` : tab === "filename" ? html`
         <${DownloadFilenames} hash=${d.hash} name=${d.name}
                               onRenamed=${() => setReload((n) => n + 1)} />
@@ -230,9 +232,12 @@ function DetailActions({ d, isGuest, categories, onPatch, onDelete, onClear }) {
 
 // The Comments tab body: your own comment/rating editor, a "Get from Kad"
 // trigger, and the per-source comments list (GET downloads/{hash}/comments —
-// includes any retrieved Kad notes). Re-fetches on each downloads store tick so
-// Kad notes arriving mid-search surface without a bespoke polling timer.
-function DownloadComments({ hash, comment, rating, tick, parts }) {
+// includes any retrieved Kad notes). Fetched once per file, then kept current
+// by the comments_updated SSE event, whose payload is this same body: Kad notes
+// arriving mid-search and source comments both land without polling. `running`
+// comes from the downloads store (the flag is part of EqualDownload, so its
+// start -> finish edge arrives as download_updated).
+function DownloadComments({ hash, comment, rating, running, parts }) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
@@ -240,10 +245,12 @@ function DownloadComments({ hash, comment, rating, tick, parts }) {
     api.get("downloads/" + hash + "/comments")
       .then((d) => { if (alive) setData(d); })
       .catch(() => { if (alive) setData({ count: 0, comments: [] }); });
-    return () => { alive = false; };
-  }, [hash, tick]);
+    const off = store.subscribe("comments:updated", (p) => {
+      if (alive && p && p.hash === hash) setData(p);
+    });
+    return () => { alive = false; off(); };
+  }, [hash]);
 
-  const running = !!(data && data.kad_comment_search_running);
   const list = (data && data.comments) || [];
   // The daemon only accepts a comment/rating on a *shared* file, i.e. a
   // partfile with >= 1 complete part; otherwise PATCH returns 409 not_shared.


### PR DESCRIPTION
The download detail's Comments tab re-fetched GET /downloads/{hash}/comments on every tick of the downloads store, so an open tab on an active download issued roughly one request per second. amuled already emits a comments_updated SSE event whose payload is byte-for-byte that same body (EVENTS.md), and it was simply not wired up on the client.

- events.js: subscribe to comments_updated and republish it on the "comments:updated" store key, matching the existing search:result / log:appended one-off event pattern.
- download-detail.js: DownloadComments now fetches once per hash and applies the event payload directly when its hash matches, so retrieved Kad notes and source-reported comments both land without polling. Because EqualComments is deliberately excluded from EqualDownload, notes arriving mid-search on an otherwise idle (paused/stopped) download previously stayed invisible until the lookup finished; they now show up as they arrive.
- The "Searching Kad…" button state reads kad_comment_search_running from the downloads store rather than from the comments body: the Comments tab pins liveTick to 0, so the detail object never refreshes while that tab is open, whereas the list item does (the flag is part of EqualDownload, so its start -> finish edge arrives as download_updated).

Verified against a running amuled: one GET /comments over a 90s open tab (previously one per tick), the button flipping to "Searching Kad…" and back on a real Kad lookup, and no console errors.