### PR TITLE
chore(ci): drop the java-kotlin CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,8 +89,9 @@ jobs:
           - language: c-cpp
             # build-mode: autobuild
             build-mode: manual
-          - language: java-kotlin
-            build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
+          # java-kotlin was dropped: the tree's last Java file, the generated
+          # ECCodes.java, went with the committed EC headers, so the analysis
+          # had nothing left to scan and failed on every run.
           - language: python
             build-mode: none
           #- language: ruby


### PR DESCRIPTION
## Summary

`CodeQL Advanced / Analyze (java-kotlin)` fails on every run because the repository has no Java left to scan.

## Why it started failing

The tree's last `.java` file was the generated `ECCodes.java`, removed in `e86646c40` (#716) along with the other committed EC headers. `git ls-files '*.java'` now returns nothing, so the analysis has an empty source set.

## Change

Removes the `java-kotlin` entry from the language matrix, leaving `actions`, `c-cpp` and `python` — what the repository actually contains. Build modes for the remaining three are untouched (`none`, `manual`, `none`).
