### PR TITLE
feat(ec): make the EC authentication throttle configurable

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -579,13 +579,18 @@ void CECServerSocket::WriteDoneAndQueueEmpty()
 //-------------------- ExternalConn --------------------
 
 ExternalConn::ExternalConn(amuleIPV4Address addr, wxString *msg)
-// Ten failures a minute, then five minutes out. Deliberately looser than
-// amuleapi's five, because an EC client retries on its own: amulegui
-// reconnects on a dropped link, so a saved password that has gone stale burns
-// attempts with no human in the loop, and a tight threshold would lock out
-// someone who never typed anything. Ten still caps a guesser at nine attempts
-// a minute against the thousands per second possible before this.
-: m_authRateLimiter(CRateLimiter::Config{ 60u, 10u, 300u })
+// Defaults are ten failures a minute, then five minutes out -- deliberately
+// looser than amuleapi's five, because an EC client retries on its own:
+// amulegui reconnects on a dropped link, so a saved password that has gone
+// stale burns attempts with no human in the loop, and a tight threshold would
+// lock out someone who never typed anything. Ten still caps a guesser at nine
+// attempts a minute against the thousands per second possible before this.
+//
+// Read once at construction, so changing them takes a restart -- the same as
+// every other setting on this listener, which is rebuilt at startup anyway.
+: m_authRateLimiter(CRateLimiter::Config{ thePrefs::ECAuthFailureWindowSeconds(),
+	  thePrefs::ECAuthFailureThreshold(),
+	  thePrefs::ECAuthLockoutSeconds() })
 {
 	wxString msgLocal;
 	m_ECServer = NULL;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -202,6 +202,9 @@ bool CPreferences::s_ECRequireEncryption;
 wxString CPreferences::s_ECAddr;
 wxString CPreferences::s_ECNetworkInterface;
 uint32 CPreferences::s_ECPort;
+uint32 CPreferences::s_ECAuthFailureWindowSeconds;
+uint32 CPreferences::s_ECAuthFailureThreshold;
+uint32 CPreferences::s_ECAuthLockoutSeconds;
 wxString CPreferences::s_ECPassword;
 bool CPreferences::s_TransmitOnlyUploadingClients;
 bool CPreferences::s_IPFilterClients;
@@ -1464,6 +1467,17 @@ void CPreferences::BuildItemList(const wxString &appdir)
 		(new Cfg_Str_Encrypted("/ExternalConnect/ECPassword", s_ECPassword, "")));
 	NewCfgItem(IDC_UPNP_EC_ENABLED,
 		(new Cfg_Bool("/ExternalConnect/UPnPECEnabled", s_UPnPECEnabled, false)));
+	// Brute-force throttle for the EC password exchange. Config-only, with no
+	// dialog field: the defaults suit everyone who is not tuning for an
+	// unusual deployment, and a busy Remote Controls page is a poor place to
+	// explain a sliding window. amuleapi exposes the same three knobs for its
+	// own login, so an operator can now tune both front doors rather than only
+	// the narrower one.
+	s_MiscList.push_back(
+		MkCfg_Int("/ExternalConnect/AuthFailureWindowSeconds", s_ECAuthFailureWindowSeconds, 60));
+	s_MiscList.push_back(
+		MkCfg_Int("/ExternalConnect/AuthFailureThreshold", s_ECAuthFailureThreshold, 10));
+	s_MiscList.push_back(MkCfg_Int("/ExternalConnect/AuthLockoutSeconds", s_ECAuthLockoutSeconds, 300));
 
 	/**
 	 * GUI behavior

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -620,6 +620,11 @@ public:
 	static const wxString &GetECNetworkInterface() { return s_ECNetworkInterface; }
 	static void SetECNetworkInterface(const wxString &val) { s_ECNetworkInterface = val; }
 	static uint32 ECPort() { return s_ECPort; }
+	// EC password-exchange throttle. Config-only (no dialog field); see the
+	// registration in Preferences.cpp for why.
+	static uint32 ECAuthFailureWindowSeconds() { return s_ECAuthFailureWindowSeconds; }
+	static uint32 ECAuthFailureThreshold() { return s_ECAuthFailureThreshold; }
+	static uint32 ECAuthLockoutSeconds() { return s_ECAuthLockoutSeconds; }
 	static void SetECPort(uint32 val) { s_ECPort = val; }
 	static const wxString &ECPassword() { return s_ECPassword; }
 	static void SetECPass(const wxString &pass) { s_ECPassword = pass; }
@@ -1107,6 +1112,9 @@ protected:
 	static wxString s_ECAddr;
 	static wxString s_ECNetworkInterface;
 	static uint32 s_ECPort;
+	static uint32 s_ECAuthFailureWindowSeconds;
+	static uint32 s_ECAuthFailureThreshold;
+	static uint32 s_ECAuthLockoutSeconds;
 	static wxString s_ECPassword;
 	static bool s_TransmitOnlyUploadingClients;
 

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -508,6 +508,18 @@ target_link_libraries (AuthTest
 	mulecommon
 )
 
+# EC password-exchange throttle: exercises the limiter at the values the
+# listener ships with. The limiter lives in mulecommon, so nothing
+# webapi-specific is needed here.
+add_executable (RateLimiterTest
+	RateLimiterTest.cpp
+)
+add_test (NAME RateLimiterTest COMMAND RateLimiterTest)
+target_link_libraries (RateLimiterTest
+	muleunit
+	mulecommon
+)
+
 # amuleapi state cache — snapshot semantics + concurrent-reader
 # correctness on the shared_timed_mutex.
 add_executable (StateTest

--- a/unittests/tests/RateLimiterTest.cpp
+++ b/unittests/tests/RateLimiterTest.cpp
@@ -1,0 +1,156 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <common/RateLimiter.h>
+#include <muleunit/test.h>
+
+using namespace muleunit;
+
+// The External Connection listener's shipped defaults, copied here rather than
+// read from Preferences: the limiter is a standalone class and pulling in the
+// preferences machinery would need a running app.
+//
+// So this fixture asserts the limiter behaves correctly *at the numbers EC
+// ships with* -- it does not verify that Preferences.cpp still registers those
+// numbers. Changing a default there and not here leaves this suite green. What
+// it does catch is a regression in the limiter itself: AuthTest exercises the
+// same class with small synthetic values, and these cases add the ones EC
+// depends on, including that the window slides rather than tumbles.
+namespace
+{
+const unsigned EC_WINDOW = 60;
+const unsigned EC_THRESHOLD = 10;
+const unsigned EC_LOCKOUT = 300;
+
+CRateLimiter::Config EcDefaults()
+{
+	CRateLimiter::Config cfg;
+	cfg.window_seconds = EC_WINDOW;
+	cfg.threshold = EC_THRESHOLD;
+	cfg.lockout_seconds = EC_LOCKOUT;
+	return cfg;
+}
+} // namespace
+
+DECLARE_SIMPLE(RateLimiterTest)
+
+TEST(RateLimiterTest, AllowsNineFailuresThenLocksOnTheTenth)
+{
+	std::time_t now = 1000;
+	CRateLimiter rl(EcDefaults(), [&] { return now; });
+
+	// The threshold is the count that arms the lockout, so the first nine
+	// failures must each leave the next attempt permitted.
+	for (unsigned i = 0; i < EC_THRESHOLD - 1; ++i) {
+		rl.NoteFailure("10.0.0.1");
+		ASSERT_FALSE(rl.Check("10.0.0.1").locked_out);
+	}
+
+	rl.NoteFailure("10.0.0.1");
+	ASSERT_TRUE(rl.Check("10.0.0.1").locked_out);
+}
+
+TEST(RateLimiterTest, ReportsTheFullLockoutOnTheFirstRefusal)
+{
+	std::time_t now = 1000;
+	CRateLimiter rl(EcDefaults(), [&] { return now; });
+
+	for (unsigned i = 0; i < EC_THRESHOLD; ++i) {
+		rl.NoteFailure("10.0.0.1");
+	}
+	// The daemon puts this number in front of the user, so it has to be the
+	// real remaining time rather than a constant.
+	ASSERT_EQUALS((std::time_t)EC_LOCKOUT, rl.Check("10.0.0.1").retry_after_seconds);
+
+	now += 100;
+	ASSERT_EQUALS((std::time_t)(EC_LOCKOUT - 100), rl.Check("10.0.0.1").retry_after_seconds);
+}
+
+TEST(RateLimiterTest, LockoutExpiresAndTheAddressIsUsableAgain)
+{
+	std::time_t now = 1000;
+	CRateLimiter rl(EcDefaults(), [&] { return now; });
+
+	for (unsigned i = 0; i < EC_THRESHOLD; ++i) {
+		rl.NoteFailure("10.0.0.1");
+	}
+	ASSERT_TRUE(rl.Check("10.0.0.1").locked_out);
+
+	now += EC_LOCKOUT + 1;
+	ASSERT_FALSE(rl.Check("10.0.0.1").locked_out);
+}
+
+TEST(RateLimiterTest, SuccessClearsTheStreak)
+{
+	std::time_t now = 1000;
+	CRateLimiter rl(EcDefaults(), [&] { return now; });
+
+	// A user who mistypes, gets in, then mistypes again must not be locked
+	// out by the two streaks adding up: nine plus nine is well past the
+	// threshold, but the success in between resets the count.
+	for (unsigned i = 0; i < EC_THRESHOLD - 1; ++i) {
+		rl.NoteFailure("10.0.0.1");
+	}
+	rl.NoteSuccess("10.0.0.1");
+	for (unsigned i = 0; i < EC_THRESHOLD - 1; ++i) {
+		rl.NoteFailure("10.0.0.1");
+	}
+	ASSERT_FALSE(rl.Check("10.0.0.1").locked_out);
+}
+
+TEST(RateLimiterTest, BucketsAreIndependentPerAddress)
+{
+	std::time_t now = 1000;
+	CRateLimiter rl(EcDefaults(), [&] { return now; });
+
+	for (unsigned i = 0; i < EC_THRESHOLD; ++i) {
+		rl.NoteFailure("10.0.0.1");
+	}
+	ASSERT_TRUE(rl.Check("10.0.0.1").locked_out);
+	// One guesser must not lock everyone else out of the daemon.
+	ASSERT_FALSE(rl.Check("10.0.0.2").locked_out);
+}
+
+TEST(RateLimiterTest, WindowSlidesRatherThanTumbling)
+{
+	std::time_t now = 1000;
+	CRateLimiter rl(EcDefaults(), [&] { return now; });
+
+	// The failure that matters is the one that ages out. Spend the whole
+	// allowance, let a single stamp expire, and only one more failure should
+	// fit before the lockout arms again -- a tumbling window would have
+	// cleared the entire count at the boundary and allowed the full
+	// allowance a second time.
+	for (unsigned i = 0; i < EC_THRESHOLD - 1; ++i) {
+		rl.NoteFailure("10.0.0.1");
+	}
+	now += EC_WINDOW + 1;
+
+	for (unsigned i = 0; i < EC_THRESHOLD - 1; ++i) {
+		rl.NoteFailure("10.0.0.1");
+		ASSERT_FALSE(rl.Check("10.0.0.1").locked_out);
+	}
+	rl.NoteFailure("10.0.0.1");
+	ASSERT_TRUE(rl.Check("10.0.0.1").locked_out);
+}


### PR DESCRIPTION
amuleapi already exposes its login limiter's window, threshold and lockout as `amuleapi.conf` keys under `[Auth]`. The EC throttle shipped in #741 hardcoded, so an operator can tune the narrower front door but not the one that grants full control of the daemon — shutdown, arbitrary downloads, config changes. That's backwards.

## What changes

Three keys under `/ExternalConnect` in `amule.conf`, with the defaults from #741:

| key | default |
|---|---|
| `AuthFailureWindowSeconds` | 60 |
| `AuthFailureThreshold` | 10 |
| `AuthLockoutSeconds` | 300 |

Registered through `s_MiscList` rather than `NewCfgItem`, since they need no dialog field — that's the existing pattern for config-only settings such as `/eMule/AdvancedSpamFilter` and `/Obfuscation/CryptoPaddingLenght`. They're written to `amule.conf` on save, so they're discoverable rather than hidden.

Read once at construction, so a change takes a restart — the same as every other setting on this listener, which is built at startup anyway.

## Tests

`RateLimiterTest` covers the limiter at the values EC ships with: the allowance, the retry-after countdown, lockout expiry, per-address isolation, that a success clears the streak, and that the window slides rather than tumbles.

Mutation-checked rather than assumed — neutering `NoteSuccess` trips two assertions, and swapping the sliding window for a tumbling one trips another. Restoring makes it pass.

Scope worth stating: the fixture copies the defaults rather than reading `Preferences`, because the limiter is a standalone class and pulling in the preferences machinery would need a running app. So it verifies the limiter's behaviour at those numbers, not that `Preferences.cpp` still registers them — changing a default there and not here leaves the suite green. The test comment says so.

No new strings; config keys aren't translatable, so the catalogs are untouched.
