### PR TITLE
fix(gui): open the notebook tab context menu at the pointer

### DIFF
--- a/src/MuleNotebook.cpp
+++ b/src/MuleNotebook.cpp
@@ -181,7 +181,11 @@ void CMuleNotebook::OnRMButton(wxMouseEvent &event)
 		menu.Append(MP_CLOSE_ALL_TABS, wxString(_("Close all tabs")));
 		menu.Append(MP_CLOSE_OTHER_TABS, wxString(_("Close other tabs")));
 
-		PopupMenu(&menu, event.GetPosition());
+		// Pop up at the pointer. On wxGTK the right-click lands on the tab
+		// strip, which sits outside the client area PopupMenu() positions
+		// against, so event.GetPosition() offset the menu upward by the
+		// tab-strip height. The default position uses the cursor instead.
+		PopupMenu(&menu);
 	}
 }
 


### PR DESCRIPTION
The right-click context menu on notebook tabs (e.g. the search-results tabs) opened misplaced on wxGTK — above the tab, near the top of the notebook, instead of at the cursor.

`CMuleNotebook::OnRMButton` passed `event.GetPosition()` to `PopupMenu()`. The right-click lands on the tab strip, which on a native wxGTK `wxNotebook` sits outside the client area `PopupMenu()` positions against, so the menu was offset upward by the tab-strip height. Dropping the explicit position lets it open at the pointer (wxMSW/wxOSX already default to the cursor, so no change there).

Verified on Linux (wxGTK): right-clicking a search-result tab now opens the menu at the cursor, and Close / Close all tabs / Close other tabs still act on the correct tab.
