### PR TITLE
fix(security): restrict config files to 0600 and drop hand-rolled HKDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.10...3.31)
 project (amule)
 
 set (MIN_BOOST_VERSION 1.70)
-set (MIN_CRYPTOPP_VERSION 5.6)
+set (MIN_CRYPTOPP_VERSION 8.1)
 set (MIN_GDLIB_VERSION 2.0.0)
 set (MIN_WX_VERSION 3.2.0)
 set (PACKAGE "amule")

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,13 +10,16 @@ following packages:
 | CMake     | 3.10            |                                   |
 | zlib      | 1.2.3           |                                   |
 | wxWidgets | 3.2.0           | 3.2 branch or newer               |
-| Crypto++  | 5.6             | classic or cryptopp-modern        |
+| Crypto++  | 8.1             | classic or cryptopp-modern        |
 | Boost     | 1.47            | headers only; only `asio` is used |
 
 The Crypto++ row accepts either the classic
 [weidai11/cryptopp](https://github.com/weidai11/cryptopp) library (minimum
-5.6) or the [cryptopp-modern](https://github.com/cryptopp-modern/cryptopp-modern)
-fork (any release). The cmake check disambiguates the two by `CRYPTOPP_VERSION`.
+8.1, for ChaCha20-Poly1305) or the
+[cryptopp-modern](https://github.com/cryptopp-modern/cryptopp-modern) fork (any
+release — it is based on 8.9.0, so every release clears the minimum). The cmake
+check disambiguates the two by `CRYPTOPP_VERSION`, which the fork encodes as a
+calendar version.
 
 For `amuleweb` you'll also need a POSIX-compliant regex library — part of
 the standard C library on most GNU systems.

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -186,6 +186,11 @@ msgstr ""
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 19:56+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -190,6 +190,11 @@ msgstr "فشل لفتح %s (%s)"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 19:57+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -201,6 +201,11 @@ msgstr "Fallu al abrir ficheru ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISU: Nun pues amestate a tí mesmu como una fonte pa un enllaz eD2k teniendo ID baxa."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 19:59+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -191,6 +191,11 @@ msgstr "Грешка при запис на файла с кредити"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -185,6 +185,11 @@ msgstr ""
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 19:59+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -201,6 +201,11 @@ msgstr "No s'ha pogut obrir el fitxer de enllaços ED2K."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVÍS: No us podeu afegir com a font per a un enllaç eD2k mentre teniu ID Baixa."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:00+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -199,6 +199,11 @@ msgstr "Selhalo otvírání souboru ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROVÁNÍ: Nemůžete přidat sebe jako zdroj pro eD2k odkaz, když máte LowID."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:01+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -191,6 +191,11 @@ msgstr "Kunne ikke åbne %s (%s)"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -210,6 +210,11 @@ msgstr "Fehler beim Öffnen der ED2KLinks-Datei."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WARNUNG: Man kann sich nicht als Quelle für einen eD2k-Verweis hinzufügen während man eine niedrige ID hat."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:03+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -201,6 +201,11 @@ msgstr "Αποτυχία ανοίγματος %s (%s)"
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν μπορείτε να προσθέσετε τον εαυτό σας σαν πηγή για έναν σύνδεσμο eD2k ενώ έχετε χαμηλή προτεραιότητα."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -186,6 +186,11 @@ msgstr ""
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -212,6 +212,11 @@ msgstr "Error al abrir el archivo de enlaces ED2K."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: no puede añadirse a sí mismo como fuente para un enlace eD2k teniendo Id Baja."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -201,6 +201,11 @@ msgstr "Ei suuda avada ED2KLinks faili."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "HOIATUS: Sa ei saa ennast eD2k lingi jaoks allikana lisada ajal kui omad lowid'd."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:05+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -202,6 +202,11 @@ msgstr "Huts ED2KLinks fitxategia irekitzerakoan."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "KONTUZ: Ezin duzu zure burua ezarri eD2k lotura batean Id baxua duzunean."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -202,6 +202,11 @@ msgstr "ED2KLinks-tiedoston avaus epäonnistui."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VAROITUS: Et voi lisätä itseäsi lähteeksi eD2k-linkkiin kun sinulla on LowID."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:06+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -209,6 +209,11 @@ msgstr "Échec de l'ouverture du fichier ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVERTISSEMENT : Vous ne pouvez pas vous ajouter vous-même en tant que source pour un lien eD2k alors que vous avez un LowID."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:07+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -222,6 +222,11 @@ msgstr "Non se puido abrir o ficheiro con ligazóns eD2k."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Non podes engadirte a ti mesmo como unha fonte para un enlace eD2k tendo ID baixa."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:08+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -196,6 +196,11 @@ msgstr "פתיחת הקובץ %s·(%s נכשלה"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -194,6 +194,11 @@ msgstr "Neuspjelo otvaranje %s (%s)"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -205,6 +205,11 @@ msgstr "ED2KLinks fájl megnyitása sikertelen."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "FIGYELEM: Nem adhatod magad forrásként egy eD2k hivatkozáshoz amíg alacsony azonosítód (lowid) van."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -211,6 +211,11 @@ msgstr "Impossibile aprire il link ed2k."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link eD2k finché avrai un ID basso."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -197,6 +197,11 @@ msgstr "%s（%s）を開くことはできませんでした"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:12+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -196,6 +196,11 @@ msgstr "%s(%s)을 열지 못했습니다."
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:13+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -199,6 +199,11 @@ msgstr "Nepavyko atverti %s (%s)"
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "DĖMESIO: jei jūsų ID yra žemas, negalite įdėti savęs prie eD2k nuorodos šaltinių."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -187,6 +187,11 @@ msgstr ""
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:13+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -203,6 +203,11 @@ msgstr "Kon bestand ED2KLinks niet openen."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "WAARSCHUWING: U kunt uzelf niet toevoegen als bron voor een eD2k-link terwijl u een laag id hebt."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:14+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -199,6 +199,11 @@ msgstr "Greidde ikkje å opne %s·(%s)"
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ÅTVARING: Du kan ikkje leggje deg sjølv til som kjelde for ei eD2k lenkje medan du har ein lågid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:15+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -203,6 +203,11 @@ msgstr "Nie udało się otworzyć pliku ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UWAGA: Nie możesz dodać samego siebie jako źródło linku ed2k, gdy masz lowid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:16+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -210,6 +210,11 @@ msgstr "Falha ao abrir arquivo de Ligações ED2K."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "CUIDADO: Você não pode adicionar você mesmo como uma fonte para uma ligação eD2k quando tem um lowid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:16+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -208,6 +208,11 @@ msgstr "Falha ao abrir ficheiro de ligações eD2k."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "AVISO: Não se pode adicionar a si próprio como fonte para um link eD2k enquanto tiver lowid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:17+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -200,6 +200,11 @@ msgstr "A eșuat deschiderea fișierului legătură eD2k."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ATENȚIE: Nu vă puteți adăuga ca sursă pentru o legătură eD2k cât timp aveți lowid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:18+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -207,6 +207,11 @@ msgstr "Не удалось открыть файл ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Вы не можете добавить себя в качестве источника для eD2k ссылки если у вас lowid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -202,6 +202,11 @@ msgstr "Ni bilo mogoče odpreti datoteke ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "OPOZORILO: če imete nizek ID, sebe ne morete dodati kot vira za povezavo eD2k."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -197,6 +197,11 @@ msgstr "Deshtoi ne hapjen %s (%s)"
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -200,6 +200,11 @@ msgstr "Kunde inte öppna ED2KLinks-filen"
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "VARNING: Du kan inte lägga till dig själv som källa för en eD2k-länk när du har lowid."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -185,6 +185,11 @@ msgstr ""
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -203,6 +203,11 @@ msgstr "ED2KBağlantı dosyası açılamadı."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "UYARI: DüşükID olduğunuz sürece kendinizi bir kaynak olarak eD2k bağlantılarına ekleyemezsiniz."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:20+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -200,6 +200,11 @@ msgstr "Не вдалося відкрити файл ED2KLinks."
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "ЗАСТЕРЕЖЕННЯ: ви не можете додати себе як джерело для eD2k-посилання маючи LowID."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -185,6 +185,11 @@ msgstr ""
 
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:21+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -207,6 +207,11 @@ msgstr "打开 ED2K 链接文件失败。"
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：在 Low ID 的情况下，你不能添加自己作为 ed2k 链接的源。"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 12:21+0200\n"
+"POT-Creation-Date: 2026-07-31 17:05+0200\n"
 "PO-Revision-Date: 2026-07-30 20:21+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -206,6 +206,11 @@ msgstr "無法開啟 ED2K 連結檔。"
 #: src/amuleAppCommon.cpp
 msgid "WARNING: You can't add yourself as a source for an eD2k link while having a lowid."
 msgstr "警告：LowID 時不可以將自己加入 eD2k 連結來源。"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Restricted permissions on %s to owner-only."
+msgstr ""
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."

--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -75,12 +75,10 @@
 #include CRYPTO_HEADER(aes.h)
 #include CRYPTO_HEADER(gcm.h)
 #include CRYPTO_HEADER(hmac.h)
-// ChaCha20-Poly1305 arrived in cryptopp 8.1; aMule's floor is 5.6, so the EC
-// layer negotiates it rather than requiring it.
-#if defined(CRYPTOPP_VERSION) && CRYPTOPP_VERSION >= 810
-#define CRYPTOPP_INC_HAVE_CHACHA20POLY1305 1
+// ChaCha20-Poly1305 arrived in cryptopp 8.1, which is aMule's floor, so it is
+// always compiled in. The EC layer still *negotiates* it, because that is about
+// what the peer can do, not what this build has.
 #include CRYPTO_HEADER(chachapoly.h)
-#endif
 #endif
 
 #if defined(__clang__)

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -23,10 +23,12 @@
 //
 
 #include "ExternalConnector.h"
-#include "config.h"            // Needed for VERSION and readline detection
-#include <common/Format.h>     // Needed for CFormat
-#include <common/LocaleInit.h> // Needed for aMuleInitLocale()
-#include <wx/tokenzr.h>        // For wxStringTokenizer
+
+#include <common/FileFunctions.h> // RestrictToOwner
+#include "config.h"               // Needed for VERSION and readline detection
+#include <common/Format.h>        // Needed for CFormat
+#include <common/LocaleInit.h>    // Needed for aMuleInitLocale()
+#include <wx/tokenzr.h>           // For wxStringTokenizer
 
 // For readline
 #ifdef HAVE_LIBREADLINE
@@ -675,6 +677,9 @@ void CaMuleExternalConnector::LoadConfigFile()
 		m_configFile = new CECFileConfig(m_configFileName);
 	}
 	if (m_configFile) {
+		// Same reasoning as the core's amule.conf: this file stores the EC
+		// password, and the stored value is what authenticates.
+		RestrictToOwner(CPath(m_configFileName));
 		m_language = m_configFile->Read("/Locale", "");
 		// Match the default across amulecmd / amuleweb / amulegui.
 		// Use the literal loopback address rather than "localhost":

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -2087,8 +2087,13 @@ void CPreferences::SavePreferences()
 	// exists. Cheap to repeat: RestrictToOwner stats first and does nothing
 	// when the mode is already owner-only, which it stays, because wxFileConfig
 	// carries the mode across the replace it does on every later save.
-	RestrictToOwner(CPath(GetConfigDir() + "amule.conf"));
-	RestrictToOwner(CPath(GetConfigDir() + "amule.conf.bak"));
+	// theApp->m_configFile, not a literal: this file is compiled into amulegui
+	// too, where the config is remote.conf. Hardcoding "amule.conf" here left a
+	// fresh amulegui install's remote.conf at the umask default until its next
+	// start -- the same gap this call exists to close for the daemon.
+	const wxString &configFile = theApp->m_configFile;
+	RestrictToOwner(CPath(GetConfigDir() + configFile));
+	RestrictToOwner(CPath(GetConfigDir() + configFile + ".bak"));
 }
 
 void CPreferences::SaveCats()

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -2080,6 +2080,15 @@ void CPreferences::SavePreferences()
 
 	// Ensure that the changes are saved to disk.
 	cfg->Flush();
+
+	// On a fresh install the file did not exist when the startup pass ran, so
+	// wxFileConfig has only just created it -- with whatever the umask allows,
+	// which on Debian and Ubuntu is group-writable. Tighten it here, once it
+	// exists. Cheap to repeat: RestrictToOwner stats first and does nothing
+	// when the mode is already owner-only, which it stays, because wxFileConfig
+	// carries the mode across the replace it does on every later save.
+	RestrictToOwner(CPath(GetConfigDir() + "amule.conf"));
+	RestrictToOwner(CPath(GetConfigDir() + "amule.conf.bak"));
 }
 
 void CPreferences::SaveCats()

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -47,6 +47,7 @@
 #include "AutostartManager.h"       // Needed for --configure-autostart handling
 #include "ProtocolHandlerManager.h" // Needed for --configure-protocols handling
 #include "CamuleFileConfig.h"       // CamuleFileConfig + CCtypeAsciiScope (#852)
+#include <common/FileFunctions.h>   // Needed for RestrictToOwner
 #include <common/Format.h>          // Needed for CFormat
 #include "CFile.h"                  // Needed for CFile
 #include "ED2KLink.h"               // Needed for command line passing of links
@@ -734,6 +735,17 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		CCtypeAsciiScope scope;
 		wxConfig::Set(new CamuleFileConfig("", "", thePrefs::GetConfigDir() + m_configFile));
 	}
+
+	// The config holds the EC password, which is the credential itself rather
+	// than a verifier -- anything that can read this file can drive the daemon.
+	// It is created with whatever the umask allows, which on Debian and Ubuntu
+	// defaults to group-writable. Tighten it here rather than at creation so
+	// configs that already exist are covered too. The .bak is a full copy and
+	// needs the same treatment.
+	if (RestrictToOwner(CPath(thePrefs::GetConfigDir() + m_configFile))) {
+		AddLogLineN(CFormat(_("Restricted permissions on %s to owner-only.")) % m_configFile);
+	}
+	RestrictToOwner(CPath(thePrefs::GetConfigDir() + m_configFile + ".bak"));
 
 	// Make a backup of the log file
 	CPath logfileName = CPath(thePrefs::GetConfigDir() + m_logFile);

--- a/src/libs/common/FileFunctions.cpp
+++ b/src/libs/common/FileFunctions.cpp
@@ -35,6 +35,10 @@
 #endif
 #include <algorithm> // Needed for std::min
 
+#ifndef __WINDOWS__
+#include <sys/stat.h> // chmod / stat for RestrictToOwner
+#endif
+
 #include "FileFunctions.h"
 #include "StringFunctions.h"
 #include "SmartPtr.h" // Needed for CSmartPtr
@@ -277,4 +281,30 @@ UnpackResult UnpackArchive(const CPath &path, const char *files[])
 		return UnpackResult(false, type);
 	}
 }
+bool RestrictToOwner(const CPath &file)
+{
+#ifdef __WINDOWS__
+	(void)file;
+	return false;
+#else
+	if (!file.FileExists()) {
+		return false;
+	}
+	const wxCharBuffer path = file.GetRaw().mb_str(wxConvFile);
+	struct stat st;
+	if (::stat(path.data(), &st) != 0) {
+		return false;
+	}
+	// Only act when something is actually loose, so the common case is a
+	// single stat and no write to the filesystem.
+	const mode_t loose = st.st_mode & (S_IRWXG | S_IRWXO);
+	if (loose == 0) {
+		return false;
+	}
+	// mulecommon sits below the logger, so report the outcome to the caller
+	// rather than logging here.
+	return ::chmod(path.data(), S_IRUSR | S_IWUSR) == 0;
+#endif
+}
+
 // File_checked_for_headers

--- a/src/libs/common/FileFunctions.h
+++ b/src/libs/common/FileFunctions.h
@@ -92,5 +92,25 @@ typedef std::pair<bool, EFileType> UnpackResult;
  */
 UnpackResult UnpackArchive(const CPath &file, const char *files[]);
 
+/**
+ * Restrict @a file to owner read/write (0600) if it is currently looser.
+ *
+ * For config files holding credentials. aMule's own configs are created with
+ * whatever the umask allows -- 0644 on macOS, and 0664 under the 0002 umask
+ * Debian and Ubuntu ship, which leaves the file group-*writable*.
+ *
+ * Called at startup rather than at creation so existing installs are fixed on
+ * the first run of a version that does this, not just new ones. Safe to repeat:
+ * it stats first and only acts when something needs tightening. wxFileConfig
+ * replaces the file on save but carries the mode across, so one call holds.
+ *
+ * No-op on Windows, which has no POSIX mode bits; there the file is protected
+ * by the profile directory's ACL, the same compromise Credentials.cpp makes.
+ *
+ * @return true only when permissions were actually tightened, so the caller can
+ *         say so once; this library sits below the logger.
+ */
+bool RestrictToOwner(const CPath &file);
+
 #endif
 // File_checked_for_headers

--- a/src/libs/ec/cpp/ECCrypt.cpp
+++ b/src/libs/ec/cpp/ECCrypt.cpp
@@ -27,13 +27,9 @@
 // Go through the tree's cryptopp wrapper rather than including the headers
 // directly: it carries the deprecation pragmas those headers need under this
 // project's -Werror settings, and knows the include prefix. CRYPTOPP_INC_NEED_AEAD
-// adds aes/gcm/hmac (+ chachapoly where the version allows) to its usual set.
+// adds aes/gcm/hmac/chachapoly to its usual set.
 #define CRYPTOPP_INC_NEED_AEAD
 #include "../../../CryptoPP_Inc.h"
-
-#ifdef CRYPTOPP_INC_HAVE_CHACHA20POLY1305
-#define EC_HAVE_CHACHA20POLY1305 1
-#endif
 
 #include <algorithm>
 #include <cstring>
@@ -54,10 +50,8 @@ size_t KeyLenFor(uint8_t cipher)
 	switch (cipher) {
 	case Cipher_AES128_GCM:
 		return KEY_LEN_AES128;
-#ifdef EC_HAVE_CHACHA20POLY1305
 	case Cipher_ChaCha20_Poly1305:
 		return KEY_LEN_CHACHA;
-#endif
 	default:
 		return 0;
 	}
@@ -79,7 +73,6 @@ std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher> MakeCipher(uint8_t ciphe
 		}
 		return std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher>(
 			new CryptoPP::GCM<CryptoPP::AES>::Decryption);
-#ifdef EC_HAVE_CHACHA20POLY1305
 	case Cipher_ChaCha20_Poly1305:
 		if (encrypt) {
 			return std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher>(
@@ -87,7 +80,6 @@ std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher> MakeCipher(uint8_t ciphe
 		}
 		return std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher>(
 			new CryptoPP::ChaCha20Poly1305::Decryption);
-#endif
 	default:
 		return nullptr;
 	}
@@ -98,10 +90,8 @@ std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher> MakeCipher(uint8_t ciphe
 std::vector<uint8_t> SupportedCiphers()
 {
 	std::vector<uint8_t> out;
-#ifdef EC_HAVE_CHACHA20POLY1305
 	// Preferred first: the server picks the first entry the client also has.
 	out.push_back(Cipher_ChaCha20_Poly1305);
-#endif
 	out.push_back(Cipher_AES128_GCM);
 	return out;
 }
@@ -149,40 +139,19 @@ std::vector<uint8_t> HkdfSha256(const std::vector<uint8_t> &ikm,
 		return out;
 	}
 	try {
-		// Extract: PRK = HMAC(salt, ikm). An empty salt means a block of zeros.
-		std::vector<uint8_t> effectiveSalt = salt;
-		if (effectiveSalt.empty()) {
-			effectiveSalt.assign(SHA256_LEN, 0);
-		}
-		uint8_t prk[SHA256_LEN];
-		{
-			CryptoPP::HMAC<CryptoPP::SHA256> hmac(effectiveSalt.data(), effectiveSalt.size());
-			if (!ikm.empty()) {
-				hmac.Update(ikm.data(), ikm.size());
-			}
-			hmac.Final(prk);
-		}
-
-		// Expand: T(n) = HMAC(PRK, T(n-1) || info || n)
-		out.reserve(outLen);
-		std::vector<uint8_t> prev;
-		uint8_t counter = 1;
-		while (out.size() < outLen) {
-			CryptoPP::HMAC<CryptoPP::SHA256> hmac(prk, sizeof(prk));
-			if (!prev.empty()) {
-				hmac.Update(prev.data(), prev.size());
-			}
-			if (!info.empty()) {
-				hmac.Update(info.data(), info.size());
-			}
-			hmac.Update(&counter, 1);
-			uint8_t block[SHA256_LEN];
-			hmac.Final(block);
-			prev.assign(block, block + SHA256_LEN);
-			const size_t take = std::min(outLen - out.size(), SHA256_LEN);
-			out.insert(out.end(), block, block + take);
-			++counter;
-		}
+		// The length guard above stays: DeriveKey throws on an over-long
+		// request, and callers here expect an empty vector rather than an
+		// exception.
+		out.resize(outLen);
+		CryptoPP::HKDF<CryptoPP::SHA256> hkdf;
+		hkdf.DeriveKey(out.data(),
+			out.size(),
+			ikm.data(),
+			ikm.size(),
+			salt.data(),
+			salt.size(),
+			info.data(),
+			info.size());
 	} catch (const CryptoPP::Exception &) {
 		out.clear();
 	}

--- a/src/libs/ec/cpp/ECCrypt.h
+++ b/src/libs/ec/cpp/ECCrypt.h
@@ -53,7 +53,7 @@ namespace ECCrypt
 enum Cipher : uint8_t
 {
 	Cipher_None = 0,
-	/// Mandatory baseline: present in every Crypto++ down to the 5.6 floor.
+	/// Mandatory baseline: present in every Crypto++ we accept.
 	Cipher_AES128_GCM = 1,
 	/// Preferred where available. Roughly 2.6x faster than AES-GCM in a
 	/// Crypto++ build without hardware AES -- which is every Raspberry Pi up
@@ -84,9 +84,9 @@ std::vector<uint8_t> RandomBytes(size_t count);
 /**
  * HKDF-SHA256 (RFC 5869), extract-then-expand.
  *
- * Hand-rolled over HMAC-SHA256 rather than using Crypto++'s `hkdf.h`, which
- * only appeared in 5.6.3 while aMule's declared floor is 5.6.0. HMAC-SHA256 is
- * present in every version and already used elsewhere in the tree.
+ * Thin wrapper over Crypto++'s `hkdf.h`. Kept as a function of its own for the
+ * vector-in/vector-out shape the rest of this layer uses, and because the
+ * RFC 5869 length cap is enforced here rather than surfacing as an exception.
  */
 std::vector<uint8_t> HkdfSha256(const std::vector<uint8_t> &ikm,
 	const std::vector<uint8_t> &salt,


### PR DESCRIPTION
Two changes in the same area: the config files stop being world- or group-readable, and the Crypto++ floor moves up so hand-written crypto can be deleted.

## Owner-only config files

`amule.conf` and `remote.conf` hold the EC password, and in this protocol the stored value **is** the credential — anything that can read the file can drive the daemon, without inverting any hash. `--amule-config-file` is a shipped feature that does exactly that.

They were created with whatever the umask allowed: `0644` on macOS, and `0664` under the `0002` umask Debian and Ubuntu ship — **group-writable**, so another user in the group could modify them.

They're now tightened to `0600` in two places, because one alone leaves a hole:

- **At startup**, so configs that already exist are fixed on the first run of this version rather than only new installs.
- **After the first `Flush()`**, because on a clean install the file does not yet exist when the startup pass runs. Without this, a brand-new install sat at the umask default for its entire first session, until the next restart.

Both call sites derive the name from `theApp->m_configFile` rather than a literal, so the same code covers `amule.conf` for the core and daemon and `remote.conf` for amulegui. That matters: `Preferences.cpp` is compiled into amulegui too, and hardcoding the core's name there left a fresh amulegui install's `remote.conf` at the umask default until its next start.

`amule.conf.bak` is a full copy including the password and follows the same name, so it gets the same treatment.

The helper returns whether it changed anything instead of logging — `mulecommon` sits below the logger — so the notice is printed once, by the caller, and only when something was actually loosened. It stats first and does nothing when the mode is already owner-only.

No-op on Windows, which has no POSIX mode bits; there the file is protected by the profile directory's ACL, the same compromise `Credentials.cpp` already makes.

## Crypto++ 8.1 floor

The 5.6 floor predates the EC encryption work and had started costing more than it bought: it forced ChaCha20-Poly1305 behind a version gate, and forced **HKDF to be written by hand**, because cryptopp's own `hkdf.h` only appeared in 5.6.3.

With the floor at 8.1 both go — ChaCha is compiled in unconditionally, and `HkdfSha256` becomes a thin wrapper over `CryptoPP::HKDF`. Net **−30 lines**, and one less piece of hand-rolled crypto. The RFC 5869 vector in `ECCryptTest` passes unchanged, which is what proves the two implementations agree byte for byte; had they differed, every derived key would have changed silently.

**8.1 is conservative** — nothing in circulation is below it:

| repository | crypto++ |
|---|---|
| Debian 11 (oldstable) | 8.4.0 |
| Ubuntu 22.04 LTS · openSUSE Leap 15.5–15.6 | 8.6.0 |
| Debian 12 (stable) | 8.7.0 |
| Fedora | 8.8.0 |
| Ubuntu 24.04 · Arch · Alpine · FreeBSD · Homebrew · MSYS2 | 8.9.0 |

The `cryptopp-modern` fork is unaffected: it is based on 8.9.0 and the cmake check already exempts its calendar versioning. `docs/INSTALL.md` updated.

## Test plan

Real daemons on **macOS and Ubuntu** (the latter under `umask 0002`, which is what produces the group-writable case):

| | macOS | Ubuntu |
|---|---|---|
| `amule.conf`, clean install, first run only | `600` | `600` |
| `amule.conf.bak` | `600` | `600` |
| existing `644`, after restart | `600` | `600` |

amulegui separately, on macOS: a clean install writes `remote.conf` at `600` on the first run, and an existing `644` file is tightened on the next. amulegui did not create a `remote.conf.bak` across three runs, so that path is covered by construction rather than observation.

The two-call design came out of testing rather than assumption: wxFileConfig **replaces** the config on save (inode changes) but **carries the mode across** — confirmed on both platforms with mtime/inode controls proving the file really was rewritten. That is why a startup call holds for the life of the install, and why the post-`Flush()` call is needed only for the clean-install case.

Build clean on macOS and Ubuntu, clang-format 18 clean, Tier-2 clang-tidy clean with 0 compiler errors, `ctest` 30/30. One new msgid, none discarded.
