### PR TITLE
fix(amuleapi): probe amuleapi.conf for portable installs, drop the dead config-dir resolver

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -582,7 +582,10 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser &parser)
 	if (!UsesConnectorConfigFile() || !parser.Found("config-file", &m_configFileName)) {
 		m_configFileName = "remote.conf";
 	}
-	m_configDir = GetConfigDir(m_configFileName);
+	// Portable detection is "does <cwd>/config/<probe> exist", so each
+	// connector probes for the file it actually owns rather than for
+	// remote.conf regardless.
+	m_configDir = GetConfigDir(PortableProbeFile());
 	m_configFileName = m_configDir + m_configFileName;
 
 	wxString aMuleConfigFile;

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -159,6 +159,16 @@ public:
 	 * loads nothing -- the subclass is the only source of configuration.
 	 */
 	virtual bool UsesConnectorConfigFile() const { return true; }
+
+	/**
+	 * Filename whose presence in <cwd>/config marks a portable install.
+	 *
+	 * Defaults to this connector's own config file (remote.conf). A
+	 * subclass that keeps its settings elsewhere overrides it: probing for
+	 * a file the tool never reads or writes can only detect portability by
+	 * accident, when some other tool happens to have left one behind.
+	 */
+	virtual wxString PortableProbeFile() const { return "remote.conf"; }
 	virtual void LoadAmuleConfig(CECFileConfig &cfg);
 	virtual void OnInitCommandSet();
 	virtual bool OnInit();

--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -28,7 +28,6 @@
 #include <wx/fileconf.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
-#include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
 #include <wx/utils.h>
 #include <wx/wfstream.h>
@@ -185,19 +184,6 @@ bool WriteFileAtomic0600(const wxString &target_path, const std::string &body)
 }
 
 } // namespace
-
-wxString DefaultConfigDir()
-{
-	// Prefer the wx-standard "user data dir" — it already encapsulates
-	// the per-platform conventions amuled / amulegui use, so amuleapi
-	// drops its files alongside theirs by default. Operators with a
-	// custom amule home override the location at the CLI.
-	const wxString d = wxStandardPaths::Get().GetUserDataDir();
-	// GetUserDataDir() returns e.g. "/Users/foo/Library/Application Support/aMule"
-	// on macOS or "/home/foo/.aMule" on Linux. Both already align with
-	// where amule.conf lives.
-	return d;
-}
 
 bool CAmuleApiConfig::Load(const wxString &config_dir)
 {

--- a/src/webapi/AmuleApiConfig.h
+++ b/src/webapi/AmuleApiConfig.h
@@ -164,8 +164,6 @@ public:
 
 	const std::string &LastError() const { return m_lastError; }
 
-	bool WriteJwtSecretFile(const wxString &config_dir, const std::vector<unsigned char> &secret_32);
-
 	// Re-reads amuleapi-passwords, keeping the current values if the read
 	// fails so a transient error can't lock everyone out.
 	//
@@ -181,6 +179,10 @@ public:
 	void ReloadCredentials();
 
 private:
+	// Writes amuleapi-jwt-secret with owner-only permissions. Internal to
+	// Load()'s first-run path -- callers get the secret via JwtSecret().
+	bool WriteJwtSecretFile(const wxString &config_dir, const std::vector<unsigned char> &secret_32);
+
 	// Rewrites one role's record at the current KDF cost without moving
 	// the file's modification time — an upgrade is not a password change,
 	// and only a password change should end sessions.
@@ -205,14 +207,5 @@ private:
 
 	std::string m_lastError;
 };
-
-// Canonical config dir per platform. Mirrors amule's own
-// GetUserDataDir() but without the dependency on `amule.h` — amuleapi
-// runs standalone and can't pull in the GUI/daemon-side helpers.
-//
-// POSIX (XDG):    ${XDG_CONFIG_HOME:-$HOME/.config}/aMule
-//  macOS:          $HOME/Library/Application Support/aMule
-//  Windows:        %APPDATA%/aMule
-wxString DefaultConfigDir();
 
 #endif // WEBAPI_CONFIG_H

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -185,13 +185,12 @@ bool CamuleapiApp::OnInit()
 		return false;
 	}
 
-	// Resolve the config dir. Order: explicit --config-dir > whatever
-	// the base class picked (m_configDir, populated from --config-file
-	// or the platform default) > wxStandardPaths::GetUserDataDir().
-	wxString config_dir = m_cliConfigDirOverride.IsEmpty() ? m_configDir : m_cliConfigDirOverride;
-	if (config_dir.IsEmpty()) {
-		config_dir = DefaultConfigDir();
-	}
+	// Resolve the config dir: explicit --config-dir wins, otherwise take
+	// what the base class resolved in OnCmdLineParsed via the core's
+	// GetConfigDir(). That is always set by the time we get here, so there
+	// is no third fallback -- amuleapi and amuled run the same resolver
+	// rather than each having their own idea of where config lives.
+	const wxString config_dir = m_cliConfigDirOverride.IsEmpty() ? m_configDir : m_cliConfigDirOverride;
 
 	// Tee stdout/stderr into a log file (unless --no-log-file), as early as
 	// possible so config-load errors, EC warnings and a crash backtrace are all
@@ -249,14 +248,7 @@ bool CamuleapiApp::OnInit()
 
 bool CamuleapiApp::LoadAmuleapiConfig()
 {
-	wxString config_dir = m_cliConfigDirOverride.IsEmpty() ? m_configDir : m_cliConfigDirOverride;
-	if (config_dir.IsEmpty()) {
-		config_dir = DefaultConfigDir();
-		// Persist the resolved dir back into m_configDir so the base
-		// class's later --write-config (and any subclasses) see the
-		// same path.
-		m_configDir = config_dir;
-	}
+	const wxString config_dir = m_cliConfigDirOverride.IsEmpty() ? m_configDir : m_cliConfigDirOverride;
 
 	if (!m_apiConfig.Load(config_dir)) {
 		Show(CFormat("amuleapi: failed to load config: %s\n") %

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -207,6 +207,11 @@ private:
 	/// exist to manage that file.
 	bool UsesConnectorConfigFile() const override { return false; }
 
+	// amuleapi keeps its settings in amuleapi.conf and never reads or
+	// writes remote.conf, so amuleapi.conf is what marks a portable
+	// amuleapi. amulecmd / amuleweb keep the remote.conf default.
+	wxString PortableProbeFile() const override { return "amuleapi.conf"; }
+
 	bool m_cliHasEcEncryption = false;
 	bool m_cliHasEcPassword = false;
 };

--- a/unittests/tests/AmuleApiConfigTest.cpp
+++ b/unittests/tests/AmuleApiConfigTest.cpp
@@ -70,12 +70,6 @@ wxString MakeTmpDir(const char *tag)
 }
 END_DECLARE;
 
-TEST(AmuleApiConfig, DefaultConfigDirIsNonEmpty)
-{
-	const wxString d = DefaultConfigDir();
-	ASSERT_TRUE(!d.IsEmpty());
-}
-
 TEST(AmuleApiConfig, FreshLoadCreatesAllThreeFiles)
 {
 	const wxString dir = MakeTmpDir("fresh");


### PR DESCRIPTION
Two related changes to how amuleapi locates its config directory: deleting a dead resolver that made it look as though amuleapi had its own idea of where config lives, and fixing the one place where it genuinely did diverge.

## 1. The dead resolver

`DefaultConfigDir()` in `src/webapi/AmuleApiConfig.cpp` reads like amuleapi's fallback, and it resolves differently from the core — `wxStandardPaths::GetUserDataDir()`, with no portable branch and no trailing separator, against `GetConfigDir()`'s portable check plus separator.

It is unreachable, so that divergence has never had an effect. Both call sites sit behind `if (config_dir.IsEmpty())`, and that is never true: `CaMuleExternalConnector::OnCmdLineParsed` (`ExternalConnector.cpp:585`) assigns `m_configDir` from the core's `GetConfigDir()` during command-line parsing, before `OnInit()` runs, and amuleapi reaches it — it overrides `UsesConnectorConfigFile()` to `false` and calls the base at `App.cpp:179`.

Confirmed by instrumenting the binary rather than by reading it: a probe on that branch never fired, in a portable tree, a non-portable tree, or with an explicit `--config-dir`. In every case `m_configDir` was already populated and already carried the trailing separator.

So there is one implementation of this logic in the tree — `GetConfigDir()` in `OtherFunctions.cpp` — and amuled and amuleapi have always shared it. A spawned amuleapi is tighter still: `amule.cpp:1167` passes `--config-dir=` + `thePrefs::GetConfigDir()`, inheriting the core's resolved value verbatim.

Removed: the function, its declaration, the now-unused `<wx/stdpaths.h>`, and the unit test asserting on it — that test is why it looked alive. Also the comments describing a three-step precedence chain whose third step does not exist. Those are the actively harmful part: they are what makes the file read as a second source of truth when there is only one.

`WriteJwtSecretFile()` moves to the private section alongside its siblings; it has no callers outside the class.

No behaviour change is possible in this commit — the deleted code could not execute.

## 2. The real divergence: the portable probe

Portable detection asks whether `<cwd>/config/<probe>` exists, and every connector passed `remote.conf`. That is right for amulecmd and amuleweb, whose config file it is. It is wrong for amuleapi, which keeps its settings in `amuleapi.conf` and never reads or writes `remote.conf`.

The result was detection by accident in one direction and none at all in the other: putting `amuleapi.conf` in a portable tree's `config/` did nothing, while the tree *was* treated as portable whenever some other tool had left a `remote.conf` behind.

Adds a `PortableProbeFile()` hook on `CaMuleExternalConnector`, defaulting to `remote.conf`, overridden by amuleapi. After this every binary probes for the file it actually owns:

| binary | probes | its own config file? |
|---|---|---|
| amule / amuled | `amule.conf` | yes |
| amulegui | `remote.conf` | yes |
| amulecmd / amuleweb | `remote.conf` | yes |
| amuleapi | `amuleapi.conf` (was `remote.conf`) | yes (was no) |

amulegui resolves through `CamuleAppCommon` rather than this base and already probed its own file, so it is untouched.

Net effect for an operator: if `<cwd>/config/amuleapi.conf` exists it is used, otherwise the default per-user location — which is what the other binaries have always done with their own files.

## What this deliberately does not do

Portable mode still cannot engage from scratch. Every probe names a file the tool itself creates, so a brand-new portable tree resolves to the user data directory until each tool has run once and written its config into `config/`.

Fixing *that* means probing `amule.conf` — the marker placed by whoever set the portable install up, before any tool has run. I have it working, and it is left out on purpose: it moves where existing installations look. A portable tree carrying only `remote.conf` would stop being detected, and one where amuleapi had been writing into the home directory would find a fresh config and need its password set again. That is a migration, and it wants its own change and a changelog note rather than riding along here.

Worth noting a normal, non-portable install is unaffected by any of this: `GetConfigDir()`'s fallback branch ignores the probe filename entirely, so amuled and amuleapi already resolve identically there on every platform.

## Verified

- `amule`, `amuled`, `amulegui`, `amuleapi`, `amulecmd`, `amuleweb` all build.
- Behaviour checked directly: with only `amuleapi.conf` in `config/`, amuleapi goes portable and amulecmd does not; with only `remote.conf`, the reverse. `--config-dir` still wins over both.
- `AmuleApiConfigTest` passes; `unittests/curl-tests/amuleapi/run-all.sh` 32/32 against a live daemon.
- clang-format v18, and diff-scoped clang-tidy against both `.clang-tidy-new-code` and `.clang-tidy` — clean, run with the sysroot extra-args so the checks execute rather than dropping out on a broken AST.
