### PR TITLE
feat(security): hand amuleapi an ephemeral EC token instead of the stored password

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -1,177 +1,195 @@
 # amuleapi — quick start
 
 amuleapi is a standalone HTTP daemon that serves a versioned JSON REST API
-and a long-lived Server-Sent Events stream backed by amuled. It connects
-to amuled as an EC client (same protocol amuleweb and amulecmd use) and
-exposes its own HTTP surface on a separate port. amuleapi is the first
-shipping REST API for aMule — there is no prior on-the-wire surface to
-migrate from.
+and a Server-Sent Events stream backed by amuled. It connects to amuled as
+an EC client — the same protocol amuleweb and amulecmd use — and serves its
+own HTTP surface on a separate port.
 
 > aMule's older web frontend, **amuleweb**, is **deprecated** — it may be removed in aMule 3.2 or later (it is not being removed yet). amuleapi is its intended replacement.
 
-For the endpoint list see the [What ships](#what-ships) section below. Full per-endpoint contracts (methods, query params, request bodies, response shapes, error codes) live in [`docs/api/REFERENCE.md`](api/REFERENCE.md); the SSE event catalog and Last-Event-ID reconnect semantics live in [`docs/api/EVENTS.md`](api/EVENTS.md). The source of truth for routing is [`src/webapi/Api.cpp`](../src/webapi/Api.cpp).
+Per-endpoint contracts live in [`docs/api/REFERENCE.md`](api/REFERENCE.md);
+the SSE event catalog and reconnect semantics in
+[`docs/api/EVENTS.md`](api/EVENTS.md). The source of truth for routing is
+[`src/webapi/Api.cpp`](../src/webapi/Api.cpp). A map of the surface is under
+[What ships](#what-ships) below.
+
+## Let aMule start it — the recommended setup
+
+**This is the most secure way to run amuleapi, and the one to prefer unless
+you have a reason not to.** A standalone amuleapi needs a long-lived EC
+password of its own; an auto-started one never gets a durable EC credential
+at all.
+
+Configure it under *Preferences → Remote Controls* (**aMule API server
+parameters**): tick **Run amuleapi (REST API) on startup**, set the
+**listening interface**, **HTTP port** and **admin password**, and
+optionally tick **Enable guest access** with a **guest password**. All of it
+is equally editable from a remote amulegui over EC. aMule then spawns:
+
+```sh
+amuleapi --config-dir=<amule data dir> --bind=<BindAddress> --http-port=<HttpPort>
+```
+
+Note what is *not* there: no EC password, and no path to `amule.conf`.
+
+### Why it is more secure
+
+In the EC protocol the stored password value **is** the credential — the
+challenge hashes it directly, so anything holding it can authenticate. A
+network-facing daemon holding that value holds the equivalent of your EC
+password for its whole run.
+
+So aMule doesn't give it one. At startup it generates a random 128-bit
+token, writes it `0600` into the config directory, and accepts it as a
+second valid EC credential for that run only. amuleapi reads the token and
+deletes the file immediately; aMule deletes it regardless after ten
+seconds, so a child that dies before reading cannot leave a secret at rest.
+The token is never passed on the command line, because `argv` is readable
+by any local user through `ps`.
+
+The result: nothing durable to steal from the API daemon, and nothing to
+rotate if it is compromised — restarting aMule invalidates the token.
+
+The admin and guest passwords are unaffected by this and travel their own
+route; see [Passwords](#passwords).
+
+Setting an admin password is what allows binding a non-loopback interface —
+amuleapi refuses to start otherwise. Changing the interface or port prompts
+you to restart aMule; password changes need no restart. amuleapi stops when
+aMule exits.
+
+### Headless — no GUI at all
+
+A server running `amuled` alone does not need amulegui for any of this. Stop
+amuled first (it rewrites `amule.conf` on exit, so edits made while it runs
+are lost), then add to `amule.conf`:
+
+```ini
+[AmuleApi]
+Enabled=1
+BindAddress=127.0.0.1
+HttpPort=4713
+Path=amuleapi
+```
+
+`Path` is the amuleapi executable — a bare name is looked up on `PATH`, so
+leave it alone unless yours lives somewhere unusual. Note the key is
+`HttpPort`, not `Port`.
+
+Then set the admin password with amuleapi itself:
+
+```sh
+amuleapi --set-admin-pass=mySecret123
+```
+
+No path needed: amuleapi defaults to the same per-platform directory amuled
+uses — see [Files and the config directory](#files-and-the-config-directory).
+Add `--config-dir=<path>` only if you start amuled with `-c <path>`.
+
+That writes `amuleapi-passwords` and exits without starting anything. Start
+amuled and it brings amuleapi up with the token, exactly as the GUI flow
+does — the GUI only ever edited these same keys and called the same
+credential store.
+
+Passwords deliberately have no `amule.conf` key: `/AmuleApi/Password` is
+transient and is deleted from the file if it ever appears there.
 
 ## Requirements
 
-- A running `amuled` (or a monolithic `aMule` with EC enabled) that
-  amuleapi can connect to over the EC protocol.
-- The EC password from `amule.conf[ExternalConnect]/Password` (set via
-  `amuled --ec-config` if you've never run it).
+- A running `amuled` (or monolithic `aMule`) with EC enabled.
+- For a **standalone** amuleapi only: the EC password from
+  `amule.conf[ExternalConnect]/Password` (set it with `amuled --ec-config`
+  if you never have).
 
-## First-run setup
+## Files and the config directory
 
-amuleapi keeps its config in the same per-platform aMule data directory
-that `amuled` uses.
+amuleapi keeps its files in the same per-platform aMule data directory
+amuled uses, deliberately: operators reading both sets of config together
+don't have to switch directories. amuleapi never writes amuled's files, and
+amuled never writes amuleapi's.
 
-> **Cohabitation with amuled.** This is the same directory amuled
-> keeps `amule.conf` and `*.met` in — intentionally so. amuleapi's
-> own files (`amuleapi.conf`, `amuleapi-jwt-secret`,
-> `amuleapi-passwords`, and by default the `amuleapi.log` log file)
-> sit alongside amuled's without colliding, and operators reading
-> both sets of configs together don't have to context-switch
-> directories. amuleapi never *writes* amuled's files; the one point
-> of contact is read-only — launched with `--amule-config-file` (as
-> aMule's [auto-start](#auto-starting-from-amule) does), it reads
-> connection and admin-password settings out of `amule.conf`. amuled
-> never touches amuleapi's files.
+| Platform | Default config dir                     |
+| -------- | -------------------------------------- |
+| Linux    | `~/.aMule/`                            |
+| macOS    | `~/Library/Application Support/aMule/` |
+| Windows  | `%APPDATA%\aMule\`                     |
 
-The default location:
+Override with `--config-dir=/path/to/dir`.
 
-| Platform | Default config dir                                  |
-| -------- | --------------------------------------------------- |
-| Linux    | `~/.aMule/`                                         |
-| macOS    | `~/Library/Application Support/aMule/`              |
-| Windows  | `%APPDATA%\aMule\`                                  |
+Each amuleapi file is written mode `0600`:
 
-Override with `amuleapi --config-dir=/path/to/dir`.
+| File                  | Purpose                                                                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `amuleapi.conf`       | Runtime config: HTTP bind/port/CORS, outbound EC connection, login rate limits, SSE ring size. [Reference below](#amuleapiconf-reference). |
+| `amuleapi-jwt-secret` | 32-byte HMAC signing key for issued tokens. Generated on first launch.                                                       |
+| `amuleapi-passwords`  | Admin and guest passwords as salted PBKDF2-HMAC-SHA256 records. Never stored in plaintext and never readable back — only replaceable. Also written by aMule and amuled. |
+| `amuleapi-ec-token`   | The ephemeral EC token, when aMule started amuleapi. Exists for seconds at most; see [above](#why-it-is-more-secure).        |
 
-The directory holds three amuleapi-specific config/secret files, each
-written with mode `0600`:
+amuleapi also writes `amuleapi.log` here by default; see [Logging](#logging).
 
-| File                      | Purpose                                                                                                  |
-| ------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `amuleapi.conf`           | INI-style runtime config (HTTP bind/port/CORS, outbound EC connection to amuled, login rate-limit knobs, SSE event-bus ring size). Full reference below. |
-| `amuleapi-jwt-secret`     | 32-byte HMAC signing key for issued tokens. Auto-generated on first launch if absent.                    |
-| `amuleapi-passwords`      | Admin and guest passwords, each a salted PBKDF2-HMAC-SHA256 record. Plaintext is never persisted, and a stored password cannot be read back — only replaced. The only place these are stored; also written by aMule and amuled. |
+## Passwords
 
-By default amuleapi also writes an `amuleapi.log` file here (a copy of
-its console output); see [Logging](#logging) to relocate or disable it.
-
-Set passwords via the dedicated CLI flags. Each invocation writes the
-file and exits — the HTTP server is NOT brought up, no EC connection
-is attempted, and the exit code reflects success / failure (so
-`amuleapi --set-admin-pass=... && systemctl restart amuleapi` actually
-short-circuits if the write fails):
+Admin and guest passwords live only in `amuleapi-passwords` — no copy goes
+into `amule.conf`, because two copies can disagree. Set them from the
+preferences panel (aMule writes the file directly; a remote amulegui sends
+the change over EC and amuled writes it), or from the CLI:
 
 ```sh
 amuleapi --set-admin-pass=mySecret123
 amuleapi --set-guest-pass=readOnlyPass
 ```
 
-An empty password row means "this role is disabled" and
-`POST /api/v0/auth/login` returns `login_disabled` for that role.
+Each invocation writes the file and exits — no HTTP server, no EC
+connection — and the exit code reflects success, so
+`amuleapi --set-admin-pass=… && systemctl restart amuleapi` short-circuits
+on failure. Changes are picked up at the next login, with no restart.
 
-## Running
+An empty password means the role is disabled: `POST /api/v0/auth/login`
+returns `login_disabled` for it. Unticking **Enable guest access** clears
+the guest password, which is what turns guest access off.
+
+Because the stored form cannot be reversed, the preference fields are
+write-only: they open empty, and leaving one empty keeps the current
+password. The panel says whether an admin password is currently set.
+
+Running amuleapi on a *different* host from aMule? The preferences panel
+writes the credential file on aMule's host, while that amuleapi reads its
+own. Configure it with `--set-admin-pass` or `PATCH /auth/passwords`.
+
+## Running it standalone
 
 ```sh
-amuleapi --host=127.0.0.1 --port=4712 --password=$EC_PASSWORD
+amuleapi --host=127.0.0.1 --port=4712
 ```
 
-> **Two ports.** `--port=4712` is the EC port amuleapi USES to talk
-> to amuled (i.e. it's a client of amuled on 4712). amuleapi's OWN
-> HTTP listener is on `amuleapi.conf[Server]/Port` (default 4713)
-> — that's the port REST clients hit. The example above starts a
-> daemon that consumes 4712 (outbound to amuled) and serves 4713
-> (inbound from REST clients).
+**Two ports.** `--port=4712` is the EC port amuleapi *uses* to reach amuled.
+Its own HTTP listener is `amuleapi.conf[Server]/Port` (default `4713`) —
+that is the port REST clients hit. amuleweb can run concurrently on its own
+port; the two are independent EC clients.
 
-- `--host` / `--port` / `--password` specify the EC connection to
-  `amuled` (default port `4712`).
-- HTTP serves on `amuleapi.conf[Server]/Port` (default `4713`).
-- amuleweb can run concurrently on its own port (default `4711`); the
-  two daemons talk to amuled independently as separate EC clients.
+**Keep the EC password out of `argv`.** Omit `--password` and let amuleapi
+read it from `amuleapi.conf[EC]/Password`, a `0600` file. `--password=…` puts
+the secret in `argv`, visible to any local user via `ps` —
+`--password=$EC_PASSWORD` does not help, since the shell expands it before
+exec. There is no environment or stdin path; the config file is the
+non-`argv` option. Better still, use the [auto-start](#let-amule-start-it--the-recommended-setup)
+flow, which needs no durable EC credential at all.
 
-> **Keep the EC password out of the command line.** `--password` is
-> only an override — omit it and amuleapi reads the EC password from
-> `amuleapi.conf[EC]/Password` (a `0600` file), which is the way to
-> avoid exposing the secret in the process arguments. Passing
-> `--password=…` puts the value in `argv`, where it is visible to any
-> local user via `ps` / `/proc/<pid>/cmdline`; `--password=$EC_PASSWORD`
-> does not help, since the shell expands the value into `argv` before
-> exec. There is no environment-variable or stdin path for the EC
-> password — the config file is the non-`argv` option. (In the
-> auto-start flow, `--amule-config-file` reads the already-hashed EC
-> password from `amule.conf`, also without touching `argv`.)
-
-aMule does not ship init-system units (systemd, launchd, Windows
-service) for any of its daemons. If you want one, write a downstream
-unit that wraps the command above.
+aMule ships no init-system units (systemd, launchd, Windows service) for any
+of its daemons. Write a downstream unit wrapping the command above if you
+want one.
 
 ### Logging
 
-By default amuleapi tees a copy of everything it prints to the console
-into `amuleapi.log` in its config dir, installed as early as possible so
-config-load errors, EC warnings, and a crash backtrace are all captured.
-The output is low-volume (startup plus warnings/errors — there is no
-per-request access log), and the file is rotated at 10 MiB as a runaway
-guard.
+amuleapi tees its console output into `amuleapi.log` in the config dir,
+installed early enough to capture config-load errors, EC warnings and a
+crash backtrace. Output is low volume — startup plus warnings and errors,
+no per-request access log — and rotates at 10 MiB.
 
-- `--log-file=/path/to/amuleapi.log` — write the log somewhere other
-  than the default `<config-dir>/amuleapi.log`.
-- `--no-log-file` — don't write a log file; print to the console only.
+- `--log-file=/path/to/file` — write it elsewhere.
+- `--no-log-file` — console only.
 
-The daemon prints `amuleapi: logging to <path>` on startup so you can see
-where it landed.
-
-### Auto-starting from aMule
-
-aMule can launch amuleapi for you when it starts, the same way it can
-launch amuleweb. Everything is configured under *Preferences → Remote
-Controls* (**aMule API server parameters**): tick **Run amuleapi (REST
-API) on startup**, then set the **listening interface**, **HTTP port**,
-**admin password**, and optionally tick **Enable guest access** and give
-it a **guest password**. The first three map to `/AmuleApi/Enabled`,
-`/AmuleApi/BindAddress` and `/AmuleApi/HttpPort` in `amule.conf`; the
-passwords do not — see below. All of it is equally editable from a remote
-amulegui over EC. aMule then spawns:
-
-```sh
-amuleapi --amule-config-file=<amule.conf> --config-dir=<amule data dir> --bind=<AmuleApi/BindAddress> --http-port=<AmuleApi/HttpPort>
-```
-
-`--amule-config-file` points amuleapi at aMule's own `amule.conf` so it
-reads the EC host/port/(hashed) password from there, exactly as amuleapi's
-sibling amuleweb does. Nothing sensitive is passed on the command line.
-
-The admin and guest passwords travel a different route. They are stored in
-`amuleapi-passwords` in the config directory, salted and stretched, and
-that file is the *only* place they live — no copy goes into `amule.conf`,
-because two copies of a password are two copies that can disagree. When
-you set one in the preferences panel, aMule writes that file directly; on
-a remote amulegui the request goes to amuled over EC and amuled writes it.
-Either way amuleapi picks the change up on the next login, with no restart.
-
-Because the stored form cannot be reversed, the password fields are
-write-only: they open empty, and leaving one empty keeps the current
-password rather than clearing it. The panel says beside the admin field
-whether a password is currently set. Unticking **Enable guest access**
-clears the stored guest password, which is exactly what turns guest access
-off.
-
-Setting an admin password is what lets you bind a non-loopback interface
-and expose the API to other hosts; amuleapi refuses to start otherwise.
-Changing the interface or the port prompts you to restart aMule, which
-relaunches amuleapi with the new parameters — password changes need no
-restart. amuleapi is stopped when aMule exits.
-
-When amuleapi is started **standalone** (no `--amule-config-file`), the
-bind address and port come from `amuleapi.conf` instead, but the
-credentials work identically: same file, set with `--set-admin-pass` /
-`--set-guest-pass` or over REST.
-
-One thing to watch if you run amuleapi on a *different* host from aMule:
-the preferences panel writes the credential file on aMule's host, while a
-remotely-run amuleapi reads the one on its own. Configure that amuleapi
-with `--set-admin-pass` or `PATCH /auth/passwords` instead.
+The daemon prints `amuleapi: logging to <path>` on startup.
 
 ## Verifying
 
@@ -179,29 +197,26 @@ with `--set-admin-pass` or `PATCH /auth/passwords` instead.
 # Public — no auth.
 curl -s http://127.0.0.1:4713/api/v0/version
 
-# Login → token.
-# `?type=bearer` opts into the SDK-client response shape: the JWT
-# lands in the JSON body so a shell script can extract it. Browser
-# clients call /auth/login WITHOUT ?type=bearer and authenticate via
-# the HttpOnly session cookie set on the response — that's the
-# default to keep the token out of any XSS-readable surface.
+# Login → token. `?type=bearer` opts into the SDK-client shape, putting
+# the JWT in the body so a script can extract it. Browser clients omit it
+# and use the HttpOnly session cookie set on the response, which keeps the
+# token off any XSS-readable surface.
 TOKEN=$(curl -s -X POST "http://127.0.0.1:4713/api/v0/auth/login?type=bearer" \
     -H 'Content-Type: application/json' \
     -d '{"password":"mySecret123"}' | jq -r .token)
 
-# Authenticated GETs.
-curl -s -H "Authorization: Bearer $TOKEN" \
-    http://127.0.0.1:4713/api/v0/status
+# Authenticated GET.
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/status
 
-# Live event stream — open in a separate terminal and trigger
-# mutations elsewhere to watch events flow.
-curl -s -N -H "Authorization: Bearer $TOKEN" \
-    http://127.0.0.1:4713/api/v0/events
+# Live event stream — run in a second terminal and trigger mutations
+# elsewhere to watch events flow.
+curl -s -N -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/events
 ```
 
 ## `amuleapi.conf` reference
 
-INI-style file written with mode `0600`. The defaults file is created on first launch if absent — edits roundtrip through `wxFileConfig`, so quotes and comments are preserved across daemon restarts. The full surface:
+INI-style, mode `0600`, created with defaults on first launch. Edits
+roundtrip through `wxFileConfig`, so quotes and comments survive restarts.
 
 ```ini
 [Server]
@@ -215,6 +230,7 @@ StaticRoot=
 Host=127.0.0.1
 Port=4712
 Password=
+Encryption=1
 
 [Auth]
 LoginFailureWindowSeconds=60
@@ -227,44 +243,35 @@ EventBusRingCapacity=16384
 
 ### `[Server]` — HTTP listener
 
-| Key | Default | Meaning |
-| --- | --- | --- |
-| `BindAddress` | `127.0.0.1` | Interface the HTTP listener binds to. Non-loopback binds are rejected at startup unless at least one of admin/guest passwords is set (the "publicly listening with no password" footgun gate in `App.cpp`). Overridable with `--bind=…` on the CLI. |
-| `Port` | `4713` | TCP port for inbound REST traffic. Distinct from amuled's EC port (`[EC]/Port`, default 4712). Overridable with `--http-port=…`. |
-| `AllowCORS` | `0` | `1` enables CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials: true`, `Vary: Origin`, preflight OPTIONS). Required for browser clients hosted on a different origin. See §CORS below. |
-| `CorsOriginAllowlist` | *(empty)* | Comma-separated list of origins that may set credentialed CORS requests. Empty + `AllowCORS=1` echoes the caller's `Origin` verbatim (wildcard-equivalent that remains cookie-compatible). |
-| `StaticRoot` | *(empty)* | Absolute filesystem path of a bundled web frontend. Empty (default) auto-discovers the bundled placeholder via the install-path chain (`make install` target on Linux/Windows, `aMule.app/Contents/Resources/amuleapi-static` on macOS) — same pattern amuleweb uses for templates, see [`WebInterface.cpp:146`](../src/webserver/src/WebInterface.cpp#L146). If no install is found, the daemon stays API-only and non-`/api/` paths return `404`. A non-empty `StaticRoot` overrides discovery and serves `GET`/`HEAD` requests outside `/api/` from that directory, with `index.html` SPA fallback for extension-less misses. Reads are containment-checked (symlinks pointing outside the root are rejected on POSIX; lexical `..`-rejection on Windows where symlinks require elevation), capped at 16 MiB per asset, and emit a mtime-size `ETag` so subsequent loads short-circuit to `304` via `If-None-Match`. |
+- `BindAddress` / `Port` — where amuleapi listens. A non-loopback
+  `BindAddress` requires an admin password.
+- `AllowCORS` / `CorsOriginAllowlist` — see [CORS](#cors).
+- `StaticRoot` — directory to serve a frontend bundle from. Empty keeps the
+  daemon API-only.
 
 ### `[EC]` — outbound connection to amuled
 
-| Key | Default | Meaning |
-| --- | --- | --- |
-| `Host` | `127.0.0.1` | Hostname or IP of the running amuled daemon. amuleapi is a long-lived EC client; CLI `--host=…` overrides. |
-| `Port` | `4712` | amuled's EC listener port (matches amuled's `[ExternalConn]/ECPort`). CLI `--port=…` overrides. |
-| `Password` | *(empty)* | Plaintext EC password matching amuled's `[ExternalConn]/ECPassword`. Stored cleartext because the base class wants a hashable plaintext — the `0600` file mode matches `amuleapi-jwt-secret` and `amuleapi-passwords`. CLI `--password=…` overrides. |
+- `Host` / `Port` — where amuled's EC listener is.
+- `Password` — the EC password. Used only when no token was issued; left
+  empty in the auto-start flow.
+- `Encryption` — negotiate an encrypted EC session (default on).
 
 ### `[Auth]` — login rate limiter
 
-Drives the `/auth/login` per-IP throttle (`CRateLimiter` in `Auth.cpp`). Failures inside the sliding window count toward the threshold; tripping it locks the offending IP out for `LoginLockoutSeconds`. Successful logins reset the bucket immediately.
-
-| Key | Default | Meaning |
-| --- | --- | --- |
-| `LoginFailureWindowSeconds` | `60` | Sliding window in seconds. Failures older than this fall off the count. |
-| `LoginFailureThreshold` | `5` | Failures within the window before the IP is locked out. |
-| `LoginLockoutSeconds` | `300` | Duration of the IP lockout once tripped. While locked, `/auth/login` returns `429 rate_limited` with a `Retry-After` header. |
+`LoginFailureThreshold` failures within `LoginFailureWindowSeconds` lock
+that address out for `LoginLockoutSeconds`.
 
 ### `[Streaming]` — SSE event bus
 
-| Key | Default | Meaning |
-| --- | --- | --- |
-| `EventBusRingCapacity` | `16384` | Number of events the in-memory SSE bus retains for `Last-Event-ID` replay. Sized to absorb a cold-start tick on a busy node (5 K downloads + 5 K shared can publish ~10 K `*_added` events in a single tick). Worst-case memory ≈ capacity × ~1 KB JSON payload. Values below the bus's compile-time floor (16) are clamped up. Raise this on operator-heavy nodes where reconnecting clients are hitting `resync` events from natural traffic; lower it (e.g. `32`) only for the smoke-test gap-path scenario. |
+`EventBusRingCapacity` bounds the replay ring backing `Last-Event-ID`.
 
-CLI `--bind`, `--http-port`, `--host`, `--port`, `--password`, and `--config-dir` override the matching keys at runtime without rewriting the file.
+CLI `--bind`, `--http-port`, `--host`, `--port`, `--password` and
+`--config-dir` override the matching keys without rewriting the file.
 
 ## CORS
 
-By default amuleapi serves no CORS headers (same-origin only). To allow
-cross-origin browser clients, set in `amuleapi.conf`:
+amuleapi serves no CORS headers by default (same-origin only). To allow
+cross-origin browser clients:
 
 ```ini
 [Server]
@@ -272,87 +279,68 @@ AllowCORS=1
 CorsOriginAllowlist=https://your-app.example.com,https://staging.example.com
 ```
 
-Leave `CorsOriginAllowlist` empty to echo any caller's `Origin` header
-(wildcard-equivalent that stays cookie-compatible).
-
-> **CORS note.** The empty-allowlist form is *not* literally
-> `Access-Control-Allow-Origin: *`. amuleapi echoes the caller's
-> exact `Origin` value, which is the only shape browsers accept
-> together with `Access-Control-Allow-Credentials: true` (RFC 6454
-> + Fetch spec). A literal `*` would refuse cookie auth on cross-
-> origin requests — which is what every browser session relies on.
+An empty `CorsOriginAllowlist` echoes the caller's `Origin`. That is *not*
+literally `Access-Control-Allow-Origin: *` — echoing the exact origin is the
+only form browsers accept together with `Access-Control-Allow-Credentials:
+true`, and a literal `*` would break cookie auth cross-origin.
 
 ## What ships
 
-The daemon serves a versioned REST surface under `/api/v0/`. This is the
-map of what's there; the full per-endpoint contracts — methods, query
-params, request/response bodies, error codes — live in
-[`docs/api/REFERENCE.md`](api/REFERENCE.md), which stays authoritative and
-current.
+A versioned REST surface under `/api/v0/`. Full contracts — methods, query
+params, bodies, error codes — are in
+[`docs/api/REFERENCE.md`](api/REFERENCE.md).
 
-- **Auth** — `auth/login`, `auth/logout`, `auth/session` (JWT and
-  session-cookie).
+- **Auth** — `auth/login`, `auth/logout`, `auth/session` (JWT and session
+  cookie).
 - **System** — `version`, `version/check`, `status`, `preferences`.
-- **Downloads** — the transfer queue: list and per-file detail; add,
-  pause/resume, cancel, `clear_completed`; per-file comments,
-  source-reported filenames, and A4AF (alternate sources) listing and
-  swap.
-- **Shared files** — list and detail, `reload`, `verify` (re-hash local
-  data), and the shared-directory roots (`shared/directories`, with
-  GET/PUT/POST/DELETE).
-- **Clients (peers)** — the per-peer view (optional
-  `?filter=uploads|downloads|active` for the legacy "Uploads" subset),
-  per-client detail, and browsing a peer's shared files ("View Files").
-- **Servers** — the ed2k server list: add, connect, remove, and
-  `servers/update` (refresh the list from a URL).
-- **Network control** — `networks/connect` / `disconnect`,
-  `kad/bootstrap`, and the `kad` status view.
-- **Categories** — list plus create / edit / delete.
-- **Search** — `search` (start), `search/results`, `search/stop`,
-  download a result, and per-result comments/ratings.
+- **Downloads** — queue list and per-file detail; add, pause/resume, cancel,
+  `clear_completed`; per-file comments, source-reported filenames, and A4AF
+  listing and swap.
+- **Shared files** — list and detail, `reload`, `verify`, and the share
+  roots (`shared/directories`).
+- **Clients (peers)** — per-peer view (`?filter=uploads|downloads|active`),
+  per-client detail, and browsing a peer's shared files.
+- **Servers** — the ed2k server list: add, connect, remove, `servers/update`.
+- **Network control** — `networks/connect` / `disconnect`, `kad/bootstrap`,
+  `kad` status.
+- **Categories** — list, create, edit, delete.
+- **Search** — `search`, `search/results`, `search/stop`, download a result,
+  per-result comments.
 - **Logs & stats** — `logs/{amule,serverinfo}`, `stats/tree`,
   `stats/graphs/{graph}`.
 
-Conventions that apply across the surface (all detailed in REFERENCE):
+Conventions across the surface:
 
-- **List windowing.** `downloads`, `clients`, `shared`, `servers`, and
+- **List windowing.** `downloads`, `clients`, `shared`, `servers` and
   `search/results` take `limit` / `offset` / `sort` / `order` and return
-  `total` / `offset` / `limit` alongside the array. Omitting them all
-  yields the full set.
-- **Bulk mutations** report one entry per input item under a unified
-  `results` array — `200`/`202` when every item succeeded, `207
-  Multi-Status` for a mix (inspect each `results[].ok`), `503` when the
-  whole batch failed on an EC disconnect. So a client submitting N items
-  learns the fate of each rather than an aggregate counter.
-- **ETag-on-GET** conditional caching (`304 Not Modified` on
-  `If-None-Match`).
-- Every runtime tunable lives in `amuleapi.conf`; see the `amuleapi.conf`
-  reference above for sections, keys, and defaults.
+  `total` / `offset` / `limit` beside the array. Omit them all for the full
+  set.
+- **Bulk mutations** return one entry per input item under `results` —
+  `200`/`202` when all succeeded, `207 Multi-Status` for a mix, `503` when
+  the batch failed on an EC disconnect. Callers learn the fate of each item,
+  not an aggregate count.
+- **ETag on GET** with `304 Not Modified` on `If-None-Match`.
 
 ### Events
 
-`GET /api/v0/events` is a long-lived Server-Sent Events stream with
-`Last-Event-ID` replay and typed `resync` frames for cache invalidation.
-The channel catalog, frame format, snapshot-then-stream bootstrap, and
-reconnect semantics are documented in
-[`docs/api/EVENTS.md`](api/EVENTS.md).
+`GET /api/v0/events` is a long-lived SSE stream with `Last-Event-ID` replay
+and typed `resync` frames for cache invalidation. Channels, frame format and
+reconnect semantics are in [`docs/api/EVENTS.md`](api/EVENTS.md).
 
 ## Security notes
 
-- The admin role grants the holder full control of the daemon's
-  network surface — that includes `POST /api/v0/servers/update
-  {"servers_url": "..."}`, which makes amuled fetch the supplied URL
-  to refresh the server list. This is the same behaviour amuled has
-  exposed via the desktop GUI and amuleweb for years, but it widens
-  what an admin token *grants* — anyone who steals one can ask
-  amuled to perform an HTTP GET against arbitrary network-reachable
-  URLs (a classic SSRF surface) and bring the response back into
-  amuled's process. The `http://` / `https://` pre-check in the API
-  is hygienic input validation, not a security boundary; protect
-  the admin password and the JWT signing secret accordingly.
-- The default `BindAddress=127.0.0.1` is load-bearing. The HTTP
-  server spawns one OS thread per Server-Sent Events subscriber, so
-  binding amuleapi to a non-loopback interface exposes the
-  thread-per-connection model to unauthenticated peers. If you need
-  remote access, put a reverse proxy in front and keep the bind on
-  loopback.
+- **Prefer the auto-start flow.** It is the only configuration in which the
+  API daemon never holds a durable EC credential. See
+  [above](#why-it-is-more-secure).
+- **The admin role grants full control of the daemon's network surface.**
+  That includes `POST /api/v0/servers/update {"servers_url": "..."}`, which
+  makes amuled fetch the supplied URL. This is long-standing amuled
+  behaviour, but it widens what an admin token *grants*: whoever holds one
+  can have amuled issue an HTTP GET against arbitrary reachable URLs (a
+  classic SSRF surface) and pull the response into amuled's process. The
+  `http://` / `https://` pre-check is input hygiene, not a boundary. Protect
+  the admin password and the JWT secret accordingly.
+- **`BindAddress=127.0.0.1` is load-bearing.** The HTTP server spawns one OS
+  thread per SSE subscriber, so a non-loopback bind exposes the
+  thread-per-connection model to unauthenticated peers. For remote access,
+  put a reverse proxy in front and keep the bind on loopback.

--- a/docs/man/amuleapi.1.in
+++ b/docs/man/amuleapi.1.in
@@ -11,7 +11,6 @@ amuleapi \- the aMule REST API + Server\-Sent Events daemon
 .RB_untranslated [ \-\-bind " " \fI<address> ]
 .RB_untranslated [ \-\-http\-port " " \fI<num> ]
 .RB_untranslated [ \-\-config\-dir " " \fI<path> ]
-.RB_untranslated [ \-\-amule\-config\-file " " \fI<path> ]
 .RB_untranslated [ \-\-log\-file " " \fI<path> ]
 .RB_untranslated [ \-\-no\-log\-file ]
 .RB_untranslated [ \-\-foreground ]
@@ -29,12 +28,10 @@ amuleapi \- the aMule REST API + Server\-Sent Events daemon
 .RB_untranslated [ \-\-help ]
 .SH DESCRIPTION
 .B_untranslated amuleapi
-is a standalone HTTP daemon that exposes a versioned JSON REST API and a
-long\-lived Server\-Sent Events stream backed by a single
-\fBamuled\fR(1) instance over the EC protocol. It is intended to run
-alongside \fBamuled\fR (which it connects to as an EC client) and serves
-its HTTP surface on a separate port from \fBamuleweb\fR(1) \- the two
-can run concurrently against the same daemon.
+serves a JSON REST API and a live event stream for a running
+\fBamuled\fR(1), so other programs can control aMule over HTTP. It
+connects to amuled the same way \fBamulecmd\fR(1) does, and listens on its
+own port, so it can run at the same time as \fBamuleweb\fR(1).
 .PP
 The wire contract for the REST API is documented at
 \fIdocs/api/REFERENCE.md\fR; the SSE event catalog lives at
@@ -66,19 +63,10 @@ aMule data directory that \fBamuled\fR uses (~/.aMule/ on Linux,
 Windows). Creates the dir with mode 0700 if absent.
 .TP
 .B_untranslated [ \-\-disable\-ec\-encryption ]\fR
-Do not encrypt the External Connection link to \fBamuled\fR(1).
-Encryption is negotiated automatically whenever the remote aMule supports it, and is on by default for every destination, local or remote.
-Equivalent to setting \fBEncryption=0\fR in the \fB[EC]\fR section of \fIamuleapi.conf\fR.
-Turning it off leaves everything after the login readable, and modifiable, by anyone able to observe the connection.
-.TP
-\fB[ \-\-amule\-config\-file\fR=\fI<path>\fR \fB]\fR
-Read the EC host, port and password from an existing \fBamule\fR(1) /
-\fBamuled\fR(1) \fIamule.conf\fR, the same way \fBamuleweb\fR(1) does. This
-is how aMule auto\-starts amuleapi (see \fIRun amuleapi on startup\fR in the
-GUI, or \fI/AmuleApi/Enabled\fR in \fIamule.conf\fR): amuled only stores the
-MD5\-hashed EC password, so passing the config file lets amuleapi
-authenticate without a plaintext \fB\-\-password\fR on the command line.
-Overrides \fB\-\-host\fR / \fB\-\-port\fR / \fB\-\-password\fR.
+Do not encrypt the link to \fBamuled\fR(1). Encryption is on by default
+whenever the remote aMule supports it. Turning it off lets anyone watching
+the connection read and alter everything after the login. Same as
+\fBEncryption=0\fR in \fIamuleapi.conf\fR.
 .TP
 \fB[ \-\-set\-admin\-pass\fR=\fI<plain>\fR \fB]\fR
 Set the admin password to \fI<plain>\fR, storing it salted and
@@ -97,13 +85,10 @@ units; if you need a system service wrapper, write a downstream unit
 that wraps the foreground command.
 .TP
 \fB[ \-\-log\-file\fR=\fI<path>\fR \fB]\fR
-Append a copy of all console output (both stdout and stderr) to
-\fI<path>\fR while still printing to the console. Enabled by default at
-\fI<config\-dir>/amuleapi.log\fR, so a log is always available to attach to
-a bug report; pass this to use a different path. The file is opened in
-append mode and capped at 10 MiB: when a write would exceed the cap it is
-rotated to \fI<path>.1\fR (replacing any previous one) and a fresh file is
-started, so on\-disk usage stays bounded.
+Write a copy of the console output to \fI<path>\fR. On by default at
+\fI<config\-dir>/amuleapi.log\fR, so there is always a log to attach to a
+bug report; use this to put it somewhere else. It is capped at 10 MiB and
+rotated to \fI<path>.1\fR, so it cannot grow without bound.
 .TP
 \fB[ \-\-no\-log\-file ]\fR
 Disable the log file entirely and print to the console only.
@@ -116,28 +101,27 @@ Print a short usage description.
 .SH FILES
 .TP
 \fI~/.aMule/amuleapi.conf\fR
-INI\-style runtime config: \fB[Server]\fR (bind address, HTTP port, CORS
-allowlist), \fB[EC]\fR (outbound connection to amuled, including
-\fBEncryption\fR which defaults to 1 and can be set to 0 to disable
-transport encryption), \fB[Auth]\fR (login
-rate\-limit knobs), \fB[Streaming]\fR (SSE event\-bus ring capacity). The
-QUICKSTART document distributed with the source has the full
-reference.
+Settings file: HTTP address and port, the connection to amuled, login
+rate limits and event\-stream sizing. The QUICKSTART document shipped with
+the source has the full reference.
 .TP
 \fI~/.aMule/amuleapi\-jwt\-secret\fR
-32\-byte HMAC signing key for issued tokens. Mode 0600. Auto\-generated
-on first launch if absent. Deleting the file invalidates every
-previously\-issued token.
+Key used to sign login tokens. Created on first launch. Deleting it signs
+out everyone.
 .TP
 \fI~/.aMule/amuleapi\-passwords\fR
-Admin and guest passwords, each stored as a salted PBKDF2\-HMAC\-SHA256
-record rather than a reversible digest. Mode 0600. This is the only
-place they are stored. Written via \fB\-\-set\-admin\-pass\fR /
-\fB\-\-set\-guest\-pass\fR, by the REST endpoint
-\fBPATCH /api/v0/auth/passwords\fR, and by \fBamule\fR(1) or
-\fBamuled\fR(1) when a password is changed in the Remote Controls
-preferences. A change takes effect on the next login without
-restarting amuleapi, and invalidates tokens issued before it.
+The admin and guest passwords, stored so they cannot be read back, only
+replaced. This is the only place they are kept. Set them with
+\fB\-\-set\-admin\-pass\fR / \fB\-\-set\-guest\-pass\fR, from the REST API, or
+from the Remote Controls preferences in \fBamule\fR(1). A change applies at
+the next login and signs out anyone already logged in.
+.TP
+\fI~/.aMule/amuleapi\-ec\-token\fR
+Short\-lived login token, written by \fBamule\fR(1) / \fBamuled\fR(1) when
+they start amuleapi themselves. Created fresh each time, read once and
+deleted straight away, so an auto\-started amuleapi needs no EC password of
+its own. Started by hand, amuleapi finds no token and uses
+\fB[EC]/Password\fR from \fIamuleapi.conf\fR instead.
 .SH REPORTING BUGS
 Please report bugs either on our forum
 (\fIhttps://github.com/amule-org/amule/discussions\fR), or in our

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -310,6 +310,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 19:56+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -317,6 +317,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 19:57+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -330,6 +330,11 @@ msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l b
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FALLU"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 19:59+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -317,6 +317,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -309,6 +309,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 19:59+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -330,6 +330,11 @@ msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha troba
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:00+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -326,6 +326,11 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "CHYBA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:01+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -318,6 +318,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -338,6 +338,11 @@ msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings ka
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEHLER"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:03+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -334,6 +334,11 @@ msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστ�
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -310,6 +310,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -340,6 +340,11 @@ msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecut
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -330,6 +330,11 @@ msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb program
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIGA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:05+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -331,6 +331,11 @@ msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra e
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROREA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -331,6 +331,11 @@ msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amu
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIRHE"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:06+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -338,6 +338,11 @@ msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le bi
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERREUR"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:07+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -351,6 +351,11 @@ msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:08+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -324,6 +324,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -322,6 +322,11 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "GREŠKA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -333,6 +333,11 @@ msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program ne
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HIBA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -343,6 +343,11 @@ msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRORE"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -329,6 +329,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:12+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -327,6 +327,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:13+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -332,6 +332,11 @@ msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amulew
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "KLAIDA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -314,6 +314,11 @@ msgstr "Jūs esiet iespējojuši 'Kad palaiž, palaist arī tīmekļa serveri' i
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "KĻŪDA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:13+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -332,6 +332,11 @@ msgstr "U heeft ingesteld om de webserver te starten bij het opstarten, maar amu
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FOUT"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:14+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -332,6 +332,11 @@ msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan 
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEIL"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:15+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -332,6 +332,11 @@ msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale b
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "BŁĄD"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:16+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -338,6 +338,11 @@ msgstr "Você pediu para rodar o servidor web na início, mas o binário do amul
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:16+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -337,6 +337,11 @@ msgstr "Pediu para executar o servidor web no arranque, mas o executável não p
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:17+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -329,6 +329,11 @@ msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar a
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "EROARE"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:18+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -336,6 +336,11 @@ msgstr "Вы хотите запускать веб-сервер при загр
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ОШИБКА"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -331,6 +331,11 @@ msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa 
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "NAPAKA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -329,6 +329,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:19+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -329,6 +329,11 @@ msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan int
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEL"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -309,6 +309,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -331,6 +331,11 @@ msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amulewe
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HATA"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:20+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -329,6 +329,11 @@ msgstr "Ви встановили запуск веб-сервера під ча
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ПОМИЛКА"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -309,6 +309,11 @@ msgstr ""
 #: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
+msgstr ""
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
 msgstr ""
 
 #: src/amule.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:21+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -335,6 +335,11 @@ msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "错误"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 17:05+0200\n"
+"POT-Creation-Date: 2026-07-31 20:09+0200\n"
 "PO-Revision-Date: 2026-07-30 20:21+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -335,6 +335,11 @@ msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb
 #: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "錯誤"
+
+#: src/amule.cpp
+#, c-format
+msgid "Could not write the amuleapi EC token to %s; amuleapi will fall back to its configured password."
+msgstr ""
 
 #: src/amule.cpp
 #, fuzzy, c-format

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -883,10 +883,17 @@ if (NEED_LIB_MULEAPPCORE)
 		PUBLIC wxWidgets::BASE
 		PRIVATE CRYPTOPP::CRYPTOPP
 		# webcommon owns the amuleapi credential format (hashing + the
-		# amuleapi-passwords file), shared with the amuleapi binary so the
-		# two can never disagree about it. Built unconditionally, so this
+		# amuleapi-passwords file) and the EC token amuled hands the
+		# amuleapi it spawns, shared with the amuleapi binary so the two
+		# can never disagree about either. Built unconditionally, so this
 		# holds even for a -DBUILD_AMULEAPI=NO configure.
-		PRIVATE webcommon
+		#
+		# PUBLIC, not PRIVATE: amule.cpp calls webcommon directly and is
+		# compiled into the amule / amuled executables rather than into
+		# this library, so those targets need the header path too. The
+		# objects already reached them transitively; only the includes
+		# did not.
+		PUBLIC webcommon
 	)
 
 	# The GeoIP resolver (IP2Country.cpp + geoip/MaxMindDBDatabase.cpp) now

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -264,6 +264,13 @@ private:
 
 	uint64_t m_passwd_salt;
 
+	// The credential this connection authenticated with -- the configured
+	// EC password, or the ephemeral token the core issued to the amuleapi
+	// it spawned. Per-socket precisely because two clients may be using
+	// different credentials at the same time; ActivateAEAD() keys the
+	// session from this rather than re-reading preferences.
+	wxString m_authSecret;
+
 	// Transport encryption, chosen during EC_OP_AUTH_REQ and only turned on
 	// once the password verifies. Held here until then because a client that
 	// fails authentication must never get a working key.
@@ -471,7 +478,15 @@ void CECServerSocket::ActivateAEAD()
 	if (m_aeadCipher == ECCrypt::Cipher_None) {
 		return;
 	}
-	const wxString secret = thePrefs::ECPassword().Lower();
+	// Key off whichever credential this connection actually authenticated
+	// with, NOT unconditionally off the configured password. The client
+	// derives its half from the secret it presented (RemoteConnect.cpp:
+	// m_aeadSecret = pass.Lower()), so a peer that authenticated with the
+	// ephemeral token would otherwise end up with a different key than we
+	// do -- the handshake would succeed and the first sealed packet would
+	// fail. m_authSecret is per-socket, so concurrent clients using
+	// different credentials each key their own session.
+	const wxString secret = m_authSecret.Lower();
 	const wxCharBuffer buf = secret.utf8_str();
 	const std::vector<uint8_t> ikm(
 		(const uint8_t *)buf.data(), (const uint8_t *)buf.data() + strlen(buf.data()));
@@ -894,6 +909,33 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 
 			passh.Decode(MD5Sum(thePrefs::ECPassword().Lower() + saltHash).GetHash());
 
+			// Second accepted credential: the ephemeral token the core
+			// issued to the amuleapi it spawned, so that daemon never
+			// needs the password-equivalent value out of amule.conf.
+			//
+			// Empty when no token was issued, and an empty token must
+			// never authenticate anyone -- so the emptiness is tested
+			// here rather than relying on a digest of "" failing to
+			// collide.
+			const wxString &ecToken = theApp->GetEcToken();
+			CMD4Hash tokenh;
+			const bool tokenUsable = !ecToken.IsEmpty() &&
+						 tokenh.Decode(MD5Sum(ecToken.Lower() + saltHash).GetHash());
+
+			// Compare against both without short-circuiting. The naive
+			// `if (pw) ... else if (token) ...` leaks which credential
+			// matched through timing, and -- more usefully to an attacker
+			// -- whether a token is live at all. Both branches are
+			// evaluated and the results OR'd, so acceptance is one
+			// decision.
+			//
+			// The per-comparison timing is not itself a concern: the
+			// digests are salted per connection, so anything learned about
+			// one is stale on the next, and the rate limiter above bounds
+			// attempts regardless.
+			const bool matchedPassword = passwd && passwd->GetMD4Data() == passh;
+			const bool matchedToken = passwd && tokenUsable && passwd->GetMD4Data() == tokenh;
+
 			// Operator policy: refuse anything that did not negotiate
 			// encryption. Checked ahead of the password so the client gets
 			// the real reason rather than a misleading "wrong password",
@@ -908,12 +950,19 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				AddLogLineN(wxString(wxGetTranslation(err)) + " " + GetPeer());
 				response = new CECPacket(EC_OP_AUTH_FAIL);
 				response->AddTag(CECTag(EC_TAG_STRING, err));
-			} else if (passwd && passwd->GetMD4Data() == passh) {
-				// The password is good, so both ends hold the same secret and
-				// the keys will match. Switch on now rather than after the
-				// reply: EC_OP_AUTH_OK is then itself sealed, which proves to
-				// the client that its peer really does know the password --
-				// something the plain challenge never established.
+			} else if (passwd && (matchedPassword || matchedToken)) {
+				// One of the two accepted credentials matched, so both ends
+				// hold the same secret and the keys will match. Switch on now
+				// rather than after the reply: EC_OP_AUTH_OK is then itself
+				// sealed, which proves to the client that its peer really does
+				// know the secret -- something the plain challenge never
+				// established.
+				//
+				// Remember WHICH one for ActivateAEAD: the client keys its
+				// half from the credential it presented, so keying ours from
+				// the configured password regardless would break every
+				// token-authenticated session the moment it was sealed.
+				m_authSecret = matchedPassword ? thePrefs::ECPassword() : ecToken;
 				// Clear the bucket: a legitimate user who mistyped a few
 				// times must not carry that streak into their next
 				// connection.

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -90,6 +90,8 @@
 #include "ServerUDPSocket.h"            // Needed for CServerUDPSocket
 #include "Statistics.h"                 // Needed for CStatistics
 #include "AmuleApiCredentials.h"        // Needed for AmuleApiCredentials::RefreshState
+#include <AtomicFile.h>                 // webcommon::WriteFileAtomic0600 for the EC token
+#include <Credentials.h>                // webcommon::EcTokenFilePath / GenerateEcToken
 #include "TerminationProcessAmuleApi.h" // Needed for CTerminationProcessAmuleApi
 #include "TerminationProcessAmuleweb.h" // Needed for CTerminationProcessAmuleweb
 #include "ThreadTasks.h"
@@ -1131,7 +1133,6 @@ bool CamuleApp::OnInit()
 
 	// Run amuleapi?
 	if (thePrefs::GetAmuleApiIsEnabled()) {
-		wxString aMuleConfigFile = thePrefs::GetConfigDir() + m_configFile;
 		// Not a const&: the __WXMAC__ block below reassigns this. clang-tidy runs
 		// on Linux where that block is #ifdef'd out, so it can't see the write.
 		// NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
@@ -1155,15 +1156,43 @@ bool CamuleApp::OnInit()
 		}
 #endif
 
-		// --amule-config-file hands amuleapi the EC host/port/hashed-password
-		// out of amule.conf, exactly like amuleweb. Its admin and guest
-		// credentials do NOT travel this way: they live in amuleapi-passwords
-		// in the config dir below, which both processes write. The HTTP bind
-		// address and port are passed explicitly. A non-loopback bind requires
-		// an admin password, or amuleapi refuses to start; all of this is
-		// configured in the Remote Controls preferences.
+		// Hand the child an ephemeral EC credential instead of letting it
+		// read the password-equivalent value out of amule.conf. Written
+		// 0600 into the config dir the child is about to be pointed at,
+		// under the one name both sides derive from webcommon; the child
+		// deletes it the moment it has read it, and OnCoreTimer removes
+		// it regardless once the deadline below expires.
+		//
+		// The path is deliberately NOT on the command line: argv is
+		// world-readable via ps, so passing it would advertise exactly
+		// where to look for the window the file exists.
+		//
+		// A failure here is not fatal -- amuleapi still has its own
+		// configured EC password to fall back on -- but it is worth
+		// saying, because the fallback is the credential we are trying
+		// to stop using.
+		m_ecToken = wxString::FromUTF8(webcommon::GenerateEcToken().c_str());
+		const std::string tokenPath =
+			webcommon::EcTokenFilePath(std::string(thePrefs::GetConfigDir().utf8_str()));
+		if (webcommon::WriteFileAtomic0600(tokenPath, std::string(m_ecToken.utf8_str()) + "\n")) {
+			m_ecTokenFileExpiryMs = theStats::GetUptimeMillis() + EC_TOKEN_FILE_TTL_MS;
+		} else {
+			AddLogLineC(CFormat(_("Could not write the amuleapi EC token to %s; "
+					      "amuleapi will fall back to its configured password.")) %
+				    wxString::FromUTF8(tokenPath.c_str()));
+			m_ecToken.Clear();
+		}
+
+		// No --amule-config-file here, unlike amuleweb above: amuleapi
+		// takes the ephemeral token written just now instead of reading
+		// the hashed EC password out of amule.conf. It finds the token
+		// through the config dir passed below, which is also where its
+		// admin and guest credentials live (amuleapi-passwords, written
+		// by both processes). The HTTP bind address and port are passed
+		// explicitly. A non-loopback bind requires an admin password, or
+		// amuleapi refuses to start; all of this is configured in the
+		// Remote Controls preferences.
 		wxString cmd = QUOTE + amuleapiPath +
-			       QUOTE " " QUOTE "--amule-config-file=" + aMuleConfigFile +
 			       QUOTE " " QUOTE "--config-dir=" + thePrefs::GetConfigDir() +
 			       QUOTE " " QUOTE "--bind=" + thePrefs::GetAmuleApiBindAddress() + QUOTE +
 			       wxString::Format(wxT(" --http-port=%u"), thePrefs::GetAmuleApiPort());
@@ -1838,6 +1867,22 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 		knownfiles->Save();
 		m_mediaTagsDirtiedMs = 0;
 		msPrevKnownMet = msCur;
+	}
+
+	// Backstop for the amuleapi EC token file. The child unlinks it as
+	// soon as it has read it, so in the normal case this finds nothing
+	// left to do -- it exists for the child that never got that far, so a
+	// live secret cannot be left at rest by a crash or a failed exec. The
+	// in-memory token stays valid either way; only the file is transient.
+	if (m_ecTokenFileExpiryMs && msCur >= m_ecTokenFileExpiryMs) {
+		m_ecTokenFileExpiryMs = 0;
+		const wxString tokenPath = wxString::FromUTF8(
+			webcommon::EcTokenFilePath(std::string(thePrefs::GetConfigDir().utf8_str())).c_str());
+		if (wxFileExists(tokenPath) && wxRemoveFile(tokenPath)) {
+			AddDebugLogLineN(logGeneral,
+				CFormat("amuleapi EC token file removed unread after %u ms: %s") %
+					EC_TOKEN_FILE_TTL_MS % tokenPath);
+		}
 	}
 
 	// Recommended by lugdunummaster himself - from emule 0.30c

--- a/src/amule.h
+++ b/src/amule.h
@@ -120,6 +120,12 @@ class CUInt128;
 #define CORE_TIMER_PERIOD 100
 #endif
 
+// How long the amuleapi EC token file may sit on disk before the core
+// removes it whether or not the child read it. Long enough to cover a
+// slow exec on a loaded machine, short enough that a secret is not
+// left at rest for anything a person would notice.
+#define EC_TOKEN_FILE_TTL_MS 10000
+
 #define CONNECTED_ED2K (1 << 0)
 #define CONNECTED_KAD_NOT (1 << 1)
 #define CONNECTED_KAD_OK (1 << 2)
@@ -533,11 +539,38 @@ protected:
 	int webserver_pid;
 	int amuleapi_pid;
 
+	// Ephemeral EC credential for the amuleapi we spawn. Generated fresh
+	// every start, handed over through a 0600 file in the config dir that
+	// the child deletes as soon as it has read it, and accepted by the EC
+	// server alongside the configured password for the rest of this run.
+	//
+	// The point is that amuleapi never needs the value in amule.conf. That
+	// stored value IS the credential -- the challenge hashes it directly --
+	// so a compromised network-facing daemon holding it would hold something
+	// equivalent to the user's EC password. This holds a secret that dies
+	// with the process instead.
+	//
+	// Empty when we did not spawn amuleapi, in which case no token is
+	// accepted at all.
+	wxString m_ecToken;
+
+	// Uptime-ms deadline after which the token file is removed whether or
+	// not the child read it. Without it a child that dies before reading
+	// leaves a live secret at rest, and "no token on disk after startup"
+	// stops being true. Same stamp-and-sweep shape as m_mediaTagsDirtiedMs.
+	// 0 = nothing pending.
+	uint64 m_ecTokenFileExpiryMs = 0;
+
 	wxString server_msg;
 
 	CTimer *core_timer;
 
 public:
+	// The ephemeral EC credential handed to the spawned amuleapi, or empty
+	// when none was issued. Read by the EC server's authentication path,
+	// which accepts it alongside the configured password.
+	const wxString &GetEcToken() const { return m_ecToken; }
+
 #ifdef ENABLE_VERSION_CHECK
 	// Result of the last completed version check, relayed over EC to
 	// amuleapi (the /version "update" object) and read by the UIs.

--- a/src/libwebcommon/AtomicFile.cpp
+++ b/src/libwebcommon/AtomicFile.cpp
@@ -1,0 +1,99 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//
+
+#include "AtomicFile.h"
+
+#include <cstdio>
+
+#ifndef _WIN32
+#include <cerrno>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#else
+#include <fstream>
+#endif
+
+namespace webcommon
+{
+
+bool WriteFileAtomic0600(const std::string &path, const std::string &body)
+{
+#ifndef _WIN32
+	const std::string tmp = path + ".tmp";
+
+	const int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+	if (fd < 0) {
+		return false;
+	}
+	::fchmod(fd, S_IRUSR | S_IWUSR); // belt+braces against odd umasks
+
+	std::size_t written = 0;
+	while (written < body.size()) {
+		const ssize_t n = ::write(fd, body.data() + written, body.size() - written);
+		if (n < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			::close(fd);
+			::unlink(tmp.c_str());
+			return false;
+		}
+		written += static_cast<std::size_t>(n);
+	}
+	if (::fsync(fd) != 0) {
+		::close(fd);
+		::unlink(tmp.c_str());
+		return false;
+	}
+	if (::close(fd) != 0) {
+		::unlink(tmp.c_str());
+		return false;
+	}
+	if (::rename(tmp.c_str(), path.c_str()) != 0) {
+		::unlink(tmp.c_str());
+		return false;
+	}
+	return true;
+#else
+	// Windows: no permission story to enforce, so this is a plain
+	// truncating write. Kept atomic-ish only in the sense that a failed
+	// write is reported; callers holding a secret are warned in the
+	// header that confidentiality is not provided here.
+	std::ofstream f(path.c_str(), std::ios::binary | std::ios::trunc);
+	if (!f.is_open()) {
+		return false;
+	}
+	if (!body.empty()) {
+		f.write(body.data(), static_cast<std::streamsize>(body.size()));
+	}
+	f.flush();
+	const bool ok = f.good();
+	f.close();
+	return ok;
+#endif
+}
+
+} // namespace webcommon

--- a/src/libwebcommon/AtomicFile.h
+++ b/src/libwebcommon/AtomicFile.h
@@ -1,0 +1,55 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//
+
+#ifndef LIBWEBCOMMON_ATOMICFILE_H
+#define LIBWEBCOMMON_ATOMICFILE_H
+
+#include <string>
+
+namespace webcommon
+{
+
+// Writes `body` to `path` owner-only, without ever exposing a partial or
+// world-readable version of it.
+//
+// POSIX: create a sibling temp with mode 0600, write it in full, fsync,
+// then rename(2) onto the target. The file is never observable in a
+// half-written state, and never exists with looser permissions than the
+// ones it is created with -- creating at 0600 rather than chmod-ing after
+// the fact closes the window where another user could open it. fchmod is
+// applied anyway as belt and braces against an odd umask.
+//
+// Windows: best-effort. There is no equivalent permission story here --
+// see RestrictToOwner() in FileFunctions.cpp, which is a no-op on Windows
+// for the same reason -- so callers holding a secret must not rely on this
+// for confidentiality on that platform.
+//
+// Returns false on any failure, leaving the previous contents of `path`
+// intact. Reports nothing: this lives below the logger for the same reason
+// the file helpers in mulecommon do, so the caller decides what to say.
+bool WriteFileAtomic0600(const std::string &path, const std::string &body);
+
+} // namespace webcommon
+
+#endif // LIBWEBCOMMON_ATOMICFILE_H

--- a/src/libwebcommon/CMakeLists.txt
+++ b/src/libwebcommon/CMakeLists.txt
@@ -8,6 +8,9 @@
 # JWT / ETag / route-pattern primitives, link against this lib too.
 
 add_library (webcommon STATIC
+	# Owner-only atomic file write, shared by the credential store, the
+	# amuleapi config writer and the EC token amuled hands its child.
+	AtomicFile.cpp
 	ConstantTime.cpp
 	# Credentials.cpp is also linked into the aMule core: amuled applies a
 	# password pushed from amulegui over EC, and monolithic amule applies

--- a/src/libwebcommon/Credentials.cpp
+++ b/src/libwebcommon/Credentials.cpp
@@ -24,6 +24,7 @@
 
 #include "Credentials.h"
 
+#include "AtomicFile.h"
 #include "ConstantTime.h"
 
 // cryptopp headers pull in deprecated implicit copy ctors + throw()
@@ -294,10 +295,15 @@ bool MakeRecord(const std::string &md5_hex, std::string &record)
 	return true;
 }
 
-std::string CredentialsFilePath(const std::string &config_dir)
+namespace
+{
+
+// Join a config dir and a well-known leaf name. Shared by every file this
+// module names so the separator handling cannot drift between them.
+std::string JoinConfigDir(const std::string &config_dir, const char *leaf)
 {
 	if (config_dir.empty()) {
-		return std::string("amuleapi-passwords");
+		return std::string(leaf);
 	}
 	const char sep = config_dir[config_dir.size() - 1];
 #ifdef _WIN32
@@ -305,7 +311,55 @@ std::string CredentialsFilePath(const std::string &config_dir)
 #else
 	const bool has_sep = (sep == '/');
 #endif
-	return config_dir + (has_sep ? "" : "/") + "amuleapi-passwords";
+	return config_dir + (has_sep ? "" : "/") + leaf;
+}
+
+} // namespace
+
+std::string CredentialsFilePath(const std::string &config_dir)
+{
+	return JoinConfigDir(config_dir, "amuleapi-passwords");
+}
+
+std::string EcTokenFilePath(const std::string &config_dir)
+{
+	return JoinConfigDir(config_dir, "amuleapi-ec-token");
+}
+
+bool ReadAndConsumeEcToken(const std::string &path, std::string &out)
+{
+	std::ifstream f(path.c_str(), std::ios::binary);
+	if (!f.is_open()) {
+		return false;
+	}
+	std::ostringstream buf;
+	buf << f.rdbuf();
+	f.close();
+
+	// Unlink regardless of what we just read: a file that failed to parse
+	// is still not something to leave lying around, and the caller has no
+	// later moment at which removing it would be safer.
+	::remove(path.c_str());
+
+	const std::string token = TrimAscii(buf.str());
+	if (!IsMd5Hex(token)) {
+		// Same 32-hex-char shape as an MD5 digest -- see GenerateEcToken
+		// for why that width. Reject anything else rather than attempt a
+		// connection with a truncated or tampered value.
+		return false;
+	}
+	out = ToLower(token);
+	return true;
+}
+
+std::string GenerateEcToken()
+{
+	// 16 bytes -> 32 hex chars, the exact width EC's challenge-response
+	// already consumes as an MD5 hex digest.
+	unsigned char raw[16];
+	CryptoPP::AutoSeededRandomPool rng;
+	rng.GenerateBlock(raw, sizeof(raw));
+	return ToHex(raw, sizeof(raw));
 }
 
 bool LoadCredentialsFile(const std::string &config_dir, Credentials &out, std::string &error)
@@ -367,58 +421,14 @@ bool SaveCredentialsFile(const std::string &config_dir, const Credentials &in, s
 	     << "guest=" << in.guest << "\n";
 	const std::string text = body.str();
 
-#ifndef _WIN32
-	// Crash-safe: write a sibling temp, fsync, then rename(2) onto the
-	// target. A partial write or a crash mid-write leaves the original
-	// intact, which matters because this file holds the only credentials
-	// the daemon has.
-	const std::string tmp = path + ".tmp";
-	const int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-	if (fd < 0) {
-		error = "cannot create " + tmp;
-		return false;
-	}
-	::fchmod(fd, S_IRUSR | S_IWUSR); // belt+braces against odd umasks
-
-	std::size_t written = 0;
-	while (written < text.size()) {
-		const ssize_t n = ::write(fd, text.data() + written, text.size() - written);
-		if (n < 0) {
-			if (errno == EINTR) {
-				continue;
-			}
-			::close(fd);
-			::unlink(tmp.c_str());
-			error = "write failed on " + tmp;
-			return false;
-		}
-		written += static_cast<std::size_t>(n);
-	}
-	if (::fsync(fd) != 0 || ::close(fd) != 0) {
-		::unlink(tmp.c_str());
-		error = "fsync/close failed on " + tmp;
-		return false;
-	}
-	if (::rename(tmp.c_str(), path.c_str()) != 0) {
-		::unlink(tmp.c_str());
-		error = "rename failed onto " + path;
+	// Crash-safe and owner-only; see WriteFileAtomic0600. This file holds
+	// the only credentials the daemon has, so a partial write or a crash
+	// mid-write must leave the previous contents intact.
+	if (!WriteFileAtomic0600(path, text)) {
+		error = "could not write " + path;
 		return false;
 	}
 	return true;
-#else
-	// Windows has no rename(2)-over-existing semantics; best effort.
-	std::ofstream outf(path.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
-	if (!outf.is_open()) {
-		error = "cannot open " + path;
-		return false;
-	}
-	outf.write(text.data(), static_cast<std::streamsize>(text.size()));
-	if (!outf.good()) {
-		error = "write failed on " + path;
-		return false;
-	}
-	return true;
-#endif
 }
 
 bool UpdateCredentialFile(

--- a/src/libwebcommon/Credentials.h
+++ b/src/libwebcommon/Credentials.h
@@ -155,6 +155,49 @@ bool MakeRecord(const std::string &md5_hex, std::string &record);
 // path-joining rules without duplicating them.
 std::string CredentialsFilePath(const std::string &config_dir);
 
+// The short-lived EC token amuled hands to the amuleapi it spawns.
+//
+// Defined here, and only here, because both ends have to agree on it with
+// nothing carrying the location between them: amuled writes it, and the
+// amuleapi it spawns looks for it in the same config dir it was handed. A
+// second literal in the other binary would be a silent failure waiting to
+// happen -- the child would simply find nothing and fall back to its
+// configured password, with the daemon none the wiser.
+//
+// Deliberately not passed on the command line: argv is world-readable via
+// ps, so a path there would tell every local user exactly where to look
+// during the window the file exists.
+std::string EcTokenFilePath(const std::string &config_dir);
+
+// A fresh EC token: 16 random bytes as 32 lowercase hex characters.
+//
+// The width is not arbitrary. EC's challenge-response hashes the stored
+// credential as a 32-char MD5 hex digest, so a token of exactly that shape
+// drops into the existing exchange with no protocol change -- the daemon
+// simply knows a second secret. 128 bits is also well beyond guessing for
+// something that lives for one daemon run.
+//
+// Drawn from a CSPRNG (the same one that salts credential records), not
+// from the general-purpose RNG the rest of the app uses for jitter and
+// IDs.
+std::string GenerateEcToken();
+
+// Reads the token at `path` into `out` and removes the file.
+//
+// The file is unlinked whether or not it parsed, because a file that is
+// not a valid token is still something we do not want left behind, and
+// because the caller has no better moment to do it: a retry re-uses the
+// value already in memory.
+//
+// Returns true only for exactly 32 lowercase-able hex characters, ignoring
+// surrounding whitespace. Anything else -- truncated, empty, padded with
+// junk -- is rejected rather than passed on, so a half-written or tampered
+// file cannot become the credential a connection is attempted with.
+//
+// Returns false (leaving `out` untouched) when the file does not exist,
+// which is the ordinary case for a manually started amuleapi.
+bool ReadAndConsumeEcToken(const std::string &path, std::string &out);
+
 } // namespace webcommon
 
 #endif // WEBCOMMON_CREDENTIALS_H

--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -24,6 +24,8 @@
 
 #include "AmuleApiConfig.h"
 
+#include <AtomicFile.h>
+
 #include <wx/file.h>
 #include <wx/fileconf.h>
 #include <wx/filefn.h>
@@ -121,67 +123,14 @@ wxString JoinPath(const wxString &dir, const wxString &leaf)
 	return fn.GetFullPath();
 }
 
-// Crash-safe writer for the 0600 secret files: amuleapi-jwt-secret and
-// the first-run amuleapi.conf. Writes the body to a sibling `<name>.tmp`,
-// fsyncs, then atomically rename(2)s onto the target, so a partial write
-// or a crash mid-write leaves the original intact. Falls back to a
-// non-atomic best-effort path on Windows (POSIX rename(2) semantics
-// aren't available there for existing-target replacement).
-//
-// amuleapi-passwords is NOT written here — it is shared with amuled and
-// monolithic aMule, so it goes through webcommon::SaveCredentialsFile,
-// which does the same dance behind the one owner of that format.
+// Thin wx wrapper over webcommon::WriteFileAtomic0600 so the call sites
+// here can keep passing wxString paths. The writer itself is shared with
+// the credential store and with amuled, which writes the EC token into the
+// same config dir -- one implementation, so the permission and atomicity
+// guarantees cannot drift between them.
 bool WriteFileAtomic0600(const wxString &target_path, const std::string &body)
 {
-#ifndef _WIN32
-	const std::string final_p(target_path.utf8_str());
-	const std::string tmp_p = final_p + ".tmp";
-
-	const int fd = ::open(tmp_p.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-	if (fd < 0)
-		return false;
-	::fchmod(fd, S_IRUSR | S_IWUSR); // belt+braces against odd umasks
-
-	std::size_t written = 0;
-	while (written < body.size()) {
-		const ssize_t n = ::write(fd, body.data() + written, body.size() - written);
-		if (n < 0) {
-			if (errno == EINTR)
-				continue;
-			::close(fd);
-			::unlink(tmp_p.c_str());
-			return false;
-		}
-		written += static_cast<std::size_t>(n);
-	}
-	if (::fsync(fd) != 0) {
-		::close(fd);
-		::unlink(tmp_p.c_str());
-		return false;
-	}
-	if (::close(fd) != 0) {
-		::unlink(tmp_p.c_str());
-		return false;
-	}
-	if (::rename(tmp_p.c_str(), final_p.c_str()) != 0) {
-		::unlink(tmp_p.c_str());
-		return false;
-	}
-	return true;
-#else
-	// Windows: best-effort. wxFile::Write returns the bytes written;
-	// short writes are caught and reported.
-	wxFile f;
-	if (!f.Create(target_path, true))
-		return false;
-	if (body.empty()) {
-		f.Close();
-		return true;
-	}
-	const ssize_t n = f.Write(body.data(), body.size());
-	f.Close();
-	return n == static_cast<ssize_t>(body.size());
-#endif
+	return webcommon::WriteFileAtomic0600(std::string(target_path.utf8_str()), body);
 }
 
 } // namespace

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -32,7 +32,6 @@
 #include "MD4Hash.h"
 #include "config.h" // VERSION
 
-#include <ec/cpp/ECFileConfig.h>  // CECFileConfig, for --amule-config-file
 #include <ec/cpp/RemoteConnect.h> // SetEcConnectionLostHandler
 #include <wx/filename.h>          // wxFileName::FileExists
 
@@ -118,12 +117,6 @@ void CamuleapiApp::OnInitCmdLine(wxCmdLineParser &parser)
 		wxCMD_LINE_VAL_STRING,
 		wxCMD_LINE_PARAM_OPTIONAL);
 	parser.AddOption("",
-		"amule-config-file",
-		_("Read the EC connection (host/port/password) from an amule.conf instead of "
-		  "--host/--port/--password. Used by amule to auto-start amuleapi."),
-		wxCMD_LINE_VAL_STRING,
-		wxCMD_LINE_PARAM_OPTIONAL);
-	parser.AddOption("",
 		"set-admin-pass",
 		_("Set the amuleapi admin password to <plain>, storing it salted and stretched in "
 		  "amuleapi-passwords (mode 0600), then exit."),
@@ -153,9 +146,6 @@ bool CamuleapiApp::OnCmdLineParsed(wxCmdLineParser &parser)
 		m_cliHasHttpPort = true;
 	}
 	parser.Found("config-dir", &m_cliConfigDirOverride);
-	if (parser.Found("amule-config-file", &m_cliAmuleConfigFile)) {
-		m_cliHasAmuleConfigFile = true;
-	}
 	if (parser.Found("set-admin-pass", &m_cliSetAdminPass)) {
 		m_cliHasSetAdminPass = true;
 	}
@@ -295,26 +285,36 @@ bool CamuleapiApp::LoadAmuleapiConfig()
 		m_password.Decode(MD5Sum(plain).GetHash());
 	}
 
-	// --amule-config-file wins for the EC connection: read host/port and the
-	// already-hashed ECPassword straight from an amule.conf (same as
-	// amuleweb). This is how amule auto-starts amuleapi -- amule only holds
-	// the hashed EC password, so it can't pass a plaintext --password.
-	if (m_cliHasAmuleConfigFile) {
-		if (!wxFileName::FileExists(m_cliAmuleConfigFile)) {
-			Show(CFormat("amuleapi: --amule-config-file '%s' does not exist\n") %
-				m_cliAmuleConfigFile);
-			return false;
+	// Ephemeral EC token, if the aMule core that spawned us left one. Both
+	// sides derive the name from webcommon rather than passing a path,
+	// because argv is world-readable via ps: telling every local user
+	// where the secret is for as long as it exists would undo the point of
+	// writing it 0600.
+	//
+	// Wins over amuleapi.conf: when the core issued a token, that is the
+	// credential it wants us to use. An explicit --password still wins,
+	// since that is an operator deliberately overriding us.
+	//
+	// This is what replaced --amule-config-file. That flag handed us the
+	// hashed EC password straight out of amule.conf, and in this protocol
+	// the stored value IS the credential -- so a network-facing daemon was
+	// holding something equivalent to the user's password, for its whole
+	// run. The token is equivalent for connecting and worthless once the
+	// daemon it belongs to has exited.
+	//
+	// Deleted on read, not after connecting. A failed connection retries
+	// from memory, so holding the file until the handshake completes would
+	// only widen the window in which the secret is at rest for nothing.
+	if (!m_cliHasEcPassword) {
+		const std::string tokenPath = webcommon::EcTokenFilePath(std::string(config_dir.utf8_str()));
+		std::string token;
+		if (webcommon::ReadAndConsumeEcToken(tokenPath, token)) {
+			m_password.Decode(wxString::FromUTF8(token.c_str()));
+			// Worth one line: it tells an operator which credential this
+			// instance is actually using, and it is what the "no token
+			// left on disk" check looks for after startup.
+			Show("amuleapi: using the ephemeral EC token from the core.\n");
 		}
-		CECFileConfig cfg(m_cliAmuleConfigFile);
-		LoadAmuleConfig(cfg); // sets m_host / m_port / m_password
-
-		// Only the EC connection comes from amule.conf. The admin and
-		// guest credentials deliberately do NOT: there is one store for
-		// them, amuleapi-passwords, which aMule and amuled write directly
-		// when a password is changed from the preferences dialog or from
-		// amulegui over EC. An amule.conf copy would be a second store,
-		// and whichever one lost the tie-break would silently discard a
-		// password the user had just set.
 	}
 
 	return true;

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -188,11 +188,6 @@ private:
 	wxString m_cliConfigDirOverride;
 	wxString m_cliSetAdminPass;
 	wxString m_cliSetGuestPass;
-	// --amule-config-file: read the EC connection (host/port/hashed password)
-	// straight from an amule.conf, same as amuleweb. Lets amule auto-start
-	// amuleapi without a plaintext EC password.
-	wxString m_cliAmuleConfigFile;
-	bool m_cliHasAmuleConfigFile = false;
 	bool m_cliHasBindAddress = false;
 	bool m_cliHasHttpPort = false;
 	bool m_cliHasSetAdminPass = false;

--- a/unittests/tests/CredentialsTest.cpp
+++ b/unittests/tests/CredentialsTest.cpp
@@ -63,6 +63,7 @@ void RemoveTempDir(const std::string &dir)
 {
 	const wxString wxdir(dir.c_str(), wxConvUTF8);
 	wxRemoveFile(wxdir + wxT("/amuleapi-passwords"));
+	wxRemoveFile(wxdir + wxT("/amuleapi-ec-token"));
 	wxRmdir(wxdir);
 }
 } // namespace
@@ -348,6 +349,99 @@ TEST(Credentials, ChangeRejectsMalformedDigests)
 	ASSERT_TRUE(LoadCredentialsFile(dir, out, err));
 	ASSERT_TRUE(out.admin.empty());
 	ASSERT_TRUE(out.guest.empty());
+
+	RemoveTempDir(dir);
+}
+
+// --- Ephemeral EC token ------------------------------------------------
+//
+// The token is how amuled hands a spawned amuleapi a credential without
+// either process putting the password-equivalent value from amule.conf on
+// disk or on a command line. Both ends derive the filename from
+// EcTokenFilePath, so these pin the joining rules the same way the
+// amuleapi-passwords test above does -- a drift between the two binaries
+// would not fail loudly, it would just mean the child never finds the file
+// and quietly falls back to its configured password.
+
+TEST(Credentials, EcTokenFilePathJoinsLikeCredentialsPath)
+{
+	ASSERT_EQUALS(std::string("amuleapi-ec-token"), EcTokenFilePath(""));
+	ASSERT_EQUALS(std::string("/tmp/x/amuleapi-ec-token"), EcTokenFilePath("/tmp/x"));
+	ASSERT_EQUALS(std::string("/tmp/x/amuleapi-ec-token"), EcTokenFilePath("/tmp/x/"));
+	// Distinct from the credential store: one is ephemeral, the other is
+	// the persistent password file.
+	ASSERT_TRUE(EcTokenFilePath("/tmp/x") != CredentialsFilePath("/tmp/x"));
+}
+
+TEST(Credentials, GeneratedTokenHasTheMd5HexShape)
+{
+	const std::string a = GenerateEcToken();
+	// 32 lowercase hex chars: the width EC's challenge-response already
+	// consumes, which is what lets the token drop in with no wire change.
+	ASSERT_EQUALS(std::size_t(32), a.size());
+	for (const char c : a) {
+		ASSERT_TRUE((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+	}
+	// Fresh every call -- a token reused across daemon runs would defeat
+	// the point of it dying with the process.
+	ASSERT_TRUE(a != GenerateEcToken());
+}
+
+TEST(Credentials, ReadAndConsumeEcTokenReturnsItAndDeletesTheFile)
+{
+	const std::string dir = TempDir();
+	const std::string path = EcTokenFilePath(dir);
+	const std::string token = GenerateEcToken();
+
+	std::ofstream(path.c_str(), std::ios::binary) << token << "\n";
+
+	std::string got;
+	ASSERT_TRUE(ReadAndConsumeEcToken(path, got));
+	ASSERT_EQUALS(token, got);
+	// Consumed: the secret stops being at rest the moment it is in memory.
+	ASSERT_TRUE(!wxFileExists(wxString(path.c_str(), wxConvUTF8)));
+
+	// A second read finds nothing, which is the ordinary case for a
+	// manually started amuleapi.
+	std::string again;
+	ASSERT_TRUE(!ReadAndConsumeEcToken(path, again));
+
+	RemoveTempDir(dir);
+}
+
+TEST(Credentials, ReadAndConsumeEcTokenRejectsMalformedButStillDeletes)
+{
+	const std::string dir = TempDir();
+	const std::string path = EcTokenFilePath(dir);
+
+	// Truncated, non-hex and empty must all be refused rather than
+	// attempted as a credential; the file goes either way, because a file
+	// that failed to parse is still not something to leave behind.
+	const char *const bad[] = {
+		"deadbeef", "", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "5ebe2294ecd0e0f08eab7690d2a6ee69extra"
+	};
+	for (const char *body : bad) {
+		std::ofstream(path.c_str(), std::ios::binary) << body;
+		std::string got("untouched");
+		ASSERT_TRUE(!ReadAndConsumeEcToken(path, got));
+		ASSERT_EQUALS(std::string("untouched"), got);
+		ASSERT_TRUE(!wxFileExists(wxString(path.c_str(), wxConvUTF8)));
+	}
+
+	RemoveTempDir(dir);
+}
+
+TEST(Credentials, ReadAndConsumeEcTokenIgnoresSurroundingWhitespace)
+{
+	const std::string dir = TempDir();
+	const std::string path = EcTokenFilePath(dir);
+	const std::string token = GenerateEcToken();
+
+	std::ofstream(path.c_str(), std::ios::binary) << "  " << token << "\r\n";
+
+	std::string got;
+	ASSERT_TRUE(ReadAndConsumeEcToken(path, got));
+	ASSERT_EQUALS(token, got);
 
 	RemoveTempDir(dir);
 }


### PR DESCRIPTION
## Summary

In the EC protocol the stored password value **is** the credential — the challenge hashes it directly, so anything holding it can authenticate. amuled handed the amuleapi it spawned `--amule-config-file` pointing at `amule.conf`, and amuleapi read `md5(EC password)` out of it. A network-facing daemon was therefore holding something equivalent to the user's EC password, for its whole run.

It no longer needs one. amuled generates a random 128-bit token at startup, writes it `0600` into the config dir, and accepts it as a second valid EC credential **for that run only**. amuleapi reads it and unlinks it immediately; amuled removes it regardless after ten seconds, so a child that dies before reading cannot leave a secret at rest. Nothing durable is left to steal from the API daemon, and nothing needs rotating if it is compromised — restarting amuled invalidates the token.

**No flag carries the path.** Both ends derive it from webcommon, because `argv` is world-readable via `ps`: passing a path would tell every local user where to look for as long as the file exists. amuled already passes `--config-dir`, so the child knows the directory.

`--amule-config-file` goes with it. That flag was the last way amuleapi read a password-equivalent value off disk; a manually started instance uses `amuleapi.conf`'s own `[EC]/Password`, already written `0600`. **amuleweb keeps the flag** — it is unchanged.

### What this unblocks

Worth stating because it is the larger point. `amule.conf` stores the EC password as `md5(password)`, and that format is pinned by the spawned processes that read it back and reuse it verbatim as a credential — it cannot become a real password hash while anything downstream needs the stored value itself.

There were two such readers. **After this there is one: amuleweb.** amuleapi is out of that set.

amuleweb is already deprecated and may be removed in 3.2 or later. When it goes — or is converted to the same token handover — nothing spawned by the core will read a credential out of `amule.conf`, and the interactive clients become free to move that storage to a real password hash: scrypt, Argon2, or the PBKDF2 record `amuleapi-passwords` already uses.

This PR does not change the stored format and does not touch amuleweb. It removes one of the two blockers, and makes removing the other a smaller, better-understood job than it was.

### Two things the design had to account for

**The credential also keys the session.** `ActivateAEAD()` derived its `ikm` from `thePrefs::ECPassword()` unconditionally, while the client derives its half from whatever secret it presented (`RemoteConnect.cpp`: `m_aeadSecret = pass.Lower()`). Accepting a second credential without tracking *which* one matched would have authenticated the peer and then broken the first sealed packet — the handshake succeeding and the session dying immediately after. The matched secret is now remembered and keys the AEAD.

**Per socket, specifically.** `CECServerSocket` is instantiated per accepted connection — which is why `m_passwd_salt` is already per-instance. Putting the matched secret anywhere shared would let a second client overwrite the key material of an established session. amulegui on the password and amuleapi on the token hold concurrent sessions safely, and that is tested below rather than assumed.

The two credentials are compared **without short-circuiting**. `if (pw) … else if (token)` would leak which one matched and, more usefully to an attacker, whether a token is live at all. The encryption-required policy and the login rate limiter are untouched and still sit ahead of the credential check.

### Supporting changes

- `WriteFileAtomic0600` moves into webcommon, and **both** existing copies now call it — one was inlined in `SaveCredentialsFile`, the other lived in amuleapi's own `AmuleApiConfig.cpp`.
- `muleappcore`'s `webcommon` link becomes `PUBLIC`: the targets that compile `amule.cpp` directly already linked the objects transitively but not the header path.
- `EcTokenFilePath()` joins through the same helper as `CredentialsFilePath()`, so the two names cannot drift on separator handling.
- Docs: `QUICKSTART-AMULEAPI.md` rewritten (358 → 310 lines) with auto-start led as the recommended and most secure setup; the amuleapi man page drops the flag and documents the token file. The man page is not in `po4a.config.in`, so no catalog regeneration applies.

## Test plan

**Unit** — five new tests in `CredentialsTest` covering the path-join rules, the token's MD5-hex shape and freshness, and `ReadAndConsumeEcToken` for the valid, malformed, missing and whitespace cases, including that it unlinks the file whether or not it parsed. `ctest` 30/30.

**Live daemon, macOS 15 ARM64 and Ubuntu 26.04 ARM64** — identical results on both:

| Check | Result |
|---|---|
| amuled spawns amuleapi, no `--amule-config-file` | `/version` → HTTP 200 |
| Credential used | `amuleapi: using the ephemeral EC token from the core.` |
| EC link | `Succeeded! Connection established to aMule GIT` |
| Token file, **daemon still running** | gone |
| `amulecmd -P amule` concurrently | returns live status; amuleapi stays up |

**The AEAD fix is what that last row proves twice over.** `amuleapi.conf` defaults to `Encryption=1`, so the session is sealed — with mismatched keys the sealed `EC_OP_AUTH_OK` fails and the connection cannot come up at all. It did, so both ends derived the same key from the token. And the concurrent `amulecmd` run is the per-socket claim tested rather than argued: two clients, two different credentials, two independent sessions.

**Backstop** — with the child never reading it, the file appears at t+1s and is removed at t+11s (10 s TTL, 300 ms timer granularity). That is the "child dies before reading" case.

**Flag removal** — `amuleapi --amule-config-file=…` now exits with `Unknown long option`, and `--help` no longer lists it.

**Builds and gates** — full CI-aligned configure on macOS (`MONOLITHIC` + `DAEMON` + `REMOTEGUI` + `AMULECMD` + `WEBSERVER` + `TESTING` + `AMULEAPI`), 0 errors. Linux built in an isolated worktree, never the shared checkout. `git clang-format origin/master` clean and a verified fixpoint; diff-scoped clang-tidy clean against both `.clang-tidy-new-code` and `.clang-tidy`, 13 TUs analysed with 0 truncated ASTs.

## Not covered

No Windows run. `RestrictToOwner()` is a no-op there and this writer has no ACL story either, so on Windows the token file is not owner-only — the protection reduces to the deletion window. Called out in the header and worth knowing before anyone relies on the `0600` claim cross-platform.

The `amuleapi` curl matrix was not run for this change; it exercises the REST surface, which is untouched here.
