### PR TITLE
feat(security): drop -P/--password from amuleapi; simplify the quick start

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -1,346 +1,202 @@
 # amuleapi — quick start
 
-amuleapi is a standalone HTTP daemon that serves a versioned JSON REST API
-and a Server-Sent Events stream backed by amuled. It connects to amuled as
-an EC client — the same protocol amuleweb and amulecmd use — and serves its
-own HTTP surface on a separate port.
+amuleapi gives aMule an HTTP interface: a JSON REST API and a live event
+stream, so other programs can drive a running `amuled`. It connects to
+amuled the same way `amulecmd` does and listens on its own port, so it can
+run alongside `amuleweb`.
 
 > aMule's older web frontend, **amuleweb**, is **deprecated** — it may be removed in aMule 3.2 or later (it is not being removed yet). amuleapi is its intended replacement.
 
-Per-endpoint contracts live in [`docs/api/REFERENCE.md`](api/REFERENCE.md);
-the SSE event catalog and reconnect semantics in
-[`docs/api/EVENTS.md`](api/EVENTS.md). The source of truth for routing is
-[`src/webapi/Api.cpp`](../src/webapi/Api.cpp). A map of the surface is under
-[What ships](#what-ships) below.
+Endpoint details are in [`docs/api/REFERENCE.md`](api/REFERENCE.md), and the
+event stream in [`docs/api/EVENTS.md`](api/EVENTS.md).
 
-## Let aMule start it — the recommended setup
+## Let aMule start it
 
-**This is the most secure way to run amuleapi, and the one to prefer unless
-you have a reason not to.** A standalone amuleapi needs a long-lived EC
-password of its own; an auto-started one never gets a durable EC credential
-at all.
+The simplest setup, and the safest: aMule launches amuleapi for you and
+hands it a one-off login token, so amuleapi never needs a copy of your EC
+password.
 
-Configure it under *Preferences → Remote Controls* (**aMule API server
-parameters**): tick **Run amuleapi (REST API) on startup**, set the
-**listening interface**, **HTTP port** and **admin password**, and
-optionally tick **Enable guest access** with a **guest password**. All of it
-is equally editable from a remote amulegui over EC. aMule then spawns:
+In the GUI, under *Preferences → Remote Controls*, tick **Run amuleapi
+(REST API) on startup** and set the listening interface, HTTP port and admin
+password. A remote amulegui can do the same over EC. That is all — amuleapi
+then starts and stops with aMule.
 
-```sh
-amuleapi --config-dir=<amule data dir> --bind=<BindAddress> --http-port=<HttpPort>
-```
-
-Note what is *not* there: no EC password, and no path to `amule.conf`.
-
-### Why it is more secure
-
-In the EC protocol the stored password value **is** the credential — the
-challenge hashes it directly, so anything holding it can authenticate. A
-network-facing daemon holding that value holds the equivalent of your EC
-password for its whole run.
-
-So aMule doesn't give it one. At startup it generates a random 128-bit
-token, writes it `0600` into the config directory, and accepts it as a
-second valid EC credential for that run only. amuleapi reads the token and
-deletes the file immediately; aMule deletes it regardless after ten
-seconds, so a child that dies before reading cannot leave a secret at rest.
-The token is never passed on the command line, because `argv` is readable
-by any local user through `ps`.
-
-The result: nothing durable to steal from the API daemon, and nothing to
-rotate if it is compromised — restarting aMule invalidates the token.
-
-The admin and guest passwords are unaffected by this and travel their own
-route; see [Passwords](#passwords).
-
-Setting an admin password is what allows binding a non-loopback interface —
-amuleapi refuses to start otherwise. Changing the interface or port prompts
-you to restart aMule; password changes need no restart. amuleapi stops when
-aMule exits.
-
-### Headless — no GUI at all
-
-A server running `amuled` alone does not need amulegui for any of this. Stop
-amuled first (it rewrites `amule.conf` on exit, so edits made while it runs
-are lost), then add to `amule.conf`:
+Headless, with no GUI: stop amuled (it rewrites `amule.conf` when it exits),
+add this to `amule.conf`, and set a password:
 
 ```ini
 [AmuleApi]
 Enabled=1
 BindAddress=127.0.0.1
 HttpPort=4713
-Path=amuleapi
 ```
-
-`Path` is the amuleapi executable — a bare name is looked up on `PATH`, so
-leave it alone unless yours lives somewhere unusual. Note the key is
-`HttpPort`, not `Port`.
-
-Then set the admin password with amuleapi itself:
 
 ```sh
 amuleapi --set-admin-pass=mySecret123
 ```
 
-No path needed: amuleapi defaults to the same per-platform directory amuled
-uses — see [Files and the config directory](#files-and-the-config-directory).
-Add `--config-dir=<path>` only if you start amuled with `-c <path>`.
+The password command writes its file and exits. It needs no path, because
+amuleapi looks in the same place amuled does. Start amuled and amuleapi
+comes up with it.
 
-That writes `amuleapi-passwords` and exits without starting anything. Start
-amuled and it brings amuleapi up with the token, exactly as the GUI flow
-does — the GUI only ever edited these same keys and called the same
-credential store.
+An admin password is required before you can bind anything other than
+`127.0.0.1` — amuleapi refuses to start otherwise.
 
-Passwords deliberately have no `amule.conf` key: `/AmuleApi/Password` is
-transient and is deleted from the file if it ever appears there.
+## Running it yourself
 
-## Requirements
+If you start amuleapi by hand, put the EC password in its own config file,
+`amuleapi.conf`:
 
-- A running `amuled` (or monolithic `aMule`) with EC enabled.
-- For a **standalone** amuleapi only: the EC password from
-  `amule.conf[ExternalConnect]/Password` (set it with `amuled --ec-config`
-  if you never have).
+```ini
+[EC]
+Password=your-ec-password
+```
 
-## Files and the config directory
+then just:
 
-amuleapi keeps its files in the same per-platform aMule data directory
-amuled uses, deliberately: operators reading both sets of config together
-don't have to switch directories. amuleapi never writes amuled's files, and
-amuled never writes amuleapi's.
+```sh
+amuleapi
+```
 
-| Platform | Default config dir                     |
-| -------- | -------------------------------------- |
-| Linux    | `~/.aMule/`                            |
-| macOS    | `~/Library/Application Support/aMule/` |
-| Windows  | `%APPDATA%\aMule\`                     |
+There is no `--password` option. A password on the command line is visible
+to every user on the machine through `ps`, and amuleapi has two safer
+routes: the token when aMule starts it, and this file when you don't.
 
-Override with `--config-dir=/path/to/dir`.
+`--host` and `--port` point at amuled (default `127.0.0.1:4712`). amuleapi's
+own HTTP port is separate — `4713` by default, and that is the one REST
+clients use.
 
-Each amuleapi file is written mode `0600`:
-
-| File                  | Purpose                                                                                                                     |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `amuleapi.conf`       | Runtime config: HTTP bind/port/CORS, outbound EC connection, login rate limits, SSE ring size. [Reference below](#amuleapiconf-reference). |
-| `amuleapi-jwt-secret` | 32-byte HMAC signing key for issued tokens. Generated on first launch.                                                       |
-| `amuleapi-passwords`  | Admin and guest passwords as salted PBKDF2-HMAC-SHA256 records. Never stored in plaintext and never readable back — only replaceable. Also written by aMule and amuled. |
-| `amuleapi-ec-token`   | The ephemeral EC token, when aMule started amuleapi. Exists for seconds at most; see [above](#why-it-is-more-secure).        |
-
-amuleapi also writes `amuleapi.log` here by default; see [Logging](#logging).
+aMule ships no systemd or launchd units. Wrap the command in your own if you
+want one.
 
 ## Passwords
 
-Admin and guest passwords live only in `amuleapi-passwords` — no copy goes
-into `amule.conf`, because two copies can disagree. Set them from the
-preferences panel (aMule writes the file directly; a remote amulegui sends
-the change over EC and amuled writes it), or from the CLI:
+Two roles: **admin** (full control) and **guest** (read-only, off unless you
+give it a password). Set them from the preferences panel, or:
 
 ```sh
 amuleapi --set-admin-pass=mySecret123
 amuleapi --set-guest-pass=readOnlyPass
 ```
 
-Each invocation writes the file and exits — no HTTP server, no EC
-connection — and the exit code reflects success, so
-`amuleapi --set-admin-pass=… && systemctl restart amuleapi` short-circuits
-on failure. Changes are picked up at the next login, with no restart.
+An empty guest password turns guest access off. Passwords are stored so they
+cannot be read back, only replaced — which is why the preference fields open
+blank, and why leaving one empty keeps the current password. Changes apply at
+the next login, with no restart.
 
-An empty password means the role is disabled: `POST /api/v0/auth/login`
-returns `login_disabled` for it. Unticking **Enable guest access** clears
-the guest password, which is what turns guest access off.
+If amuleapi runs on a different machine from aMule, set its password there:
+the preferences panel only writes the file on aMule's own host.
 
-Because the stored form cannot be reversed, the preference fields are
-write-only: they open empty, and leaving one empty keeps the current
-password. The panel says whether an admin password is currently set.
+## Files
 
-Running amuleapi on a *different* host from aMule? The preferences panel
-writes the credential file on aMule's host, while that amuleapi reads its
-own. Configure it with `--set-admin-pass` or `PATCH /auth/passwords`.
+amuleapi keeps its files beside amuled's, in the same folder:
 
-## Running it standalone
+| Platform | Folder                                 |
+| -------- | -------------------------------------- |
+| Linux    | `~/.aMule/`                            |
+| macOS    | `~/Library/Application Support/aMule/` |
+| Windows  | `%APPDATA%\aMule\`                     |
 
-```sh
-amuleapi --host=127.0.0.1 --port=4712
-```
+Use `--config-dir` to point somewhere else.
 
-**Two ports.** `--port=4712` is the EC port amuleapi *uses* to reach amuled.
-Its own HTTP listener is `amuleapi.conf[Server]/Port` (default `4713`) —
-that is the port REST clients hit. amuleweb can run concurrently on its own
-port; the two are independent EC clients.
+| File                  | What it is                                                          |
+| --------------------- | ------------------------------------------------------------------- |
+| `amuleapi.conf`       | Settings — see [below](#amuleapiconf).                              |
+| `amuleapi-passwords`  | The admin and guest passwords.                                      |
+| `amuleapi-jwt-secret` | Signs login tokens. Delete it to sign everyone out.                 |
+| `amuleapi-ec-token`   | The one-off login token, when aMule starts amuleapi. Lasts seconds. |
+| `amuleapi.log`        | A copy of the console output. `--no-log-file` turns it off.         |
 
-**Keep the EC password out of `argv`.** Omit `--password` and let amuleapi
-read it from `amuleapi.conf[EC]/Password`, a `0600` file. `--password=…` puts
-the secret in `argv`, visible to any local user via `ps` —
-`--password=$EC_PASSWORD` does not help, since the shell expands it before
-exec. There is no environment or stdin path; the config file is the
-non-`argv` option. Better still, use the [auto-start](#let-amule-start-it--the-recommended-setup)
-flow, which needs no durable EC credential at all.
+All are readable only by you.
 
-aMule ships no init-system units (systemd, launchd, Windows service) for any
-of its daemons. Write a downstream unit wrapping the command above if you
-want one.
-
-### Logging
-
-amuleapi tees its console output into `amuleapi.log` in the config dir,
-installed early enough to capture config-load errors, EC warnings and a
-crash backtrace. Output is low volume — startup plus warnings and errors,
-no per-request access log — and rotates at 10 MiB.
-
-- `--log-file=/path/to/file` — write it elsewhere.
-- `--no-log-file` — console only.
-
-The daemon prints `amuleapi: logging to <path>` on startup.
-
-## Verifying
+## Checking it works
 
 ```sh
-# Public — no auth.
+# No login needed.
 curl -s http://127.0.0.1:4713/api/v0/version
 
-# Login → token. `?type=bearer` opts into the SDK-client shape, putting
-# the JWT in the body so a script can extract it. Browser clients omit it
-# and use the HttpOnly session cookie set on the response, which keeps the
-# token off any XSS-readable surface.
+# Log in, then use the token.
 TOKEN=$(curl -s -X POST "http://127.0.0.1:4713/api/v0/auth/login?type=bearer" \
     -H 'Content-Type: application/json' \
     -d '{"password":"mySecret123"}' | jq -r .token)
 
-# Authenticated GET.
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/status
-
-# Live event stream — run in a second terminal and trigger mutations
-# elsewhere to watch events flow.
-curl -s -N -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/events
 ```
 
-## `amuleapi.conf` reference
+Browsers should call `/auth/login` *without* `?type=bearer` — they get a
+cookie instead, which keeps the token out of reach of page scripts.
 
-INI-style, mode `0600`, created with defaults on first launch. Edits
-roundtrip through `wxFileConfig`, so quotes and comments survive restarts.
+## `amuleapi.conf`
+
+Created with sensible defaults on first run. Your edits and comments survive
+restarts.
 
 ```ini
 [Server]
-BindAddress=127.0.0.1
-Port=4713
-AllowCORS=0
+BindAddress=127.0.0.1     ; who can reach the API
+Port=4713                 ; amuleapi's own HTTP port
+AllowCORS=0               ; see CORS below
 CorsOriginAllowlist=
-StaticRoot=
+StaticRoot=               ; folder to serve a web frontend from
 
 [EC]
-Host=127.0.0.1
+Host=127.0.0.1            ; where amuled is
 Port=4712
-Password=
-Encryption=1
+Password=                 ; only needed when you start amuleapi yourself
+Encryption=1              ; encrypt the link to amuled
 
 [Auth]
 LoginFailureWindowSeconds=60
-LoginFailureThreshold=5
-LoginLockoutSeconds=300
+LoginFailureThreshold=5   ; this many bad logins...
+LoginLockoutSeconds=300   ; ...locks that address out for this long
 
 [Streaming]
 EventBusRingCapacity=16384
 ```
 
-### `[Server]` — HTTP listener
-
-- `BindAddress` / `Port` — where amuleapi listens. A non-loopback
-  `BindAddress` requires an admin password.
-- `AllowCORS` / `CorsOriginAllowlist` — see [CORS](#cors).
-- `StaticRoot` — directory to serve a frontend bundle from. Empty keeps the
-  daemon API-only.
-
-### `[EC]` — outbound connection to amuled
-
-- `Host` / `Port` — where amuled's EC listener is.
-- `Password` — the EC password. Used only when no token was issued; left
-  empty in the auto-start flow.
-- `Encryption` — negotiate an encrypted EC session (default on).
-
-### `[Auth]` — login rate limiter
-
-`LoginFailureThreshold` failures within `LoginFailureWindowSeconds` lock
-that address out for `LoginLockoutSeconds`.
-
-### `[Streaming]` — SSE event bus
-
-`EventBusRingCapacity` bounds the replay ring backing `Last-Event-ID`.
-
-CLI `--bind`, `--http-port`, `--host`, `--port`, `--password` and
-`--config-dir` override the matching keys without rewriting the file.
+`--bind`, `--http-port`, `--host`, `--port` and `--config-dir` override the
+matching settings for one run.
 
 ## CORS
 
-amuleapi serves no CORS headers by default (same-origin only). To allow
-cross-origin browser clients:
+Off by default, so only pages served from the same origin can call the API.
+To allow others:
 
 ```ini
 [Server]
 AllowCORS=1
-CorsOriginAllowlist=https://your-app.example.com,https://staging.example.com
+CorsOriginAllowlist=https://your-app.example.com
 ```
 
-An empty `CorsOriginAllowlist` echoes the caller's `Origin`. That is *not*
-literally `Access-Control-Allow-Origin: *` — echoing the exact origin is the
-only form browsers accept together with `Access-Control-Allow-Credentials:
-true`, and a literal `*` would break cookie auth cross-origin.
+Leaving the allowlist empty accepts any origin.
 
-## What ships
+## What you get
 
-A versioned REST surface under `/api/v0/`. Full contracts — methods, query
-params, bodies, error codes — are in
-[`docs/api/REFERENCE.md`](api/REFERENCE.md).
+Everything under `/api/v0/`, with full details in
+[`docs/api/REFERENCE.md`](api/REFERENCE.md):
 
-- **Auth** — `auth/login`, `auth/logout`, `auth/session` (JWT and session
-  cookie).
-- **System** — `version`, `version/check`, `status`, `preferences`.
-- **Downloads** — queue list and per-file detail; add, pause/resume, cancel,
-  `clear_completed`; per-file comments, source-reported filenames, and A4AF
-  listing and swap.
-- **Shared files** — list and detail, `reload`, `verify`, and the share
-  roots (`shared/directories`).
-- **Clients (peers)** — per-peer view (`?filter=uploads|downloads|active`),
-  per-client detail, and browsing a peer's shared files.
-- **Servers** — the ed2k server list: add, connect, remove, `servers/update`.
-- **Network control** — `networks/connect` / `disconnect`, `kad/bootstrap`,
-  `kad` status.
-- **Categories** — list, create, edit, delete.
-- **Search** — `search`, `search/results`, `search/stop`, download a result,
-  per-result comments.
-- **Logs & stats** — `logs/{amule,serverinfo}`, `stats/tree`,
-  `stats/graphs/{graph}`.
+- **Downloads** — the queue: add, pause, cancel, clear completed, plus
+  comments, filenames and alternate sources.
+- **Shared files** — list, verify, and the shared folders.
+- **Peers** — who you are connected to, and browsing their shared files.
+- **Servers** — the ed2k server list, connecting, and refreshing it.
+- **Network** — connect and disconnect ed2k and Kad.
+- **Search** — start a search, read results, download one.
+- **Categories**, **preferences**, **logs** and **statistics**.
 
-Conventions across the surface:
+Lists take `limit`, `offset`, `sort` and `order`. Bulk actions report each
+item's outcome separately rather than one overall result.
 
-- **List windowing.** `downloads`, `clients`, `shared`, `servers` and
-  `search/results` take `limit` / `offset` / `sort` / `order` and return
-  `total` / `offset` / `limit` beside the array. Omit them all for the full
-  set.
-- **Bulk mutations** return one entry per input item under `results` —
-  `200`/`202` when all succeeded, `207 Multi-Status` for a mix, `503` when
-  the batch failed on an EC disconnect. Callers learn the fate of each item,
-  not an aggregate count.
-- **ETag on GET** with `304 Not Modified` on `If-None-Match`.
+`GET /api/v0/events` streams changes as they happen and can resume where it
+left off after a dropped connection — see
+[`docs/api/EVENTS.md`](api/EVENTS.md).
 
-### Events
+## Worth knowing
 
-`GET /api/v0/events` is a long-lived SSE stream with `Last-Event-ID` replay
-and typed `resync` frames for cache invalidation. Channels, frame format and
-reconnect semantics are in [`docs/api/EVENTS.md`](api/EVENTS.md).
-
-## Security notes
-
-- **Prefer the auto-start flow.** It is the only configuration in which the
-  API daemon never holds a durable EC credential. See
-  [above](#why-it-is-more-secure).
-- **The admin role grants full control of the daemon's network surface.**
-  That includes `POST /api/v0/servers/update {"servers_url": "..."}`, which
-  makes amuled fetch the supplied URL. This is long-standing amuled
-  behaviour, but it widens what an admin token *grants*: whoever holds one
-  can have amuled issue an HTTP GET against arbitrary reachable URLs (a
-  classic SSRF surface) and pull the response into amuled's process. The
-  `http://` / `https://` pre-check is input hygiene, not a boundary. Protect
-  the admin password and the JWT secret accordingly.
-- **`BindAddress=127.0.0.1` is load-bearing.** The HTTP server spawns one OS
-  thread per SSE subscriber, so a non-loopback bind exposes the
-  thread-per-connection model to unauthenticated peers. For remote access,
-  put a reverse proxy in front and keep the bind on loopback.
+- **Keep `BindAddress` on `127.0.0.1` unless you need otherwise.** amuleapi
+  starts a thread per event-stream listener, so exposing it directly to a
+  network is not something to do casually. For remote access, put a reverse
+  proxy in front.
+- **An admin token can do anything aMule can**, including asking amuled to
+  fetch a server list from a URL you supply. Treat the admin password like
+  the password to the machine.

--- a/docs/man/amuleapi.1.in
+++ b/docs/man/amuleapi.1.in
@@ -7,7 +7,6 @@ amuleapi \- the aMule REST API + Server\-Sent Events daemon
 .B_untranslated amuleapi
 .RB [ \-h " " \fI<host> ]
 .RB [ \-p " " \fI<port> ]
-.RB [ \-P " " \fI<password> ]
 .RB_untranslated [ \-\-bind " " \fI<address> ]
 .RB_untranslated [ \-\-http\-port " " \fI<num> ]
 .RB_untranslated [ \-\-config\-dir " " \fI<path> ]
@@ -44,9 +43,6 @@ EC host to connect to (default: 127.0.0.1).
 .TP
 \fB[ \-p\fR \fI<port>\fR, \fB\-\-port\fR=\fI<port>\fR \fB]\fR
 EC port on the amuled instance (default: 4712).
-.TP
-\fB[ \-P\fR \fI<password>\fR, \fB\-\-password\fR=\fI<password>\fR \fB]\fR
-EC plaintext password (matches amuled's [ExternalConnect]/Password).
 .TP
 \fB[ \-\-bind\fR=\fI<address>\fR \fB]\fR
 HTTP bind address (default: 127.0.0.1, overrides amuleapi.conf
@@ -121,7 +117,9 @@ Short\-lived login token, written by \fBamule\fR(1) / \fBamuled\fR(1) when
 they start amuleapi themselves. Created fresh each time, read once and
 deleted straight away, so an auto\-started amuleapi needs no EC password of
 its own. Started by hand, amuleapi finds no token and uses
-\fB[EC]/Password\fR from \fIamuleapi.conf\fR instead.
+\fB[EC]/Password\fR from \fIamuleapi.conf\fR instead. There is no
+\fB\-\-password\fR option: a password given on the command line is visible
+to every local user through \fBps\fR(1).
 .SH REPORTING BUGS
 Please report bugs either on our forum
 (\fIhttps://github.com/amule-org/amule/discussions\fR), or in our

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -513,11 +513,13 @@ void CaMuleExternalConnector::OnInitCmdLine(wxCmdLineParser &parser, const char 
 		_("aMule's port for External Connection. (default: 4712)"),
 		wxCMD_LINE_VAL_NUMBER,
 		wxCMD_LINE_PARAM_OPTIONAL);
-	parser.AddOption("P",
-		"password",
-		_("External Connection password."),
-		wxCMD_LINE_VAL_STRING,
-		wxCMD_LINE_PARAM_OPTIONAL);
+	if (UsesEcPasswordOption()) {
+		parser.AddOption("P",
+			"password",
+			_("External Connection password."),
+			wxCMD_LINE_VAL_STRING,
+			wxCMD_LINE_PARAM_OPTIONAL);
+	}
 	if (UsesConnectorConfigFile()) {
 		parser.AddOption("f",
 			"config-file",
@@ -621,12 +623,14 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser &parser)
 		m_port = port;
 	}
 
-	wxString pass_plain;
-	if (parser.Found("password", &pass_plain)) {
-		if (!pass_plain.IsEmpty()) {
-			m_password.Decode(MD5Sum(pass_plain).GetHash());
-		} else {
-			m_password.Clear();
+	if (UsesEcPasswordOption()) {
+		wxString pass_plain;
+		if (parser.Found("password", &pass_plain)) {
+			if (!pass_plain.IsEmpty()) {
+				m_password.Decode(MD5Sum(pass_plain).GetHash());
+			} else {
+				m_password.Clear();
+			}
 		}
 	}
 

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -161,6 +161,21 @@ public:
 	virtual bool UsesConnectorConfigFile() const { return true; }
 
 	/**
+	 * Whether this connector offers -P / --password on the command line.
+	 *
+	 * amuleapi returns false. A password passed there lands in argv, which
+	 * any local user can read out of ps, and amuleapi has two ways to get
+	 * the credential that do not: the ephemeral token the core writes when
+	 * it spawns amuleapi, and [EC]/Password in its own amuleapi.conf.
+	 * Keeping the option registered would keep offering the one route that
+	 * leaks.
+	 *
+	 * amulecmd and amuleweb keep it. Both are commonly run by hand, and
+	 * neither owns a config file that could hold the value instead.
+	 */
+	virtual bool UsesEcPasswordOption() const { return true; }
+
+	/**
 	 * Filename whose presence in <cwd>/config marks a portable install.
 	 *
 	 * Defaults to this connector's own config file (remote.conf). A

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -163,7 +163,6 @@ bool CamuleapiApp::OnCmdLineParsed(wxCmdLineParser &parser)
 	// second case. Same shape as the bind / http-port branches above.
 	m_cliHasEcHost = parser.Found("host");
 	m_cliHasEcPort = parser.Found("port");
-	m_cliHasEcPassword = parser.Found("password");
 	m_cliHasEcEncryption = parser.Found("disable-ec-encryption");
 
 	return CaMuleExternalConnector::OnCmdLineParsed(parser);
@@ -268,7 +267,7 @@ bool CamuleapiApp::LoadAmuleapiConfig()
 		// command line -- same shape as host/port/password above.
 		m_ECEncryption = m_apiConfig.EcCfg().encryption;
 	}
-	if (!m_cliHasEcPassword && !m_apiConfig.EcCfg().password.empty()) {
+	if (!m_apiConfig.EcCfg().password.empty()) {
 		// amuleapi.conf [EC]/Password is plaintext; the base class
 		// expects an MD5-hashed CMD4Hash (because that's what amuled
 		// stores). MD5-hash here so a one-line amuleapi.conf edit
@@ -284,8 +283,9 @@ bool CamuleapiApp::LoadAmuleapiConfig()
 	// writing it 0600.
 	//
 	// Wins over amuleapi.conf: when the core issued a token, that is the
-	// credential it wants us to use. An explicit --password still wins,
-	// since that is an operator deliberately overriding us.
+	// credential it wants us to use. Nothing overrides it: there is no
+	// --password to override it with, so the token and amuleapi.conf are
+	// the only two sources.
 	//
 	// This is what replaced --amule-config-file. That flag handed us the
 	// hashed EC password straight out of amule.conf, and in this protocol
@@ -297,7 +297,7 @@ bool CamuleapiApp::LoadAmuleapiConfig()
 	// Deleted on read, not after connecting. A failed connection retries
 	// from memory, so holding the file until the handshake completes would
 	// only widen the window in which the secret is at rest for nothing.
-	if (!m_cliHasEcPassword) {
+	{
 		const std::string tokenPath = webcommon::EcTokenFilePath(std::string(config_dir.utf8_str()));
 		std::string token;
 		if (webcommon::ReadAndConsumeEcToken(tokenPath, token)) {

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -201,6 +201,11 @@ private:
 	/// --write-config and --create-config-from too, since all three only
 	/// exist to manage that file.
 	bool UsesConnectorConfigFile() const override { return false; }
+	// No -P/--password: it would put the EC secret in argv, where ps
+	// exposes it to every local user. amuleapi gets the credential from
+	// the token the core writes when it spawns us, or from [EC]/Password
+	// in amuleapi.conf.
+	bool UsesEcPasswordOption() const override { return false; }
 
 	// amuleapi keeps its settings in amuleapi.conf and never reads or
 	// writes remote.conf, so amuleapi.conf is what marks a portable
@@ -208,7 +213,6 @@ private:
 	wxString PortableProbeFile() const override { return "amuleapi.conf"; }
 
 	bool m_cliHasEcEncryption = false;
-	bool m_cliHasEcPassword = false;
 };
 
 DECLARE_APP(CamuleapiApp)

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -212,10 +212,14 @@ SECOND_HOST="localhost:4714"
 SECOND_CONFIG_DIR=$(mktemp -d -t amuleapi_19_search_second.XXXXXX)
 SECOND_LOG=$(mktemp -t amuleapi_19_search_second_log.XXXXXX)
 "$AMULEAPI_BIN" --config-dir="$SECOND_CONFIG_DIR" \
-	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--host="$EC_HOST" --port="$EC_PORT" \
 	--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+# amuleapi takes no --password; the call above also wrote a defaults
+# amuleapi.conf, so put the EC credential in there.
+sed -i'.bak' "s|^Password=.*|Password=$EC_PASSWORD|" "$SECOND_CONFIG_DIR/amuleapi.conf"
+rm -f "$SECOND_CONFIG_DIR/amuleapi.conf.bak"
 "$AMULEAPI_BIN" --config-dir="$SECOND_CONFIG_DIR" \
-	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--host="$EC_HOST" --port="$EC_PORT" \
 	--http-port=4714 >"$SECOND_LOG" 2>&1 &
 SECOND_PID=$!
 
@@ -661,10 +665,13 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	SECOND2_CONFIG_DIR=$(mktemp -d -t amuleapi_19_close_second.XXXXXX)
 	SECOND2_LOG=$(mktemp -t amuleapi_19_close_second_log.XXXXXX)
 	"$AMULEAPI_BIN" --config-dir="$SECOND2_CONFIG_DIR" \
-		--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+		--host="$EC_HOST" --port="$EC_PORT" \
 		--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+		# Same reason as the first second-instance above.
+		sed -i'.bak' "s|^Password=.*|Password=$EC_PASSWORD|" "$SECOND2_CONFIG_DIR/amuleapi.conf"
+		rm -f "$SECOND2_CONFIG_DIR/amuleapi.conf.bak"
 	"$AMULEAPI_BIN" --config-dir="$SECOND2_CONFIG_DIR" \
-		--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+		--host="$EC_HOST" --port="$EC_PORT" \
 		--http-port=4715 >"$SECOND2_LOG" 2>&1 &
 	SECOND2_PID=$!
 	for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
@@ -709,10 +716,14 @@ fi
 FOREIGN_CONFIG_DIR=$(mktemp -d -t amuleapi_19_foreign.XXXXXX)
 FOREIGN_LOG=$(mktemp -t amuleapi_19_foreign_log.XXXXXX)
 "$AMULEAPI_BIN" --config-dir="$FOREIGN_CONFIG_DIR" \
-	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--host="$EC_HOST" --port="$EC_PORT" \
 	--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+# Same reason as the other extra instances: no --password, so the EC
+# credential goes into the amuleapi.conf the call above just created.
+sed -i'.bak' "s|^Password=.*|Password=$EC_PASSWORD|" "$FOREIGN_CONFIG_DIR/amuleapi.conf"
+rm -f "$FOREIGN_CONFIG_DIR/amuleapi.conf.bak"
 "$AMULEAPI_BIN" --config-dir="$FOREIGN_CONFIG_DIR" \
-	--host="$EC_HOST" --port="$EC_PORT" --password="$EC_PASSWORD" \
+	--host="$EC_HOST" --port="$EC_PORT" \
 	--http-port=4716 >"$FOREIGN_LOG" 2>&1 &
 FOREIGN_PID=$!
 for i in 1 2 3 4 5 6 7 8 9 10 11 12; do

--- a/unittests/curl-tests/amuleapi/24-sse-resync.sh
+++ b/unittests/curl-tests/amuleapi/24-sse-resync.sh
@@ -70,7 +70,7 @@ Port=4713
 [EC]
 Host=127.0.0.1
 Port=4712
-Password=
+Password=amule
 
 [Auth]
 LoginFailureWindowSeconds=60
@@ -81,7 +81,7 @@ LoginLockoutSeconds=300
 EventBusRingCapacity=4
 EOF
 "$BIN" --config-dir="$CONFIG_DIR" \
-	--host=127.0.0.1 --port=4712 --password=amule \
+	--host=127.0.0.1 --port=4712 \
 	> "$LOG" 2>&1 &
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
 	if curl -s -o /dev/null --max-time 1 "$HOST/api/v0/version" 2>/dev/null; then

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -81,7 +81,7 @@ CorsOriginAllowlist=$allowlist
 [EC]
 Host=127.0.0.1
 Port=4712
-Password=
+Password=amule
 
 [Auth]
 LoginFailureWindowSeconds=60
@@ -89,7 +89,7 @@ LoginFailureThreshold=5
 LoginLockoutSeconds=300
 EOF
 	"$BIN" --config-dir="$CONFIG_DIR" \
-		--host=127.0.0.1 --port=4712 --password=amule \
+		--host=127.0.0.1 --port=4712 \
 		> "$LOG" 2>&1 &
 	# Wait for /version to respond.
 	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -91,12 +91,19 @@ run_phase() {
 	# file as-is instead of generating a per-process secret.
 	printf '%s' "$JWT_SECRET" > /tmp/amuleapi-regtest/amuleapi-jwt-secret
 	chmod 600 /tmp/amuleapi-regtest/amuleapi-jwt-secret
+	# The first of these also writes a defaults amuleapi.conf, which the
+	# EC password is seeded into below. Neither connects to amuled -- they
+	# write the credential file and exit -- so no EC settings are needed
+	# here at all.
 	"$BIN" --config-dir=/tmp/amuleapi-regtest \
-		--host=127.0.0.1 --port=4712 --password=amule \
 		--set-admin-pass=adminpass > /dev/null 2>&1
 	"$BIN" --config-dir=/tmp/amuleapi-regtest \
-		--host=127.0.0.1 --port=4712 --password=amule \
 		--set-guest-pass=guestpass > /dev/null 2>&1
+	# amuleapi has no --password: it takes the EC credential from the
+	# ephemeral token the core writes when it spawns amuleapi, or from
+	# amuleapi.conf. Nothing spawns it here, so seed the config file.
+	sed -i'.bak' "s|^Password=.*|Password=amule|" /tmp/amuleapi-regtest/amuleapi.conf
+	rm -f /tmp/amuleapi-regtest/amuleapi.conf.bak
 	# 27-static-frontend exercises the static-frontend serve path. It
 	# plants symlinks + an oversized file into StaticRoot during the
 	# run, so the dir has to be writable. The bundled source tree is
@@ -118,7 +125,7 @@ run_phase() {
 		rm -f /tmp/amuleapi-regtest/amuleapi.conf.bak
 	fi
 	"$BIN" --config-dir=/tmp/amuleapi-regtest \
-		--host=127.0.0.1 --port=4712 --password=amule \
+		--host=127.0.0.1 --port=4712 \
 		> /tmp/amuleapi.log 2>&1 &
 	# Poll /version until the daemon is ready instead of guessing the
 	# cold-start time. The first EC GET_UPDATE roundtrip can take a


### PR DESCRIPTION
## Summary

A password on the command line lands in `argv`, where any local user can read it out of `ps`. amuleapi has two routes that do not: the ephemeral token the core writes when it spawns amuleapi (#749), and `[EC]/Password` in its own `amuleapi.conf`. Keeping `-P` / `--password` registered kept offering the one that leaks, so it goes.

Gated behind a new `UsesEcPasswordOption()` hook on `CaMuleExternalConnector`, the same shape as the existing `UsesConnectorConfigFile()`. **amulecmd and amuleweb keep the option**: both are released, their command-line interface is long-standing, and removing a documented flag would break existing scripts. amuleapi is unreleased, so it carries no such constraint — which is the whole reason this is viable here and not there.

### Test harness

The amuleapi curl matrix passed `--password` in eight places. Those move to seeding `[EC]/Password` in the `amuleapi.conf` each phase already writes. Three of them are the extra amuleapi instances `19-search` spins up — `SECOND`, `SECOND2` and `FOREIGN` — each with its own config dir.

### Docs

The quick start is rewritten for someone setting this up rather than someone implementing it: **346 lines to 202**. The protocol reasoning is gone, the auto-start path is stated plainly as the simplest and safest, and the per-section config prose is folded into comments in the sample file. The man page loses the option and explains why in the one place a reader is already being told where the credential comes from.

## Test plan

Verified against a daemon **connected to ed2k (LowID) and Kad**, with `AMULE_SHARED_DIR` set so the fixture phases actually run:

| | |
|---|---|
| curl phases passing | **30 of 31** |
| `19-search` | 108/108 |
| `17-shared-priority-patch` / `30-shared-verify` | 42/42, 9/9 |
| `ctest` | 30/30 |

The one failure — `22-sse-diff-emission`'s search-completion frame — **reproduces identically on master with master's binary**, against the same daemon. It is timing-dependent on a LowID connection, and this PR does not touch that phase.

`git clang-format origin/master` clean; diff-scoped clang-tidy clean against both `.clang-tidy-new-code` and `.clang-tidy`, 5 TUs each with 0 truncated ASTs. No catalog movement: `_("External Connection password.")` still exists for amulecmd and amuleweb and only changed indentation, so `update-po.sh` produces nothing but a timestamp.

### Why the connected daemon mattered

Worth recording, because the first run of this was misleading. Against a *disconnected* daemon the same suite showed seventeen failures in `19-search` alone, all of which look like the ordinary "no network, no search results" noise — and one of them was a real bug of mine: the `FOREIGN` instance left with no credential after the flag was removed. It was indistinguishable from the surrounding noise until the daemon could actually search.

A second bug surfaced the same way: a malformed comment in one of the seeding blocks, which `bash -n` accepts because `amuleapi.conf, so put…` parses perfectly well as a command. It only failed at runtime, in a phase whose failure looked environmental.

Both are fixed, and neither would have been caught by the green-looking run.

## Note

`--host` and `--port` are unaffected; only the credential option is removed. Anyone starting amuleapi by hand needs `[EC]/Password` in `amuleapi.conf`, which is the documented path and was already the recommended one.

