### PR TITLE
feat(gui): clearer search-page buttons, and confirm before clearing history

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3267,6 +3267,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -5948,7 +5952,11 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:27+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3308,6 +3308,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -6032,7 +6036,11 @@ msgid "Shared folder"
 msgstr "ملفات مشاركة"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:28+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3368,6 +3368,11 @@ msgid "Reset Fields"
 msgstr "Llimpiar Campos"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Resultáu de la gueta"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultaos"
 
@@ -6143,7 +6148,12 @@ msgid "Shared folder"
 msgstr "Carpetes compartíes"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Remembrar estes opciones"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:28+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3301,6 +3301,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -6008,7 +6012,11 @@ msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3266,6 +3266,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -5947,7 +5951,11 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:29+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3358,6 +3358,11 @@ msgid "Reset Fields"
 msgstr "Buida els camps"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Resultat de la cerca"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultats"
 
@@ -6117,7 +6122,12 @@ msgid "Shared folder"
 msgstr "Carpetes compartides"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Recorda la configuració"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:29+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3356,6 +3356,11 @@ msgid "Reset Fields"
 msgstr "Vyprázdnit pole"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Výsledek hledání"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Výsledky"
 
@@ -6121,7 +6126,12 @@ msgid "Shared folder"
 msgstr "Sdílené adresáře"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Zapamatovat si toto nastavení"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:30+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3318,6 +3318,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -6049,7 +6053,11 @@ msgid "Shared folder"
 msgstr "Delte Filer"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:30+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3356,6 +3356,11 @@ msgid "Reset Fields"
 msgstr "Setze Felder zurück."
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Suchresultate:"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Ergebnisse"
 
@@ -6113,7 +6118,12 @@ msgid "Shared folder"
 msgstr "Freigegebene Ordner"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Diese Einstellungen speichern"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:31+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3379,6 +3379,11 @@ msgid "Reset Fields"
 msgstr "Επαναφορά πεδίων"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Αποτέλεσμα Αναζήτησης"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Αποτελέσματα"
 
@@ -6157,7 +6162,12 @@ msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3267,6 +3267,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -5948,7 +5952,11 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:31+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3355,6 +3355,11 @@ msgid "Reset Fields"
 msgstr "Reiniciar los campos"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Resultado de la búsqueda"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
@@ -6098,7 +6103,12 @@ msgid "Shared folder"
 msgstr "Carpeta compartida"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Recordar estas opciones"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3359,6 +3359,11 @@ msgid "Reset Fields"
 msgstr "Lähtesta väljad"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Otsingu tulemus"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Tulemused"
 
@@ -6120,7 +6125,12 @@ msgid "Shared folder"
 msgstr "Jagatud kataloogid"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Pea need seaded meeles"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:32+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3360,6 +3360,11 @@ msgid "Reset Fields"
 msgstr "Eremuak garbitu"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Bilaketa emaitza"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Emaitzak"
 
@@ -6119,7 +6124,12 @@ msgid "Shared folder"
 msgstr "Partekatutako karpetak"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Ezarpen hauek gogoratu"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:33+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3360,6 +3360,11 @@ msgid "Reset Fields"
 msgstr "Nollaa kentät"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Haun tulos"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Tulokset"
 
@@ -6119,7 +6124,12 @@ msgid "Shared folder"
 msgstr "Jaetut kansiot"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Muista nämä asetukset"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:33+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3353,6 +3353,11 @@ msgid "Reset Fields"
 msgstr "Réinitialiser les Champs"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Résultat de la recherche"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Résultats"
 
@@ -6092,7 +6097,12 @@ msgid "Shared folder"
 msgstr "Dossier partagé"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Se rappeler de ces réglages"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:34+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3369,6 +3369,11 @@ msgid "Reset Fields"
 msgstr "Borrar campos"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Resultados da busca"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
@@ -6127,7 +6132,12 @@ msgid "Shared folder"
 msgstr "Cartafoles compartidos"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Recordar esas opcións"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:34+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3331,6 +3331,11 @@ msgid "Reset Fields"
 msgstr "אפס שדות"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "תוצאות מסנן"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "תוצאות"
 
@@ -6083,7 +6088,11 @@ msgid "Shared folder"
 msgstr "קבצים משותפים"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:34+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3328,6 +3328,11 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Rezultati pretrage"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultati"
 
@@ -6072,7 +6077,11 @@ msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:35+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3339,6 +3339,11 @@ msgid "Reset Fields"
 msgstr "Mezők törlése"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Keresés eredménye"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Eredmények"
 
@@ -6094,7 +6099,12 @@ msgid "Shared folder"
 msgstr "Megosztott mappák"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Emlékezzen ezekre a beállításokra"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:36+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3365,6 +3365,11 @@ msgid "Reset Fields"
 msgstr "Azzera campi"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Risultato della ricerca"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Risultati"
 
@@ -6094,8 +6099,13 @@ msgid "Shared folder"
 msgstr "Cartella condivisa"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
 msgstr "Cancella la cronologia delle ricerche"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Search warning"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3357,6 +3357,11 @@ msgid "Reset Fields"
 msgstr "フィールドをリセット"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "フィルタの結果"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "結果"
 
@@ -6114,7 +6119,12 @@ msgid "Shared folder"
 msgstr "共有ファイル"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "設定を記憶する"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3377,6 +3377,11 @@ msgid "Reset Fields"
 msgstr "항목 초기화"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "필터링 결과"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "결과"
 
@@ -6147,7 +6152,12 @@ msgid "Shared folder"
 msgstr "공유 파일"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "설정을 기억"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3391,6 +3391,11 @@ msgid "Reset Fields"
 msgstr "Atstatyti laukelius"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Filtruoti rezultatus"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Paieškos rezultatai"
 
@@ -6172,7 +6177,12 @@ msgid "Shared folder"
 msgstr "Dalinami failai"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Įsiminti parinktis"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:47+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3283,6 +3283,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultāti"
 
@@ -5981,7 +5985,11 @@ msgid "Shared folder"
 msgstr "Kopīgotās datnes"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:37+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3363,6 +3363,11 @@ msgid "Reset Fields"
 msgstr "Velden leegmaken"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Zoekresultaat"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultaten"
 
@@ -6122,7 +6127,12 @@ msgid "Shared folder"
 msgstr "Gedeelde mappen"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Onthoud deze instellingen"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:38+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3376,6 +3376,11 @@ msgid "Reset Fields"
 msgstr "Nullstill felta"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Filtrér resultat"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultat"
 
@@ -6148,7 +6153,12 @@ msgid "Shared folder"
 msgstr "Delte filer"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Hugs desse innstillingane"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:38+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3373,6 +3373,11 @@ msgid "Reset Fields"
 msgstr "Zresetuj pola"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Wynik wyszukiwania"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Wyniki"
 
@@ -6151,7 +6156,12 @@ msgid "Shared folder"
 msgstr "Udostępnione foldery"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Zapamiętaj te ustawienia"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:39+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3361,6 +3361,11 @@ msgid "Reset Fields"
 msgstr "Reiniciar Campos"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Resultado da Busca"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
@@ -6090,8 +6095,13 @@ msgid "Shared folder"
 msgstr "Pasta compartilhada"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
 msgstr "Limpar o histórico de busca"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Search warning"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:39+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3366,6 +3366,11 @@ msgid "Reset Fields"
 msgstr "Limpar campos"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Resultados de Pesquisas"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultados"
 
@@ -6127,7 +6132,12 @@ msgid "Shared folder"
 msgstr "Pastas partilhadas"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Lembrar estas preferências"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:40+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3368,6 +3368,11 @@ msgid "Reset Fields"
 msgstr "Resetare câmpuri"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Rezultat căutare"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultate"
 
@@ -6134,7 +6139,12 @@ msgid "Shared folder"
 msgstr "Dosare partajate"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Amintește aceste configurări"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:41+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3390,6 +3390,11 @@ msgid "Reset Fields"
 msgstr "Сбросить значения"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Результаты поиска"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Результаты"
 
@@ -6173,7 +6178,12 @@ msgid "Shared folder"
 msgstr "Публикуемые папки"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Запомнить настройки"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:42+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3387,6 +3387,11 @@ msgid "Reset Fields"
 msgstr "Ponastavi polja"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Rezultat iskanja"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultati"
 
@@ -6169,7 +6174,12 @@ msgid "Shared folder"
 msgstr "Deljene mape"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Zapomni si te nastavitve"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:42+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3369,6 +3369,11 @@ msgid "Reset Fields"
 msgstr "Reseto fushat"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Rezultatet e filterit"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Rezultatet"
 
@@ -6138,7 +6143,12 @@ msgid "Shared folder"
 msgstr "File te ndara"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Mbaji mend keto rregullime"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:43+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3358,6 +3358,11 @@ msgid "Reset Fields"
 msgstr "Återställ fält"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Sökresultat"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Resultat"
 
@@ -6115,7 +6120,12 @@ msgid "Shared folder"
 msgstr "Delade mappar"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Kom ihåg dessa inställningar"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:47+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3266,6 +3266,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -5947,7 +5951,11 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3346,6 +3346,11 @@ msgid "Reset Fields"
 msgstr "Alanları Sıfırla"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Arama Sonucu"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Sonuçlar"
 
@@ -6085,7 +6090,12 @@ msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Bu ayarları hatırla"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:44+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3387,6 +3387,11 @@ msgid "Reset Fields"
 msgstr "Очистити поля"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "Здобутки пошуку"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "Здобутки"
 
@@ -6174,7 +6179,12 @@ msgid "Shared folder"
 msgstr "Спільні теки"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "Запам'ятати ці налаштування"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3266,6 +3266,10 @@ msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Clear Search Results"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr ""
 
@@ -5947,7 +5951,11 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+msgid "Clear Search History"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:45+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3357,6 +3357,11 @@ msgid "Reset Fields"
 msgstr "重置表单"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "搜索结果"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "搜索结果"
 
@@ -6086,7 +6091,12 @@ msgid "Shared folder"
 msgstr "共享的文件夹"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "记住搜索历史"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-07-31 20:09+0200\n"
+"POT-Creation-Date: 2026-08-01 10:47+0200\n"
 "PO-Revision-Date: 2026-07-31 22:45+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3352,6 +3352,11 @@ msgid "Reset Fields"
 msgstr "清空欄位"
 
 #: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Clear Search Results"
+msgstr "搜尋結果"
+
+#: src/muuli_wdr.cpp
 msgid "Results"
 msgstr "搜尋結果"
 
@@ -6102,7 +6107,12 @@ msgid "Shared folder"
 msgstr "分享資料夾"
 
 #: src/SearchDlg.cpp
-msgid "Clear search history"
+#, fuzzy
+msgid "Clear Search History"
+msgstr "記住這些設定"
+
+#: src/SearchDlg.cpp
+msgid "Clear the saved search history? This cannot be undone."
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -24,6 +24,7 @@
 //
 
 #include <wx/app.h>
+#include <wx/statline.h> // Needed for wxStaticLine
 #include <wx/artprov.h>  // Needed for wxArtProvider::GetBitmap (search-tab close icon)
 #include <wx/clipbrd.h>  // Needed for wxTheClipboard (search-name Paste enable check)
 #include <wx/combobox.h> // Needed for the IDC_SEARCHNAME history dropdown
@@ -142,30 +143,40 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	s_search_sizer->Show(s_extended_sizer, false);
 	s_search_sizer->Show(s_filter_sizer, false);
 
-	// Clear-history button, sitting between the search-type choice and the
-	// Extended Parameters checkbox. Two reasons it is built here instead of in
-	// muuli_wdr: the right-click route it backs up is unreachable on wxMSW
-	// (the native combobox's child EDIT window never forwards WM_CONTEXTMENU
-	// to wx -- ShouldForwardFromEditToCombo in src/msw/combobox.cpp forwards
-	// only key, focus and clipboard messages), and keeping the existing
-	// _("Clear search history") msgid in this file preserves its position in
-	// the catalogs, whereas adding the same string to muuli_wdr.cpp would move
-	// the pot entry (xgettext orders entries by file scan order) and trip the
-	// pot-sync gate for no benefit. Bound directly on the instance, so no new
-	// window id is needed. (issue #697)
-	if (wxWindow *typeChoice = FindWindow(ID_SEARCHTYPE)) {
-		if (wxSizer *row = typeChoice->GetContainingSizer()) {
+	// Clear-history button, sitting in the action row directly after "Reset
+	// Fields" -- next to the other one-shot commands rather than among the
+	// search parameters, and beside "Clear Search Results" so the two
+	// destructive actions read as a pair.
+	//
+	// Still built here rather than in muuli_wdr because it is not a static
+	// control: it is shown or hidden with the remember-history preference
+	// (ApplySearchHistoryPref) and enabled only while the combo holds terms
+	// (UpdateClearHistoryButton), and it backs up a right-click route that is
+	// unreachable on wxMSW (the native combobox's child EDIT window never
+	// forwards WM_CONTEXTMENU to wx -- ShouldForwardFromEditToCombo in
+	// src/msw/combobox.cpp forwards only key, focus and clipboard messages).
+	// Bound directly on the instance, so no new window id is needed.
+	// (issue #697)
+	//
+	// The separator is inserted with it and tracked so the pref-driven hide
+	// takes both away; leaving a stray divider behind would open a gap in the
+	// row wherever history is switched off.
+	if (wxWindow *resetBtn = FindWindow(IDC_SEARCH_RESET)) {
+		if (wxSizer *row = resetBtn->GetContainingSizer()) {
 			size_t at = row->GetItemCount();
 			size_t index = 0;
 			for (const wxSizerItem *item : row->GetChildren()) {
-				if (item->GetWindow() == typeChoice) {
+				if (item->GetWindow() == resetBtn) {
 					at = index + 1;
 					break;
 				}
 				++index;
 			}
-			m_clearHistoryBtn = new wxButton(this, wxID_ANY, _("Clear search history"));
-			row->Insert(at, m_clearHistoryBtn, wxSizerFlags().Center().Border(wxALL, 5));
+			m_clearHistorySep = new wxStaticLine(
+				this, wxID_ANY, wxDefaultPosition, wxSize(-1, 20), wxLI_VERTICAL);
+			row->Insert(at, m_clearHistorySep, wxSizerFlags().Center().Border(wxALL, 5));
+			m_clearHistoryBtn = new wxButton(this, wxID_ANY, _("Clear Search History"));
+			row->Insert(at + 1, m_clearHistoryBtn, wxSizerFlags().Center().Border(wxALL, 5));
 			m_clearHistoryBtn->Bind(wxEVT_BUTTON, &CSearchDlg::OnBnClickedClearHistory, this);
 		}
 	}
@@ -183,6 +194,9 @@ void CSearchDlg::ApplySearchHistoryPref()
 
 	if (m_clearHistoryBtn) {
 		m_clearHistoryBtn->Show(wantHistory);
+	}
+	if (m_clearHistorySep) {
+		m_clearHistorySep->Show(wantHistory);
 	}
 
 	// Only populate when the preference allows it. searchhistory.dat is left
@@ -274,7 +288,22 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 
 void CSearchDlg::OnBnClickedClearHistory(wxCommandEvent &WXUNUSED(evt))
 {
-	ClearSearchHistory();
+	ConfirmAndClearSearchHistory();
+}
+
+// Both routes into clearing -- this button and the combo's context menu --
+// delete searchhistory.dat outright with no undo, so both ask first. The
+// prompt lives here rather than in ClearSearchHistory() so the latter stays
+// usable as a plain action if anything ever needs to clear without asking.
+void CSearchDlg::ConfirmAndClearSearchHistory()
+{
+	const int answer = wxMessageBox(_("Clear the saved search history? This cannot be undone."),
+		_("Clear Search History"),
+		wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION,
+		this);
+	if (answer == wxYES) {
+		ClearSearchHistory();
+	}
 }
 
 CSearchDlg::~CSearchDlg() {}
@@ -451,14 +480,21 @@ void CSearchDlg::OnSearchNameContextMenu(wxContextMenuEvent &WXUNUSED(evt))
 	// Separator: "Clear" is a one-shot action, not another edit command --
 	// keeping it visually apart avoids reading it as one of the group above.
 	menu.AppendSeparator();
-	wxMenuItem *clearItem = menu.Append(wxID_ANY, _("Clear search history"));
+	wxMenuItem *clearItem = menu.Append(wxID_ANY, _("Clear Search History"));
 	clearItem->Enable(combo->GetCount() > 0);
 
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->Cut(); }, wxID_CUT);
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->Copy(); }, wxID_COPY);
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->Paste(); }, ID_SEARCHNAME_PASTE);
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->SetSelection(-1, -1); }, wxID_SELECTALL);
-	menu.Bind(wxEVT_MENU, [this](wxCommandEvent &) { ClearSearchHistory(); }, clearItem->GetId());
+	// Deferred off the popup's own modal loop: this handler runs while
+	// PopupMenu() is still unwinding, and putting a modal dialog up before the
+	// menu has finished tearing down misbehaves on wxOSX. The button route
+	// needs no such care -- no popup is involved there.
+	menu.Bind(
+		wxEVT_MENU,
+		[this](wxCommandEvent &) { CallAfter(&CSearchDlg::ConfirmAndClearSearchHistory); },
+		clearItem->GetId());
 
 	PopupMenu(&menu);
 }

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -29,6 +29,8 @@
 #include <wx/panel.h>    // Needed for wxPanel
 #include <wx/notebook.h> // needed for wxBookCtrlEvent in wx 2.8
 
+class wxStaticLine;
+
 #include "Types.h" // Needed for uint16 and uint32
 
 #include <map> // Needed for std::map (per-tab progress cache)
@@ -250,6 +252,9 @@ private:
 	void LoadSearchHistory();
 	void RecordSearchHistory(const wxString &term);
 	void ClearSearchHistory();
+	// Asks first, then clears. Used by every user-facing route so neither the
+	// button nor the context menu can wipe the history without a prompt.
+	void ConfirmAndClearSearchHistory();
 	void OnSearchNameContextMenu(wxContextMenuEvent &evt);
 
 public:
@@ -275,10 +280,12 @@ private:
 	// history" item missing until the preference was toggled.
 	bool m_searchNameCtxBound = false;
 
-	// Clear-history button, inserted next to the search-type choice at
-	// construction. Held rather than looked up by id so show/hide stays
-	// cheap and cannot silently miss.
+	// Clear-history button, inserted into the action row after "Reset Fields"
+	// at construction, together with the divider that precedes it. Both are
+	// held rather than looked up by id so the pref-driven show/hide stays
+	// cheap and cannot silently miss one of them.
 	wxButton *m_clearHistoryBtn = nullptr;
+	wxStaticLine *m_clearHistorySep = nullptr;
 	void OnBnClickedClearHistory(wxCommandEvent &evt);
 
 	// Greys the button out when there is nothing stored to clear, mirroring

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -363,7 +363,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item43->Add( item52, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticLine *item53 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item43->Add( item53, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxButton *item54 = new wxButton( parent, IDC_CLEAR_RESULTS, _("Clear"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxButton *item54 = new wxButton( parent, IDC_CLEAR_RESULTS, _("Clear Search Results"), wxDefaultPosition, wxDefaultSize, 0 );
     item54->Enable( false );
     item43->Add( item54, wxSizerFlags().Center().Border(wxALL, 5) );
     item1->Add( item43, wxSizerFlags().Center().Border(wxALL, 5) );


### PR DESCRIPTION
Three small changes to the Search page, all about making the two destructive actions distinguishable at a glance.

**`Clear` → `Clear Search Results`.** On a page that also offers to clear the search *history*, a bare "Clear" does not say which of the two it means.

**`Clear search history` → `Clear Search History`, moved into the action row** directly after "Reset Fields". It is a one-shot command like the buttons it now sits with, not a search parameter, and placing it beside "Clear Search Results" lets the two read as a pair. The row becomes:

```
Start | Extend | Stop | Download | Reset Fields | Clear Search History | Clear Search Results
```

The divider preceding it is inserted with it and tracked as a member, so the remember-history preference hides both together instead of leaving a stray separator and a gap.

**Clearing the history now asks first.** It deletes `searchhistory.dat` outright with no undo, and the button now sits one position from "Clear Search Results", which is trivially repeatable — a misclick should not silently destroy the stored terms. The prompt defaults to No.

Both routes go through the confirmation: the button, and the search box's right-click menu, whose item is relabelled to match. The menu route defers via `CallAfter` because its handler runs while `PopupMenu()` is still unwinding, and a modal dialog raised there misbehaves on wxOSX — the same deferral this file already documents for the EC-reply path, for a different reason. `ClearSearchHistory()` itself stays unprompted so it remains usable if anything ever needs to clear without asking.

Catalogs regenerated for the three changed msgids; the bare `"Clear"` msgid survives, still used elsewhere in the tree.

**Verified:** monolithic amule and aMuleGUI build clean on macOS; the resulting button order was checked against the sizer order, and the confirmation on both routes, the enable/disable state and the preference-driven hide of button + divider were exercised in the running GUI. clang-format 18 and both clang-tidy tiers clean on the diff, 0 compiler errors.
