### PR TITLE
feat(ec): poll every search's progress in one request

### DIFF
--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -281,9 +281,30 @@ confirmation — the server does not echo those two tags.
 **Feature capabilities** gate whole operations rather than the framing:
 `EC_TAG_CAN_PARTIAL_UPDATE`, `EC_TAG_CAN_MULTI_SEARCH`,
 `EC_TAG_CAN_CHAT`, `EC_TAG_CAN_SHAREDDIRS_CONFIG`,
-`EC_TAG_CAN_SEARCH_LIST`. The server echoes each of these in its
-`EC_OP_AUTH_OK` response when it supports it, so the client learns what
-is negotiated for this connection.
+`EC_TAG_CAN_SEARCH_LIST`, `EC_TAG_CAN_SEARCH_PROGRESS_UNION`. The server
+echoes each of these in its `EC_OP_AUTH_OK` response when it supports it,
+so the client learns what is negotiated for this connection.
+
+`EC_TAG_CAN_SEARCH_PROGRESS_UNION` changes the reply shape of
+`EC_OP_SEARCH_PROGRESS`, so it is advertised only alongside
+`EC_TAG_CAN_MULTI_SEARCH` — a single-search client has one search and no
+use for the union. Once negotiated, **every** `EC_OP_SEARCH_PROGRESS` from
+that connection answers in the union shape: one child entry per search,
+keyed by `EC_TAG_SEARCH_ID`, whose children are the same tags the per-id
+form puts at the top level.
+
+A client should name the searches it is tracking, one `EC_TAG_SEARCH_ID`
+per search. That narrows which searches come back and makes the daemon
+refresh exactly those in its search LRU, as a per-id poll did; naming none
+reports everything the daemon holds. Naming ids does **not** opt back into
+the single-search reply — the shape is fixed by the capability, not by the
+request. A daemon that keyed the union off "no ids named" would answer a
+client that named several about only the first, and the client would read
+every other search's absence as an expiry.
+
+The union reply carries no `EC_TAG_SEARCH_EXPIRED`: it reports the whole
+set, so an id the client asked about and did not get back is one the
+daemon no longer holds.
 
 `EC_TAG_CAN_NOTIFY` is the one exception to both patterns: the server
 records it and simply pushes notifications or does not, so there is

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -334,6 +334,13 @@ private:
 	// single-search path runs verbatim (the `0xffffffff` sentinel bucket,
 	// wipe-on-start, parameterless stop) so old clients keep working.
 	bool m_multiSearchActive;
+	// Set when the client advertised `EC_TAG_CAN_SEARCH_PROGRESS_UNION`: an
+	// `EC_OP_SEARCH_PROGRESS` carrying no `EC_TAG_SEARCH_ID` reports every
+	// search this connection could hold a tab for, one child per search,
+	// instead of a single search's progress. Only consulted together with
+	// `m_multiSearchActive` — a single-search client's id-less request keeps
+	// meaning "the current search" (amulecmd's `search progress`).
+	bool m_searchProgressUnionActive;
 	// Set when the client advertised EC_TAG_CAN_CHAT: it wants incoming peer
 	// chat messages relayed over EC and polls EC_OP_GET_CHAT_MESSAGES. The
 	// daemon always supports this, so the flag just mirrors the client tag.
@@ -399,6 +406,7 @@ CECServerSocket::CECServerSocket(ECNotifier *notifier)
 , m_partialUpdateActive(false)
 , m_partialSearchActive(false)
 , m_multiSearchActive(false)
+, m_searchProgressUnionActive(false)
 , m_chatActive(false)
 {
 	wxASSERT(theApp->ECServerHandler);
@@ -845,6 +853,15 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// single-search sentinel path — see the search handlers.
 					m_multiSearchActive = true;
 				}
+				if (request->GetTagByName(EC_TAG_CAN_SEARCH_PROGRESS_UNION)) {
+					// Client reads an id-less EC_OP_SEARCH_PROGRESS as "every
+					// open search", each reported as a child tag, so it polls
+					// once instead of once per search. Only honoured together
+					// with multi-search: for a single-search client an id-less
+					// request still means "the current search", which is what
+					// amulecmd's `search progress` with no argument expects.
+					m_searchProgressUnionActive = true;
+				}
 				if (request->GetTagByName(EC_TAG_CAN_CHAT)) {
 					// Client (amulegui) wants incoming peer chat messages
 					// relayed over EC. The daemon always supports this, so
@@ -1002,6 +1019,16 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// searches by `EC_TAG_SEARCH_ID` rather than the
 					// legacy single-search sentinel.
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_MULTI_SEARCH));
+					if (m_searchProgressUnionActive) {
+						// Confirm the union form of EC_OP_SEARCH_PROGRESS:
+						// the client then sends one id-less request per poll
+						// instead of one per open search tab. Nested inside
+						// the multi-search echo on purpose -- the union
+						// addresses its children by search ID, which only
+						// exists in that mode.
+						response->AddTag(
+							CECEmptyTag(EC_TAG_CAN_SEARCH_PROGRESS_UNION));
+					}
 				}
 				// Confirm we serve EC_OP_GET/SET_SHARED_DIRS, so a remote
 				// GUI can present an editable shared-folders panel instead
@@ -2284,6 +2311,148 @@ static CECPacket *Get_EC_Response_Search_List()
 	return response;
 }
 
+// Emit one search's progress into `out`: the reply packet itself for a request
+// naming a single `EC_TAG_SEARCH_ID`, or one child entry per search for the
+// union form below. Both callers share this function so the two shapes cannot
+// drift -- whatever a per-id poll reports is exactly what a union child
+// reports, which is what lets a client switch between them without any
+// second decode path.
+//
+// A browse ("View Files") ID is not a CSearchList search: report its lifecycle
+// from the persisted browse state (browsing / finished / failed) + bar, keyed
+// by search ID, plus the running result count so amuleGUI's tab marker and hit
+// count update. Reading the persisted state -- rather than the browsing client,
+// which is transient and, for a browse that fails on disconnect, reaped before
+// the next poll -- means the terminal "failed" still reaches amuleGUI so its
+// tab marker flips instead of sticking at "browsing".
+// EC_TAG_SEARCH_BROWSE_STATUS is the discriminator the GUI branches on before
+// the normal progress decode.
+//
+// EC_TAG_SEARCH_STATUS MUST be added first in both branches: the GUI reads the
+// reply's (or the entry's) first tag via GetFirstTagSafe.
+static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
+{
+	if (theApp->searchlist->HasBrowseStatus(sid)) {
+		const uint8 browseStatus = theApp->searchlist->GetBrowseStatusById(sid);
+		// Bar value (0..100 running, 0xffff done/failed) so amuleGUI drives
+		// the browse tab's gauge via the same UpdateSearchProgress path as
+		// a search.
+		const uint16 bar = static_cast<uint16>(theApp->searchlist->GetSearchBarStatusById(sid));
+		out.AddTag(CECTag(EC_TAG_SEARCH_STATUS, bar));
+		out.AddTag(CECTag(EC_TAG_SEARCH_BROWSE_STATUS, browseStatus));
+		out.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
+		out.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
+			static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
+		// Also emit the standard lifecycle tags (mapped from the browse
+		// status) so amuleapi / amuleweb consume a browse through their
+		// existing SEARCH_PROGRESS handling with no special-casing:
+		// browsing -> RUNNING, finished/failed -> FINISHED. Percent is the
+		// dir-based bar value (0..100), snapped to 100 once terminal.
+		const bool browsing = browseStatus == BROWSE_IN_PROGRESS;
+		out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE,
+			static_cast<uint8>(browsing ? CSearchList::SEARCH_LIFECYCLE_RUNNING
+						    : CSearchList::SEARCH_LIFECYCLE_FINISHED)));
+		out.AddTag(CECTag(
+			EC_TAG_SEARCH_LIFECYCLE_PERCENT, static_cast<uint8>(bar == 0xffff ? 100 : bar)));
+		return;
+	}
+	// Per-ID lifecycle. STATE / PERCENT / RESULT_COUNT are addressed by the
+	// search ID.
+	const CSearchList::SearchLifecycleState st = theApp->searchlist->GetSearchLifecycleStateById(sid);
+	const uint8 pct = theApp->searchlist->GetSearchLifecyclePercentById(sid);
+	// EC_TAG_SEARCH_STATUS: the overloaded sentinel the GUI decodes in
+	// Search_Update_Progress — a finished Kad search reports 0xfffe (clears the
+	// "!" marker + resets the bar), a finished ed2k search 0xffff, otherwise the
+	// running percent. Shared with the monolithic bar via GetSearchBarStatusById.
+	out.AddTag(CECTag(EC_TAG_SEARCH_STATUS, theApp->searchlist->GetSearchBarStatusById(sid)));
+	// Echo the ID so the client can confirm which search this is for.
+	out.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
+	out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(st)));
+	// Per-id kind (not the scalar): a multi-search client polls each tab by id
+	// and needs THIS search's real type, e.g. to enable the Kad-only "More"
+	// button on the right tab.
+	out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_KIND,
+		static_cast<uint8>(theApp->searchlist->GetSearchLifecycleKindById(sid))));
+	out.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
+		static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
+	out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT, pct));
+}
+
+// Progress for every search this connection could hold a tab for, one child
+// per search, so a client with N open tabs polls once instead of N times.
+//
+// Enumerates searches *and* browse ids -- unlike Get_EC_Response_Search_List,
+// which is deliberately narrow because it drives tab *discovery* and folding
+// browses in there would invent a bogus search tab per open browse. Nothing is
+// discovered here: a client only ever looks up ids it already has tabs for, so
+// including browses is exactly right and is what lets a "View Files" tab share
+// the one poll.
+//
+// There is no EC_TAG_SEARCH_EXPIRED in the union. The per-id form needs it
+// because a reply about one id is otherwise indistinguishable from silence;
+// here the whole set is present, so a client treats any tab whose id is absent
+// as expired -- which also catches an LRU eviction the per-id form only
+// notices when it happens to poll that id.
+static CECPacket *Get_EC_Response_Search_Progress_Union(const CECPacket *request)
+{
+	CECPacket *response = new CECPacket(EC_OP_SEARCH_PROGRESS);
+
+	// The ids the client is actually tracking, when it names them. It costs
+	// nothing to carry -- they ride in the one request either way -- and it
+	// keeps the LRU meaning exactly what it meant before: Touch marks the
+	// searches a client still has open. Touching everything the daemon holds
+	// instead would make an abandoned search as protected as a live tab, so the
+	// search evicted by an overflowing ring stops being the least-used one.
+	std::vector<uint32> wanted;
+	for (const CECTag &tag : *request) {
+		if (tag.GetTagName() == EC_TAG_SEARCH_ID) {
+			wanted.push_back(static_cast<uint32>(tag.GetInt()));
+		}
+	}
+
+	auto emitOne = [&](wxUIntPtr sid) {
+		// Same guard as the per-id path: Touch() on an id the registry does
+		// not know would silently insert it, growing the ring past
+		// kMaxEcSearches for ids Register() never admitted.
+		if (s_ecSearches.Has(static_cast<uint32>(sid))) {
+			s_ecSearches.Touch(static_cast<uint32>(sid));
+		}
+		CECTag entry(EC_TAG_SEARCH_ID, static_cast<uint32>(sid));
+		AppendSearchProgress(entry, sid);
+		response->AddTag(entry);
+	};
+
+	if (!wanted.empty()) {
+		// Answer about the ids the client named, resolving each one exactly as
+		// the per-id form does. Deliberately NOT a walk of the daemon's own
+		// maps filtered by these ids: a Kad search is addressed by an id with
+		// the high bit set (0x80000001...), which is not the key those maps are
+		// stored under, so filtering silently dropped every Kad search from the
+		// reply and the client read that absence as an expiry.
+		for (uint32 want : wanted) {
+			// The gate the per-id path uses -- the core's own knowledge, which
+			// covers browse ids too (see IsKnownSearchId). An id that fails it
+			// is left out, and its absence is how the client learns it expired.
+			if (want == 0 || !theApp->searchlist->IsKnownSearchId(want)) {
+				continue;
+			}
+			emitOne(want);
+		}
+		return response;
+	}
+
+	// No ids named: report everything the daemon holds. Used by a stateless
+	// caller that has no tracked set to enumerate.
+	for (const auto &known : theApp->searchlist->GetKnownSearchIds()) {
+		emitOne(known.first);
+	}
+	for (const auto &browse : theApp->searchlist->GetBrowseSearchIds()) {
+		emitOne(browse.first);
+	}
+
+	return response;
+}
+
 static CECPacket *Get_EC_Response_Search_Results_Download(const CECPacket *request)
 {
 	CECPacket *response = new CECPacket(EC_OP_STRINGS);
@@ -3157,6 +3326,20 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		wxUIntPtr sid = 0xffffffff;
 		if (m_multiSearchActive) {
 			const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
+			// Union form. A client that advertised
+			// EC_TAG_CAN_SEARCH_PROGRESS_UNION always gets the union shape:
+			// naming ids narrows which searches come back, it does not opt
+			// back into the single-search reply. Gating this on `!idTag`
+			// instead would answer such a client about its FIRST id only and
+			// leave every other search out, which it reads as an expiry.
+			// Checked before `want` is resolved, since the id-less fallback
+			// below (s_ecSearches.Current()) is the legacy meaning this
+			// capability replaces.
+			if (m_searchProgressUnionActive) {
+				delete response;
+				response = Get_EC_Response_Search_Progress_Union(request);
+				break;
+			}
 			uint32 want = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
 			// See the matching comment in the EC_OP_SEARCH_RESULTS case above:
 			// gate on the core's own knowledge, not the EC-only registry, so a
@@ -3183,70 +3366,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				s_ecSearches.Touch(want);
 			}
 			sid = want;
-			// A browse ("View Files") ID is not a CSearchList search: report its
-			// lifecycle from the persisted browse state (browsing / finished /
-			// failed) + bar, keyed by search ID, plus the running result count so
-			// amuleGUI's tab marker and hit count update. Reading the persisted
-			// state — rather than the browsing client, which is transient and, for
-			// a browse that fails on disconnect, reaped before the next poll —
-			// means the terminal "failed" still reaches amuleGUI so its tab marker
-			// flips instead of sticking at "browsing".
-			// EC_TAG_SEARCH_BROWSE_STATUS is the discriminator the GUI branches on
-			// before the normal progress decode.
-			if (theApp->searchlist->HasBrowseStatus(sid)) {
-				const uint8 browseStatus = theApp->searchlist->GetBrowseStatusById(sid);
-				// Bar value (0..100 running, 0xffff done/failed) so amuleGUI drives
-				// the browse tab's gauge via the same UpdateSearchProgress path as
-				// a search. Kept first for consistency with the search reply
-				// (GetFirstTagSafe).
-				const uint16 bar =
-					static_cast<uint16>(theApp->searchlist->GetSearchBarStatusById(sid));
-				response->AddTag(CECTag(EC_TAG_SEARCH_STATUS, bar));
-				response->AddTag(CECTag(EC_TAG_SEARCH_BROWSE_STATUS, browseStatus));
-				response->AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
-				response->AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
-					static_cast<uint32>(
-						theApp->searchlist->GetSearchResults(sid).size())));
-				// Also emit the standard lifecycle tags (mapped from the browse
-				// status) so amuleapi / amuleweb consume a browse through their
-				// existing SEARCH_PROGRESS handling with no special-casing:
-				// browsing -> RUNNING, finished/failed -> FINISHED. Percent is the
-				// dir-based bar value (0..100), snapped to 100 once terminal.
-				const bool browsing = browseStatus == BROWSE_IN_PROGRESS;
-				response->AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE,
-					static_cast<uint8>(
-						browsing ? CSearchList::SEARCH_LIFECYCLE_RUNNING
-							 : CSearchList::SEARCH_LIFECYCLE_FINISHED)));
-				response->AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT,
-					static_cast<uint8>(bar == 0xffff ? 100 : bar)));
-				break;
-			}
-			// Per-ID lifecycle. STATE / PERCENT / RESULT_COUNT are addressed
-			// by the search ID; KIND reflects the most-recently-started
-			// search's type (the scalar), which is exact for the common case
-			// and cosmetic for older searches.
-			CSearchList::SearchLifecycleState st =
-				theApp->searchlist->GetSearchLifecycleStateById(sid);
-			uint8 pct = theApp->searchlist->GetSearchLifecyclePercentById(sid);
-			// EC_TAG_SEARCH_STATUS: the overloaded sentinel the GUI decodes in
-			// Search_Update_Progress — a finished Kad search reports 0xfffe
-			// (clears the "!" marker + resets the bar), a finished ed2k search
-			// 0xffff, otherwise the running percent. Shared with the monolithic
-			// bar via GetSearchBarStatusById. This MUST be the first tag: the
-			// GUI reads the reply's first tag (GetFirstTagSafe).
-			response->AddTag(CECTag(
-				EC_TAG_SEARCH_STATUS, theApp->searchlist->GetSearchBarStatusById(sid)));
-			// Echo the ID so the client can confirm which search this is for.
-			response->AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
-			response->AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(st)));
-			// Per-id kind (not the scalar): a multi-search client polls each tab
-			// by id and needs THIS search's real type, e.g. to enable the
-			// Kad-only "More" button on the right tab.
-			response->AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_KIND,
-				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleKindById(sid))));
-			response->AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
-				static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
-			response->AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT, pct));
+			AppendSearchProgress(*response, sid);
 			break;
 		}
 		// EC_TAG_SEARCH_STATUS: unchanged overloaded sentinel for pre-3.1

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -3322,24 +3322,20 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 	}
 
 	case EC_OP_SEARCH_PROGRESS: {
+		// Union form, decided before anything is allocated. A client that
+		// advertised EC_TAG_CAN_SEARCH_PROGRESS_UNION always gets the union
+		// shape: naming ids narrows which searches come back, it does not opt
+		// back into the single-search reply. Gating this on "no ids named"
+		// instead would answer such a client about its FIRST id only and leave
+		// every other search out, which it reads as an expiry.
+		if (m_multiSearchActive && m_searchProgressUnionActive) {
+			response = Get_EC_Response_Search_Progress_Union(request);
+			break;
+		}
 		response = new CECPacket(EC_OP_SEARCH_PROGRESS);
 		wxUIntPtr sid = 0xffffffff;
 		if (m_multiSearchActive) {
 			const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
-			// Union form. A client that advertised
-			// EC_TAG_CAN_SEARCH_PROGRESS_UNION always gets the union shape:
-			// naming ids narrows which searches come back, it does not opt
-			// back into the single-search reply. Gating this on `!idTag`
-			// instead would answer such a client about its FIRST id only and
-			// leave every other search out, which it reads as an expiry.
-			// Checked before `want` is resolved, since the id-less fallback
-			// below (s_ecSearches.Current()) is the legacy meaning this
-			// capability replaces.
-			if (m_searchProgressUnionActive) {
-				delete response;
-				response = Get_EC_Response_Search_Progress_Union(request);
-				break;
-			}
 			uint32 want = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
 			// See the matching comment in the EC_OP_SEARCH_RESULTS case above:
 			// gate on the core's own knowledge, not the EC-only registry, so a

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -213,6 +213,14 @@ public:
 	}
 	void SendPacket(const CECPacket *request) { m_ECClient->SendPacket(request); }
 	bool IsServerPartialUpdateActive() const { return m_ECClient->ServerSupportsPartialUpdate(); }
+	// True when an id-less EC_OP_SEARCH_PROGRESS returns every search as
+	// children, so a client polling N searches can do it in one round trip.
+	// Null-checked: the refresher can reach this between a drop and a
+	// reconnect, unlike the always-connected callers above.
+	bool IsServerSearchProgressUnionActive() const
+	{
+		return m_ECClient && m_ECClient->ServerSupportsSearchProgressUnion();
+	}
 	// Version string of the connected core, from the EC AUTH_OK handshake.
 	// Empty when not connected (m_ECClient null) or when the daemon is old
 	// enough to omit the EC_TAG_SERVER_VERSION tag.

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3206,73 +3206,104 @@ void CSearchListRem::ProcessUpdate(const CECTag *reply, CECPacket *full_req, int
 	}
 }
 
+void CSearchListRem::ApplySearchProgress(const CECTag *src)
+{
+	// Per-search progress: STATUS is the first tag; EC_TAG_SEARCH_ID is
+	// echoed so we can update this specific tab's lifecycle. An expired
+	// search (evicted on the daemon) reports done so its "!" clears.
+	const CECTag *idTag = src->GetTagByName(EC_TAG_SEARCH_ID);
+	const CECTag *browseTag = src->GetTagByName(EC_TAG_SEARCH_BROWSE_STATUS);
+	if (idTag && theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+		if (browseTag) {
+			// A browse ("View Files") tab: update its lifecycle marker
+			// (browsing / finished / failed) AND drive the gauge from the
+			// bar value (EC_TAG_SEARCH_STATUS) via the same per-tab path a
+			// search uses.
+			theApp->amuledlg->m_searchwnd->SetBrowseStatus(
+				idTag->GetInt(), (uint32)browseTag->GetInt());
+			if (const CECTag *barTag = src->GetTagByName(EC_TAG_SEARCH_STATUS)) {
+				theApp->amuledlg->m_searchwnd->UpdateSearchProgress(
+					idTag->GetInt(), (uint32)barTag->GetInt());
+			}
+		} else {
+			const bool expired = src->GetTagByName(EC_TAG_SEARCH_EXPIRED) != nullptr;
+			if (expired) {
+				// The daemon has discarded this search -- a deliberate
+				// close from another client, or LRU eviction -- so
+				// its tab here can only mislead: mapping this to the
+				// plain "finished" status (0xfffe) would make it
+				// indistinguishable from a search that ended
+				// normally, and "Download" on one of its results
+				// would silently do nothing (the daemon's m_results
+				// no longer has the hash). Close the tab locally
+				// instead -- CloseSearchTab does not send
+				// EC_OP_SEARCH_STOP, since the daemon already
+				// doesn't know this id (got3nks, PR #680 review).
+				// CSearchListRem::RemoveResults (called from there)
+				// also erases m_kadActive for this id.
+				const uint32 sid = (uint32)idTag->GetInt();
+				m_activeSearches.erase(sid);
+				if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+					theApp->amuledlg->m_searchwnd->CloseSearchTab(sid);
+				}
+			} else {
+				// Cache whether this tab is a *running* Kad search so
+				// IsKadSearch can gate the "More" button — enabled
+				// only while the search runs, disabled once it
+				// completes (the progress lifecycle is the gate; no
+				// extra status). Update before the progress call,
+				// which refreshes that button for the visible tab.
+				const CECTag *kindTag = src->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+				const CECTag *stateTag = src->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
+				if (kindTag && stateTag) {
+					m_kadActive[(uint32)idTag->GetInt()] =
+						(kindTag->GetInt() == KadSearch) &&
+						(stateTag->GetInt() == CSearchList::SEARCH_LIFECYCLE_RUNNING);
+				}
+				theApp->amuledlg->m_searchwnd->UpdateSearchProgress(
+					idTag->GetInt(), (uint32)src->GetFirstTagSafe()->GetInt());
+			}
+		}
+	}
+}
+
 void CSearchListRem::HandlePacket(const CECPacket *packet)
 {
 	if (packet->GetOpCode() == EC_OP_SEARCH_PROGRESS) {
 		if (m_conn->ServerSupportsMultiSearch()) {
-			// Per-search progress: STATUS is the first tag; EC_TAG_SEARCH_ID is
-			// echoed so we can update this specific tab's lifecycle. An expired
-			// search (evicted on the daemon) reports done so its "!" clears.
-			const CECTag *idTag = packet->GetTagByName(EC_TAG_SEARCH_ID);
-			const CECTag *browseTag = packet->GetTagByName(EC_TAG_SEARCH_BROWSE_STATUS);
-			if (idTag && theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
-				if (browseTag) {
-					// A browse ("View Files") tab: update its lifecycle marker
-					// (browsing / finished / failed) AND drive the gauge from the
-					// bar value (EC_TAG_SEARCH_STATUS) via the same per-tab path a
-					// search uses.
-					theApp->amuledlg->m_searchwnd->SetBrowseStatus(
-						idTag->GetInt(), (uint32)browseTag->GetInt());
-					if (const CECTag *barTag =
-							packet->GetTagByName(EC_TAG_SEARCH_STATUS)) {
-						theApp->amuledlg->m_searchwnd->UpdateSearchProgress(
-							idTag->GetInt(), (uint32)barTag->GetInt());
+			if (m_conn->ServerSupportsSearchProgressUnion()) {
+				// Union form: one child per search the daemon holds, so a
+				// client with N open tabs costs one round trip instead of N.
+				// Every child is an EC_TAG_SEARCH_ID entry whose own value is
+				// the search id and whose children are that search's progress.
+				std::set<uint32> reported;
+				for (const CECTag &entry : *packet) {
+					if (entry.GetTagName() != EC_TAG_SEARCH_ID) {
+						continue;
 					}
-				} else {
-					const bool expired =
-						packet->GetTagByName(EC_TAG_SEARCH_EXPIRED) != nullptr;
-					if (expired) {
-						// The daemon has discarded this search -- a deliberate
-						// close from another client, or LRU eviction -- so
-						// its tab here can only mislead: mapping this to the
-						// plain "finished" status (0xfffe) would make it
-						// indistinguishable from a search that ended
-						// normally, and "Download" on one of its results
-						// would silently do nothing (the daemon's m_results
-						// no longer has the hash). Close the tab locally
-						// instead -- CloseSearchTab does not send
-						// EC_OP_SEARCH_STOP, since the daemon already
-						// doesn't know this id (got3nks, PR #680 review).
-						// CSearchListRem::RemoveResults (called from there)
-						// also erases m_kadActive for this id.
-						const uint32 sid = (uint32)idTag->GetInt();
-						m_activeSearches.erase(sid);
-						if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
-							theApp->amuledlg->m_searchwnd->CloseSearchTab(sid);
-						}
-					} else {
-						// Cache whether this tab is a *running* Kad search so
-						// IsKadSearch can gate the "More" button — enabled
-						// only while the search runs, disabled once it
-						// completes (the progress lifecycle is the gate; no
-						// extra status). Update before the progress call,
-						// which refreshes that button for the visible tab.
-						const CECTag *kindTag =
-							packet->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
-						const CECTag *stateTag =
-							packet->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
-						if (kindTag && stateTag) {
-							m_kadActive[(uint32)idTag->GetInt()] =
-								(kindTag->GetInt() == KadSearch) &&
-								(stateTag->GetInt() ==
-									CSearchList::
-										SEARCH_LIFECYCLE_RUNNING);
-						}
-						theApp->amuledlg->m_searchwnd->UpdateSearchProgress(
-							idTag->GetInt(),
-							(uint32)packet->GetFirstTagSafe()->GetInt());
+					reported.insert((uint32)entry.GetInt());
+					ApplySearchProgress(&entry);
+				}
+				// The union carries no EC_TAG_SEARCH_EXPIRED: it reports the
+				// daemon's whole set, so a tab whose id is missing from it is
+				// one the daemon no longer has -- closed from another client,
+				// or evicted by the LRU. Same verdict the per-id poll reaches
+				// via the explicit tag, and it lands on the same cycle rather
+				// than whenever that particular id next gets polled.
+				//
+				// Snapshot first: CloseSearchTab erases from m_activeSearches.
+				const std::set<uint32> tracked = m_activeSearches;
+				for (uint32 id : tracked) {
+					if (reported.count(id)) {
+						continue;
+					}
+					m_activeSearches.erase(id);
+					if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
+						theApp->amuledlg->m_searchwnd->CloseSearchTab(id);
 					}
 				}
+			} else {
+				ApplySearchProgress(packet);
 			}
 		} else {
 			CoreNotify_Search_Update_Progress(packet->GetFirstTagSafe()->GetInt());
@@ -3515,7 +3546,25 @@ void CSearchListRem::ProcessItemUpdate(const CEC_SearchFile_Tag *tag, CSearchFil
 
 bool CSearchListRem::Phase1Done(const CECPacket *WXUNUSED(reply))
 {
-	if (m_conn->ServerSupportsMultiSearch()) {
+	// The empty check matters: with no open tabs the per-id path below sends
+	// nothing, and an unconditional union request would turn that into a
+	// roundtrip every cycle.
+	if (m_conn->ServerSupportsSearchProgressUnion() && !m_activeSearches.empty()) {
+		// One request covers every open tab: the daemon answers with one
+		// child per search. Costs a single round trip no matter how many are
+		// open, where the per-id path below sends one each -- and kept sending
+		// them for searches that had long finished, since a tab only leaves
+		// m_activeSearches when it is closed.
+		//
+		// The ids ride along so the daemon keeps bumping exactly the searches
+		// this client still has open in its LRU, as the per-id poll did. An id
+		// missing from the reply is one the daemon no longer holds.
+		CECPacket progress_req(EC_OP_SEARCH_PROGRESS);
+		for (uint32 id : m_activeSearches) {
+			progress_req.AddTag(CECTag(EC_TAG_SEARCH_ID, id));
+		}
+		m_conn->SendRequest(this, &progress_req);
+	} else if (m_conn->ServerSupportsMultiSearch()) {
 		// Poll progress for each open search so every tab's lifecycle ("!",
 		// progress bar) is tracked independently. Snapshot the set: an expired
 		// reply may erase from m_activeSearches while iterating.

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -734,6 +734,14 @@ public:
 	// the state machine the same way for the same reason.
 	void RequestSearchList();
 
+	// Decode one search's progress and apply it to that search's tab. `src` is
+	// either the whole EC_OP_SEARCH_PROGRESS reply (a per-id poll, where the
+	// progress tags sit at the top level) or one child entry of the union form
+	// (every open search in a single reply). Both shapes carry an identical tag
+	// set -- the daemon emits them from one function -- so there is exactly one
+	// decode here rather than one per shape.
+	void ApplySearchProgress(const CECTag *src);
+
 	// Monolithic CSearchList API parity over EC. IsKadSearch reports whether a
 	// given tab is a *live* Kad search — the SearchDlg "More" button gate —
 	// from m_kadActive, which HandlePacket fills from each search's per-id

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -212,6 +212,7 @@ EC_TAG_AEAD_CIPHER                        0x001C
 EC_TAG_AEAD_CLIENT_NONCE                  0x001D
 EC_TAG_AEAD_SERVER_NONCE                  0x001E
 EC_TAG_CAN_PARTIAL_SEARCH                 0x001F
+EC_TAG_CAN_SEARCH_PROGRESS_UNION          0x0020
 
 
 EC_TAG_CLIENT_NAME                        0x0100

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -132,6 +132,15 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	// unknown tag and the client stays single-search.
 	if (canMultiSearch)
 		AddTag(CECEmptyTag(EC_TAG_CAN_MULTI_SEARCH));
+	// Client polls every open search's progress with ONE id-less
+	// EC_OP_SEARCH_PROGRESS instead of one request per search. Strictly an
+	// extension of multi-search, so it is only advertised alongside it: an
+	// id-less progress request from a single-search client keeps its legacy
+	// "the current search" meaning, which is what amulecmd's `search progress`
+	// with no argument relies on. Old daemons ignore the unknown tag and never
+	// echo it, and the client then falls back to polling per id.
+	if (canMultiSearch)
+		AddTag(CECEmptyTag(EC_TAG_CAN_SEARCH_PROGRESS_UNION));
 	// Client wants incoming peer chat messages relayed over EC (amulegui
 	// surfaces them read-only). Only advertised by clients with a chat
 	// window; old servers ignore the unknown tag and never relay.
@@ -189,6 +198,7 @@ m_req_fifo_thr(20)
 , m_serverChat(false)
 , m_serverSharedDirsConfig(false)
 , m_serverSearchList(false)
+, m_serverSearchProgressUnion(false)
 {
 }
 
@@ -572,6 +582,13 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			// the client stays on the single-search sentinel path.
 			if (reply->GetTagByName(EC_TAG_CAN_MULTI_SEARCH)) {
 				m_serverMultiSearch = true;
+			}
+			// Server confirmed it answers an id-less EC_OP_SEARCH_PROGRESS
+			// with every open search's progress as children, so one request
+			// covers every tab. Old daemons omit the echo and the client
+			// keeps polling one request per search id.
+			if (reply->GetTagByName(EC_TAG_CAN_SEARCH_PROGRESS_UNION)) {
+				m_serverSearchProgressUnion = true;
 			}
 			// Server confirmed chat relay: it will buffer incoming peer
 			// messages and hand them out via EC_OP_GET_CHAT_MESSAGES. Old

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -208,6 +208,15 @@ private:
 	// is the pre-#680 behaviour.
 	bool m_serverSearchList;
 
+	// Set when the server echoed `EC_TAG_CAN_SEARCH_PROGRESS_UNION` in
+	// AUTH_OK, confirming that an EC_OP_SEARCH_PROGRESS carrying no
+	// `EC_TAG_SEARCH_ID` reports every open search as children instead of
+	// just one. Advertised only alongside multi-search, so an id-less
+	// request from a single-search client keeps its legacy "current search"
+	// meaning. Old daemons don't echo it; the client then polls per id,
+	// which costs one round trip per open search tab.
+	bool m_serverSearchProgressUnion;
+
 	// Client opts into chat relay (advertise `EC_TAG_CAN_CHAT`). Off by
 	// default; a client with a chat window sets it via SetCanChat(). Read
 	// when building the login packet.
@@ -265,6 +274,8 @@ public:
 	bool ServerSupportsSharedDirsConfig() const { return m_serverSharedDirsConfig; }
 
 	bool ServerSupportsSearchList() const { return m_serverSearchList; }
+
+	bool ServerSupportsSearchProgressUnion() const { return m_serverSearchProgressUnion; }
 
 	bool ConnectToCore(const wxString &host,
 		int port,

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1349,6 +1349,32 @@ std::string IPv4ToDotted(std::uint32_t ip_host_order)
 
 } // namespace
 
+bool ParseSearchProgressUnion(
+	const CECPacket *resp, std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> &out)
+{
+	// Opcode gate, not a child-count gate: see the header. A reply we cannot
+	// parse must NOT reach the caller as an empty union, because the caller
+	// reads absence as expiry and would retire every tracked search at once.
+	if (!resp || resp->GetOpCode() != EC_OP_SEARCH_PROGRESS) {
+		return false;
+	}
+	for (const CECTag &entry : *resp) {
+		if (entry.GetTagName() != EC_TAG_SEARCH_ID) {
+			continue;
+		}
+		std::uint32_t pct = 0;
+		std::uint32_t st = 0;
+		if (const CECTag *t = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT)) {
+			pct = static_cast<std::uint32_t>(t->GetInt());
+		}
+		if (const CECTag *t = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE)) {
+			st = static_cast<std::uint32_t>(t->GetInt());
+		}
+		out[static_cast<std::uint32_t>(entry.GetInt())] = { pct, st };
+	}
+	return true;
+}
+
 void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out)
 {
 	if (!resp)

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -93,6 +93,25 @@ void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out);
 // then `state.AppendAmuleLog(...)` to fold them into the cache.
 void ParseAmuleLogFromPacket(const CECPacket *resp, std::vector<std::string> &out_new_lines);
 
+// Union `EC_OP_SEARCH_PROGRESS` response → {search id: {percent, lifecycle
+// state}} for every search the daemon reported.
+//
+// Returns false unless the reply really is an `EC_OP_SEARCH_PROGRESS`, and the
+// caller MUST honour that: absence from a union reply is how a search is
+// learnt to have expired, so treating a reply this could not parse as an empty
+// union would retire every search the caller is tracking in one pass --
+// active=false, terminal snapshot, a final search_progress SSE frame to every
+// subscriber. The per-id form this replaces cannot do that: it expires only on
+// an explicit `EC_TAG_SEARCH_EXPIRED`, and an unexpected reply just leaves the
+// values alone. An `EC_OP_FAILED` (the daemon has ~30 paths that emit one)
+// must therefore fall back to per-id polling, not be read as "all gone".
+//
+// An *empty* union with the right opcode is NOT malformed -- it is the daemon
+// legitimately saying it holds none of the searches asked about -- so the
+// opcode, not the child count, is the discriminator.
+bool ParseSearchProgressUnion(
+	const CECPacket *resp, std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> &out);
+
 // `EC_OP_GET_PREFERENCES` response → flat prefs + bundled categories
 // (the EC packet carries categories under `EC_TAG_PREFS_CATEGORIES`).
 // One roundtrip populates both /preferences and /categories.

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -201,18 +201,12 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		const CECPacket *resp = app.SendRecvSerialized(req.get());
 		if (!resp)
 			return false;
-		have_union = true;
-		for (const CECTag &entry : *resp) {
-			if (entry.GetTagName() != EC_TAG_SEARCH_ID)
-				continue;
-			std::uint32_t pct = 0;
-			std::uint32_t st = 0;
-			if (const CECTag *t = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT))
-				pct = static_cast<std::uint32_t>(t->GetInt());
-			if (const CECTag *t = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE))
-				st = static_cast<std::uint32_t>(t->GetInt());
-			union_progress[static_cast<std::uint32_t>(entry.GetInt())] = { pct, st };
-		}
+		// Only trust a reply that really is a union. Anything else -- an
+		// EC_OP_FAILED, a packet with no search children -- must fall through
+		// to the per-id polling below rather than be read as an empty union:
+		// absence is the expiry signal, so a misread would retire every
+		// tracked search in one pass. Slower, but correct.
+		have_union = ParseSearchProgressUnion(resp, union_progress);
 		delete resp;
 	}
 

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -178,7 +178,45 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// directly with no sentinel-decode fallback. Each request addresses its
 	// search by EC_TAG_SEARCH_ID; a search evicted from the daemon's ring comes
 	// back as EC_TAG_SEARCH_EXPIRED, which we resolve to a terminal snapshot.
-	for (std::uint32_t sid : state.ActiveSearchIds()) {
+	// Progress for every active search in ONE roundtrip when the daemon
+	// advertises the union: an id-less EC_OP_SEARCH_PROGRESS answers with one
+	// child per search it holds. Matters more here than in amuleGUI because
+	// SendRecvSerialized is synchronous and process-wide mutexed, so N searches
+	// meant N serialized round trips inside a single tick. Absence from the
+	// union is the daemon saying it no longer holds that search, which is the
+	// same verdict the per-id form reports as EC_TAG_SEARCH_EXPIRED.
+	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> union_progress;
+	bool have_union = false;
+	const std::vector<std::uint32_t> active_sids = state.ActiveSearchIds();
+	// Nothing active means nothing to ask about. Without this guard the union
+	// would cost a roundtrip every tick forever on an idle daemon, where the
+	// per-id loop below simply had nothing to iterate.
+	if (app.IsServerSearchProgressUnionActive() && !active_sids.empty()) {
+		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
+		// Name the searches we track so the daemon bumps exactly those in its
+		// LRU, matching what the per-id poll did.
+		for (std::uint32_t sid : active_sids) {
+			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
+		}
+		const CECPacket *resp = app.SendRecvSerialized(req.get());
+		if (!resp)
+			return false;
+		have_union = true;
+		for (const CECTag &entry : *resp) {
+			if (entry.GetTagName() != EC_TAG_SEARCH_ID)
+				continue;
+			std::uint32_t pct = 0;
+			std::uint32_t st = 0;
+			if (const CECTag *t = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT))
+				pct = static_cast<std::uint32_t>(t->GetInt());
+			if (const CECTag *t = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE))
+				st = static_cast<std::uint32_t>(t->GetInt());
+			union_progress[static_cast<std::uint32_t>(entry.GetInt())] = { pct, st };
+		}
+		delete resp;
+	}
+
+	for (std::uint32_t sid : active_sids) {
 		std::uint32_t percent = 0;
 		std::uint32_t lifecycle_state = 0;
 		bool expired = false;
@@ -202,7 +240,16 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			}
 			delete resp;
 		}
-		if (!expired) {
+		if (!expired && have_union) {
+			// Already fetched above; absent means the daemon dropped it.
+			const auto found = union_progress.find(sid);
+			if (found == union_progress.end()) {
+				expired = true;
+			} else {
+				percent = found->second.first;
+				lifecycle_state = found->second.second;
+			}
+		} else if (!expired) {
 			std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
 			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
 			const CECPacket *resp = app.SendRecvSerialized(req.get());

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1667,3 +1667,67 @@ TEST(Refresher, ServerPriorityMapsBothWays)
 	ASSERT_TRUE(!ServerPriorityCode("HIGH", untouched)); // case-sensitive by design
 	ASSERT_EQUALS(static_cast<std::uint32_t>(4242), untouched);
 }
+
+// --- union EC_OP_SEARCH_PROGRESS -------------------------------------------
+//
+// Absence from a union reply is how amuleapi learns a search expired, so the
+// parser's return value is load-bearing: a reply it could not parse must be
+// rejected outright rather than handed back as an empty union, which the
+// caller would read as "every tracked search is gone" and retire in one pass.
+
+TEST(Refresher, SearchProgressUnionParsesEveryEntry)
+{
+	CECPacket resp(EC_OP_SEARCH_PROGRESS);
+	for (std::uint32_t sid = 1; sid <= 3; ++sid) {
+		CECTag entry(EC_TAG_SEARCH_ID, sid);
+		entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT, static_cast<uint8>(sid * 10)));
+		entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(1)));
+		resp.AddTag(entry);
+	}
+
+	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> out;
+	ASSERT_TRUE(ParseSearchProgressUnion(&resp, out));
+	ASSERT_EQUALS(static_cast<size_t>(3), out.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(20), out[2].first);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1), out[2].second);
+}
+
+TEST(Refresher, SearchProgressUnionOmitsExpiredSearch)
+{
+	// Two tracked searches, one reported: the missing id must simply not be in
+	// the map, which is what tells the caller to retire that search.
+	CECPacket resp(EC_OP_SEARCH_PROGRESS);
+	CECTag entry(EC_TAG_SEARCH_ID, static_cast<std::uint32_t>(7));
+	entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT, static_cast<uint8>(100)));
+	entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(2)));
+	resp.AddTag(entry);
+
+	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> out;
+	ASSERT_TRUE(ParseSearchProgressUnion(&resp, out));
+	ASSERT_TRUE(out.find(7) != out.end());
+	ASSERT_TRUE(out.find(8) == out.end());
+}
+
+TEST(Refresher, SearchProgressUnionAcceptsEmptyReply)
+{
+	// Right opcode, no children: the daemon legitimately holds none of the
+	// searches asked about. Accepted, so the caller retires all of them. The
+	// discriminator is the opcode, never the child count.
+	CECPacket resp(EC_OP_SEARCH_PROGRESS);
+	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> out;
+	ASSERT_TRUE(ParseSearchProgressUnion(&resp, out));
+	ASSERT_TRUE(out.empty());
+}
+
+TEST(Refresher, SearchProgressUnionRejectsFailureReply)
+{
+	// EC_OP_FAILED must NOT be read as an empty union: that would retire every
+	// tracked search at once. Rejecting it sends the caller back to per-id
+	// polling, which expires only on an explicit EC_TAG_SEARCH_EXPIRED.
+	CECPacket resp(EC_OP_FAILED);
+	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> out;
+	ASSERT_TRUE(!ParseSearchProgressUnion(&resp, out));
+	ASSERT_TRUE(out.empty());
+
+	ASSERT_TRUE(!ParseSearchProgressUnion(NULL, out));
+}


### PR DESCRIPTION
amuleGUI and amuleapi both polled `EC_OP_SEARCH_PROGRESS` once per open search, so N tabs cost N roundtrips every cycle. The set was never pruned on completion either — a search only leaves `m_activeSearches` when its tab closes — so finished searches kept being asked about a lifecycle that could no longer change.

This adds `EC_TAG_CAN_SEARCH_PROGRESS_UNION`. A client that advertises it gets one child entry per search instead of a single search's progress, so one request covers every tab. It is advertised only alongside multi-search: a single-search client has one search and no use for the union, and `amulecmd`'s `search progress` with no argument keeps its existing meaning.

The daemon emits per-id and union tags from one `AppendSearchProgress` helper, and amuleGUI decodes both through one `ApplySearchProgress`, so the two shapes cannot drift. Old daemons never echo the capability and both clients keep their per-id path.

Three details worth calling out for review:

**The reply shape is fixed by the capability, not by the request.** Naming ids narrows which searches come back; it does not opt back into the single-search reply. Keying the union off "no ids named" answers a client that named several about only the first, and the client reads every other search's absence as an expiry.

**The request names the ids the client tracks**, and the daemon reports and Touches exactly those, resolving each through `CSearchList::IsKnownSearchId` as the per-id form does. amuleGUI's results poll takes the union branch, which never Touched, so the per-id progress poll was its only LRU refresh — dropping it would let an overflowing ring evict a search the user still has open.

**Both clients skip the request entirely when they track nothing**, so an idle daemon costs no progress roundtrip at all.

Verified with 30/30 unit tests, all 30 amuleapi curl phases (19-search at 108/108, covering local, global and Kad), and a loopback packet capture on Linux confirming one `EC_OP_SEARCH_PROGRESS` carrying four ids where there were four separate requests before, and none while idle. Tier-1 and Tier-2 clang-tidy clean on the diff with the sysroot args, and clang-format clean.

Note on scope: amuleapi only polls searches while they are in flight (`active` flips false as soon as a search finishes), so its N is typically one or two. amuleGUI is where the waste was — it polled every open tab forever, finished or not. amuleapi still fetches search *results* per id; moving that to the existing results union is a separate change, since it needs `EC_TAG_SEARCH_PARENT` support in the union builder and moves amuleapi onto incremental result application.
