### PR TITLE
fix(core): start the networks when the IP filter is already loaded

### DIFF
--- a/src/IPFilter.cpp
+++ b/src/IPFilter.cpp
@@ -561,9 +561,10 @@ void CIPFilter::StartPendingNetworks()
 		// OnIPFilterEvent runs this again once loading finishes.
 		return;
 	}
-	if (m_connectToAnyServerWhenReady || m_startKADWhenReady) {
-		AddLogLineC(_("Connecting"));
+	if (!m_connectToAnyServerWhenReady && !m_startKADWhenReady) {
+		return;
 	}
+	AddLogLineC(_("Connecting"));
 	if (m_connectToAnyServerWhenReady) {
 		m_connectToAnyServerWhenReady = false;
 		theApp->serverconnect->ConnectToAnyServer();
@@ -572,6 +573,9 @@ void CIPFilter::StartPendingNetworks()
 		m_startKADWhenReady = false;
 		theApp->StartKad();
 	}
+	// Called from startup as well as from the handler, where the
+	// unconditional refresh below covers only the filtering above it.
+	theApp->ShowConnectionState(true);
 }
 
 // File_checked_for_headers

--- a/src/IPFilter.cpp
+++ b/src/IPFilter.cpp
@@ -543,6 +543,24 @@ void CIPFilter::OnIPFilterEvent(CIPFilterEvent &evt)
 		theApp->serverlist->FilterServers();
 	}
 	// Now start networks we didn't start earlier
+	StartPendingNetworks();
+	theApp->ShowConnectionState(true); // refresh connection status
+	if (thePrefs::GetSrcSeedsOn()) {
+		theApp->downloadqueue->LoadSourceSeeds();
+	}
+	// Trigger filter update if configured
+	if (m_updateAfterLoading) {
+		m_updateAfterLoading = false;
+		Update(thePrefs::IPFilterURL());
+	}
+}
+
+void CIPFilter::StartPendingNetworks()
+{
+	if (!m_ready) {
+		// OnIPFilterEvent runs this again once loading finishes.
+		return;
+	}
 	if (m_connectToAnyServerWhenReady || m_startKADWhenReady) {
 		AddLogLineC(_("Connecting"));
 	}
@@ -553,15 +571,6 @@ void CIPFilter::OnIPFilterEvent(CIPFilterEvent &evt)
 	if (m_startKADWhenReady) {
 		m_startKADWhenReady = false;
 		theApp->StartKad();
-	}
-	theApp->ShowConnectionState(true); // refresh connection status
-	if (thePrefs::GetSrcSeedsOn()) {
-		theApp->downloadqueue->LoadSourceSeeds();
-	}
-	// Trigger filter update if configured
-	if (m_updateAfterLoading) {
-		m_updateAfterLoading = false;
-		Update(thePrefs::IPFilterURL());
 	}
 }
 

--- a/src/IPFilter.h
+++ b/src/IPFilter.h
@@ -100,6 +100,16 @@ public:
 	void StartKADWhenReady() { m_startKADWhenReady = true; }
 	void ConnectToAnyServerWhenReady() { m_connectToAnyServerWhenReady = true; }
 
+	/**
+	 * Starts whichever networks the two flags above requested, and clears them.
+	 *
+	 * Called from the load-finished handler, and again once the flags have been
+	 * set during startup: loading runs on a worker thread, so it can finish -- and
+	 * its event be dispatched -- before the caller gets round to asking for a
+	 * network. Doing nothing when no flag is set makes the second call harmless.
+	 */
+	void StartPendingNetworks();
+
 private:
 	/** Handles the result of loading the dat-files. */
 	void OnIPFilterEvent(CIPFilterEvent &);

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1096,6 +1096,17 @@ bool CamuleApp::OnInit()
 	sharedfiles->Reload();
 #endif
 
+	// Source seeds need two things: the part files they belong to, loaded
+	// just above, and a filter to check the seeded IPs against, which the
+	// load-finished handler waits for before running this same load. When
+	// the filter wins that race the handler runs first and iterates an
+	// empty queue, dropping every seed, so run it again here. Re-adding a
+	// source already in the queue is a no-op, so the overlap is harmless
+	// when the handler ran partway through the load.
+	if (thePrefs::GetSrcSeedsOn() && ipfilter->IsReady()) {
+		downloadqueue->LoadSourceSeeds();
+	}
+
 	// Fire the deferred startup HTTP downloads now that the heavy local
 	// I/O is done — see the comment in OnInit() further up.
 #ifdef ENABLE_VERSION_CHECK

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1213,14 +1213,20 @@ bool CamuleApp::OnInit()
 
 	// Autoconnect if that option is enabled
 	if (thePrefs::DoAutoConnect()) {
-		// IP filter is still loading and will be finished on event.
-		// Tell it to autoconnect.
+		// The IP filter may still be loading, in which case its
+		// load-finished event starts the networks these flags ask for.
 		if (thePrefs::GetNetworkED2K()) {
 			ipfilter->ConnectToAnyServerWhenReady();
 		}
 		if (thePrefs::GetNetworkKademlia()) {
 			ipfilter->StartKADWhenReady();
 		}
+		// It may equally have finished already: it loads on a worker
+		// thread, and the splash pumps the event loop while the local
+		// I/O above runs, so a fast filter -- a small file, or none --
+		// is dispatched long before this point, and nothing would start
+		// the networks afterwards. No-op while it is still loading.
+		ipfilter->StartPendingNetworks();
 	}
 
 	// Enable GeoIP. The resolver is headless and core-owned so the daemon


### PR DESCRIPTION
Autoconnect does not connect. It raises two flags on the IP filter — `ConnectToAnyServerWhenReady()` and `StartKADWhenReady()` — and leaves the connecting to the filter's load-finished handler, `OnIPFilterEvent`, which is the only place that reads them. That handler runs once, from a queued event, and there is no later retry.

The filter loads on a worker thread and is constructed early in `OnInit`, while the flags go up at the end of it, after the part-file load and the shared-file scan. Nothing dispatched events in between until the startup splash added in #760 began pumping the loop to paint its progress bar. Now a filter that loads quickly — a small `ipfilter.dat`, or none, which is the default — has its event delivered at the first repaint, long before the flags go up. They then stay up forever, and neither eD2k nor Kad is ever started.

Split the network-starting tail of the handler into `CIPFilter::StartPendingNetworks()` and call it again right after the flags are set. It returns immediately while the filter is still loading, so the ordinary path is unchanged and the handler remains what starts the networks; when the filter got there first, the startup path starts them instead.

Only the monolithic build is affected. The splash is monolithic-only, so `amuled` and `amulegui` never pump the loop during startup and always had the flags up in time.

The same race has a second victim in the same handler: it loads the source seeds by walking the download queue, which on that path has not been loaded yet, so the walk covers no files and every seed is silently dropped. That load now runs again once the part files are in, guarded on the filter being ready so the handler still owns the ordinary path; re-adding a source already in the queue is a no-op, so a handler that ran partway through the part-file load costs nothing. This one is narrower than the networks — `UseSrcSeeds` defaults to off.

The handler's third startup consumer, `FilterServers()`, needs no change. `CServerList::AddServer` already skips filtered entries whenever the filter is ready, so on this path the servers are checked as `server.met` is read, and on the ordinary one the handler's sweep catches whatever got in while the filter was still loading.

`StartPendingNetworks()` also refreshes the connection state when it starts something, since on this path the handler's own refresh runs before the networks are up.

### Verification

macOS monolithic build, scratch config with an empty `ipfilter.dat` (which makes the filter win the race), `Autoconnect=1` and `ConnectToKad=1`, `server.met` and `nodes.dat` present.

Before, on master:

```
19:47:43: IP filter is ready
19:47:43: Startup phases: network 5 ms, 0 part files 1 ms, shared scan 14 ms (estimate was 0)
(nothing further — no connection attempt)
```

After:

```
19:48:12: IP filter is ready
19:48:12: Startup phases: network 4 ms, 0 part files 1 ms, shared scan 1 ms (estimate was 0)
19:48:12: Connecting
19:48:12: Connecting to eMule Sunrise (176.123.5.89:4725) using protocol obfuscation.
19:48:13: Connected to eMule Sunrise (176.123.5.89:4725)
19:48:13: Kad started.
19:48:14: Connected to Kad (firewalled)
19:48:22: Connected to eMule Sunrise with LowID
```

Also built with `BUILD_DAEMON=YES` to cover the non-splash path. The seeds change is covered by the build and by inspection only — exercising it needs `UseSrcSeeds` on and part files carrying `.seeds` companions, which this scratch config has not; the log above is the networks path.
