### PR TITLE
fix(gui): size the Preferences sidebar from what the rows measure

### DIFF
--- a/src/MacAppHelper.h
+++ b/src/MacAppHelper.h
@@ -25,6 +25,16 @@ extern "C" {
 // window is hidden via "minimize to tray".
 void mac_set_accessory_mode(bool accessory);
 
+// Drops the inset row style from the NSTableView (or NSOutlineView) backing
+// the passed wxWindow handle, restoring the flush one. macOS 11 made the
+// inset style the default: it is what draws a selected row as a rounded
+// pill, and it reserves padding at both ends of every row, whether or not
+// the row is the selected one. The padding comes out of the cell the label
+// is drawn in, so a list whose width is derived from its longest label
+// ellipsises that label no matter how wide the column is made. Does nothing
+// if the handle is not backed by a table view, or below macOS 11.
+void mac_set_table_view_flush(void *windowHandle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/MacAppHelper.mm
+++ b/src/MacAppHelper.mm
@@ -13,6 +13,33 @@
 
 #include "MacAppHelper.h"
 
+extern "C" void mac_set_table_view_flush(void *windowHandle)
+{
+	if (!windowHandle) {
+		return;
+	}
+
+	// wxOSX hands back whichever view it made the peer from: the scroll
+	// view for a scrolled control, the table itself otherwise.
+	NSView *view = (NSView *)windowHandle;
+	NSTableView *table = nil;
+	if ([view isKindOfClass:[NSScrollView class]]) {
+		NSView *doc = [(NSScrollView *)view documentView];
+		if ([doc isKindOfClass:[NSTableView class]]) {
+			table = (NSTableView *)doc;
+		}
+	} else if ([view isKindOfClass:[NSTableView class]]) {
+		table = (NSTableView *)view;
+	}
+
+	if (!table) {
+		return;
+	}
+	if (@available(macOS 11.0, *)) {
+		table.style = NSTableViewStyleFullWidth;
+	}
+}
+
 extern "C" void mac_set_accessory_mode(bool accessory)
 {
 	[NSApp setActivationPolicy:

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -66,6 +66,10 @@
 #include <wx/filename.h> // wxFileName for status-line size lookup
 #endif
 #include "CamuleArtProvider.h" // CamuleArtProvider::MakeId for the page-icon bundles
+
+#ifdef __WXMAC__
+#include "MacAppHelper.h" // mac_set_table_view_flush
+#endif
 #include "MuleColour.h"
 #include "EditServerListDlg.h"
 #include "SearchDlg.h"      // Needed for CSearchDlg::ApplySearchHistoryPref
@@ -392,6 +396,20 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	m_PrefsIcons = CastChild(ID_PREFSLISTCTRL, wxDataViewListCtrl);
 	const int kPrefsIconW = 16;
 	const int kPrefsIconH = 16;
+	// Room for the gap after the icon and the cell's left/right padding.
+	// On macOS this is only the width the list is built with, since the
+	// measurement below replaces it -- but it has to be generous, because
+	// what that measurement reports is bounded by the room the control
+	// already has: ask from a column pinned to a tight estimate and the
+	// answer comes back tight, whatever the cells actually need. On GTK
+	// and MSW no measurement follows, so this is the width itself: enough
+	// for the cell's own padding, plus room after the longest label so it
+	// does not sit against the edge of the list.
+#ifdef __WXMAC__
+	const int kCellPadding = 48;
+#else
+	const int kCellPadding = 24;
+#endif
 
 	// The page art only exists at one (16x16) size. Wrap each icon in a
 	// wxBitmapBundle with a smooth 2x upscale so DPI-aware builds render
@@ -463,17 +481,29 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 		m_PrefsIcons->AppendItem(values, (wxUIntPtr)i);
 	}
 
-	// Set list-width so that there aren't any scrollers. The native
-	// icon+text cell renderer (NSTableView on macOS, GtkCellRenderer on
-	// GTK) reserves more than just the icon's own pixel width for the
-	// icon-text gap and cell insets -- measured on macOS, kPrefsIconW's
-	// worth of padding alone clips the longest labels ("Connessione",
-	// "Contatti/emoticons") by a few pixels, so this is deliberately
-	// generous rather than tightly computed.
-	const int kSidebarPadding = kPrefsIconW + 48;
-	iconTextCol->SetWidth(maxLabelWidth + kSidebarPadding);
-	m_PrefsIcons->SetMinSize(wxSize(maxLabelWidth + kSidebarPadding + 10, -1));
-	m_PrefsIcons->SetMaxSize(wxSize(maxLabelWidth + kSidebarPadding + 10, -1));
+#ifdef __WXMAC__
+	// macOS 11 made the inset row style the default: it pads both ends of
+	// every row -- the same padding that draws a selected row as a rounded
+	// pill inside its cell rather than filling it -- and that padding comes
+	// out of the space the label is drawn in.
+	mac_set_table_view_flush(m_PrefsIcons->GetHandle());
+#endif
+
+	// Set list-width so that there aren't any scrollers. What the cell needs
+	// beyond the label text -- the icon, the gap after it and the cell's own
+	// padding -- is the renderer's business, and only one of the three ports
+	// will say what it comes to: wxOSX answers wxCOL_WIDTH_AUTOSIZE with the
+	// width its cells want, while wxGTK and the generic implementation answer
+	// with the column's current allocation, which is the width the control
+	// was handed, echoed back. So the estimate here is what MSW and GTK get,
+	// and OnShowMeasureSidebar() replaces it on macOS once the control has
+	// been laid out and can be asked.
+	m_sidebarColumn = iconTextCol;
+	SetSidebarWidth(maxLabelWidth + FromDIP(kPrefsIconW + kCellPadding));
+#ifdef __WXMAC__
+	m_sidebarTextWidth = maxLabelWidth;
+	Bind(wxEVT_SHOW, &PrefsUnifiedDlg::OnShowMeasureSidebar, this);
+#endif
 
 	// Now add the pages and calculate the minimum size
 	m_pageWidgets.assign(itemsof(pages), nullptr);
@@ -2417,6 +2447,47 @@ void PrefsUnifiedDlg::UpdateGeoIPStatus()
 #endif // !CLIENT_GUI
 }
 #endif // GEOIP_GUI
+
+#ifdef __WXMAC__
+void PrefsUnifiedDlg::OnShowMeasureSidebar(wxShowEvent &event)
+{
+	event.Skip();
+	if (m_sidebarMeasured || !event.IsShown() || !m_sidebarColumn) {
+		return;
+	}
+	m_sidebarMeasured = true;
+
+	// Now that the control is on screen it can measure the rows it is
+	// actually drawing, font and cell padding included. The answer is not
+	// ready when SetWidth() returns -- it is resolved while the control is
+	// laid out -- so the read-back waits for that to have happened.
+	m_sidebarColumn->SetWidth(wxCOL_WIDTH_AUTOSIZE);
+	CallAfter([this]() {
+		// Nothing is added to what comes back: the padding the estimate
+		// has to guess at is part of what was measured. A width narrower
+		// than the label text is not a measurement at all, so the estimate
+		// stands.
+		const int reported = m_sidebarColumn->GetWidth();
+		if (reported > m_sidebarTextWidth) {
+			SetSidebarWidth(reported);
+			m_PrefsIcons->InvalidateBestSize();
+			Layout();
+		}
+	});
+}
+#endif // __WXMAC__
+
+void PrefsUnifiedDlg::SetSidebarWidth(int columnWidth)
+{
+	m_sidebarColumn->SetWidth(columnWidth);
+	// The control has to be wider than its column: the table draws its cells
+	// at a small offset from its own left edge -- 6 points on macOS, and the
+	// other two are not zero either -- so sizing it to exactly the column
+	// width clips the cell against its right edge.
+	const int controlWidth = columnWidth + FromDIP(6);
+	m_PrefsIcons->SetMinSize(wxSize(controlWidth, -1));
+	m_PrefsIcons->SetMaxSize(wxSize(controlWidth, -1));
+}
 
 void PrefsUnifiedDlg::OnPrefsPageChange(wxDataViewEvent &event)
 {

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -41,7 +41,9 @@ class wxChoice;
 class wxButton;
 class wxPanel;
 class wxDataViewListCtrl;
+class wxDataViewColumn;
 class wxDataViewEvent;
+class wxShowEvent;
 
 class wxCommandEvent;
 class wxListEvent;
@@ -179,7 +181,22 @@ private:
 	//! Page icons, in `pages[]` order -- kept so EnableServerTab can
 	//! re-insert the server row's icon when the tab is re-shown.
 	std::vector<wxBitmapBundle> m_pageIcons;
+	//! The sidebar's single icon+text column, kept so its width can be
+	//! replaced with the control's own measurement on first show.
+	wxDataViewColumn *m_sidebarColumn = nullptr;
+#ifdef __WXMAC__
+	//! Widest label as the control's own font measures it. A reported width
+	//! narrower than this cannot be a measurement of icon-plus-text.
+	int m_sidebarTextWidth = 0;
+	//! The measurement is a one-off; the dialog is shown more than once.
+	bool m_sidebarMeasured = false;
+#endif
 	void EnableServerTab(bool enable);
+#ifdef __WXMAC__
+	void OnShowMeasureSidebar(wxShowEvent &event);
+#endif
+	//! Applies a column width, and the control width that fits it.
+	void SetSidebarWidth(int columnWidth);
 
 	void OnOk(wxCommandEvent &event);
 	void OnCancel(wxCommandEvent &event);

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2283,7 +2283,9 @@ wxSizer *preferencesDlgTop( wxWindow *parent, bool call_fit, bool set_sizer )
     prefs_sizer = item1;
 
     wxDataViewListCtrl *item2 = new wxDataViewListCtrl( parent, ID_PREFSLISTCTRL, wxDefaultPosition, wxDefaultSize, wxDV_SINGLE|wxDV_NO_HEADER|wxSUNKEN_BORDER );
-    item1->Add( item2, wxSizerFlags().Expand().Border(wxALL, 5) );
+    // Tighter than the usual 5: the list is sized to its longest label, so
+    // its border reads as slack on every row rather than as breathing room.
+    item1->Add( item2, wxSizerFlags().Expand().Border(wxALL, 2) );
     item0->Add( item1, wxSizerFlags(1).Expand().Border(wxALL, 0) );
     // Plain button row (no static-box container). A leading stretch spacer
     // right-aligns the whole group; the page-scoped "Reset" button (hidden


### PR DESCRIPTION
The sidebar's width was the widest page title, measured with the control's font, plus a constant large enough to cover whatever the cell adds on top: 48 pixels beyond the icon's own 16. Every row carries that surplus, since the width comes from the longest label alone.

The constant cannot be tuned down, because the two halves disagree about what they are measuring. `GetTextExtent()` answers for the control's font; the cell draws with the renderer's, plus an icon-text gap and padding belonging to `NSTableView`, `GtkCellRenderer` or the generic drawing code. The error is per-label, so it lands on the longest ones first — exactly the ones the width is derived from.

Only one of the three ports will say what its cells need. Asking a list built like this one for `wxCOL_WIDTH_AUTOSIZE` reports 30 pixels beyond the widest label on macOS, icon included; wxGTK and the generic implementation both answer with the column's current allocation — the width the control was handed, echoed back, which says nothing about the cells. So macOS is measured on first show, once the control has been laid out and can answer, and the other two keep an estimate of the label plus the icon plus 24.

Measuring alone still ellipsised the longest labels on macOS, and so did master: macOS 11 made the inset row style the default, which pads both ends of every row — the padding that draws a selected row as a rounded pill inside its cell rather than filling it — and that padding comes out of the space the label is drawn in, so no column width reclaims it. `mac_set_table_view_flush()` turns it off, which also restores the full-width selection the sidebar had before it was ported to `wxDataViewCtrl`.

The list's border comes down from 5 to 2 while here. On a control sized to its longest label, a border reads as slack on every row.

### Verification

Built and visually checked on macOS (arm64, wx 3.3.3), Ubuntu 26.04 arm64 (wxGTK 3.2.6) and Windows 11 arm64 (MSYS2 CLANGARM64), at the same commit on each.
