### PR TITLE
fix(gui): reconnect when the EC link goes silent instead of freezing

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -309,6 +309,39 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 	static int request_step = 0;
 	static uint32 msPrevStats = 0;
 
+	// Reply watchdog. EC has no application-level keepalive, and the daemon
+	// always answers, so requests outstanding with nothing coming back means
+	// the transport has gone quiet -- an SSH tunnel with no ServerAliveInterval,
+	// a NAT dropping an idle mapping, a proxy that stopped relaying. None of
+	// those close the socket: it stays ESTABLISHED with every queue empty and
+	// no error is ever raised, so neither OnLost nor OnError fires.
+	//
+	// Without this the failure is permanent AND silent. Once m_req_count passes
+	// m_req_fifo_thr the early-return below fires on every tick, so the client
+	// stops sending too -- and recovery would need a reply, which needs a
+	// request. The back-pressure brake becomes a deadlock the client can never
+	// leave, with a frozen UI and no message.
+	//
+	// Gated on the fifo rather than on the threshold so it trips on the real
+	// symptom (nothing answering) rather than waiting for the queue to fill.
+	if (m_connect->GetReqFifoSize() > 0 &&
+		m_connect->MillisecondsSinceLastReply() > EC_REPLY_TIMEOUT_MS) {
+		// Untranslated and debug-level on purpose: the user-facing messaging
+		// already comes from the path this drops into -- OnLost posts
+		// "Connection failure" and BeginReconnect announces the retry, both
+		// long since translated. Adding a new msgid here would have bought
+		// translators work for something nobody but a developer reads.
+		AddDebugLogLineN(logEC,
+			CFormat(wxT("EC reply watchdog: no reply for %u ms with %u requests "
+				    "pending -- treating the connection as dead")) %
+				(unsigned)m_connect->MillisecondsSinceLastReply() %
+				(unsigned)m_connect->GetReqFifoSize());
+		// Close ourselves and dispatch the loss: a self-close suppresses the
+		// asio lost-event path, so without the explicit dispatch nothing would
+		// tell the GUI. Lands in OnECConnection(false) -> BeginReconnect().
+		m_connect->CloseAndDispatchLost();
+		return;
+	}
 	if (m_connect->RequestFifoFull()) {
 		return;
 	}

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -874,6 +874,12 @@ public:
 	uint32 GetPeakConnections() { return m_peak_connections; }
 };
 
+// How long the remote GUI waits for a reply before deciding the EC connection
+// is dead. Generous on purpose: a healthy link answers in single-digit
+// milliseconds, and the poll cycle is ~3 s, so 30 s cannot be reached by a
+// merely busy daemon -- only by one that has stopped answering entirely.
+#define EC_REPLY_TIMEOUT_MS 30000
+
 class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppCommon
 {
 	wxTimer *poll_timer;

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -199,6 +199,7 @@ m_req_fifo_thr(20)
 , m_serverSharedDirsConfig(false)
 , m_serverSearchList(false)
 , m_serverSearchProgressUnion(false)
+, m_lastReplyAt(std::chrono::steady_clock::now())
 {
 }
 
@@ -334,6 +335,10 @@ void CRemoteConnect::WriteDoneAndQueueEmpty() {}
 
 void CRemoteConnect::OnConnect()
 {
+	// Start the watchdog clock here, not at construction: a wrapper reused
+	// across a reconnect would otherwise carry the previous connection's
+	// staleness into the new one and trip the timeout immediately.
+	m_lastReplyAt = std::chrono::steady_clock::now();
 	// Apply the EC-tuned TCP keepalive timings now that the underlying
 	// asio socket is fully connected on the async path (sync clients
 	// got it inside CECMuleSocket::InternalConnect already; this is
@@ -359,6 +364,13 @@ void CRemoteConnect::OnConnect()
 	} else {
 		// do nothing, calling code will take from here
 	}
+}
+
+uint64 CRemoteConnect::MillisecondsSinceLastReply() const
+{
+	return static_cast<uint64>(std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::steady_clock::now() - m_lastReplyAt)
+					   .count());
 }
 
 void CRemoteConnect::OnLost()
@@ -452,6 +464,10 @@ void CRemoteConnect::SetupAEADFromSalt(const CECPacket *reply)
 const CECPacket *CRemoteConnect::OnPacketReceived(const CECPacket *packet, uint32 trueSize)
 {
 	CECPacket *next_packet = 0;
+	// Liveness stamp for the reply watchdog. Taken for EVERY inbound packet,
+	// including the handshake ones, so a connection that has only just come up
+	// is never mistaken for one that has gone quiet.
+	m_lastReplyAt = std::chrono::steady_clock::now();
 	m_req_count--;
 	packet->DebugPrint(true, trueSize);
 	switch (m_ec_state) {

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -27,6 +27,8 @@
 #define REMOTECONNECT_H
 
 #include "ECMuleSocket.h"
+
+#include <chrono>     // steady_clock for the reply watchdog
 #include "ECPacket.h" // Needed for CECPacket
 
 #include <wx/event.h>
@@ -208,6 +210,11 @@ private:
 	// is the pre-#680 behaviour.
 	bool m_serverSearchList;
 
+	// Steady-clock stamp of the last packet received from the daemon. Steady,
+	// not wall-clock: a system clock step (NTP, sleep/wake) must not be
+	// readable as a stalled connection.
+	std::chrono::steady_clock::time_point m_lastReplyAt;
+
 	// Set when the server echoed `EC_TAG_CAN_SEARCH_PROGRESS_UNION` in
 	// AUTH_OK, confirming that an EC_OP_SEARCH_PROGRESS carrying no
 	// `EC_TAG_SEARCH_ID` reports every open search as children instead of
@@ -292,6 +299,20 @@ public:
 	const wxString &GetServerVersion() const { return m_serverVersion; }
 
 	bool RequestFifoFull() { return m_req_count > m_req_fifo_thr; }
+
+	// Number of outstanding requests: pushed by SendRequest, popped when the
+	// matching reply is handled. Unlike m_req_count this never sees the
+	// handshake packets, so it is the honest in-flight count.
+	size_t GetReqFifoSize() const { return m_req_fifo.size(); }
+
+	// Milliseconds since the last packet arrived from the daemon, or since the
+	// connection was established if none has. Drives the reply watchdog: EC has
+	// no application-level keepalive, so a transport that silently stops
+	// delivering (an SSH tunnel with no ServerAliveInterval, a NAT dropping an
+	// idle mapping, a proxy) leaves the socket ESTABLISHED with every queue
+	// empty and nothing to report. Without this the only symptom is a frozen
+	// UI -- see the CloseAndDispatchLost() comment for the same class of bug.
+	uint64 MillisecondsSinceLastReply() const;
 
 	virtual void OnConnect(); // To override connection events
 	virtual void OnLost();    // To override close events


### PR DESCRIPTION
amuleGUI could sit with a frozen UI indefinitely — no error, no reconnect — whenever the transport stopped delivering without closing. An SSH tunnel with no `ServerAliveInterval`, a NAT dropping an idle mapping, a proxy that stops relaying: none of those close the socket. It stays `ESTABLISHED` with every queue empty, so neither `OnError` nor `OnLost` ever fires and nothing notices.

The failure is self-sealing, which is what makes it permanent rather than transient. Requests pile up unanswered until `m_req_count` passes `m_req_fifo_thr`, at which point `OnPollTimer` early-returns on every tick and the client stops sending too. Recovery would need a reply, a reply needs a request, and none are going out — the back-pressure brake becomes a deadlock the client cannot leave. A field capture showed it stuck at 22 outstanding requests, unchanged and silent in both directions, for over thirteen minutes, while the daemon was demonstrably healthy and serving another EC client at normal latency throughout.

This tracks when the last packet arrived and, once requests have been outstanding for 30 s with nothing back, closes and dispatches the loss. That lands in the existing `OnECConnection(false)` → `BeginReconnect()` path, which already freezes the UI, reports the failure and redials.

Three details worth review attention:

**`CloseAndDispatchLost()` rather than a plain close.** A self-close suppresses the asio lost-event path, so a bare `CloseSocket()` would tear the connection down and still tell the GUI nothing — the same trap that function's own comment documents.

**Gated on the request fifo, not the full threshold.** It trips on the real symptom (nothing answering) instead of waiting for the queue to fill first.

**`steady_clock`, not wall-clock.** An NTP step or a sleep/wake must not be readable as a stalled link.

30 s cannot be reached by a merely busy daemon: a healthy link answers in single-digit milliseconds and the poll cycle is ~3 s.

Adds no translatable string. The user-facing messaging already comes from the path this drops into — "Connection failure" and the reconnect announcements are long since translated — so the diagnostic detail is an untranslated debug line for developers instead. `po/` regenerates to a pure timestamp diff with no msgid change.

Verified against a relay that stops forwarding while holding both sockets open, reproducing the failure shape exactly: detection at 30 s with 23 requests pending, then the normal reconnect sequence, every message coming from existing catalog entries. Both clang-tidy tiers and clang-format clean on the diff.

Note this does not fix whatever stalls a transport — in the observed case an SSH tunnel with no keepalive. It stops aMule turning such a stall into a permanent silent freeze.
