### PR TITLE
fix(gui): hide the EC "require encryption" toggle in the remote GUI

### DIFF
--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -1053,6 +1053,7 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		IDC_EXT_CONN_TCPPORTTEXT,
 		IDC_EXT_CONN_PASSWD,
 		IDC_EXT_CONN_PASSWDTEXT,
+		IDC_EXT_CONN_REQUIRE_ENCRYPTION,
 		// ffprobe "Browse" (local file picker) and "Detect" (auto-detects on the
 		// GUI host, not the daemon) cannot target the daemon filesystem. The
 		// enable toggle + path field are EC-wired and stay visible.


### PR DESCRIPTION
In amulegui connected to a core, the "Require encrypted connections" checkbox (`IDC_EXT_CONN_REQUIRE_ENCRYPTION`) was shown and drew on top of the "aMule API server parameters" box below it.

It configures the daemon's own External Connection listener — read from amuled's config, never sent over EC or stored in remote.conf — so it belongs to the same category as the other external-connection controls (`IDC_EXT_CONN_ACCEPT`, `_TCP_PORT`, `_PASSWD`, …) that `amuledOnlyPrefs[]` hides under `CLIENT_GUI`. It was simply never added to that list.

As the last child of the External Connections params box, it stayed visible while its box and siblings were hidden, so it was orphaned in the collapsed layout and overlapped the box below — one omission causing both the stray control and the overlay. Adding it to `amuledOnlyPrefs[]` fixes both.
