### PR TITLE
fix(geoip): memoise the peer country lookup instead of resolving per poll

### DIFF
--- a/src/CountryDisplay.h
+++ b/src/CountryDisplay.h
@@ -61,13 +61,17 @@
  *
  * @param fromCore Whether the core sent a country tag for this entry.
  * @param coreCode The code it sent (meaningful only when @a fromCore).
- * @param ip       Dotted address, for the monolithic local lookup.
+ * @param ip       Numeric address, for the monolithic local lookup. Numeric
+ *                 rather than dotted so it hits the resolver's cache -- the
+ *                 string overload is uncached and goes straight to the
+ *                 database, which on a paint path means a lookup per row per
+ *                 repaint.
  * @param code     Receives the ISO 3166-1 alpha-2 code; may come back empty
  *                 for an address that did not resolve.
  * @return false when no country is known at all -- render neither icon nor
  *         text.
  */
-inline bool GetDisplayCountryCode(bool fromCore, const wxString &coreCode, const wxString &ip, wxString &code)
+inline bool GetDisplayCountryCode(bool fromCore, const wxString &coreCode, uint32 ip, wxString &code)
 {
 	if (fromCore) {
 		code = coreCode;

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -356,8 +356,11 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 	// a frontend can treat tag-present as authoritative (possibly "unknown")
 	// and tag-absent as "no daemon GeoIP".
 	if (theApp->GetIP2Country() && theApp->GetIP2Country()->IsEnabled()) {
+		// Numeric-IP overload: memoised, and it skips formatting the IP into
+		// a string on the hit path. This runs for every peer on every EC
+		// poll, and a peer's country cannot change while its IP does not.
 		AddTag(CECTag(EC_TAG_CLIENT_COUNTRY,
-			       theApp->GetIP2Country()->GetCountryCode(client->GetFullIP())),
+			       theApp->GetIP2Country()->GetCountryCode(client->GetFullIPNumeric())),
 			valuemap);
 	}
 #endif

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -927,7 +927,7 @@ void CGenericClientListCtrl::DrawClientItem(wxDC *dc,
 		wxString code;
 		const bool haveCountry = GetDisplayCountryCode(client.GetClient()->IsCountryFromCore(),
 			client.GetClient()->GetCountryCode(),
-			client.GetFullIP(),
+			client.GetClient()->GetFullIPNumeric(),
 			code);
 		// Draw the country flag only — no textual code. An unknown / unresolved
 		// peer (empty code) gets neither flag nor prefix.

--- a/src/IP2Country.cpp
+++ b/src/IP2Country.cpp
@@ -37,6 +37,8 @@
 #include <wx/intl.h>
 
 #include "IP2Country.h"
+
+#include "NetworkFunctions.h" // Uint32toStringIP
 #include "geoip/MaxMindDBDatabase.h"
 
 CIP2Country::CIP2Country(const wxString &configDir)
@@ -68,6 +70,7 @@ bool CIP2Country::IsEnabled()
 
 void CIP2Country::Enable()
 {
+	// Disable() clears the cache, so no separate invalidation here.
 	Disable();
 
 	if (!CPath::FileExists(m_DataBasePath)) {
@@ -140,6 +143,7 @@ void CIP2Country::StartDownload(int monthOffset)
 
 void CIP2Country::Disable()
 {
+	InvalidateCountryCache();
 	if (m_db) {
 		m_db->Close();
 	}
@@ -265,6 +269,31 @@ wxString CIP2Country::GetCountryCode(const wxString &ip)
 	return m_db->GetCountryCode(ip);
 }
 
+const wxString &CIP2Country::GetCountryCode(uint32 ip)
+{
+	static const wxString empty;
+	if (!IsEnabled()) {
+		// Not cached: a disabled resolver has no answer to memoise, and
+		// caching the empty string here would need the enable path to
+		// invalidate anyway. Cheap enough -- IsEnabled() is two pointer reads.
+		return empty;
+	}
+	const std::unordered_map<uint32, wxString>::const_iterator it = m_countryCache.find(ip);
+	if (it != m_countryCache.end()) {
+		return it->second;
+	}
+	if (m_countryCache.size() >= kMaxCountryCacheEntries) {
+		m_countryCache.clear();
+	}
+	// Only now is the string form needed; Uint32toStringIP allocates.
+	return m_countryCache.emplace(ip, m_db->GetCountryCode(Uint32toStringIP(ip))).first->second;
+}
+
+void CIP2Country::InvalidateCountryCache()
+{
+	m_countryCache.clear();
+}
+
 void CIP2Country::NotifyUpdateFailed(const wxString &msg)
 {
 	if (m_updateFailedNotifier) {
@@ -284,6 +313,13 @@ CIP2Country::CIP2Country(const wxString &)
 CIP2Country::~CIP2Country() {}
 void CIP2Country::Enable() {}
 void CIP2Country::Disable() {}
+void CIP2Country::InvalidateCountryCache() {}
+
+const wxString &CIP2Country::GetCountryCode(uint32)
+{
+	static const wxString empty;
+	return empty;
+}
 void CIP2Country::Update(bool, bool) {}
 void CIP2Country::DownloadFinished(uint32) {}
 void CIP2Country::StartDownload(int) {}

--- a/src/IP2Country.h
+++ b/src/IP2Country.h
@@ -45,6 +45,7 @@
 #include "Types.h" // Needed for uint8, uint16 and uint32
 
 #include <functional>
+#include <unordered_map>
 
 #include <wx/string.h>
 
@@ -68,6 +69,25 @@ public:
 	// does not resolve.
 	wxString GetCountryCode(const wxString &ip);
 
+	// Same, from the numeric IP the callers already hold, and memoised.
+	//
+	// The returned reference is valid until the next call on this object, or
+	// any Enable()/Disable(): the cache is cleared wholesale on overflow and
+	// on either of those, and clear() invalidates references. Copy it if you
+	// need it to outlive the call -- in particular do not pass two of these
+	// into one expression.
+	//
+	// #439 moved this resolution from GUI paint into the core. Paint hid the
+	// cost: it ran only for visible rows, only while the list was on screen,
+	// only with someone watching. The EC client tag now resolves EVERY peer
+	// on EVERY poll -- roughly every 3 s, headless, forever -- and a peer's
+	// country cannot change while its IP does not. Measured at ~7.5us per
+	// peer per poll on a live daemon, about 37% of the client tag build.
+	//
+	// Keyed on the numeric IP so the caller need not format a string first
+	// (Uint32toStringIP allocates); the string is only built on a miss.
+	const wxString &GetCountryCode(uint32 ip);
+
 	void Enable();
 	void Disable();
 	// Refresh the on-disk MMDB from the configured source.
@@ -89,12 +109,12 @@ public:
 	// preferences panel can show the status line ("Loaded — <path>"),
 	// without re-deriving the config-dir + filename convention.
 	const wxString &GetDatabasePath() const { return m_DataBasePath; }
-
 	// Live status for the prefs panel (local, and carried to amulegui over EC,
 	// #440 remote config). IsDownloading() is true while a refresh is in
 	// flight; GetLastResult() is a short human string describing the outcome
 	// of the last completed update (empty until the first one runs).
 	bool IsDownloading() const { return m_downloading; }
+
 	const wxString &GetLastResult() const { return m_lastResult; }
 
 	// Optional hook so a GUI front-end can surface a *manual* update
@@ -106,6 +126,24 @@ public:
 	}
 
 private:
+	// Drop every memoised resolution. Called wherever the answer could change
+	// underneath the cache: enable and disable, which between them also cover a
+	// completed database refresh (DownloadFinished routes through both).
+	// Without this a headless daemon is the worst case -- entries resolved
+	// while GeoIP was off would stay empty forever, with no repaint to force a
+	// re-read and nobody watching to notice.
+	void InvalidateCountryCache();
+
+	// Numeric IP -> ISO code. Bounded: peers churn, so an unbounded map on a
+	// long-lived daemon would grow without limit. On overflow the whole map is
+	// dropped rather than evicting cleverly -- a rebuild costs one lookup per
+	// live peer, which is what a single poll cost before this existed.
+	//
+	// Not synchronised. Like the rest of this class it is touched from the main
+	// thread only; a concurrent reader during a clear() would be a race.
+	std::unordered_map<uint32, wxString> m_countryCache;
+	static const size_t kMaxCountryCacheEntries = 8192;
+
 	CMaxMindDBDatabase *m_db;
 	wxString m_DataBaseName;
 	wxString m_DataBasePath;

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -355,6 +355,16 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, long column) const
 	}
 }
 
+// Gated with its only caller (OnGetItemColumnImage below): this reaches
+// theApp->GetCountryFlags(), which only exists under GEOIP_GUI, so compiling it
+// unconditionally broke the monolithic build at -DENABLE_IP2COUNTRY=NO.
+//
+// Only the definition is gated, not the declaration: GEOIP_GUI is #defined in
+// amule.h, which this file includes but ServerListCtrl.h does not -- so the
+// header cannot see the macro and gating it there would compile the
+// declaration out from under this definition. A member function that is
+// declared, never called and never defined is fine.
+#ifdef GEOIP_GUI
 int CServerListCtrl::FlagImage(const wxString &code) const
 {
 	const auto it = m_flagImages.find(code);
@@ -383,6 +393,7 @@ int CServerListCtrl::FlagImage(const wxString &code) const
 	m_flagImages[code] = index;
 	return index;
 }
+#endif // GEOIP_GUI
 
 int CServerListCtrl::OnGetItemColumnImage(long item, long column) const
 {
@@ -395,7 +406,7 @@ int CServerListCtrl::OnGetItemColumnImage(long item, long column) const
 	const CServer *server = reinterpret_cast<const CServer *>(ItemAt(item));
 	wxString code;
 	if (GetDisplayCountryCode(
-		    server->IsCountryFromCore(), server->GetCountryCode(), server->GetFullIP(), code) &&
+		    server->IsCountryFromCore(), server->GetCountryCode(), server->GetIP(), code) &&
 		!code.IsEmpty()) {
 		return FlagImage(code);
 	}

--- a/src/UpDownClientEC.h
+++ b/src/UpDownClientEC.h
@@ -93,6 +93,10 @@ public:
 	CFriend *GetFriend() const { return m_Friend; }
 	bool GetFriendSlot() const { return m_bFriendSlot; }
 	wxString GetFullIP() const { return Uint32toStringIP(m_dwUserIP); }
+	// Numeric counterpart, matching the core client. amulegui never resolves
+	// locally -- it takes the from-core branch in GetDisplayCountryCode -- but
+	// that helper is shared with monolithic aMule and takes the numeric form.
+	uint32 GetFullIPNumeric() const { return m_dwUserIP; }
 	uint16 GetKadPort() const { return m_nKadPort; }
 	float GetKBpsDown() const { return m_kBpsDown; }
 	uint32 GetIP() const { return m_dwUserIP; }

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -199,6 +199,11 @@ public:
 	uint32 GetIP() const { return m_dwUserIP; }
 	bool HasLowID() const { return IsLowID(m_nUserIDHybrid); }
 	wxString GetFullIP() const { return Uint32toStringIP(m_FullUserIP); }
+	// The numeric form of GetFullIP(), for callers that do not need the string.
+	// Named to be hard to confuse with it: the GeoIP resolver overloads on the
+	// argument type, so passing the string variant compiles and silently takes
+	// the uncached path.
+	uint32 GetFullIPNumeric() const { return m_FullUserIP; }
 	// Country ISO code accessors (#439). Unconditional (libmaxminddb-free) so the
 	// shared client-list drawing code compiles regardless of the resolver gate.
 	// Unused by monolithic amule, which resolves country locally via


### PR DESCRIPTION
#439 moved GeoIP resolution out of GUI paint and into the core so `amuled` could resolve country codes too. Paint hid the cost: it ran only for visible rows, only while the client list was on screen, and only with a user watching. The EC client tag now resolves **every peer on every poll** — roughly every 3 s, headless, forever — to produce a value that cannot change while the peer's IP does not.

Each call formats the IP into a string (`Uint32toStringIP` allocates), then `MMDB_lookup_string` parses it back into a sockaddr via `getaddrinfo` and walks the database.

## Measurement

Found while profiling the `EC_OP_GET_UPDATE` handler on a live daemon (1204 shared files, ~26 peers). Isolated by toggling `IP2Country` off and back on with no code change, so the two figures differ only by the lookup:

| | client tag build |
|---|---|
| GeoIP on | 20.2 µs/peer/poll |
| GeoIP off | 12.6 µs/peer/poll |

So the lookup is **~7.5 µs per peer per poll — about 37% of the client tag build**, and that build is the phase that scales with peer count. Extrapolated to a node holding several hundred peers it is milliseconds per poll, on the thread that also serves ed2k.

## Approach

Cache it in `CIP2Country`, keyed on the **numeric** IP the callers already hold, so the string form is only built on a miss.

`GetDisplayCountryCode` now takes the numeric IP as well, so the monolithic per-paint lookups in `GenericClientListCtrl` and `ServerListCtrl` take the cache too. That is a signature change at those call sites, not a free ride — the string overload is uncached and goes straight to the database, so passing the dotted form would have silently kept the old behaviour there. For the same reason the client accessor is named `GetFullIPNumeric` rather than `GetFullUserIP`: the resolver overloads on argument type, and a name one word away from `GetFullIP` would let a caller take the uncached path without any diagnostic.

**Invalidation is load-bearing, not defensive.** GeoIP can be toggled at runtime and the database can be refreshed. On a headless daemon an entry resolved while it was off would otherwise stay empty forever — there is no repaint to force a re-read and nobody watching to notice. It clears on `Enable` and `Disable`, which also covers a refresh since `DownloadFinished` routes through both.

Bounded at 8192 entries. Peers churn, so an unbounded map on a long-lived daemon grows without limit. On overflow the whole map is dropped rather than evicting by recency: an LRU would have to relink a node on every *hit* — the operation that matters — to optimise a rare event. A rebuild costs one lookup per live peer, exactly what a single poll cost before this existed.

## Also fixes an unrelated build break

Found while testing the stub path, and reproduced on unmodified master: `CServerListCtrl::FlagImage` reaches `theApp->GetCountryFlags()`, which only exists under `GEOIP_GUI`, but was compiled unconditionally. So monolithic aMule failed to build at `-DENABLE_IP2COUNTRY=NO`:

```
src/ServerListCtrl.cpp:365:32: error: no member named 'GetCountryFlags' in 'CamuleGuiApp'
```

That violates the feature-gating policy — `=NO` with the dependency present should build with the feature off. It survives because that combination is not in the CI matrix.

Only the *definition* is gated, not the declaration. `GEOIP_GUI` is `#define`d in `amule.h`, which `ServerListCtrl.cpp` includes but `ServerListCtrl.h` does not, so gating the header would compile the declaration out from under its own definition — which is what my first attempt did, breaking the GeoIP-**on** build. A member function that is declared, never called and never defined is fine.

## Verification

Builds with `ENABLE_IP2COUNTRY=YES` and `=NO`, monolithic and daemon — the stub path needed its own `GetCountryCode(uint32)` and `InvalidateCountryCache()` no-ops. 30/30 unit tests, both clang-tidy tiers and clang-format clean on the diff.

Confirmed on a production daemon: flags render correctly after toggling GeoIP off and back on, which exercises the invalidation path specifically — a stale empty string there would have looked exactly like "no GeoIP available" with nothing to force a re-read.

## Not included

The EC **server** country tags (`ECSpecialCoreTags.cpp:108`, `:134`) still use the string overload. Same argument, but N is the server count rather than the peer count, and that phase measures a flat 0.04 ms — worth a follow-up rather than widening this.

No test: the invalidation contract and the overflow clear are both testable, but only once `m_db` is injectable, which it currently is not.
