### PR TITLE
perf(ec): build a client's tags only for fields that changed

### DIFF
--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -342,14 +342,14 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 : CECTag(EC_TAG_CLIENT, client->ECID())
 {
 	// General
-	AddTag(CECTag(EC_TAG_CLIENT_NAME, client->GetUserName()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_HASH, client->GetUserHash()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_USER_ID, client->GetUserIDHybrid()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SCORE, client->GetScore()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SOFTWARE, client->GetClientSoft()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SOFT_VER_STR, client->GetSoftVerStr()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_USER_IP, client->GetIP()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_USER_PORT, client->GetUserPort()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_NAME, client->GetUserName(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_HASH, client->GetUserHash(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_USER_ID, client->GetUserIDHybrid(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SCORE, client->GetScore(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SOFTWARE, client->GetClientSoft(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SOFT_VER_STR, client->GetSoftVerStr(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_USER_IP, client->GetIP(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_USER_PORT, client->GetUserPort(), valuemap);
 #ifdef ENABLE_IP2COUNTRY
 	// Peer country ISO code resolved core-side (#439). Emitted whenever GeoIP
 	// is enabled + supported — even empty for an IP that doesn't resolve — so
@@ -359,58 +359,61 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 		// Numeric-IP overload: memoised, and it skips formatting the IP into
 		// a string on the hit path. This runs for every peer on every EC
 		// poll, and a peer's country cannot change while its IP does not.
-		AddTag(CECTag(EC_TAG_CLIENT_COUNTRY,
-			       theApp->GetIP2Country()->GetCountryCode(client->GetFullIPNumeric())),
+		// It returns a const reference, which AddDiffTag takes without a copy.
+		AddDiffTag(this,
+			EC_TAG_CLIENT_COUNTRY,
+			theApp->GetIP2Country()->GetCountryCode(client->GetFullIPNumeric()),
 			valuemap);
 	}
 #endif
-	AddTag(CECTag(EC_TAG_CLIENT_FROM, (uint64)client->GetSourceFrom()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SERVER_IP, client->GetServerIP()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SERVER_PORT, client->GetServerPort()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SERVER_NAME, client->GetServerName()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_FROM, (uint64)client->GetSourceFrom(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SERVER_IP, client->GetServerIP(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SERVER_PORT, client->GetServerPort(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SERVER_NAME, client->GetServerName(), valuemap);
 
 	// Transfers to Client
-	AddTag(CECTag(EC_TAG_CLIENT_UP_SPEED, client->GetUploadDatarate()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_UP_SPEED, client->GetUploadDatarate(), valuemap);
 	if (client->GetDownloadState() == DS_DOWNLOADING || valuemap) {
-		AddTag(CECTag(EC_TAG_CLIENT_DOWN_SPEED, (double)(client->GetKBpsDown())), valuemap);
+		AddDiffTag(this, EC_TAG_CLIENT_DOWN_SPEED, (double)(client->GetKBpsDown()), valuemap);
 	}
-	AddTag(CECTag(EC_TAG_CLIENT_UPLOAD_SESSION, client->GetSessionUp()), valuemap);
-	AddTag(CECTag(EC_TAG_PARTFILE_SIZE_XFER, client->GetTransferredDown()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_UPLOAD_TOTAL, client->GetUploadedTotal()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_DOWNLOAD_TOTAL, client->GetDownloadedTotal()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_UPLOAD_SESSION, client->GetSessionUp(), valuemap);
+	AddDiffTag(this, EC_TAG_PARTFILE_SIZE_XFER, client->GetTransferredDown(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_UPLOAD_TOTAL, client->GetUploadedTotal(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_DOWNLOAD_TOTAL, client->GetDownloadedTotal(), valuemap);
 
-	AddTag(CECTag(EC_TAG_CLIENT_UPLOAD_STATE, client->GetUploadState()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_DOWNLOAD_STATE, client->GetDownloadState()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_IDENT_STATE, (uint64)client->GetCurrentIdentState()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_EXT_PROTOCOL, client->ExtProtocolAvailable()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_UPLOAD_STATE, client->GetUploadState(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_DOWNLOAD_STATE, client->GetDownloadState(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_IDENT_STATE, (uint64)client->GetCurrentIdentState(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_EXT_PROTOCOL, client->ExtProtocolAvailable(), valuemap);
 	// These are not needed atm. Keep them for now, maybe columns get reintroduced in client view.
 	// AddTag(CECTag(EC_TAG_CLIENT_WAIT_TIME, client->GetWaitTime()), valuemap);
 	// AddTag(CECTag(EC_TAG_CLIENT_XFER_TIME, client->GetUpStartTimeDelay()), valuemap);
 	// AddTag(CECTag(EC_TAG_CLIENT_QUEUE_TIME, (uint64)(::GetTickCount() - client->GetWaitStartTime())),
 	// valuemap); AddTag(CECTag(EC_TAG_CLIENT_LAST_TIME, (uint64)(::GetTickCount() -
 	// client->GetLastUpRequest())), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_WAITING_POSITION, client->GetUploadQueueWaitingPosition()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_REMOTE_QUEUE_RANK,
-		       client->IsRemoteQueueFull() ? (uint16)0xffff : client->GetRemoteQueueRank()),
+	AddDiffTag(this, EC_TAG_CLIENT_WAITING_POSITION, client->GetUploadQueueWaitingPosition(), valuemap);
+	AddDiffTag(this,
+		EC_TAG_CLIENT_REMOTE_QUEUE_RANK,
+		client->IsRemoteQueueFull() ? (uint16)0xffff : client->GetRemoteQueueRank(),
 		valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_OLD_REMOTE_QUEUE_RANK, client->GetOldRemoteQueueRank()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_OBFUSCATION_STATUS, client->GetObfuscationStatus()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_KAD_PORT, client->GetKadPort()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_FRIEND_SLOT, client->GetFriendSlot()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_OLD_REMOTE_QUEUE_RANK, client->GetOldRemoteQueueRank(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_OBFUSCATION_STATUS, client->GetObfuscationStatus(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_KAD_PORT, client->GetKadPort(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_FRIEND_SLOT, client->GetFriendSlot(), valuemap);
 
 	if (detail_level == EC_DETAIL_UPDATE) {
 		return;
 	}
 	const CKnownFile *file = client->GetUploadFile();
 	if (file) {
-		AddTag(CECTag(EC_TAG_PARTFILE_NAME, file->GetFileName().GetPrintable()), valuemap);
+		AddDiffTag(this, EC_TAG_PARTFILE_NAME, file->GetFileName().GetPrintable(), valuemap);
 		AddTag(CECTag(EC_TAG_CLIENT_UPLOAD_FILE, file->ECID()), valuemap);
 	} else {
 		AddTag(CECIntTag(EC_TAG_CLIENT_UPLOAD_FILE, 0), valuemap);
 	}
 	const CPartFile *pfile = client->GetRequestFile();
-	AddTag(CECTag(EC_TAG_CLIENT_REQUEST_FILE, pfile ? pfile->ECID() : 0), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_REMOTE_FILENAME, client->GetClientFilename()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_REQUEST_FILE, pfile ? pfile->ECID() : 0, valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_REMOTE_FILENAME, client->GetClientFilename(), valuemap);
 
 	if (detail_level != EC_DETAIL_INC_UPDATE) {
 		return;
@@ -418,13 +421,13 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 	// Friend status + DL/UP modifier (issue #423). IsFriend() is the
 	// friends-list membership (distinct from the FRIEND_SLOT reserved
 	// upload slot above); GetScoreRatio() is the GUI "DL/UP modifier".
-	AddTag(CECTag(EC_TAG_CLIENT_IS_FRIEND, client->IsFriend()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_SCORE_RATIO, (double)client->GetScoreRatio()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_DISABLE_VIEW_SHARED, client->HasDisabledSharedFiles()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_VERSION, client->GetVersion()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_MOD_VERSION, client->GetClientModString()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_OS_INFO, client->GetClientOSInfo()), valuemap);
-	AddTag(CECTag(EC_TAG_CLIENT_AVAILABLE_PARTS, client->GetAvailablePartCount()), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_IS_FRIEND, client->IsFriend(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_SCORE_RATIO, (double)client->GetScoreRatio(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_DISABLE_VIEW_SHARED, client->HasDisabledSharedFiles(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_VERSION, client->GetVersion(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_MOD_VERSION, client->GetClientModString(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_OS_INFO, client->GetClientOSInfo(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_AVAILABLE_PARTS, client->GetAvailablePartCount(), valuemap);
 	if (pfile) {
 		const BitVector &partStatus = client->GetPartStatus();
 		if (partStatus.size() == pfile->GetPartCount()) {
@@ -438,7 +441,7 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 					valuemap);
 			}
 		}
-		AddTag(CECTag(EC_TAG_CLIENT_NEXT_REQUESTED_PART, client->GetNextRequestedPart()), valuemap);
+		AddDiffTag(this, EC_TAG_CLIENT_NEXT_REQUESTED_PART, client->GetNextRequestedPart(), valuemap);
 		AddTag(CECTag(EC_TAG_CLIENT_LAST_DOWNLOADING_PART, client->GetLastDownloadingPart()),
 			valuemap);
 	}

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -74,7 +74,7 @@ class CValueMap
 	std::map<ec_tagname_t, CECTag> m_map_tag;
 
 	template <class T>
-	void CreateTagT(ec_tagname_t tagname, T value, std::map<ec_tagname_t, T> &map, CECTag *parent)
+	void CreateTagT(ec_tagname_t tagname, const T &value, std::map<ec_tagname_t, T> &map, CECTag *parent)
 	{
 		if ((map.count(tagname) == 0) || (map[tagname] != value)) {
 			parent->AddTag(CECTag(tagname, value));
@@ -119,12 +119,12 @@ public:
 		CreateTagT<uint64>(tagname, value, m_map_uint64, parent);
 	}
 
-	void CreateTag(ec_tagname_t tagname, CMD4Hash value, CECTag *parent)
+	void CreateTag(ec_tagname_t tagname, const CMD4Hash &value, CECTag *parent)
 	{
 		CreateTagT<CMD4Hash>(tagname, value, m_map_md4, parent);
 	}
 
-	void CreateTag(ec_tagname_t tagname, CUInt128 value, CECTag *parent)
+	void CreateTag(ec_tagname_t tagname, const CUInt128 &value, CECTag *parent)
 	{
 		CreateTagT<CUInt128>(tagname, value, m_map_uint128, parent);
 	}
@@ -143,7 +143,9 @@ public:
 		CreateTagT<double>(tagname, value, m_map_double, parent);
 	}
 
-	void CreateTag(ec_tagname_t tagname, wxString value, CECTag *parent)
+	// By const reference: wxString copies allocate, and the callers hand us
+	// values straight from getters that already return a reference.
+	void CreateTag(ec_tagname_t tagname, const wxString &value, CECTag *parent)
 	{
 		CreateTagT<wxString>(tagname, value, m_map_string, parent);
 	}
@@ -183,7 +185,7 @@ public:
 // them for the same tag means neither sees the other's last value and a change
 // can be suppressed -- a field that silently stops updating in the GUI.
 template <typename T>
-inline void AddDiffTag(CECTag *parent, ec_tagname_t tagname, T value, CValueMap *valuemap)
+inline void AddDiffTag(CECTag *parent, ec_tagname_t tagname, const T &value, CValueMap *valuemap)
 {
 	if (valuemap) {
 		valuemap->CreateTag(tagname, value, parent);

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -69,6 +69,8 @@ class CValueMap
 	std::map<ec_tagname_t, CMD4Hash> m_map_md4;
 	std::map<ec_tagname_t, CUInt128> m_map_uint128;
 	std::map<ec_tagname_t, wxString> m_map_string;
+	std::map<ec_tagname_t, double> m_map_double;
+	std::map<ec_tagname_t, bool> m_map_bool;
 	std::map<ec_tagname_t, CECTag> m_map_tag;
 
 	template <class T>
@@ -92,6 +94,8 @@ public:
 		m_map_md4 = valuemap.m_map_md4;
 		m_map_uint128 = valuemap.m_map_uint128;
 		m_map_string = valuemap.m_map_string;
+		m_map_double = valuemap.m_map_double;
+		m_map_bool = valuemap.m_map_bool;
 		m_map_tag = valuemap.m_map_tag;
 	}
 
@@ -125,6 +129,20 @@ public:
 		CreateTagT<CUInt128>(tagname, value, m_map_uint128, parent);
 	}
 
+	// bool has its own CECTag constructor, so it needs its own overload here
+	// too -- without it a bool argument is ambiguous across the integer
+	// overloads, and picking one of those by cast would change the tag's wire
+	// type and break every client that reads it.
+	void CreateTag(ec_tagname_t tagname, bool value, CECTag *parent)
+	{
+		CreateTagT<bool>(tagname, value, m_map_bool, parent);
+	}
+
+	void CreateTag(ec_tagname_t tagname, double value, CECTag *parent)
+	{
+		CreateTagT<double>(tagname, value, m_map_double, parent);
+	}
+
 	void CreateTag(ec_tagname_t tagname, wxString value, CECTag *parent)
 	{
 		CreateTagT<wxString>(tagname, value, m_map_string, parent);
@@ -144,6 +162,35 @@ public:
 
 	void ForgetTag(ec_tagname_t tagname) { m_map_tag.erase(tagname); }
 };
+
+// Add `value` under `tagname` to `parent`, letting the value map decide whether
+// it changed -- and constructing the CECTag only if it did.
+//
+// The difference from `parent->AddTag(CECTag(tagname, value), valuemap)` is
+// where the work happens. That form builds the tag first (calling the getter,
+// copying the string, allocating the tag) and only then asks the map whether it
+// was needed, discarding it if not; it also caches whole CECTag objects. This
+// form compares the raw value against a typed cache and builds nothing when it
+// is unchanged. On the client list -- rebuilt in full on every EC poll, where
+// most fields of most peers are static -- that is the difference between
+// paying for every field of every peer and paying only for what moved.
+//
+// `valuemap` may be NULL: callers that are not doing an incremental update pass
+// nothing, and then every tag is emitted unconditionally.
+//
+// A given tagname must be written through ONE of the two forms consistently.
+// They keep separate caches (typed maps here, `m_map_tag` there), so mixing
+// them for the same tag means neither sees the other's last value and a change
+// can be suppressed -- a field that silently stops updating in the GUI.
+template <typename T>
+inline void AddDiffTag(CECTag *parent, ec_tagname_t tagname, T value, CValueMap *valuemap)
+{
+	if (valuemap) {
+		valuemap->CreateTag(tagname, value, parent);
+	} else {
+		parent->AddTag(CECTag(tagname, value));
+	}
+}
 
 class CEC_Category_Tag : public CECTag
 {

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -76,10 +76,20 @@ class CValueMap
 	template <class T>
 	void CreateTagT(ec_tagname_t tagname, const T &value, std::map<ec_tagname_t, T> &map, CECTag *parent)
 	{
-		if ((map.count(tagname) == 0) || (map[tagname] != value)) {
-			parent->AddTag(CECTag(tagname, value));
-			map[tagname] = value;
+		// One probe, not two. The unchanged path is the common one -- it is the
+		// reason this function exists -- and count()+operator[] walked the tree
+		// twice for it, plus a third time to assign on a change. lower_bound
+		// doubles as the insertion hint on a miss.
+		const typename std::map<ec_tagname_t, T>::iterator it = map.lower_bound(tagname);
+		if (it != map.end() && it->first == tagname) {
+			if (it->second != value) {
+				parent->AddTag(CECTag(tagname, value));
+				it->second = value;
+			}
+			return;
 		}
+		parent->AddTag(CECTag(tagname, value));
+		map.insert(it, std::pair<const ec_tagname_t, T>(tagname, value));
 	}
 
 public:
@@ -128,6 +138,25 @@ public:
 	{
 		CreateTagT<CUInt128>(tagname, value, m_map_uint128, parent);
 	}
+
+	// String literals must not reach the bool overload. `const char*` -> bool is
+	// a standard conversion and beats the user-defined one to wxString, so
+	// without these a literal would emit a BOOL tag through the value map and a
+	// STRING tag through the plain CECTag path (which has both pointer
+	// constructors) -- the same call site producing a different wire type on an
+	// incremental update than on a full request. No current caller passes one;
+	// these exist so that none ever can.
+	void CreateTag(ec_tagname_t tagname, const char *value, CECTag *parent)
+	{
+		CreateTag(tagname, wxString(value), parent);
+	}
+
+#ifdef USE_WX_EXTENSIONS
+	void CreateTag(ec_tagname_t tagname, const wxChar *value, CECTag *parent)
+	{
+		CreateTag(tagname, wxString(value), parent);
+	}
+#endif
 
 	// bool has its own CECTag constructor, so it needs its own overload here
 	// too -- without it a bool argument is ambiguous across the integer

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -21,6 +21,41 @@ target_link_libraries (CTagTest
 	muleunit
 )
 
+# CValueMap is the incremental-update filter behind every EC tag that carries a
+# value map. Its failure mode is silence -- a field wrongly judged unchanged
+# just stops updating in the GUI -- so the contract is pinned here rather than
+# left to a clean daemon run. Needs no app, no daemon and no database: the EC
+# tag types and their generated codes are the whole dependency.
+add_executable (CValueMapTest
+	CValueMapTest.cpp
+	# LoggerConsole.cpp provides the no-op DoECLogLine + theLogger symbols that
+	# libec.a's Debug build references unconditionally (ECPacket / ECSocket /
+	# ECTag debug-print paths). Release preprocesses those calls to
+	# `do {} while(0)` via the ECLog.h define, so the symbols are unused there
+	# and only the Debug matrix entries fail to link. Same reason RefresherTest
+	# pulls this TU in.
+	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+)
+
+add_test (NAME CValueMapTest
+	COMMAND CValueMapTest
+)
+
+target_include_directories (CValueMapTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs/ec/cpp
+)
+
+target_link_libraries (CValueMapTest
+	muleunit
+	ec
+	mulecommon
+)
+
 add_executable (CUInt128Test
 	CUInt128Test.cpp
 	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp

--- a/unittests/tests/CValueMapTest.cpp
+++ b/unittests/tests/CValueMapTest.cpp
@@ -1,0 +1,240 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// CValueMap is the incremental-update filter behind every EC tag that carries
+// a value map: it decides whether a field has changed since the last response
+// to this client, and only then does the tag get built and emitted.
+//
+// Its failure mode is silence. A field that is wrongly judged unchanged simply
+// stops updating in the GUI -- no crash, no log line, nothing a build or a
+// clean daemon run would catch. These tests pin the contract instead.
+
+#include <muleunit/test.h>
+
+#include <ec/cpp/ECSpecialTags.h>
+
+using namespace muleunit;
+
+namespace
+{
+// Children of a throwaway parent: CreateTag appends to whatever it is given,
+// so the child count is the observable "did this get emitted".
+size_t EmittedCount(const CECTag &parent)
+{
+	return parent.GetTagCount();
+}
+} // namespace
+
+DECLARE_SIMPLE(CValueMapTest)
+
+TEST(CValueMapTest, FirstValueIsAlwaysEmitted)
+{
+	CValueMap vm;
+	CECEmptyTag parent(1);
+	vm.CreateTag(100, (uint32)42, &parent);
+	ASSERT_EQUALS((size_t)1, EmittedCount(parent));
+}
+
+TEST(CValueMapTest, UnchangedValueIsSuppressed)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, (uint32)42, &first);
+	ASSERT_EQUALS((size_t)1, EmittedCount(first));
+
+	// Same value again: nothing should reach the second parent.
+	CECEmptyTag second(1);
+	vm.CreateTag(100, (uint32)42, &second);
+	ASSERT_EQUALS((size_t)0, EmittedCount(second));
+}
+
+TEST(CValueMapTest, ChangedValueIsEmittedAgain)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, (uint32)42, &first);
+
+	CECEmptyTag second(1);
+	vm.CreateTag(100, (uint32)43, &second);
+	ASSERT_EQUALS((size_t)1, EmittedCount(second));
+
+	// And the new value is what is now remembered, not the original.
+	CECEmptyTag third(1);
+	vm.CreateTag(100, (uint32)43, &third);
+	ASSERT_EQUALS((size_t)0, EmittedCount(third));
+}
+
+TEST(CValueMapTest, StringsRoundTripThroughTheirOwnCache)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, wxString(wxT("alpha")), &first);
+	ASSERT_EQUALS((size_t)1, EmittedCount(first));
+
+	CECEmptyTag second(1);
+	vm.CreateTag(100, wxString(wxT("alpha")), &second);
+	ASSERT_EQUALS((size_t)0, EmittedCount(second));
+
+	CECEmptyTag third(1);
+	vm.CreateTag(100, wxString(wxT("beta")), &third);
+	ASSERT_EQUALS((size_t)1, EmittedCount(third));
+}
+
+// bool needs its own overload to resolve ambiguity -- without it a bool
+// argument is ambiguous across uint8/16/32/64 and does not compile. It is NOT
+// a wire-format concern: CECTag(name, bool) calls InitInt() exactly as
+// CECTag(name, uint8) does, so folding it into the integer overload would
+// produce an identical tag. Only the caching behaviour is observable here, so
+// that is all this asserts.
+TEST(CValueMapTest, BoolCachesSeparatelyFromItsValue)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, true, &first);
+	ASSERT_EQUALS((size_t)1, EmittedCount(first));
+	ASSERT_EQUALS((uint64_t)1, first.GetFirstTagSafe()->GetInt());
+
+	CECEmptyTag second(1);
+	vm.CreateTag(100, true, &second);
+	ASSERT_EQUALS((size_t)0, EmittedCount(second));
+
+	CECEmptyTag third(1);
+	vm.CreateTag(100, false, &third);
+	ASSERT_EQUALS((size_t)1, EmittedCount(third));
+	ASSERT_EQUALS((uint64_t)0, third.GetFirstTagSafe()->GetInt());
+}
+
+// double is a genuine value concern, unlike bool: routed through an integer
+// overload the fractional part is lost, so the round-trip is what this asserts
+// rather than the emit counts alone.
+TEST(CValueMapTest, DoubleKeepsItsFractionalPart)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, 1.5, &first);
+	ASSERT_EQUALS((size_t)1, EmittedCount(first));
+	ASSERT_EQUALS(1.5, first.GetFirstTagSafe()->GetDoubleData());
+
+	CECEmptyTag second(1);
+	vm.CreateTag(100, 1.5, &second);
+	ASSERT_EQUALS((size_t)0, EmittedCount(second));
+
+	// 1.5 and 2.5 would both truncate to different ints, so also check a pair
+	// that collides under truncation: 1.5 -> 1 and 1.25 -> 1.
+	CECEmptyTag third(1);
+	vm.CreateTag(100, 1.25, &third);
+	ASSERT_EQUALS((size_t)1, EmittedCount(third));
+	ASSERT_EQUALS(1.25, third.GetFirstTagSafe()->GetDoubleData());
+}
+
+// A string literal must not reach the bool overload. `const char*` -> bool is a
+// standard conversion and beats the user-defined one to wxString, so without an
+// explicit pointer overload this would emit a boolean tag here while the plain
+// CECTag path -- which has its own pointer constructors -- emitted a string one.
+TEST(CValueMapTest, StringLiteralDoesNotBecomeABool)
+{
+	CValueMap vm;
+	CECEmptyTag parent(1);
+	vm.CreateTag(100, "n/a", &parent);
+	ASSERT_EQUALS((size_t)1, EmittedCount(parent));
+	ASSERT_EQUALS(wxString(wxT("n/a")), parent.GetFirstTagSafe()->GetStringData());
+}
+
+// Distinct tag names never share a slot, even at the same value.
+TEST(CValueMapTest, DifferentTagsAreIndependent)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, (uint32)42, &first);
+	vm.CreateTag(101, (uint32)42, &first);
+	ASSERT_EQUALS((size_t)2, EmittedCount(first));
+
+	CECEmptyTag second(1);
+	vm.CreateTag(100, (uint32)42, &second);
+	vm.CreateTag(101, (uint32)99, &second);
+	ASSERT_EQUALS((size_t)1, EmittedCount(second));
+}
+
+// AddDiffTag has two branches -- value map present, and absent for callers not
+// doing an incremental update -- and the design rests on them producing the
+// same tag. The bug this file was written for lived exactly there: a string
+// literal took the bool overload through the map and the const char*
+// constructor without it, so one call site emitted different wire types on an
+// incremental update than on a full request.
+TEST(CValueMapTest, AddDiffTagBranchesAgreeOnLiterals)
+{
+	CValueMap vm;
+	CECEmptyTag viaMap(1);
+	CECEmptyTag viaDirect(1);
+	AddDiffTag(&viaMap, 100, "n/a", &vm);
+	AddDiffTag(&viaDirect, 100, "n/a", nullptr);
+
+	ASSERT_EQUALS((size_t)1, EmittedCount(viaMap));
+	ASSERT_EQUALS((size_t)1, EmittedCount(viaDirect));
+	ASSERT_EQUALS(viaDirect.GetFirstTagSafe()->IsString(), viaMap.GetFirstTagSafe()->IsString());
+	ASSERT_TRUE(viaMap.GetFirstTagSafe()->IsString());
+	ASSERT_EQUALS(
+		viaDirect.GetFirstTagSafe()->GetStringData(), viaMap.GetFirstTagSafe()->GetStringData());
+}
+
+TEST(CValueMapTest, AddDiffTagBranchesAgreeOnStrings)
+{
+	CValueMap vm;
+	CECEmptyTag viaMap(1);
+	CECEmptyTag viaDirect(1);
+	AddDiffTag(&viaMap, 100, wxString(wxT("alpha")), &vm);
+	AddDiffTag(&viaDirect, 100, wxString(wxT("alpha")), nullptr);
+
+	ASSERT_EQUALS(viaDirect.GetFirstTagSafe()->IsString(), viaMap.GetFirstTagSafe()->IsString());
+	ASSERT_EQUALS(
+		viaDirect.GetFirstTagSafe()->GetStringData(), viaMap.GetFirstTagSafe()->GetStringData());
+}
+
+// Without a value map every call emits, incremental filtering being the map's
+// whole job -- so a NULL-map caller must never be silently suppressed.
+TEST(CValueMapTest, AddDiffTagWithoutMapAlwaysEmits)
+{
+	CECEmptyTag parent(1);
+	AddDiffTag(&parent, 100, (uint32)42, nullptr);
+	AddDiffTag(&parent, 100, (uint32)42, nullptr);
+	ASSERT_EQUALS((size_t)2, EmittedCount(parent));
+}
+
+// The hazard that keeps EC_TAG_CLIENT_UPLOAD_FILE on the old path: one tag name
+// written through two different types keeps two independent caches, so neither
+// sees the other's last value and a transition between them is not suppressed.
+// Documented in the PR; executable here so converting that site later fails.
+TEST(CValueMapTest, OneTagNameAcrossTwoTypesKeepsSeparateCaches)
+{
+	CValueMap vm;
+	CECEmptyTag first(1);
+	vm.CreateTag(100, (uint32)1, &first);
+	ASSERT_EQUALS((size_t)1, EmittedCount(first));
+
+	// Same name, same numeric value, different type: a shared cache would
+	// suppress this. Separate caches must emit it.
+	CECEmptyTag second(1);
+	vm.CreateTag(100, true, &second);
+	ASSERT_EQUALS((size_t)1, EmittedCount(second));
+}


### PR DESCRIPTION
The client list is rebuilt in full on every EC poll. Each field went through `AddTag(CECTag(name, value), valuemap)`, which **constructs the tag first** — calling the getter, copying the string, allocating the tag — and only then asks the value map whether it was needed, discarding it if not. The diff suppressed the field from the wire but not the work, and that work was identical whether a peer was idle or saturating the link.

`CValueMap` already had the other form. `CreateTag` compares the raw value against a typed cache and builds a `CECTag` only when it differs. It was simply unused: **all 56** value-map call sites in `ECSpecialCoreTags.cpp` took the build-then-discard path, none took this one.

This routes the client tag's fields through it, takes the values by reference rather than by copy, and reduces `CreateTagT` to a single map probe.

## Measurement

A microbenchmark of the client tag shape — 37 fields, mixed scalars and strings, re-emitted every poll with a few actually moving — against the real `CValueMap`:

| | 3 of 37 changing | 10 of 37 changing |
|---|---|---|
| build-then-discard | 3.42 µs/peer/poll | 3.25 µs |
| **this branch** | **0.48 µs** | **0.78 µs** |

A microbenchmark rather than field data, deliberately. This ran on a production daemon in the same window as the GeoIP cache (#771) and the two cannot be separated there

Three things account for the difference. Not building the tag when the value is unchanged is the bulk of it. Taking values by reference matters more than it looks: `CreateTagT`, the `wxString`/`CMD4Hash`/`CUInt128` overloads and the helper all took their argument by copy, so each string field paid a copy into the helper and a second into `CreateTag` where the original paid one into the tag — some getters return a `const` reference (`GetUserName`, `GetSoftVerStr`, `GetClientFilename`) and were copied outright, others return by value (`GetServerName`, `GetFileName().GetPrintable()`) where `const T&` binds the temporary instead. Integer overloads stay by value: a reference to a `uint8` buys nothing and costs an indirection. Finally `CreateTagT` probed the map twice on the unchanged path — `count()` then `operator[]`, and three times on a change — where one `lower_bound` now serves as both probe and insertion hint.

It also cuts the number of whole `CECTag` objects held in `m_map_tag`, which caches a field's data buffer per peer. Four tags in the client builder still take that path — `UPLOAD_FILE`, `PART_STATUS`, `UPLOAD_PART_STATUS`, `LAST_DOWNLOADING_PART` — so this is reduced, not eliminated.

## Details that would otherwise change behaviour

**`bool` and `double` need their own `CreateTag` overloads, for different reasons.** `bool` resolves ambiguity — without it a `bool` argument is ambiguous across the integer overloads and does not compile. It is *not* a wire-format concern: `CECTag(name, bool)` calls `InitInt()` exactly as `CECTag(name, uint8)` does, so folding it into an integer overload would produce an identical tag. `double` is a genuine value concern — routed through an integer overload it loses its fractional part.

**A string literal must not reach the `bool` overload.** `CreateTag` had no pointer overload, and `const char*` to `bool` is a standard conversion that beats the user-defined one to `wxString`. A literal would therefore have bound to `bool` through the value map while the plain `CECTag` path — which has its own `const char*` and `const wxChar*` constructors — built a string tag, so one call site would carry a different wire type on an incremental update than on a full request. No caller passes a literal today, which is precisely why nothing caught it; the overloads now forward to `wxString` so none ever can.

**`EC_TAG_CLIENT_UPLOAD_FILE` deliberately stays on the old path.** It is written from two branches, one a file ECID and the other a `CECIntTag` zero. The two forms keep separate caches — typed maps here, `m_map_tag` there — so converting one would leave neither seeing the other's last value, and a transition between the branches could be suppressed. The field would freeze in the GUI.

`ForgetTag` only clears `m_map_tag` and so would not reach the typed caches, but it has no callers anywhere in the tree.

## Testing

`CValueMapTest` is new, and pins the contract this change alters. `CValueMap` needs no app, daemon or database — the EC tag types are the whole dependency — and its failure mode is silence: a field wrongly judged unchanged simply stops updating in the GUI, with no crash and no log line for CI or a clean daemon run to catch.

Twelve cases. Beyond the basics (emit on first, suppress on same, emit on change, per-type caches, tag independence), three cover the hazards above: the two branches of `AddDiffTag` producing the same tag, since that divergence is where the literal bug lived; a string literal staying a string; and one tag name written through two types keeping separate caches, which turns the `EC_TAG_CLIENT_UPLOAD_FILE` rationale into something that fails if someone converts it later.

Each of those was checked by mutation rather than assumed. Folding `double` through the integer cache fails `DoubleKeepsItsFractionalPart`; breaking the value-map-absent branch fails both `AddDiffTag` equivalence cases; removing the pointer overload fails the literal case. All restore to green.

## Verification

Builds clean in Debug and Release, 31/31 unit tests, both clang-tidy tiers and clang-format clean on the diff.

Run on a production daemon for roughly an hour alongside the GeoIP cache, with the peer list watched for stale entries — the specific risk being the cache split described above, which would present as a field that silently stops updating rather than as a crash. None observed.

## Not included

The EC **server** country tags (`ECSpecialCoreTags.cpp:108`, `:134`) still use the string overload. Same argument, but N is the server count rather than the peer count, and that phase measures a flat 0.04 ms — a follow-up rather than a reason to widen this.
