### PR TITLE
perf(gui): poll the remote GUI's active page every ~1 s instead of ~3 s

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -858,7 +858,7 @@ void CamuleRemoteGuiApp::BeginReconnect()
 			knownfiles->ArmReconnectReconcile();
 		}
 		if (poll_timer) {
-			poll_timer->Start(1000);
+			poll_timer->Start(EC_POLL_INTERVAL_MS);
 		}
 		if (amuledlg) {
 			amuledlg->StartGuiTimer();
@@ -1003,7 +1003,7 @@ void CamuleRemoteGuiApp::Startup()
 	knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
 
 	// Start the Poll Timer
-	poll_timer->Start(1000);
+	poll_timer->Start(EC_POLL_INTERVAL_MS);
 	amuledlg->StartGuiTimer();
 
 	// Drain any pre-connect URL queued by ProtocolHandler_QueueSchemeLink

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -347,18 +347,13 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 	}
 
 	switch (request_step) {
-	case 0:
-		// We used to update the connection state here, but that's done with the stats in the next
-		// step now.
-		request_step++;
-		break;
-	case 1: {
+	case 0: {
 		CECPacket stats_req(EC_OP_STAT_REQ, EC_DETAIL_INC_UPDATE);
 		m_connect->SendRequest(&m_stats_updater, &stats_req);
 		request_step++;
 		break;
 	}
-	case 2:
+	case 1:
 		if (amuledlg->m_sharedfileswnd->IsShown() || amuledlg->m_chatwnd->IsShown() ||
 			amuledlg->m_serverwnd->IsShown()) {
 			// update downloads, shared files and servers
@@ -368,7 +363,7 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			// "Server Info" sub-panel reaches feature parity with
 			// the monolithic build. ed2k server messages are bursty
 			// (one-off on connect, the occasional ID-change notice,
-			// disconnect) so the natural ~3 s cadence of step 2 is
+			// disconnect) so the natural cadence of the page step is
 			// plenty.
 			if (amuledlg->m_serverwnd->IsShown()) {
 				CECPacket srvinfo_req(EC_OP_GET_SERVERINFO);

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -639,7 +639,7 @@ class CSearchListRem : public CRemoteContainer<CSearchFile, uint32, CEC_SearchFi
 	//
 	// Absence-implies-deletion forced the daemon to re-send every result of
 	// every open search on every poll just to say "still here" -- with two
-	// finished searches and ~900 results that measured 12 KB every 3 s, of
+	// finished searches and ~900 results that measured 12 KB per poll, of
 	// which none carried a single changed field. With removal made explicit
 	// the daemon can skip an unchanged result entirely, and an idle search
 	// costs nothing.
@@ -874,16 +874,22 @@ public:
 	uint32 GetPeakConnections() { return m_peak_connections; }
 };
 
-// Tick of the remote GUI's poll timer. The handler walks a three-step
-// round-robin, so any one step -- stats, or a page's data -- comes round every
-// three ticks, i.e. ~1.5 s. Requests are incremental updates against the
-// daemon's value maps, so a shorter tick costs a near-empty reply when nothing
-// moved rather than a proportionally larger one.
+// Tick of the remote GUI's poll timer. The handler alternates between two
+// steps -- the stats request, then the active page's data -- so either comes
+// round every two ticks, i.e. ~1 s. Requests are incremental updates against
+// the daemon's value maps, so a shorter tick costs a near-empty reply when
+// nothing moved rather than a proportionally larger one.
+//
+// The round-robin is what keeps at most one step's worth of requests on the
+// wire per tick, and it pauses rather than skips under back-pressure: the
+// fifo-full early return happens before the switch, so the step index does not
+// advance and the cycle resumes where it stopped instead of firing everything
+// that came due while the link was stalled.
 #define EC_POLL_INTERVAL_MS 500
 
 // How long the remote GUI waits for a reply before deciding the EC connection
 // is dead. Generous on purpose: a healthy link answers in single-digit
-// milliseconds, and the poll cycle is ~1.5 s, so 30 s cannot be reached by a
+// milliseconds, and the poll cycle is ~1 s, so 30 s cannot be reached by a
 // merely busy daemon -- only by one that has stopped answering entirely.
 #define EC_REPLY_TIMEOUT_MS 30000
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -874,9 +874,16 @@ public:
 	uint32 GetPeakConnections() { return m_peak_connections; }
 };
 
+// Tick of the remote GUI's poll timer. The handler walks a three-step
+// round-robin, so any one step -- stats, or a page's data -- comes round every
+// three ticks, i.e. ~1.5 s. Requests are incremental updates against the
+// daemon's value maps, so a shorter tick costs a near-empty reply when nothing
+// moved rather than a proportionally larger one.
+#define EC_POLL_INTERVAL_MS 500
+
 // How long the remote GUI waits for a reply before deciding the EC connection
 // is dead. Generous on purpose: a healthy link answers in single-digit
-// milliseconds, and the poll cycle is ~3 s, so 30 s cannot be reached by a
+// milliseconds, and the poll cycle is ~1.5 s, so 30 s cannot be reached by a
 // merely busy daemon -- only by one that has stopped answering entirely.
 #define EC_REPLY_TIMEOUT_MS 30000
 


### PR DESCRIPTION
The remote GUI's poll handler walks a round-robin, one step per timer tick. At a 1000 ms tick across three steps, any one step — the stats request, or the active page's data — came round only every ~3 s. Two changes bring that to ~1 s: the tick halves to 500 ms, and the round-robin loses a step that did nothing.

**The dead step.** The first case's body went away in 255dd9510, which stopped requesting the connection state once the stats packet began carrying it. The empty case survived as a spacer, and its own comment has said so ever since. A step that sends nothing still costs a full tick, so a third of every cycle was spent waiting.

**Why the tick had to move at all.** The handler only runs on a tick boundary, so a wall-clock guard can only round up to the next one — on a 1000 ms tick the achievable intervals are 1000, 2000, 3000 and nothing between. The tick is the scheduling quantum, so reaching sub-2 s meant lowering it regardless of how the steps are scheduled.

**Why this is affordable now.** The cadence was set when each poll rebuilt its whole subject — a full client or file list every time, whatever had changed. Requests are now incremental updates against the daemon's value maps (#758, #771, #772), so a poll with nothing to report costs a near-empty reply rather than a proportionally larger one.

That said, this is a **3× increase in poll rate** for the stats and page requests, and it should be read as one. The wire volume stays near zero while idle, but the daemon-side cost of serving `EC_OP_GET_UPDATE` does not shrink with the reply — it still walks the file and client lists to compute the diff. Measured on a production daemon (1204 shared files, ~26 peers) that phase runs 0.34–2.05 ms, so at 1 Hz it is roughly 0.03–0.2% of a core, against 3× less than that before. The preceding optimisations are what make that trade sensible; without them this would have tripled a materially larger number.

**What does not change.** Two parts of the handler carry their own wall-clock guards and keep their real intervals — the statistics tree still honours `GetStatsInterval()`, and the ED2K link scan still runs at 1 s. Both are merely evaluated more often, which is a subtraction and a compare. The reconnect timer is a separate `wxTimer` and is untouched. The 30 s reply watchdog is wall-clock based, so its behaviour is unchanged; the comment stating the cycle length as its justification is updated.

**Why the round-robin stays.** Giving each concern its own guard, as the link scan already has, is the cleaner design and would allow per-concern intervals. It was not taken here because two of the round-robin's properties are load-bearing and would have to be rebuilt rather than inherited. The cycle emits at most one step's worth of requests per tick, so independently-scheduled concerns cannot drift into alignment and burst against a request FIFO whose threshold is 20. And the fifo-full early return sits above the switch, so back-pressure pauses the cycle in place instead of leaving every concern overdue to fire at once on recovery — the worst moment for it. Both are now documented where the interval is defined.

This matters most for the three sends with no in-flight guard of their own: `EC_OP_STAT_REQ`, `EC_OP_GET_SERVERINFO` and `EC_OP_GET_CHAT_MESSAGES` go out through `SendRequest` rather than `DoRequery`, which drops a request whose container is not `IDLE`. They are the ones relying on the round-robin to rate-limit them, and they keep it.

**Verification.** Builds clean in Release on macOS with no new warnings in the touched files, 31/31 unit tests, clang-format and diff-scoped clang-tidy (Tier-2) both clean with zero compiler errors. Running on a live GUI against a production daemon.
