### PR TITLE
perf(ec): stop rebuilding the whole file list on every GET_UPDATE poll

### DIFF
--- a/src/ECIdDiff.h
+++ b/src/ECIdDiff.h
@@ -1,0 +1,70 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef ECIDDIFF_H
+#define ECIDDIFF_H
+
+#include <vector>
+
+#include "Types.h" // Needed for uint32
+
+/**
+ * Which ECIDs the client was told about last cycle and is no longer being
+ * told about, i.e. the ones that need an explicit `EC_TAG_FILE_REMOVED`.
+ *
+ * Both inputs must be sorted ascending and duplicate-free, which lets this be
+ * a single linear pass over two contiguous arrays instead of a lookup per
+ * file. `Get_EC_Response_GetUpdate` gets that ordering for free: it walks the
+ * encoder map, which is a std::map keyed by ECID.
+ *
+ * Deliberately pure, and deliberately not taking a CECPacket. The failure
+ * mode of getting this wrong is silent in both directions -- a missed removal
+ * leaves an entry in the client's list forever with no error anywhere, and a
+ * spurious one deletes a file the user still has -- so it is worth being able
+ * to test it without an app, a daemon, or a connected client.
+ *
+ * @param previous ECIDs sent in the previous response.
+ * @param current  ECIDs being sent in this one.
+ * @param removed  Receives the difference, ascending. Cleared first.
+ */
+inline void ComputeRemovedIds(
+	const std::vector<uint32> &previous, const std::vector<uint32> &current, std::vector<uint32> &removed)
+{
+	removed.clear();
+	std::vector<uint32>::const_iterator cur = current.begin();
+	const std::vector<uint32>::const_iterator curEnd = current.end();
+	for (const uint32 prev : previous) {
+		// `previous` ascends too, so the cursor only ever moves forward
+		// across the whole call -- this is O(previous + current), not
+		// O(previous * current).
+		while (cur != curEnd && *cur < prev) {
+			++cur;
+		}
+		if (cur == curEnd || *cur != prev) {
+			removed.push_back(prev);
+		}
+	}
+}
+
+#endif // ECIDDIFF_H

--- a/src/ECIdDiff.h
+++ b/src/ECIdDiff.h
@@ -25,6 +25,9 @@
 #ifndef ECIDDIFF_H
 #define ECIDDIFF_H
 
+#include <algorithm>  // Needed for std::is_sorted
+#include <cassert>    // Needed for assert
+#include <functional> // Needed for std::less_equal
 #include <vector>
 
 #include "Types.h" // Needed for uint32
@@ -51,6 +54,26 @@
 inline void ComputeRemovedIds(
 	const std::vector<uint32> &previous, const std::vector<uint32> &current, std::vector<uint32> &removed)
 {
+	// Preconditions, not defensive coding. An input that is out of order, or
+	// that carries a duplicate, makes this quietly return the wrong set
+	// rather than fail -- and both wrong answers are invisible at runtime: a
+	// missed removal leaves a row in the client's list for the life of the
+	// connection, and a spurious one deletes a file the user still has.
+	// Checking turns that into a debug-run abort.
+	//
+	// `less_equal` makes is_sorted reject equal neighbours as well as
+	// out-of-order ones, so one pass covers both halves of the contract. It
+	// is O(n) against a merge that is already O(n), and only in debug builds.
+	//
+	// assert() rather than the wxASSERT used elsewhere in the tree, because
+	// this header is deliberately usable without an app and wxASSERT is not:
+	// wx installs its assert handler from the wxApp constructor, so with no
+	// wxApp -- which is exactly the case in the unit tests -- wxASSERT is a
+	// silent no-op and the check would not fire where it is easiest to
+	// exercise. Verified by feeding it unsorted and duplicate input.
+	assert(std::is_sorted(previous.begin(), previous.end(), std::less_equal<uint32>()));
+	assert(std::is_sorted(current.begin(), current.end(), std::less_equal<uint32>()));
+
 	removed.clear();
 	std::vector<uint32>::const_iterator cur = current.begin();
 	const std::vector<uint32>::const_iterator curEnd = current.end();

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -26,7 +26,7 @@
 
 #include "config.h" // Needed for VERSION
 
-#include <set>       // Needed for std::set (m_lastSentFileIds)
+#include <set>       // Needed for std::set (m_lastSentSharedFileIds)
 #include <list>      // Needed for std::list (multi-search LRU ring)
 #include <algorithm> // Needed for std::find (multi-search LRU ring)
 
@@ -38,6 +38,7 @@
 #include <common/MD5Sum.h>
 #include "libs/ec/cpp/ECCrypt.h"
 
+#include "ECIdDiff.h"            // Needed for ComputeRemovedIds
 #include "ExternalConn.h"        // Interface declarations
 #include "ECFullResponseCache.h" // Needed for s_ec*FullCache
 #include "updownclient.h"        // Needed for CUpDownClient
@@ -72,11 +73,38 @@ class CKnownFile_Encoder
 	// number of sources for each part for progress bar colouring
 	RLE_Data m_enc_data;
 
+	// Reconcile epoch, stamped by CFileEncoderMap::UpdateEncoders on every
+	// encoder whose file is still listed. Encoders left carrying an older
+	// stamp have lost their file and are swept. Replaces the per-call set of
+	// live ECIDs that used to serve the same purpose -- see UpdateEncoders.
+	uint64 m_seenEpoch;
+
+	// Whether `Get_EC_Response_GetUpdate` has already sent this file to the
+	// client carrying its identifying fields. False on a freshly-built
+	// encoder, which is what makes a re-created encoder re-send full detail
+	// without the caller having to erase anything.
+	//
+	// Deliberately specific to that one response path rather than a general
+	// "the client has this file": a path that has never sent the identity
+	// must not take the unchanged-file shortcut, or the client is left with a
+	// child-less tag it turns into a ghost entry (#808). The two amuleweb
+	// handlers answer the same question from their own sets instead, because
+	// they iterate a CopyFileList snapshot rather than the encoder map and
+	// reaching the encoder would cost the lookup this exists to avoid. That
+	// is why this is one flag and not a per-path bitmask -- a second bit
+	// would have no writer.
+	bool m_sentOnUpdatePath;
+
 protected:
 	const CKnownFile *m_file;
 
 public:
-	CKnownFile_Encoder(const CKnownFile *file = 0) { m_file = file; }
+	CKnownFile_Encoder(const CKnownFile *file = nullptr)
+	: m_seenEpoch(0)
+	, m_sentOnUpdatePath(false)
+	{
+		m_file = file;
+	}
 
 	virtual ~CKnownFile_Encoder() {}
 
@@ -88,6 +116,12 @@ public:
 	virtual bool IsShared() { return true; }
 	virtual bool IsPartFile_Encoder() { return false; }
 	const CKnownFile *GetFile() { return m_file; }
+
+	uint64 GetSeenEpoch() const { return m_seenEpoch; }
+	void SetSeenEpoch(uint64 epoch) { m_seenEpoch = epoch; }
+
+	bool WasSentOnUpdatePath() const { return m_sentOnUpdatePath; }
+	void MarkSentOnUpdatePath() { m_sentOnUpdatePath = true; }
 };
 
 /*!
@@ -149,10 +183,21 @@ public:
 	~CFileEncoderMap();
 	// If freshEcids is non-null, receives the ECIDs whose encoder was
 	// (re-)created this call. Freshly-created encoders signal that the
-	// caller's per-ECID EC caches (CObjTagMap valuemap, sent-with-detail
-	// set) are stale w.r.t. the client's local view and must be dropped
-	// so INC_UPDATE emissions re-send identifying fields.
+	// caller's per-ECID EC caches (CObjTagMap valuemap, and the encoder's
+	// own sent-with-detail mask) are stale w.r.t. the client's local view
+	// and must be dropped so INC_UPDATE emissions re-send identifying fields.
 	void UpdateEncoders(IDSet *freshEcids = nullptr);
+
+private:
+	// Monotonic reconcile counter; see UpdateEncoders. Two things make a
+	// stamp comparison safe. The counter is a member of this map, and the map
+	// belongs to one CECServerSocket, so it is per-connection and encoders
+	// are never shared across clients -- there is no cross-client collision
+	// to reason about. And every UpdateEncoders call takes a fresh value
+	// before stamping anything, so no encoder can be carrying the value the
+	// current call is about to use. 64-bit on top of that, so it also cannot
+	// wrap back onto a live encoder's stamp within any plausible uptime.
+	uint64 m_epoch = 0;
 };
 
 CFileEncoderMap::~CFileEncoderMap()
@@ -167,18 +212,29 @@ CFileEncoderMap::~CFileEncoderMap()
 // or if we have new files without encoder yet.
 void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 {
-	IDSet curr_files, dead_files;
+	IDSet dead_files;
+	// Stamp every encoder whose file is still listed with this epoch; the
+	// sweep below then takes anything left behind. This used to build a set
+	// of the live ECIDs instead, which cost a red-black-tree insertion per
+	// file plus a lookup per encoder in the sweep -- on every poll, for every
+	// connected client, to find the handful of files that actually came or
+	// went. The stamp is a store through a pointer each loop already holds.
+	const uint64 epoch = ++m_epoch;
 	// Downloads
 	std::vector<CPartFile *> downloads;
 	theApp->downloadqueue->CopyFileList(downloads, true);
 	for (uint32 i = downloads.size(); i--;) {
 		uint32 id = downloads[i]->ECID();
-		curr_files.insert(id);
-		if (!count(id)) {
-			(*this)[id] = new CPartFile_Encoder(downloads[i]);
+		iterator it = find(id);
+		if (it == end()) {
+			CKnownFile_Encoder *enc = new CPartFile_Encoder(downloads[i]);
+			enc->SetSeenEpoch(epoch);
+			(*this)[id] = enc;
 			if (freshEcids) {
 				freshEcids->insert(id);
 			}
+		} else {
+			it->second->SetSeenEpoch(epoch);
 		}
 	}
 	// Shares
@@ -186,18 +242,23 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 	theApp->sharedfiles->CopyFileList(shares);
 	for (uint32 i = shares.size(); i--;) {
 		uint32 id = shares[i]->ECID();
-		// Check if it is already there.
-		// The curr_files.count(id) is enough, the IsCPartFile() is just a speedup.
-		if (shares[i]->IsCPartFile() && curr_files.count(id)) {
-			(*this)[id]->SetShared();
+		iterator it = find(id);
+		// Check if it is already there. Carrying this epoch means the
+		// downloads loop above already reached it, which is what the old
+		// `curr_files.count(id)` tested; the IsCPartFile() is just a speedup.
+		if (shares[i]->IsCPartFile() && it != end() && it->second->GetSeenEpoch() == epoch) {
+			it->second->SetShared();
 			continue;
 		}
-		curr_files.insert(id);
-		if (!count(id)) {
-			(*this)[id] = new CKnownFile_Encoder(shares[i]);
+		if (it == end()) {
+			CKnownFile_Encoder *enc = new CKnownFile_Encoder(shares[i]);
+			enc->SetSeenEpoch(epoch);
+			(*this)[id] = enc;
 			if (freshEcids) {
 				freshEcids->insert(id);
 			}
+		} else {
+			it->second->SetSeenEpoch(epoch);
 		}
 	}
 	// Check for removed files, and store them in a set for deletion.
@@ -205,7 +266,7 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 	//		iterator to_del = it++; erase(to_del) ;
 	// works or invalidates it too.)
 	for (iterator it = begin(); it != end(); ++it) {
-		if (!curr_files.count(it->first)) {
+		if (it->second->GetSeenEpoch() != epoch) {
 			dead_files.insert(it->first);
 		}
 	}
@@ -351,14 +412,27 @@ private:
 	// <sender GUI_ID, "name|message">.
 	std::list<std::pair<uint64, wxString>> m_chatQueue;
 	static const size_t MAX_CHAT_MESSAGES = 100;
-	// Set of file ECIDs sent in the previous response for each EC
-	// request path. Diffed against the current snapshot to compute the
-	// removal list emitted to partial-update-capable clients. Tracked
-	// per-path because amulegui uses `EC_OP_GET_UPDATE` (mixed shared +
-	// partfile, served by `Get_EC_Response_GetUpdate`) while amuleweb
-	// drives two separate INC_UPDATE streams via `EC_OP_GET_SHARED_FILES`
-	// and `EC_OP_GET_DLOAD_QUEUE` (each served by its own handler).
-	std::set<uint32> m_lastSentFileIds;
+	// File ECIDs sent in the previous response for each EC request path.
+	// Diffed against the current snapshot to compute the removal list emitted
+	// to partial-update-capable clients. Tracked per-path because amulegui
+	// uses `EC_OP_GET_UPDATE` (mixed shared + partfile, served by
+	// `Get_EC_Response_GetUpdate`) while amuleweb drives two separate
+	// INC_UPDATE streams via `EC_OP_GET_SHARED_FILES` and
+	// `EC_OP_GET_DLOAD_QUEUE` (each served by its own handler).
+	//
+	// `m_lastSentFileIds` is held sorted ascending in a vector rather than a
+	// std::set: `Get_EC_Response_GetUpdate` walks the encoder map, which is
+	// keyed by ECID, so the current IDs come out already in order and the
+	// diff is a linear merge over two contiguous arrays -- where the set
+	// cost a tree insertion per file to build and a tree lookup per file to
+	// diff, on every poll, whether or not anything had changed.
+	//
+	// The other two keep the set. Their handlers iterate a CopyFileList
+	// snapshot, which is neither ECID-ordered nor necessarily the whole
+	// list (`queryitems` filters it), so neither the ordering the merge
+	// needs nor the encoder-in-hand the mask below needs is available
+	// without paying for a lookup that would cancel the saving out.
+	std::vector<uint32> m_lastSentFileIds;
 	std::set<uint32> m_lastSentSharedFileIds;
 	std::set<uint32> m_lastSentPartFileIds;
 	// `EC_OP_SEARCH_RESULTS` at `EC_DETAIL_UPDATE` (amuleweb's polling
@@ -378,18 +452,25 @@ private:
 	// to track.
 	std::set<uint32> m_lastSentSearchResultIds;
 
-	// Set of file ECIDs already sent to the client with full detail
+	// Which file ECIDs have already been sent to the client with full detail
 	// (EC_DETAIL_INC_UPDATE / EC_DETAIL_UPDATE payload, not the legacy
-	// childless alive-marker or the partial-update skip-silently path).
-	// Used by `Get_EC_Response_Get{Update,SharedFiles,DownloadQueue}` to
-	// gate the `m_ecGen <= ec_threshold` shortcut: that shortcut produces
-	// a ghost entry on the client (empty CKnownFile from a child-less tag,
-	// or silent absence in partial-update mode) when the client has never
-	// received the ECID's metadata. Per-path because each handler has its
-	// own `m_lastEcGenSeen*` cadence — once the ECID is seen on one path,
-	// the client only has the data for that path's view. Same rationale
-	// as `m_lastSent*FileIds` above.
-	std::set<uint32> m_sentWithDetailIds;
+	// childless alive-marker or the partial-update skip-silently path) now
+	// lives as a flag on the encoder itself -- see
+	// CKnownFile_Encoder::WasSentOnUpdatePath. It used to be three per-path
+	// sets here, each costing a tree lookup per file on every poll to answer
+	// a question the encoder was already in a position to answer.
+	//
+	// Keeping it on the encoder also bounds it. The sets were only ever
+	// inserted into: an ECID whose file went away stayed in them for the life
+	// of the connection, so a long-lived client on a churning library grew
+	// them without limit. An encoder is destroyed with its file, and a
+	// re-created one starts at zero, which is exactly the "re-send full
+	// detail" state the freshEcids handling used to arrange by erasing.
+	//
+	// The two amuleweb paths keep their sets, for the reason given on
+	// `m_lastSentSharedFileIds` above: they iterate a snapshot rather than
+	// the encoder map, so reaching the encoder to read a mask would cost the
+	// lookup the mask exists to avoid.
 	std::set<uint32> m_sentWithDetailIdsShared;
 	std::set<uint32> m_sentWithDetailIdsPart;
 };
@@ -1383,8 +1464,7 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	CObjTagMap &tagmap,
 	uint64 &io_lastEcGenSeen,
 	bool partial_update_active,
-	std::set<uint32> &io_lastSentFileIds,
-	std::set<uint32> &io_sentWithDetailIds)
+	std::vector<uint32> &io_lastSentFileIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_SHARED_FILES);
 
@@ -1402,28 +1482,36 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	// prior encoder was either destroyed (file dropped from m_Files_map /
 	// downloadqueue) or never existed. In both cases the peer's mirrored
 	// state for that ECID is empty, so any INC_UPDATE the ctor would
-	// suppress against a cached value in `tagmap.GetValueMap(ecid)` or a
-	// membership in `io_sentWithDetailIds` produces a hash-less tag that
-	// the client rejects (`amule-remote-gui.cpp` #808 guard). Drop both
-	// caches so the file re-appears in full detail on this response.
+	// suppress against a cached value in `tagmap.GetValueMap(ecid)` produces
+	// a hash-less tag that the client rejects (`amule-remote-gui.cpp` #808
+	// guard). Drop the cache so the file re-appears in full detail on this
+	// response. The encoder's own sent-with-detail mask needs no clearing:
+	// a freshly-built encoder starts at zero by construction.
 	std::set<uint32> freshEcids;
 	encoders.UpdateEncoders(&freshEcids);
 	for (uint32 ecid : freshEcids) {
 		tagmap.EraseValueMap(ecid);
-		io_sentWithDetailIds.erase(ecid);
 	}
 
-	// Snapshot the IDs of all files currently alive on the server. Used
-	// by the partial-update path below to diff against the previous cycle
-	// and synthesize `EC_TAG_FILE_REMOVED` markers.
-	std::set<uint32> current_file_ids;
+	// The IDs of all files currently alive on the server, ascending -- the
+	// encoder map is keyed by ECID, so iterating it below appends them in
+	// order. Used by the partial-update path to diff against the previous
+	// cycle and synthesize `EC_TAG_FILE_REMOVED` markers; a legacy client
+	// infers removal from absence instead, so for one of those this is never
+	// read and is not worth building.
+	std::vector<uint32> current_file_ids;
+	if (partial_update_active) {
+		current_file_ids.reserve(encoders.size());
+	}
 
 	for (CFileEncoderMap::iterator it = encoders.begin(); it != encoders.end(); ++it) {
 		const CKnownFile *cur_file = it->second->GetFile();
 		const uint32 ecid = cur_file->ECID();
-		current_file_ids.insert(ecid);
+		if (partial_update_active) {
+			current_file_ids.push_back(ecid);
+		}
 
-		if (cur_file->GetECGen() <= ec_threshold && io_sentWithDetailIds.count(ecid)) {
+		if (cur_file->GetECGen() <= ec_threshold && it->second->WasSentOnUpdatePath()) {
 			// Nothing exported has changed since the client's last
 			// view of this file AND the client has previously
 			// received this ECID with full detail. Two paths
@@ -1466,16 +1554,17 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 			// Add information if partfile is shared
 			filetag.AddTag(EC_TAG_PARTFILE_SHARED, it->second->IsShared(), &valuemap);
 
-			CPartFile_Encoder *enc = static_cast<CPartFile_Encoder *>(encoders[ecid]);
+			// `it->second` is this ECID's encoder already; looking it
+			// up again by key would be a second tree descent per file.
+			CPartFile_Encoder *enc = static_cast<CPartFile_Encoder *>(it->second);
 			enc->Encode(&filetag);
 			response->AddTag(filetag);
 		} else {
 			CEC_SharedFile_Tag filetag(cur_file, EC_DETAIL_INC_UPDATE, &valuemap);
-			CKnownFile_Encoder *enc = encoders[ecid];
-			enc->Encode(&filetag);
+			it->second->Encode(&filetag);
 			response->AddTag(filetag);
 		}
-		io_sentWithDetailIds.insert(ecid);
+		it->second->MarkSentOnUpdatePath();
 	}
 
 	if (partial_update_active) {
@@ -1483,12 +1572,10 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 		// file that was in the previous response but is no longer
 		// alive on the server. Replaces the legacy client's bulk
 		// "anything missing == deleted" inference.
-		for (std::set<uint32>::const_iterator it = io_lastSentFileIds.begin();
-			it != io_lastSentFileIds.end();
-			++it) {
-			if (!current_file_ids.count(*it)) {
-				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, *it));
-			}
+		std::vector<uint32> removed;
+		ComputeRemovedIds(io_lastSentFileIds, current_file_ids, removed);
+		for (uint32 ecid : removed) {
+			response->AddTag(CECTag(EC_TAG_FILE_REMOVED, ecid));
 		}
 		io_lastSentFileIds.swap(current_file_ids);
 	}
@@ -3046,8 +3133,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				m_obj_tagmap,
 				m_lastEcGenSeen,
 				m_partialUpdateActive,
-				m_lastSentFileIds,
-				m_sentWithDetailIds);
+				m_lastSentFileIds);
 		}
 		break;
 	case EC_OP_GET_ULOAD_QUEUE:

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1499,6 +1499,13 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	// cycle and synthesize `EC_TAG_FILE_REMOVED` markers; a legacy client
 	// infers removal from absence instead, so for one of those this is never
 	// read and is not worth building.
+	// The removal merge needs that list ascending, and it gets it for free
+	// only because the encoder map is ordered by ECID. Tie the guarantee to
+	// the type: re-basing CFileEncoderMap on an unordered container would go
+	// on compiling and silently hand the merge an unsorted list, whose wrong
+	// answer nothing at runtime would report.
+	static_assert(std::is_base_of<std::map<uint32, CKnownFile_Encoder *>, CFileEncoderMap>::value,
+		"Get_EC_Response_GetUpdate relies on CFileEncoderMap iterating in ECID order");
 	std::vector<uint32> current_file_ids;
 	if (partial_update_active) {
 		current_file_ids.reserve(encoders.size());

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -26,6 +26,33 @@ target_link_libraries (CTagTest
 # just stops updating in the GUI -- so the contract is pinned here rather than
 # left to a clean daemon run. Needs no app, no daemon and no database: the EC
 # tag types and their generated codes are the whole dependency.
+add_executable (ECIdDiffTest
+	ECIdDiffTest.cpp
+	# See the note on CValueMapTest below: libec.a references DoECLogLine /
+	# theLogger unconditionally in Debug, so the no-op definitions have to be
+	# linked in or only the Debug matrix entries fail.
+	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+)
+
+add_test (NAME ECIdDiffTest
+	COMMAND ECIdDiffTest
+)
+
+target_include_directories (ECIdDiffTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs/ec/cpp
+)
+
+target_link_libraries (ECIdDiffTest
+	muleunit
+	ec
+	mulecommon
+)
+
 add_executable (CValueMapTest
 	CValueMapTest.cpp
 	# LoggerConsole.cpp provides the no-op DoECLogLine + theLogger symbols that

--- a/unittests/tests/ECIdDiffTest.cpp
+++ b/unittests/tests/ECIdDiffTest.cpp
@@ -1,0 +1,147 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include "ECIdDiff.h"
+
+using namespace muleunit;
+
+// `ComputeRemovedIds` decides which files the daemon tells a partial-update
+// client to delete. Both ways of getting it wrong are silent: a missed removal
+// leaves an entry in the client's list for the life of the connection with no
+// error logged anywhere, and a spurious one deletes a file the user still has.
+// Neither shows up as a crash, a failed request, or a wrong-looking packet --
+// only as a list that quietly disagrees with the daemon.
+//
+// It is a pure function over two sorted vectors, so unlike the surrounding
+// handler it needs no app, no daemon and no connected client to exercise.
+
+DECLARE_SIMPLE(ECIdDiff)
+
+// Convenience: run the diff and hand back the result by value.
+static std::vector<uint32> Diff(const std::vector<uint32> &previous, const std::vector<uint32> &current)
+{
+	std::vector<uint32> removed;
+	ComputeRemovedIds(previous, current, removed);
+	return removed;
+}
+
+TEST(ECIdDiff, NothingChangedRemovesNothing)
+{
+	const std::vector<uint32> ids = { 1, 5, 9, 40 };
+	ASSERT_TRUE(Diff(ids, ids).empty());
+}
+
+TEST(ECIdDiff, BothEmpty)
+{
+	ASSERT_TRUE(Diff(std::vector<uint32>(), std::vector<uint32>()).empty());
+}
+
+// The first poll of a connection: nothing was sent before, so however many
+// files exist now, none of them can have been removed.
+TEST(ECIdDiff, FirstPollRemovesNothing)
+{
+	ASSERT_TRUE(Diff(std::vector<uint32>(), { 3, 7, 11 }).empty());
+}
+
+TEST(ECIdDiff, EverythingGone)
+{
+	const std::vector<uint32> removed = Diff({ 3, 7, 11 }, std::vector<uint32>());
+	ASSERT_EQUALS(3u, removed.size());
+	ASSERT_EQUALS(3u, removed[0]);
+	ASSERT_EQUALS(7u, removed[1]);
+	ASSERT_EQUALS(11u, removed[2]);
+}
+
+// The cursor starts at the front, so a removal at the very front is the case
+// an off-by-one in the initial position would miss.
+TEST(ECIdDiff, RemovedAtFront)
+{
+	const std::vector<uint32> removed = Diff({ 1, 5, 9 }, { 5, 9 });
+	ASSERT_EQUALS(1u, removed.size());
+	ASSERT_EQUALS(1u, removed[0]);
+}
+
+TEST(ECIdDiff, RemovedInMiddle)
+{
+	const std::vector<uint32> removed = Diff({ 1, 5, 9 }, { 1, 9 });
+	ASSERT_EQUALS(1u, removed.size());
+	ASSERT_EQUALS(5u, removed[0]);
+}
+
+// The cursor has run off the end by the time the last id is considered, so
+// this is the case a missing `cur == curEnd` guard would get wrong.
+TEST(ECIdDiff, RemovedAtEnd)
+{
+	const std::vector<uint32> removed = Diff({ 1, 5, 9 }, { 1, 5 });
+	ASSERT_EQUALS(1u, removed.size());
+	ASSERT_EQUALS(9u, removed[0]);
+}
+
+// Additions must never be reported as removals -- that would delete a file
+// from the client's list on the very poll it first appeared.
+TEST(ECIdDiff, AdditionsAreNotRemovals)
+{
+	ASSERT_TRUE(Diff({ 5 }, { 1, 5, 9 }).empty());
+}
+
+// Adds and removes in the same cycle, interleaved so the cursor has to step
+// over new ids while still matching the surviving ones.
+TEST(ECIdDiff, AddAndRemoveInTheSameCycle)
+{
+	const std::vector<uint32> removed = Diff({ 10, 20, 30, 40 }, { 5, 20, 25, 40, 50 });
+	ASSERT_EQUALS(2u, removed.size());
+	ASSERT_EQUALS(10u, removed[0]);
+	ASSERT_EQUALS(30u, removed[1]);
+}
+
+// Disjoint sets: every previous id is gone and every current one is new. The
+// cursor must not be left behind by the leading run of smaller new ids.
+TEST(ECIdDiff, DisjointSets)
+{
+	const std::vector<uint32> removed = Diff({ 100, 200 }, { 1, 2, 3 });
+	ASSERT_EQUALS(2u, removed.size());
+	ASSERT_EQUALS(100u, removed[0]);
+	ASSERT_EQUALS(200u, removed[1]);
+}
+
+// The output is cleared, not appended to -- the handler reuses one vector.
+TEST(ECIdDiff, OutputIsClearedNotAppended)
+{
+	std::vector<uint32> removed = { 777, 888 };
+	ComputeRemovedIds({ 1, 2 }, { 1 }, removed);
+	ASSERT_EQUALS(1u, removed.size());
+	ASSERT_EQUALS(2u, removed[0]);
+}
+
+// ECIDs are assigned from a counter that keeps climbing across a long daemon
+// uptime, so the comparisons must stay correct above the signed-32-bit range.
+TEST(ECIdDiff, HighIdsCompareUnsigned)
+{
+	const std::vector<uint32> removed =
+		Diff({ 2147483647u, 2147483648u, 4294967295u }, { 2147483647u, 4294967295u });
+	ASSERT_EQUALS(1u, removed.size());
+	ASSERT_EQUALS(2147483648u, removed[0]);
+}


### PR DESCRIPTION
Serving one `EC_OP_GET_UPDATE` walked the library three times over, and did so whether or not anything had changed.

`UpdateEncoders` built a `std::set` of every live ECID, costing a red-black-tree insertion per file to fill and a lookup per encoder in the sweep that follows it. The response walk built a second set of the same ECIDs, purely to diff against the previous cycle for `EC_TAG_FILE_REMOVED`, and that diff did a tree lookup per file. A third set, `m_sentWithDetailIds`, cost another lookup per file to answer whether the client had already received that ECID's identifying fields.

None of the three depended on what had changed. All of it ran to discover that roughly 1% of the library had moved.

## What replaces them

**The live-ECID set becomes an epoch stamped on the encoder.** The set only ever answered "is this encoder's file still listed". The loops that build the encoder map already hold each encoder, so they mark it with the current reconcile counter and the sweep takes whatever was left behind. No container, no allocation, no lookups.

**The current-ID set becomes a sorted vector diffed by linear merge.** The encoder map is a `std::map` keyed by ECID, so walking it yields the current IDs already ascending, and the removal diff is a single pass over two contiguous arrays. A legacy client infers removal from absence and never reads that list, so for one of those it is not built at all.

**The sent-with-detail set becomes a flag on the encoder.** That also bounds it. The set was only ever inserted into, so an ECID whose file went away stayed in it for the life of the connection, and a long-lived client on a churning library grew it without limit. An encoder dies with its file, and a rebuilt one starts false — which is exactly the "re-send full detail" state the `freshEcids` handling previously had to arrange by erasing entries.

Two lookups per emitted file also go: the walk holds the encoder in `it->second` and was re-finding it by key as `encoders[ecid]`.

## Measurement

On a production daemon, 1205 shared files, before and after, same node:

| phase | before | after |
|---|---|---|
| `sync` (UpdateEncoders) | 0.43–0.49 ms | **0.22 ms** |
| `walk` (response loop) | 0.68–0.85 ms | **0.23 ms** |
| `diff` (removals) | 0.11–0.13 ms | **0.00 ms** |
| **total** | **1.22–1.47 ms** | **0.45 ms** |

About 2.9x, across three sample windows that agree to within 0.01 ms. The per-file mechanism matches the intent: `walk` went from ~600 ns/file to ~190 ns, consistent with removing two of three tree operations per file, and `sync` from ~380 to ~182 ns, consistent with removing one of two.

Whole-handler p50 fell from 1.89–2.35 ms to 0.72–0.75 ms, but **only the three phases above are attributable to this change**. Peer count on the node fell from 35–42 to 25 between the runs, and `rest` is dominated by the client path, which this does not touch. Roughly 0.8–1.0 ms of the total improvement is this change and the remainder is the lighter peer load.

The same instrumentation now reports `emit=11–12` against `enc=1206`, i.e. about 1% of the library changes per poll. That is the number the whole argument rests on and it had never actually been measured — the counter it replaces reported the size of the sent-with-detail set, which was structurally always equal to the encoder count and so said nothing.

## Scope

Confined to the `EC_OP_GET_UPDATE` path, which is what amulegui and amuleapi poll. The two amuleweb handlers keep their sets deliberately: they iterate a `CopyFileList` snapshot rather than the encoder map, so it is neither ordered for the merge nor holding the encoder for the flag, and reaching for either would cost the lookup the change exists to remove.

No wire change in either direction. A partial-update client gets the same skips and the same removal markers; a legacy client gets the same child-less alive marker for every unchanged file and, as before, no removal markers at all.

## Test

`ComputeRemovedIds` is split out as a pure function over two sorted vectors so it can be exercised without an app, a daemon or a connected client. It is worth pinning because both ways of getting it wrong are silent: a missed removal leaves an entry in the client's list for the life of the connection, and a spurious one deletes a file the user still has, with nothing logged either way.

Twelve cases, each checked by mutation rather than assumed. Dropping the end-of-list guard, stepping the cursor past an equal ID, and omitting the output clear are all caught — the last by exactly one case, which is why the set is not trimmed further.

## Verification

Builds clean in Release, 32/32 unit tests, clang-format and both clang-tidy tiers clean on the diff with zero compiler errors. Running on a production daemon.

**Draft pending visual confirmation in amuleGUI.** Every failure mode here is silent, so the remaining check is a connected client exercising an add and a delete: a row that lingers forever means the merge missed a removal, one that vanishes and returns means it emitted a spurious one, an empty row means the sent-with-detail flag failed, and a downloading file whose progress freezes while others move would mean the epoch or the flag wrongly took the unchanged-file shortcut.
