### PR TITLE
perf(ec): hold the EC file encoders in a sorted vector, not a std::map

### DIFF
--- a/src/ECIdDiff.h
+++ b/src/ECIdDiff.h
@@ -25,9 +25,9 @@
 #ifndef ECIDDIFF_H
 #define ECIDDIFF_H
 
-#include <algorithm>  // Needed for std::is_sorted
+#include <algorithm>  // Needed for std::adjacent_find
 #include <cassert>    // Needed for assert
-#include <functional> // Needed for std::less_equal
+#include <functional> // Needed for std::greater_equal
 #include <vector>
 
 #include "Types.h" // Needed for uint32
@@ -39,7 +39,7 @@
  * Both inputs must be sorted ascending and duplicate-free, which lets this be
  * a single linear pass over two contiguous arrays instead of a lookup per
  * file. `Get_EC_Response_GetUpdate` gets that ordering for free: it walks the
- * encoder map, which is a std::map keyed by ECID.
+ * encoder map, which is kept sorted by ECID.
  *
  * Deliberately pure, and deliberately not taking a CECPacket. The failure
  * mode of getting this wrong is silent in both directions -- a missed removal
@@ -61,9 +61,17 @@ inline void ComputeRemovedIds(
 	// connection, and a spurious one deletes a file the user still has.
 	// Checking turns that into a debug-run abort.
 	//
-	// `less_equal` makes is_sorted reject equal neighbours as well as
-	// out-of-order ones, so one pass covers both halves of the contract. It
-	// is O(n) against a merge that is already O(n), and only in debug builds.
+	// One pass covers both halves of the contract: adjacent_find looks for the
+	// first neighbouring pair that is not strictly increasing, which catches an
+	// equal pair as well as an out-of-order one. O(n) against a merge that is
+	// already O(n), and only in debug builds.
+	//
+	// adjacent_find rather than is_sorted with a `<=` comparator, which is what
+	// this was. is_sorted requires its comparator to be a strict weak ordering
+	// and `<=` is not irreflexive, so a hardened standard library is entitled
+	// to -- and libstdc++ under _GLIBCXX_DEBUG does -- abort on the predicate
+	// itself. That would fire on the debug build these checks exist to serve.
+	// adjacent_find takes a plain binary predicate with no ordering contract.
 	//
 	// assert() rather than the wxASSERT used elsewhere in the tree, because
 	// this header is deliberately usable without an app and wxASSERT is not:
@@ -71,8 +79,10 @@ inline void ComputeRemovedIds(
 	// wxApp -- which is exactly the case in the unit tests -- wxASSERT is a
 	// silent no-op and the check would not fire where it is easiest to
 	// exercise. Verified by feeding it unsorted and duplicate input.
-	assert(std::is_sorted(previous.begin(), previous.end(), std::less_equal<uint32>()));
-	assert(std::is_sorted(current.begin(), current.end(), std::less_equal<uint32>()));
+	assert(std::adjacent_find(previous.begin(), previous.end(), std::greater_equal<uint32>()) ==
+		previous.end());
+	assert(std::adjacent_find(current.begin(), current.end(), std::greater_equal<uint32>()) ==
+		current.end());
 
 	removed.clear();
 	std::vector<uint32>::const_iterator cur = current.begin();

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -248,14 +248,6 @@ private:
 	// before stamping anything, so no encoder can be carrying the value the
 	// current call is about to use. 64-bit on top of that, so it also cannot
 	// wrap back onto a live encoder's stamp within any plausible uptime.
-	// Monotonic reconcile counter; see UpdateEncoders. Two things make a
-	// stamp comparison safe. The counter is a member of this map, and the map
-	// belongs to one CECServerSocket, so it is per-connection and encoders
-	// are never shared across clients -- there is no cross-client collision
-	// to reason about. And every UpdateEncoders call takes a fresh value
-	// before stamping anything, so no encoder can be carrying the value the
-	// current call is about to use. 64-bit on top of that, so it also cannot
-	// wrap back onto a live encoder's stamp within any plausible uptime.
 	uint64 m_epoch = 0;
 };
 
@@ -378,11 +370,19 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 
 	// The GET_UPDATE walk relies on this order to feed the removal merge, and
 	// getting it wrong loses or invents removals silently. Debug-only, and
-	// `less_equal` rejects duplicate ECIDs as well as misordering -- a
-	// duplicate would mean two encoders for one file.
-	assert(std::is_sorted(m_entries.begin(),
-		m_entries.end(),
-		[](const value_type &a, const value_type &b) { return a.first <= b.first; }));
+	// rejects duplicate ECIDs as well as misordering -- a duplicate would mean
+	// two encoders for one file.
+	//
+	// adjacent_find rather than is_sorted: is_sorted requires its comparator to
+	// be a strict weak ordering, and the `<=` needed to reject equal neighbours
+	// is not irreflexive. Hardened standard libraries check exactly that and
+	// abort -- which would land on the debug build this change is verified
+	// against. adjacent_find takes a plain binary predicate with no such
+	// contract.
+	assert(std::adjacent_find(
+		       m_entries.begin(), m_entries.end(), [](const value_type &a, const value_type &b) {
+			       return a.first >= b.first;
+		       }) == m_entries.end());
 }
 
 //-------------------- CECServerSocket --------------------
@@ -1541,6 +1541,11 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request,
 
 		CEC_SharedFile_Tag filetag(cur_file, detail_level);
 		CKnownFile_Encoder *enc = encoders[ecid];
+		// UpdateEncoders ran at the top of this handler against the same
+		// snapshot, so every file here has an encoder. NULL would be a crash
+		// on the next line either way; assert so it reads as the contract it
+		// is rather than an unchecked dereference.
+		wxASSERT(enc);
 		if (detail_level != EC_DETAIL_UPDATE) {
 			enc->ResetEncoder();
 		}
@@ -1824,6 +1829,8 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request,
 		CEC_PartFile_Tag filetag(cur_file, detail_level);
 
 		CPartFile_Encoder *enc = static_cast<CPartFile_Encoder *>(encoders[ecid]);
+		// See the matching note in Get_EC_Response_GetSharedFiles.
+		wxASSERT(enc);
 		if (detail_level != EC_DETAIL_UPDATE) {
 			enc->ResetEncoder();
 		}

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -175,20 +175,79 @@ public:
 	virtual bool IsPartFile_Encoder() { return true; }
 };
 
-class CFileEncoderMap : public std::map<uint32, CKnownFile_Encoder *>
+// The encoders for the files this connection has told its client about, held
+// in ECID order.
+//
+// A sorted vector rather than a std::map. The response walk touches every
+// entry on every poll and does very little per entry, so its cost was
+// dominated by chasing red-black-tree pointers around the heap rather than by
+// the work itself -- a linear scan of a contiguous array is something the
+// prefetcher can follow, a tree traversal is not. Lookup becomes a binary
+// search, which is now the rarer operation: #775 removed the per-file lookups,
+// leaving only the reconcile below and two amuleweb call sites. Structural
+// change is rarer still, so paying O(n) to merge new entries or compact away
+// dead ones is the right side of the trade.
+class CFileEncoderMap
 {
 	typedef std::set<uint32> IDSet;
 
 public:
+	typedef std::pair<uint32, CKnownFile_Encoder *> value_type;
+	typedef std::vector<value_type> Storage;
+	typedef Storage::iterator iterator;
+	typedef Storage::const_iterator const_iterator;
+
 	~CFileEncoderMap();
+
+	iterator begin() { return m_entries.begin(); }
+	iterator end() { return m_entries.end(); }
+	size_t size() const { return m_entries.size(); }
+
+	// Binary search by ECID; end() when absent.
+	iterator find(uint32 id);
+
+	// The encoder for `id`, or NULL. Unlike std::map::operator[] this does
+	// not insert a default-constructed entry on a miss -- that entry would
+	// have held a NULL encoder, which the next reconcile would then have
+	// dereferenced.
+	CKnownFile_Encoder *operator[](uint32 id);
+
 	// If freshEcids is non-null, receives the ECIDs whose encoder was
 	// (re-)created this call. Freshly-created encoders signal that the
 	// caller's per-ECID EC caches (CObjTagMap valuemap, and the encoder's
-	// own sent-with-detail mask) are stale w.r.t. the client's local view
+	// own sent-with-detail flag) are stale w.r.t. the client's local view
 	// and must be dropped so INC_UPDATE emissions re-send identifying fields.
 	void UpdateEncoders(IDSet *freshEcids = nullptr);
 
 private:
+	// Order entries, and order an entry against a bare ECID, so the same
+	// predicate serves both the sort and the binary search.
+	struct KeyLess
+	{
+		bool operator()(const value_type &a, const value_type &b) const { return a.first < b.first; }
+		bool operator()(const value_type &a, uint32 id) const { return a.first < id; }
+		bool operator()(uint32 id, const value_type &b) const { return id < b.first; }
+	};
+
+	// Entries created during a reconcile, merged in once the pass that made
+	// them is done. Appending here rather than inserting into the middle of
+	// m_entries keeps a first poll -- where every file is new -- from paying
+	// a memmove of the whole array per file.
+	Storage m_pending;
+	void FlushPending();
+
+	// Sorted ascending by ECID. The GET_UPDATE walk depends on that order:
+	// it appends each ECID it passes to the list the removal merge consumes.
+	Storage m_entries;
+
+	// Monotonic reconcile counter; see UpdateEncoders. Two things make a
+	// stamp comparison safe. The counter is a member of this map, and the map
+	// belongs to one CECServerSocket, so it is per-connection and encoders
+	// are never shared across clients -- there is no cross-client collision
+	// to reason about. And every UpdateEncoders call takes a fresh value
+	// before stamping anything, so no encoder can be carrying the value the
+	// current call is about to use. 64-bit on top of that, so it also cannot
+	// wrap back onto a live encoder's stamp within any plausible uptime.
 	// Monotonic reconcile counter; see UpdateEncoders. Two things make a
 	// stamp comparison safe. The counter is a member of this map, and the map
 	// belongs to one CECServerSocket, so it is per-connection and encoders
@@ -203,16 +262,46 @@ private:
 CFileEncoderMap::~CFileEncoderMap()
 {
 	// DeleteContents() causes infinite recursion here!
-	for (iterator it = begin(); it != end(); ++it) {
-		delete it->second;
+	for (const value_type &e : m_entries) {
+		delete e.second;
 	}
+	// Normally empty: every reconcile merges what it created before it
+	// returns. Covers a throw part-way through one.
+	for (const value_type &e : m_pending) {
+		delete e.second;
+	}
+}
+
+CFileEncoderMap::iterator CFileEncoderMap::find(uint32 id)
+{
+	const iterator it = std::lower_bound(m_entries.begin(), m_entries.end(), id, KeyLess());
+	return (it != m_entries.end() && it->first == id) ? it : m_entries.end();
+}
+
+CKnownFile_Encoder *CFileEncoderMap::operator[](uint32 id)
+{
+	const iterator it = find(id);
+	return it == m_entries.end() ? nullptr : it->second;
+}
+
+void CFileEncoderMap::FlushPending()
+{
+	if (m_pending.empty()) {
+		return;
+	}
+	// Sort what arrived, then merge the two runs. Both are already ordered,
+	// so this is linear in the total rather than a re-sort of everything.
+	std::sort(m_pending.begin(), m_pending.end(), KeyLess());
+	const Storage::difference_type split = static_cast<Storage::difference_type>(m_entries.size());
+	m_entries.insert(m_entries.end(), m_pending.begin(), m_pending.end());
+	std::inplace_merge(m_entries.begin(), m_entries.begin() + split, m_entries.end(), KeyLess());
+	m_pending.clear();
 }
 
 // Check if encoder contains files that are no longer used
 // or if we have new files without encoder yet.
 void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 {
-	IDSet dead_files;
 	// Stamp every encoder whose file is still listed with this epoch; the
 	// sweep below then takes anything left behind. This used to build a set
 	// of the live ECIDs instead, which cost a red-black-tree insertion per
@@ -229,7 +318,7 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 		if (it == end()) {
 			CKnownFile_Encoder *enc = new CPartFile_Encoder(downloads[i]);
 			enc->SetSeenEpoch(epoch);
-			(*this)[id] = enc;
+			m_pending.emplace_back(id, enc);
 			if (freshEcids) {
 				freshEcids->insert(id);
 			}
@@ -237,6 +326,12 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 			it->second->SetSeenEpoch(epoch);
 		}
 	}
+	// Merge before the shares pass, not after both. A partfile appears in
+	// both lists, and the check below asks whether this reconcile has already
+	// reached it -- which it answers with find(). Leaving the new entries
+	// unmerged would hide them from that lookup and build a second encoder
+	// for the same ECID.
+	FlushPending();
 	// Shares
 	std::vector<CKnownFile *> shares;
 	theApp->sharedfiles->CopyFileList(shares);
@@ -253,7 +348,7 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 		if (it == end()) {
 			CKnownFile_Encoder *enc = new CKnownFile_Encoder(shares[i]);
 			enc->SetSeenEpoch(epoch);
-			(*this)[id] = enc;
+			m_pending.emplace_back(id, enc);
 			if (freshEcids) {
 				freshEcids->insert(id);
 			}
@@ -261,21 +356,33 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 			it->second->SetSeenEpoch(epoch);
 		}
 	}
-	// Check for removed files, and store them in a set for deletion.
-	// (std::map documentation is unclear if a construct like
-	//		iterator to_del = it++; erase(to_del) ;
-	// works or invalidates it too.)
-	for (iterator it = begin(); it != end(); ++it) {
+	FlushPending();
+
+	// Anything still carrying an older stamp has lost its file. Delete those
+	// encoders and close the gaps in one pass, preserving order. This used to
+	// collect the dead into a set and then erase them one at a time, each
+	// erase being a fresh lookup; compacting in place is a single sweep and
+	// keeps the array contiguous for the walk that reads it next.
+	iterator out = m_entries.begin();
+	for (iterator it = m_entries.begin(); it != m_entries.end(); ++it) {
 		if (it->second->GetSeenEpoch() != epoch) {
-			dead_files.insert(it->first);
+			delete it->second;
+			continue;
 		}
+		if (out != it) {
+			*out = *it;
+		}
+		++out;
 	}
-	// then delete them
-	for (IDSet::iterator it = dead_files.begin(); it != dead_files.end(); ++it) {
-		iterator it2 = find(*it);
-		delete it2->second;
-		erase(it2);
-	}
+	m_entries.erase(out, m_entries.end());
+
+	// The GET_UPDATE walk relies on this order to feed the removal merge, and
+	// getting it wrong loses or invents removals silently. Debug-only, and
+	// `less_equal` rejects duplicate ECIDs as well as misordering -- a
+	// duplicate would mean two encoders for one file.
+	assert(std::is_sorted(m_entries.begin(),
+		m_entries.end(),
+		[](const value_type &a, const value_type &b) { return a.first <= b.first; }));
 }
 
 //-------------------- CECServerSocket --------------------
@@ -1500,12 +1607,10 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	// infers removal from absence instead, so for one of those this is never
 	// read and is not worth building.
 	// The removal merge needs that list ascending, and it gets it for free
-	// only because the encoder map is ordered by ECID. Tie the guarantee to
-	// the type: re-basing CFileEncoderMap on an unordered container would go
-	// on compiling and silently hand the merge an unsorted list, whose wrong
-	// answer nothing at runtime would report.
-	static_assert(std::is_base_of<std::map<uint32, CKnownFile_Encoder *>, CFileEncoderMap>::value,
-		"Get_EC_Response_GetUpdate relies on CFileEncoderMap iterating in ECID order");
+	// only because the encoder map is ordered by ECID. That guarantee lives on
+	// the container: CFileEncoderMap keeps its entries sorted by ECID and
+	// asserts that invariant at the end of every reconcile, so the ordering
+	// is checked where it is established rather than assumed here.
 	std::vector<uint32> current_file_ids;
 	if (partial_update_active) {
 		current_file_ids.reserve(encoders.size());


### PR DESCRIPTION
`CFileEncoderMap` becomes a `std::vector` kept sorted by ECID instead of a `std::map`. Lookup becomes a binary search, iteration becomes a linear scan, and structural change — a file appearing or disappearing — becomes a merge or a compaction rather than a per-node insert or erase.

## What it was meant to do, and didn't

The hypothesis was that the `EC_OP_GET_UPDATE` walk was dominated by chasing red-black-tree pointers, since it touches every entry each poll and does very little per entry. **That was wrong**, and the production data says so clearly. Measured on a daemon with 1206 shared files, comparing 66 windows against 22 in a matched band of 26–38 connected peers:

| phase | before | after | |
|---|---|---|---|
| `sync` — the reconcile | 0.260 ms | **0.190 ms** | −27% |
| `walk` — the response loop | 0.340 ms | 0.350 ms | +3% |
| `rest` — untouched, control | 0.600 ms | 0.495 ms | −17% |

`walk` did not improve. And because the control moved 17% in the same window, the two runs are not on equal footing even at matched peer count — against an environment that got cheaper everywhere else, flat is slightly worse than flat.

`sync` is the real result: 0.26–0.28 ms in every prior window, 0.14–0.19 ms after. That is the reconcile's ~1206 `find()` calls going from tree descents to binary searches over contiguous memory.

## Why the walk didn't move

Across the same run, `walk` tracks peer count even though it iterates a fixed 1206 files:

```
cli  5-15 : walk 0.15 ms
cli 16-25 : walk 0.19 ms
cli 26-32 : walk 0.30 ms
cli 33-38 : walk 0.38 ms
cli 39-47 : walk 0.44 ms
```

Nearly 3× on a loop whose input size never changes. The walk is memory-bound, but the misses are not in the container — they are on the encoder and `CKnownFile` objects, whose cache residency the per-peer tag building destroys between polls. Making the spine contiguous does not help when each entry immediately dereferences two unrelated heap addresses.

The direct attack, if anyone wants it later, is to move the `CKnownFile*` and the sent-with-detail flag **into the vector entry**, so the unchanged-file path touches one random address instead of two. That is a follow-up, not this change.

## Correctness

Three things travel with it, none of them cosmetic.

**`operator[]` no longer inserts on a miss.** `std::map`'s did, leaving a NULL encoder in the container that the next reconcile would dereference — a latent crash. Both call sites now assert the contract they were already relying on.

**The ordering checks become conformant.** `std::is_sorted` requires its comparator to induce a strict weak ordering, and the `<=` used to reject equal neighbours is not irreflexive; libstdc++ under `_GLIBCXX_DEBUG` aborts on the predicate itself. That would fire on a debug build, which is the only build these checks run in at all. Both sites now use `std::adjacent_find` with a plain binary predicate, which has no ordering contract and says the same thing at the same cost. This also fixes `ECIdDiff.h`, which carries the same construct from #775 and is on master today.

**The removal sweep loses a set.** Dead encoders are compacted out in one ordered pass instead of being collected into a `std::set` and erased one lookup at a time.

The merge runs after the downloads pass as well as at the end. A partfile appears in both lists, and the shares pass uses `find()` to ask whether the reconcile already reached it; leaving new entries unmerged would hide them from that lookup and build a second encoder for the same file.

## Why it is worth merging

The performance premise it was written for did not hold, and the description above says so rather than quietly reframing. It is still worth taking, on two counts that support each other.

`sync` is 27% cheaper, on every poll, for every connected client. At 1206 files that is 0.07 ms; the reconcile does one lookup per file, so the saving grows with the library, and it grows faster than linearly because a deeper tree costs more per descent while a binary search over a contiguous array stays cache-friendly. This is the phase that phase 2a will target next, and it is a better starting point.

The correctness items are not incidental to that work. The `operator[]` insert was a live latent crash on a miss, and the `is_sorted` non-conformance is on master right now, in a check whose entire purpose is to be trustworthy on debug builds — the one place a hardened standard library would abort on it. Both would need fixing regardless of what happened to `walk`.

## Verification

Release and Debug both build clean, 32/32 unit tests in both, clang-format and both clang-tidy tiers clean on the diff with no compiler errors.

Exercised against a real daemon in a Debug build, so the ordering invariant was live: the shared list served and stayed stable across repeated polls, a file added appeared and a file removed disappeared with the count exact on both sides, and a partfile entered the download queue — the merge-ordering case above. No assertion fired and the daemon shut down cleanly.

The `ComputeRemovedIds` preconditions are mutation-proven: unsorted and duplicated input both abort, naming the file and line.

Not verified: the encoder map's own invariant assert has not been shown to fire. Removing the `std::sort` in the merge on a small test config still produced ordered input, so that mutation was inconclusive rather than a pass. The identical construct is proven in `ECIdDiff.h` and asserts are live in the same build, but this specific check is unproven and would benefit from a larger-library test.

A Release build compiles all of these out, so ordering is unchecked on a production node by design.
