### PR TITLE
perf(ec): skip the file-list reconcile when neither list has changed

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -138,6 +138,7 @@ void CDownloadQueue::LoadMetFiles(const CPath &path, const LoadProgressCb &progr
 			{
 				wxMutexLocker lock(m_mutex);
 				m_filelist.push_back(toadd);
+				m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 			}
 			NotifyObservers(EventType(EventType::INSERTED, toadd));
 			Notify_DownloadCtrlAddFile(toadd);
@@ -369,6 +370,7 @@ void CDownloadQueue::AddDownload(CPartFile *file, bool paused, uint8 category)
 	{
 		wxMutexLocker lock(m_mutex);
 		m_filelist.push_back(file);
+		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 		DoSortByPriority();
 	}
 
@@ -857,14 +859,29 @@ void CDownloadQueue::RemoveFile(CPartFile *file, bool keepAsCompleted)
 	wxMutexLocker lock(m_mutex);
 
 	EraseValue(m_filelist, file);
+	m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 
 	if (keepAsCompleted) {
 		m_completedDownloads.push_back(file);
+		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 	}
 }
 
 void CDownloadQueue::ClearCompleted(const ListOfUInts32 &ecids)
 {
+	// This used to walk and erase m_completedDownloads with m_mutex unheld,
+	// unlike every other mutator, while CopyFileList reads that same list
+	// under the lock. It mattered less when the EC file-list reconcile ran
+	// unconditionally: a reconcile that raced an erase healed on the next
+	// poll a second later. It matters now that the reconcile is skipped while
+	// the list generation is unchanged -- an erase observed as "already seen"
+	// is never reconciled at all, and the entry stays in the client's list
+	// for the life of the connection.
+	//
+	// Holding the lock across Notify_DownloadCtrlRemoveFile is safe here:
+	// m_mutex is constructed wxMUTEX_RECURSIVE, so a notify handler that
+	// re-enters the queue re-acquires it rather than deadlocking.
+	wxMutexLocker lock(m_mutex);
 	for (ListOfUInts32::const_iterator it1 = ecids.begin(); it1 != ecids.end(); ++it1) {
 		uint32 ecid = *it1;
 		for (FileList::iterator it = m_completedDownloads.begin(); it != m_completedDownloads.end();
@@ -872,6 +889,7 @@ void CDownloadQueue::ClearCompleted(const ListOfUInts32 &ecids)
 			CPartFile *file = *it;
 			if (file->ECID() == ecid) {
 				m_completedDownloads.erase(it);
+				m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 				// get a new EC ID so it is resent and cleared in remote gui
 				file->RenewECID();
 				Notify_DownloadCtrlRemoveFile(file);

--- a/src/DownloadQueue.h
+++ b/src/DownloadQueue.h
@@ -30,6 +30,7 @@
 #include "ObservableQueue.h" // Needed for CObservableQueue
 #include "GetTickCount.h"    // Needed for GetTickCount64
 
+#include <atomic> // Needed for std::atomic (m_listGeneration)
 #include <deque>
 #include <functional> // Needed for std::function (LoadProgressCb)
 
@@ -252,6 +253,29 @@ public:
 	/**
 	 * Makes a copy of the file list.
 	 */
+	/**
+	 * Changes whenever a file enters or leaves the list(s) this snapshots.
+	 *
+	 * A change token, not a count of changes: a reload clears and re-adds, so
+	 * it advances the value once per file in the library. All a caller may
+	 * conclude is "same value means nothing entered or left"; the magnitude of
+	 * a difference means nothing. Comparing sizes instead would be wrong --
+	 * an add and a remove between two polls is a net-zero size change that
+	 * still has to reconcile, and two bumps make that visible.
+	 *
+	 * Lets a caller that only needs to know "did the membership change since
+	 * I last looked" skip taking the snapshot at all. `CopyFileList` is O(n)
+	 * and the EC file-list reconcile runs it on every poll for every
+	 * connected client, almost always to discover that nothing came or went.
+	 *
+	 * Read it BEFORE calling CopyFileList, never after. Read first, and the
+	 * value can only be older than the snapshot that follows -- a change
+	 * racing in between makes the next poll redo the work, which is
+	 * harmless. Read after, and a change that landed between the copy and
+	 * the read would be recorded as already seen, and lost for good.
+	 */
+	uint64 GetListGeneration() const { return m_listGeneration.load(std::memory_order_relaxed); }
+
 	void CopyFileList(std::vector<CPartFile *> &out_list, bool includeCompleted = false) const;
 
 	/**
@@ -398,6 +422,11 @@ private:
 
 	typedef std::deque<CPartFile *> FileQueue;
 	FileQueue m_filelist;
+	// See GetListGeneration(). Bumped under m_mutex wherever m_filelist OR
+	// m_completedDownloads gains or loses an entry -- CopyFileList draws
+	// from both when includeCompleted is set, which is how the EC reconcile
+	// calls it, so tracking only m_filelist would miss completions.
+	std::atomic<uint64> m_listGeneration{ 0 };
 
 	typedef std::list<CPartFile *> FileList;
 	FileList m_localServerReqQueue;

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -240,6 +240,16 @@ private:
 	// it appends each ECID it passes to the list the removal merge consumes.
 	Storage m_entries;
 
+	// The list generations this map was last reconciled against. When both
+	// still match, the lists have not gained or lost a file and the reconcile
+	// is a no-op -- see the early return in UpdateEncoders. `m_haveListGen`
+	// distinguishes "never reconciled" from "reconciled when both counters
+	// happened to be zero", which is the state at startup and would otherwise
+	// skip the very first pass and leave the map permanently empty.
+	uint64 m_lastSharedGen = 0;
+	uint64 m_lastDownloadGen = 0;
+	bool m_haveListGen = false;
+
 	// Monotonic reconcile counter; see UpdateEncoders. Two things make a
 	// stamp comparison safe. The counter is a member of this map, and the map
 	// belongs to one CECServerSocket, so it is per-connection and encoders
@@ -294,6 +304,26 @@ void CFileEncoderMap::FlushPending()
 // or if we have new files without encoder yet.
 void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 {
+	// Nothing has entered or left either list since the last reconcile, so
+	// the encoder map already mirrors them and the whole pass below -- two
+	// O(n) CopyFileList snapshots, a lookup and a stamp per file, and a sweep
+	// -- would end exactly where it started. On a library that is not
+	// churning, which is the normal case, that is every poll for every
+	// connected client.
+	//
+	// Read the counters BEFORE the snapshots, never after. Read first and the
+	// values can only be older than what CopyFileList goes on to see: a file
+	// arriving in between leaves us recording a stale generation, so the next
+	// poll reconciles again and picks it up one cycle late. Read after, and a
+	// change that landed between the copy and the read would be recorded as
+	// already seen and never reconciled at all -- a file that silently never
+	// appears, or never disappears, for the life of the connection.
+	const uint64 sharedGen = theApp->sharedfiles->GetListGeneration();
+	const uint64 downloadGen = theApp->downloadqueue->GetListGeneration();
+	if (m_haveListGen && sharedGen == m_lastSharedGen && downloadGen == m_lastDownloadGen) {
+		return;
+	}
+
 	// Stamp every encoder whose file is still listed with this epoch; the
 	// sweep below then takes anything left behind. This used to build a set
 	// of the live ECIDs instead, which cost a red-black-tree insertion per
@@ -367,6 +397,14 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 		++out;
 	}
 	m_entries.erase(out, m_entries.end());
+
+	// Record what this pass reconciled against, so the next one can tell
+	// whether anything moved. Set here rather than next to the read above so
+	// an exception part-way through leaves the map looking un-reconciled and
+	// the next poll redoes it.
+	m_lastSharedGen = sharedGen;
+	m_lastDownloadGen = downloadGen;
+	m_haveListGen = true;
 
 	// The GET_UPDATE walk relies on this order to feed the removal merge, and
 	// getting it wrong loses or invents removals silently. Debug-only, and

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -396,6 +396,7 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 	{
 		wxMutexLocker lock(list_mut);
 		m_Files_map.clear();
+		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 	}
 
 	// All part files are automatically shared.
@@ -651,6 +652,7 @@ bool CSharedFileList::AddFile(CKnownFile *pFile)
 
 	CKnownFileMap::value_type entry(pFile->GetFileHash(), pFile);
 	if (m_Files_map.insert(entry).second) {
+		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 		/* Keywords to publish on Kad */
 		m_keywords->AddKeywords(pFile);
 		theStats::AddSharedFile(pFile->GetFileSize());
@@ -847,6 +849,7 @@ void CSharedFileList::RemoveFile(CKnownFile *toremove)
 	Notify_SharedFilesRemoveFile(toremove);
 	wxMutexLocker lock(list_mut);
 	if (m_Files_map.erase(toremove->GetFileHash()) > 0) {
+		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 		theStats::RemoveSharedFile(toremove->GetFileSize());
 	}
 	// Same path key we wrote into the index in AddFile(). erase() is a

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -26,6 +26,7 @@
 #ifndef SHAREDFILELIST_H
 #define SHAREDFILELIST_H
 
+#include <atomic> // Needed for std::atomic (m_listGeneration)
 #include <functional>
 #include <list>
 #include <map>
@@ -85,6 +86,29 @@ public:
 		wxMutexLocker lock(list_mut);
 		return m_Files_map.size();
 	}
+	/**
+	 * Changes whenever a file enters or leaves the list(s) this snapshots.
+	 *
+	 * A change token, not a count of changes: a reload clears and re-adds, so
+	 * it advances the value once per file in the library. All a caller may
+	 * conclude is "same value means nothing entered or left"; the magnitude of
+	 * a difference means nothing. Comparing sizes instead would be wrong --
+	 * an add and a remove between two polls is a net-zero size change that
+	 * still has to reconcile, and two bumps make that visible.
+	 *
+	 * Lets a caller that only needs to know "did the membership change since
+	 * I last looked" skip taking the snapshot at all. `CopyFileList` is O(n)
+	 * and the EC file-list reconcile runs it on every poll for every
+	 * connected client, almost always to discover that nothing came or went.
+	 *
+	 * Read it BEFORE calling CopyFileList, never after. Read first, and the
+	 * value can only be older than the snapshot that follows -- a change
+	 * racing in between makes the next poll redo the work, which is
+	 * harmless. Read after, and a change that landed between the copy and
+	 * the read would be recorded as already seen, and lost for good.
+	 */
+	uint64 GetListGeneration() const { return m_listGeneration.load(std::memory_order_relaxed); }
+
 	void CopyFileList(std::vector<CKnownFile *> &out_list) const;
 	// Fill `out` with the basenames of all currently shared files. Used by
 	// the Directories panel's exclusion-filter live preview.
@@ -229,6 +253,9 @@ private:
 	CKnownFileList *filelist;
 
 	CKnownFileMap m_Files_map;
+	// See GetListGeneration(). Bumped under list_mut wherever m_Files_map
+	// gains or loses an entry; atomic so it can be read without the lock.
+	std::atomic<uint64> m_listGeneration{ 0 };
 	// Secondary index keyed by full path so the watcher can resolve a
 	// DELETE/RENAME event to its CKnownFile* in O(1) without walking
 	// m_Files_map. Maintained alongside m_Files_map in AddFile() and


### PR DESCRIPTION
`UpdateEncoders` rebuilt its picture of the world on every EC poll for every connected client: two O(n) `CopyFileList` snapshots, a lookup and an epoch stamp per file, and a sweep over every encoder. On a library that is not churning — the normal case — all of that ends exactly where it started.

`CSharedFileList` and `CDownloadQueue` now each carry a generation counter, bumped wherever a file enters or leaves. When both still match what the encoder map was last reconciled against, the map already mirrors the lists and the pass is skipped outright.

## Measurement

On a production daemon with 1206 shared files, load-matched at 12–19 connected peers against the previous build:

| phase | before | after | |
|---|---|---|---|
| `sync` — the reconcile | 0.180 ms | **0.000 ms** | −100% |
| `walk` — control, untouched | 0.160 ms | 0.160 ms | +0% |
| `rest` — control, untouched | 0.230 ms | 0.245 ms | +7% |
| whole handler p50 | 0.560 ms | **0.390 ms** | −30% |

`sync` eliminated 0.180 ms and p50 fell 0.170 ms. Those agreeing is the point: the saving is the removed phase and not something else drifting. Both controls held, and `sync` does not correlate with peer count — it sat at 0.18–0.19 ms from 5 peers to 47 in the previous run — so the comparison does not depend on matching load, unlike the `walk` figures in #776.

`skip=100%` in every steady-state window.

## The non-skip path, on production

A shared file was deleted while the daemon was running. The window covering it:

```
[diag] Watcher: detaching deleted file '.../test.txt' from shares
[ecperf] phases n=139 enc=1206 cli=27 emit=13 skip=98% (136/139) | avg sync=0.00 ... max sync=0.20
[ecperf] GET_UPDATE n=139 shared=1205 ...
```

Three reconciles out of 139 polls — one per connected EC client, since each `CECServerSocket` owns its own encoder map, and that is the minimum correct number. `enc` fell 1207 → 1206 and the served list 1206 → 1205, so the removal propagated rather than merely triggering work. `max sync=0.20 ms` is the full reconcile still costing what it always did: this does not make the reconcile cheaper, it makes it rare. The next window returned to `skip=100%`.

The work is now proportional to changes × clients rather than polls × clients.

## Getting the bump sites right

Eight sites, not the six that a search for the obvious container methods finds.

`m_filelist` is never erased directly — removal goes through `EraseValue(m_filelist, file)`, which a grep for `.erase(` misses entirely. Missing it would have meant downloads that never disappear from any client's list.

`CopyFileList` draws from `m_completedDownloads` as well whenever `includeCompleted` is set, which is exactly how the reconcile calls it, so a completion has to bump too.

**`ClearCompleted` now takes `m_mutex`, which it never did.** It erased from `m_completedDownloads` unlocked while `CopyFileList` reads that list under the lock. That race predates this change, but its consequence does not: an unsynchronised erase can be observed as already-seen and, with the reconcile now skipped while the generation is unchanged, never reconciled at all — where previously the next poll re-reconciled unconditionally and the discrepancy healed within about a second. Holding the lock across `Notify_DownloadCtrlRemoveFile` is safe because `m_mutex` is constructed `wxMUTEX_RECURSIVE`.

## Details that would otherwise be wrong

**Ordering is load-bearing.** The counters are read *before* the snapshots. Read first and the value can only be older than what `CopyFileList` goes on to see, so a file arriving in between merely makes the next poll reconcile again and pick it up one cycle late. Read after, and a change landing between the copy and the read would be recorded as already seen and never reconciled — a file that silently never appears, or never disappears, for the life of the connection.

**It is a change token, not a change count.** A reload clears and re-adds, so it advances once per file in the library. The only safe reading is "same value means nothing entered or left". Comparing list sizes instead would be wrong: an add and a remove between two polls is a net-zero size change that still has to reconcile, and two bumps keep that visible.

**`m_haveListGen`** separates "never reconciled" from "reconciled while both counters happened to read zero", which is the state at startup and would otherwise skip the first pass and leave the map permanently empty.

**The partfile shared flag needs no separate treatment**, which is worth stating because it looks like it might. `CPartFile_Encoder::m_shared` is false only from the constructor and true only from `SetShared()`, which the reconcile calls solely because the partfile is present in the shared list — so the false-to-true transition requires an insert into `m_Files_map` and bumps the counter. The reverse transition is already not implemented: the flag is sticky until the encoder is destroyed, so skipping cannot make it worse.

The counters are atomic so the reconcile can read them without taking either container's lock.

## Verification

Release and Debug both build clean, 32/32 unit tests in both, clang-format and both clang-tidy tiers clean on the diff with no compiler errors.

Exercised against a daemon in a Debug build before it went near production: repeated polls stable across the skip path, a file added appeared and a file removed disappeared with the count exact on both sides, so both bump directions propagate.

Then on production as above, where the deletion trace closes the one thing the local test could not — that a real membership change on a busy node drops the skip rate, reconciles exactly the connected clients, and propagates.
