### PR TITLE
fix(gui): log the splash timing under a real debug category

### DIFF
--- a/src/SplashScreen.cpp
+++ b/src/SplashScreen.cpp
@@ -273,7 +273,12 @@ void CSplashScreen::Finish()
 	// reports on, which matters when tuning the phase weighting but is noise
 	// in a user's log. The phase timings themselves are logged normally,
 	// since those are what a "startup is slow" report needs.
-	AddDebugLogLineN(logStandard,
+	//
+	// logGeneral, not logStandard: the latter is the -1 sentinel meaning "not
+	// a debug category" that AddLogLineN passes, so a debug line asking
+	// whether it is enabled sends it through CLogger::IsEnabled, whose index
+	// check rejects anything below zero and hits wxFAIL.
+	AddDebugLogLineN(logGeneral,
 		CFormat("Splash: %u repaints costing %lld ms, %lld ms taken from startup, "
 			"over %lld ms on screen") %
 			m_paintCount % m_paintMicros.GetValue() % m_updateMicros.GetValue() %


### PR DESCRIPTION
`AddDebugLogLineN` passes its category straight to `CLogger::IsEnabled`, whose index check rejects anything below zero and hits `wxFAIL`. `logStandard` is the `-1` sentinel meaning "not a debug category" — the value `AddLogLineN` passes — so asking whether it is enabled is invalid by construction. `Logger.h` says as much where it documents the category prefix: *"(except for logStandard)"*.

The macro calls `IsEnabled(type)` unconditionally, so the verbose setting made no difference. The splash always finishes, so this fired on **every Debug monolithic launch**, and assertions block by default — the GUI could not start without dismissing a dialog first. Release builds compile `AddDebugLogLineN` away entirely and were never affected, which is why it survived the build matrix.

This was the only such call site in the tree. Fixed by using `logGeneral`, which keeps the line at debug level as intended.

## Testing

Debug monolithic on macOS starts, runs and shuts down with no assertion output; the startup phase timings still log normally.
