### PR TITLE
fix(ec): seal the cached-blob response body when the connection is encrypted

### DIFF
--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -1115,6 +1115,27 @@ void CECSocket::SendCachedBodyResponse(
 	} else {
 		outputStart = m_output_queue.begin();
 	}
+
+	// Seal the body, exactly as WritePacket does and for the same reasons:
+	// after FlushBuffers so ZLIB has already produced its bytes (serialise ->
+	// deflate -> seal), and before the length is summed below so the patched
+	// length covers ciphertext plus tag.
+	//
+	// Without this the flag byte above still advertises EC_FLAG_ENCRYPTED --
+	// it is OR'd in from m_crypt_enabled after the m_my_flags mask, because
+	// it is connection state rather than a negotiated capability -- while the
+	// body goes out as plaintext. The peer then tries to verify an AEAD tag
+	// that was never written, fails, and drops the connection through the one
+	// path in ReadPacket that logs only at debug level, so the disconnect is
+	// silent at both ends.
+	if (flags & EC_FLAG_ENCRYPTED) {
+		if (!SealOutputQueue(outputStart)) {
+			AddDebugLogLineN(logEC, "SendCachedBodyResponse: sealing failed");
+			CloseAndDispatchLost();
+			return;
+		}
+	}
+
 	uint32 actual_len = 0;
 	for (std::list<CQueuedData *>::iterator it = outputStart; it != m_output_queue.end(); ++it) {
 		actual_len += (uint32_t)(*it)->GetDataLength();

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -1204,7 +1204,20 @@ const CECPacket *CECSocket::ReadPacket()
 		if (!OpenReceivedBody()) {
 			// A failed tag is the tamper signal, and it is not recoverable:
 			// the stream is no longer trustworthy.
+			//
+			// Reported unconditionally, on stderr. This is one of four ways
+			// ReadPacket can drop a connection and was the only silent one,
+			// which is backwards: the other three are protocol or zlib
+			// errors, while this one fires on tampering or on a peer that
+			// flags a packet as sealed without sealing it. A connection that
+			// dies leaving nothing in the log at either end is close to
+			// undiagnosable. One line per dropped connection, not per
+			// packet: the drop happens immediately below.
 			AddDebugLogLineN(logEC, "ReadPacket: authentication failed, dropping connection");
+			fprintf(stderr,
+				"amule: EC packet failed authentication (flagged encrypted but the tag "
+				"did not verify) - dropping the connection.\n");
+			fflush(stderr);
 			CloseAndDispatchLost();
 			return nullptr;
 		}


### PR DESCRIPTION
`amulecmd`'s `show DL` and `show Shared` drop the External Connection against a daemon with EC encryption enabled:

```
aMulecmd$ show Servers
aMulecmd$ show DL
External Connection lost - exiting.
```

The daemon is unaffected and keeps running; `show UL`, `show Servers` and `status` work on the same connection; and amulegui stays connected throughout, listing the full shared-file set.

## Cause

`SendCachedBodyResponse` advertises `EC_FLAG_ENCRYPTED` whenever the connection has crypto enabled — the bit is OR'd in from `m_crypt_enabled` *after* the `flags &= m_my_flags` mask, because it is connection state rather than a negotiated capability — but never sealed the body it had just written. `SealOutputQueue` had exactly one call site, in `WritePacket`.

So the peer received a packet flagged as sealed whose body was plaintext. It tried to verify an AEAD tag that was never written, failed, and dropped the connection.

## Why only those two commands

`EC_OP_GET_SHARED_FILES` and `EC_OP_GET_DLOAD_QUEUE` are the only opcodes that reach this path. It is the cached-blob fast path, taken when the client negotiated `UTF8_NUMBERS` and `LARGE_TAG_COUNT` and asks at `EC_DETAIL_FULL` with no query items — exactly amulecmd's profile. `show UL` has no such path, and amulegui and amuleapi poll `EC_OP_GET_UPDATE`, which does not use it either.

## Why it was silent

`ReadPacket`'s authentication-failure branch is the only one of its close paths that logs at debug level *without* an accompanying unconditional `cout`. Its neighbours — invalid flags, zlib init failure, packet read error — all print regardless of build. So neither end reported anything: the client showed a clean header read, a complete body read, no parse error, and then only `External Connection lost - exiting.`

That is also why the size, framing, tag-count, ZLIB and encoder-map theories all came up empty: the reply is produced and transmitted correctly, and the failure is a verification failure at the receiver.

The second commit fixes that asymmetry. Of the four ways `ReadPacket` can drop a connection, the three that print unconditionally are protocol and library errors, while the silent one is the one that fires on tampering or on a peer that flags a packet as sealed without sealing it. It now reports on stderr, matching `CRemoteConnect`'s connection-lost message so the two appear together rather than one on stdout and one on stderr. It is one line per dropped connection, not per packet, since the drop happens immediately after.

The other three keep their `cout` for now: moving library diagnostics off stdout is a pre-existing tidy-up and does not belong in a fix.

## The fix

Seal in `SendCachedBodyResponse` where `WritePacket` does it, and for the same reasons: after `FlushBuffers()` so ZLIB has already produced its bytes (serialise → deflate → seal), and before the length is summed so the patched length covers ciphertext plus tag.

## Verification

Before and after on the machine where it reproduces (Ubuntu 26.04 ARM64, wxGTK3 3.2.9, 800 shared files, one queued download):

| | `show DL` |
|---|---|
| current master | `External Connection lost - exiting.` |
| with this change | lists the download normally |

`show Shared` returns all 800 files, and `show UL` and `status` are unchanged. The daemon stays healthy throughout. Re-run from a pristine tree with no instrumentation present to confirm the result was not an artefact of the debugging patches used to find it.

Builds clean in Release, 32/32 unit tests, clang-format and both clang-tidy tiers clean on the diff.

## Scope

Pre-existing, not a recent regression in the EC file-list work: it reproduces on `8456cc9b7` as well as current master. It affects any EC client that takes the cached-blob path on an encrypted connection — in practice amulecmd — and leaves amulegui, amuleapi and amuleweb unaffected.
