### PR TITLE
fix(web-ui): stop polling once the session dies, instead of earning an IP ban

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -174,6 +174,8 @@ Two per-IP failure counters, both with sliding-window semantics:
 
 When the bucket fills, the next request from that IP returns `429 rate_limited` with a `Retry-After: <seconds>` header. The bucket clears on success or when the lockout expires.
 
+A polling client must treat its first `401` as terminal for that session and stop sending until it has re-authenticated. Restarting amuleapi invalidates every issued token, so a client that keeps a poll loop and an SSE reconnect running against the old cookie spends the generic limiter's whole budget within seconds and locks its own IP out for five minutes. Retrying a `401` never succeeds — only `POST /auth/login` clears it.
+
 ### JWT structure
 
 Header: `{"alg":"HS256","typ":"JWT"}`. Payload: `{"role":"admin"|"guest","iat":<unix>,"exp":<unix>,"jti":"<base64url>"}`. The signing secret is auto-generated as 32 random bytes into `${config_dir}/amuleapi-jwt-secret` on first launch (mode 0600). Delete that file and restart to invalidate every issued token. The `jti` claim drives the server-side revocation list (`/auth/logout`), and the `iat` claim drives the credential-change cutoff described above.

--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -416,6 +416,9 @@ table.data.virtual td .name-cell .name-text { min-width: 0; overflow: hidden; te
 .login-logo { height: 52px; margin: 0 auto; }
 .login-title { font-size: 16px; margin: 0; color: var(--text-dim); font-weight: 500; }
 .login-error { color: var(--bad); min-height: 1em; margin: 0; font-size: 13px; }
+/* Why we bounced back to login (expired session, lockout) — a statement of
+   fact, not a failed action, so it reads warn rather than bad. */
+.login-notice { color: var(--warn); margin: 0; font-size: 13px; }
 
 /* --- version mismatch banner --- */
 .version-banner {

--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -77,6 +77,7 @@
   "login_err_invalid_credentials": "Incorrect password.",
   "login_err_rate_limited": "Too many failed attempts. Please try again later.",
   "login_err_login_disabled": "Login unavailable: no password is configured on the server.",
+  "login_session_expired": "Your session ended — the server may have restarted. Please sign in again.",
   "login_title": "aMule Web — Sign in",
   "login_password": "Password",
   "login_sign_in": "Sign in",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -77,6 +77,7 @@
   "login_err_invalid_credentials": "Contraseña incorrecta.",
   "login_err_rate_limited": "Demasiados intentos fallidos. Inténtalo de nuevo más tarde.",
   "login_err_login_disabled": "Inicio de sesión no disponible: no hay ninguna contraseña configurada en el servidor.",
+  "login_session_expired": "Tu sesión ha terminado — puede que el servidor se haya reiniciado. Inicia sesión de nuevo.",
   "login_title": "aMule Web — Iniciar sesión",
   "login_password": "Contraseña",
   "login_sign_in": "Iniciar sesión",

--- a/src/webapi/static/js/api.js
+++ b/src/webapi/static/js/api.js
@@ -1,6 +1,8 @@
 // REST client for the amuleapi /api/v0 surface.
 //
 // - Always sends the session cookie (credentials: "include").
+// - Latches "session dead" on the first 401 and fails every later call
+//   locally (see below) — the server bans an IP that keeps knocking.
 // - Parses the {error:{code,message}} envelope into ApiError.
 // - Caches ETags per GET target and revalidates with If-None-Match so a
 //   304 short-circuits re-downloading/parsing an unchanged body.
@@ -28,11 +30,38 @@ export function bulkFailures(res) {
 // path -> { etag, data }
 const etagCache = new Map();
 
-// Optional hook invoked on any 401 so the shell can bounce to login.
+// Optional hook invoked when the session dies, so the shell can tear the
+// live-data layer down and bounce to login. Called at most once per session
+// with the reason ("unauthorized" | "rate_limited").
 let onUnauthorized = null;
 export function setUnauthorizedHandler(fn) { onUnauthorized = fn; }
 
-async function request(method, path, { body, useEtag = false } = {}) {
+// Session gate.
+//
+// amuleapi counts every 401 against the calling IP and locks the IP out for
+// five minutes once it sees 30 within 60 s. Restarting amuleapi invalidates
+// the session cookie, so without a latch the live-data layer walks straight
+// into that ban: its fallback poll loop fires GET status plus one GET per
+// active resource every 4 s, and the SSE stream reconnects on its own — every
+// one of those a fresh 401.
+//
+// So the first rejection latches the client as logged out and every later
+// call fails locally, with no fetch at all, until a successful login clears
+// it. Only the auth endpoints bypass the gate (`noGate`), so signing back in
+// still works.
+let sessionDead = false;
+
+function markSessionDead(reason) {
+  if (sessionDead) return;
+  sessionDead = true;
+  if (onUnauthorized) onUnauthorized(reason);
+}
+
+async function request(method, path, { body, useEtag = false, noGate = false } = {}) {
+  if (sessionDead && !noGate) {
+    throw new ApiError(401, "unauthorized", "session ended");
+  }
+
   const url = BASE + "/" + path.replace(/^\//, "");
   const headers = {};
   let cacheKey = null;
@@ -60,8 +89,6 @@ async function request(method, path, { body, useEtag = false } = {}) {
     return etagCache.get(cacheKey).data;
   }
 
-  if (resp.status === 401 && onUnauthorized) onUnauthorized();
-
   // No-body success (e.g. 204).
   if (resp.status === 204) return {};
 
@@ -73,6 +100,13 @@ async function request(method, path, { body, useEtag = false } = {}) {
 
   if (!resp.ok) {
     const err = payload && payload.error ? payload.error : {};
+    // 401 (cookie gone / expired / revoked) and the auth limiter's own 429
+    // are terminal for this session. Match 429 on the code, not the status:
+    // other endpoints answer 429 for their own throttles (the daemon's
+    // update check, say) and those must not log the user out.
+    if (!noGate && (resp.status === 401 || (resp.status === 429 && err.code === "rate_limited"))) {
+      markSessionDead(resp.status === 429 ? "rate_limited" : "unauthorized");
+    }
     throw new ApiError(resp.status, err.code, err.message);
   }
 
@@ -90,8 +124,16 @@ export const api = {
   patch: (path, body) => request("PATCH", path, { body }),
   del: (path, body) => request("DELETE", path, { body }),
 
-  // auth
-  login: (password) => request("POST", "auth/login", { body: { password } }),
+  // auth. login/session bypass the gate (they are how a dead session comes
+  // back); a winning login re-arms the client. logout stays gated on purpose:
+  // once the session is dead the server would only answer it with another
+  // 401, and the caller treats a failure as "logged out" anyway.
+  login: async (password) => {
+    const res = await request("POST", "auth/login", { body: { password }, noGate: true });
+    sessionDead = false;
+    etagCache.clear(); // fresh backend, possibly a fresh dataset
+    return res;
+  },
   logout: () => request("POST", "auth/logout"),
-  session: () => request("GET", "auth/session"),
+  session: () => request("GET", "auth/session", { noGate: true }),
 };

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -45,18 +45,32 @@ function App() {
   // "checking" while we probe the session; "out" when logged out; otherwise
   // the role string ("admin" | "guest").
   const [auth, setAuth] = useState("checking");
+  // Why we landed back on the login screen, when it wasn't the user's doing.
+  const [notice, setNotice] = useState("");
 
   useEffect(() => {
     let alive = true;
-    setUnauthorizedHandler(() => { if (alive) setAuth("out"); });
+    setUnauthorizedHandler((reason) => {
+      // The session is gone — an amuleapi restart invalidates the cookie.
+      // Stop the live-data layer before anything else: its poll timer and SSE
+      // stream are module-level and outlive the shell unmounting below, and
+      // each retry is another failed-auth strike the server counts towards
+      // banning this IP.
+      data.stop();
+      if (!alive) return;
+      setNotice(reason === "rate_limited" ? t("login_err_rate_limited") : t("login_session_expired"));
+      setAuth("out");
+    });
     api.session()
       .then((s) => { if (alive) setAuth(s.role || "guest"); })
       .catch(() => { if (alive) setAuth("out"); });
     return () => { alive = false; setUnauthorizedHandler(null); };
   }, []);
 
+  const onLoggedIn = (role) => { setNotice(""); setAuth(role); };
+
   if (auth === "checking") return html`<${Placeholder} kind="loading">${t("app_loading")}<//>`;
-  if (auth === "out") return html`<${Login} onSuccess=${(role) => setAuth(role)} />`;
+  if (auth === "out") return html`<${Login} notice=${notice} onSuccess=${onLoggedIn} />`;
   return html`<${Shell} role=${auth} onLogout=${() => setAuth("out")} />`;
 }
 
@@ -167,6 +181,7 @@ function Toolbar({ route, onLogout }) {
 
   const doLogout = async () => {
     try { await api.logout(); } catch (_) {}
+    data.stop(); // the SSE stream and poll timer outlive this component
     location.hash = "";
     onLogout();
   };

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -50,6 +50,28 @@ export const data = {
   refresh(key) { return active.has(key) ? seed(key) : Promise.resolve(); },
 
   isLive() { return es !== null && es.readyState === EventSource.OPEN; },
+
+  // Full teardown: no SSE, no poll timer, no pending publish, nothing
+  // seeded. Called when the session dies (an amuleapi restart invalidates
+  // the cookie) and on logout. Everything here is module-level and survives
+  // the shell unmounting, so without this the poll loop keeps firing one
+  // request per active resource every 4 s against a session the server has
+  // already rejected — which is exactly what earns the IP a ban. Leaves the
+  // registry intact: views re-register once per module load, and ensure()
+  // re-seeds them after the next login.
+  stop() {
+    if (es) { es.close(); es = null; }
+    stopPolling();
+    for (const timer of publishTimers.values()) clearTimeout(timer);
+    publishTimers.clear();
+    seedBuffers.clear();
+    collections.clear();
+    listenersAttached.clear();
+    active.clear();
+    statusActive = false;
+    sseFails = 0;
+    store.set("live", false);
+  },
 };
 
 async function seed(key) {
@@ -62,6 +84,9 @@ async function seed(key) {
   seedBuffers.set(key, buf);
   try {
     const arr = (await spec.list()) || [];
+    // stop() may have landed while the snapshot was in flight; don't
+    // resurrect a collection the teardown just dropped.
+    if (!active.has(key)) return;
     const m = new Map();
     for (const it of arr) m.set(String(it[spec.id]), it);
     // Drain buffered deltas over the fresh snapshot, in arrival order.
@@ -96,8 +121,10 @@ function publishThrottled(key) {
 }
 
 async function refreshStatus() {
-  try { store.set("status", await api.get("status")); }
-  catch (e) { /* keep last known status */ }
+  try {
+    const s = await api.get("status");
+    if (statusActive) store.set("status", s);
+  } catch (e) { /* keep last known status */ }
 }
 
 // --- SSE ---------------------------------------------------------------
@@ -116,6 +143,13 @@ function openSse() {
     // failures so a single blip doesn't thrash.
     sseFails++;
     store.set("live", false);
+    // ...except when the browser gave up for good. A response it refuses to
+    // stream — a 401 once amuleapi has been restarted, a wrong content type —
+    // fails the connection permanently (readyState CLOSED, no retry), so
+    // waiting out a retry budget that will never be spent would leave the UI
+    // frozen on stale data. Fall back now; polling's first request is what
+    // surfaces the dead session.
+    if (es && es.readyState === EventSource.CLOSED) sseFails = SSE_FAIL_THRESHOLD;
     if (sseFails >= SSE_FAIL_THRESHOLD) startPolling();
   });
 
@@ -184,9 +218,20 @@ function applyDelta(spec, op, ev) {
 function startPolling() {
   if (pollTimer) return;
   store.set("polling", true);
-  const tick = () => {
-    if (statusActive) refreshStatus();
-    for (const k of active) seed(k);
+  let ticking = false;
+  const tick = async () => {
+    if (ticking) return; // a slow link shouldn't stack ticks on top of each other
+    ticking = true;
+    try {
+      // Status goes first and is awaited: it is the cheapest probe we have,
+      // so a dead session latches the api gate (and tears this loop down)
+      // before the same tick's resource fetches go out — one rejected
+      // request per restart instead of one per active resource.
+      if (statusActive) await refreshStatus();
+      for (const k of active) seed(k);
+    } finally {
+      ticking = false;
+    }
   };
   tick();
   pollTimer = setInterval(tick, POLL_INTERVAL_MS);

--- a/src/webapi/static/js/views/login.js
+++ b/src/webapi/static/js/views/login.js
@@ -15,7 +15,7 @@ const LOGIN_ERROR_KEYS = {
   login_disabled: "login_err_login_disabled",
 };
 
-export function Login({ onSuccess }) {
+export function Login({ onSuccess, notice }) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
@@ -43,6 +43,7 @@ export function Login({ onSuccess }) {
       <form class="login-form" onSubmit=${submit}>
         <img class="login-logo" src="img/logo.png" alt="aMule" />
         <h1 class="login-title">${t("login_title")}</h1>
+        ${notice && !error ? html`<p class="login-notice" role="status">${notice}</p>` : null}
         <label class="sr-only" for="login-password">${t("login_password")}</label>
         <input ref=${input} type="password" id="login-password" class="input"
                autocomplete="current-password" required placeholder=${t("login_password")}


### PR DESCRIPTION
Restart amuleapi with the web UI open in a tab and the browser locks itself out of the daemon for five minutes. The network panel fills with a repeating `status` / `downloads` / `shared` / `clients` cycle, every request rejected, until the server switches from `401 unauthorized` to `429 rate_limited` and the UI stays dead until the lockout expires.

## Cause

A restart invalidates every issued token, so the session cookie the open tab still holds stops verifying. Nothing on the client stops knocking.

The live-data layer's state — the SSE stream, the fallback poll timer, the set of seeded resources — all lives at module scope in `events.js`, so it outlives the shell unmounting when a 401 bounces the user to the login screen. The poll loop keeps ticking every 4 s, firing `GET status` plus one `GET` per resource that was ever seeded, and `active` is never pruned, so a session that visited downloads, shared and clients goes on polling all three: 60 rejected requests a minute. The generic 401 limiter bans the IP at 30 failures in 60 s, so the lockout lands in about half a minute and renews itself for as long as the tab is open.

`api.js` already had the hook for this — `onUnauthorized` fires on every 401 — but the handler only re-rendered to the login screen. It never stopped the requests, and re-rendering is exactly what leaves the module-level timers running.

## The fix

`api.js` latches the session dead on the first 401. Every later call is rejected locally, with no `fetch` at all, until a login clears it. Only `auth/login` and `auth/session` bypass the gate, so signing back in still works, and a winning login re-arms the client and clears the ETag cache. The auth limiter's own `429` latches too, matched on the error *code* rather than the status, so the daemon's `update_check_throttled` does not sign anyone out.

`events.js` grows `data.stop()`: close the stream, kill the poll and publish timers, drop the seeded collections. The resource registry survives, since views register once per module load and re-seed through `ensure()` after the next login. `app.js` calls it from the 401 handler and from logout — before the state update in the first case, so the teardown does not depend on a render happening.

The poll tick now probes `status` first and awaits it. It is the cheapest request in the cycle, so a dead session latches the gate before the same tick's resource fetches go out: one rejected request per restart rather than one per active resource.

## The stream that fails for good

A 401 on `/events` is not a retryable error. The browser refuses to stream the response and fails the connection permanently — `readyState` goes to `CLOSED` and there is no reconnection — so the `sseFails` counter stopped one short of the threshold that starts polling. The tab then sat frozen on stale data, live badge off, never issuing the request that would have told it the session was gone.

That path now falls back immediately instead of waiting out a retry budget that will never be spent, and polling's first request is what surfaces the dead session. It is the one case in this PR that *adds* a request; without it the UI silently stops updating.

## Verification

Driving the real `api.js` and `events.js` against a stubbed browser — 401 after a restart, with `status` plus three resources seeded, over 15 poll ticks (one minute at the 4 s interval):

| | requests in the minute after the restart | outcome |
|---|---|---|
| current master | 62 | banned, and re-banned every 5 min |
| with this change | 4, then silence | under the limiter's budget |

The 4 are what is already in flight when the first rejection lands; nothing is issued afterwards. The harness is pessimistic about that number — it drives ticks back to back rather than 4 s apart, so a real tab issues fewer.

`check-i18n.mjs` passes and all four touched modules parse clean.

## Also here

The login screen now says why it is being shown — the session ended and the server may have restarted, or the lockout string if the IP is already banned — rather than appearing with no explanation. New string in `en` and `es`.

`docs/api/REFERENCE.md` gains a paragraph under Rate limiting stating that a client must treat its first `401` as terminal for the session and stop sending. The footgun is not specific to this frontend: any polling client that retries a `401` spends the limiter's whole budget in seconds.

## Not in scope

`active` is still never pruned when a view unmounts, so fallback polling keeps requesting downloads, shared and clients for the rest of the session once each has been visited. That is what made the burst four requests wide instead of one, and it is worth fixing on its own, but it needs refcounting in `ensure()` and the views' cleanup rather than a teardown path.
