### PR TITLE
fix(ec): don't dereference a NULL encoder when a file is added mid-poll

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1579,11 +1579,17 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request,
 
 		CEC_SharedFile_Tag filetag(cur_file, detail_level);
 		CKnownFile_Encoder *enc = encoders[ecid];
-		// UpdateEncoders ran at the top of this handler against the same
-		// snapshot, so every file here has an encoder. NULL would be a crash
-		// on the next line either way; assert so it reads as the contract it
-		// is rather than an unchecked dereference.
-		wxASSERT(enc);
+		if (!enc) {
+			// UpdateEncoders reads the list generations unlocked, so a file
+			// added on a worker thread (PartFileConvert's import, a completing
+			// partfile) between that read and this handler's own snapshot can
+			// be present here with no encoder built for it yet. Skip it this
+			// cycle -- it stays in current_file_ids, so it is not reported as
+			// removed -- and the next poll's reconcile sees the bumped
+			// generation and builds it. Dereferencing NULL here would crash
+			// the daemon.
+			continue;
+		}
 		if (detail_level != EC_DETAIL_UPDATE) {
 			enc->ResetEncoder();
 		}
@@ -1867,8 +1873,10 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request,
 		CEC_PartFile_Tag filetag(cur_file, detail_level);
 
 		CPartFile_Encoder *enc = static_cast<CPartFile_Encoder *>(encoders[ecid]);
-		// See the matching note in Get_EC_Response_GetSharedFiles.
-		wxASSERT(enc);
+		if (!enc) {
+			// See the matching note in Get_EC_Response_GetSharedFiles.
+			continue;
+		}
 		if (detail_level != EC_DETAIL_UPDATE) {
 			enc->ResetEncoder();
 		}


### PR DESCRIPTION
A partfile Import (or any file added on a worker thread) can crash amuled with a NULL dereference on the EC file-list path.

`CFileEncoderMap::UpdateEncoders` reads the shared-file and download-queue list generations **unlocked**, and `CPartFileConvert` is a `wxThread` that calls `downloadqueue->AddDownload` and `sharedfiles->SafeAddKFile` directly on the worker thread. So a file can be added between that unlocked generation read — which then decides the lists are unchanged and skips encoder creation — and the handler's own locked `CopyFileList` snapshot. The snapshot then contains a file with no encoder: `encoders[ecid]` returns `NULL` (since #776, `operator[]` no longer inserts on a miss), the `wxASSERT(enc)` is a no-op in release, and `enc->Encode()` dereferences `NULL` → SIGSEGV.

Repro: trigger a partfile import while an amuleweb/amulecmd client polls the file list with `EC_DETAIL_UPDATE`.

Fix: null-check the encoder in both `Get_EC_Response_GetSharedFiles` and `Get_EC_Response_GetDownloadQueue` and `continue` on a miss. The file stays in `current_file_ids`, so it is not reported as removed, and the next poll's reconcile sees the bumped generation and builds the encoder — the file simply appears one cycle later.

The dereference shape is partly pre-existing (the old `std::map` miss returned `NULL` identically), but the #777 unlocked-generation skip widened the window and removed the next-cycle self-heal, so it is worth closing now.

Built clean on macOS (amule target + ECIdDiff unit tests link).
