### PR TITLE
refactor(gui): extract column persistence out of CMuleListCtrl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -950,6 +950,7 @@ if (NEED_LIB_MULEAPPGUI)
 		ColorFrameCtrl.cpp
 		EditServerListDlg.cpp
 		FileDetailListCtrl.cpp
+		ListColumnStore.cpp
 		MuleColour.cpp
 		MuleGifCtrl.cpp
 		MuleListCtrl.cpp

--- a/src/ListColumnStore.cpp
+++ b/src/ListColumnStore.cpp
@@ -1,0 +1,259 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ListColumnStore.h"
+
+#include <wx/config.h>
+#include <wx/tokenzr.h>
+
+#include <common/StringFunctions.h> // Needed for StrToLong
+
+#include "Types.h" // Needed for EmptyString
+
+// SORT_DES/SORT_ALT/SORTING_MASK are CMuleListCtrl::MLOrder flags, not a
+// concept this store defines itself -- it just needs the same bit values
+// CMuleListCtrl encodes/decodes with, so referencing them here (rather than
+// duplicating the magic numbers) keeps there being exactly one definition.
+#include "MuleListCtrl.h"
+
+void CListColumnStore::RegisterColumn(int index, int defaultWidth, const wxString &name)
+{
+#ifdef __DEBUG__
+	// Check for valid names
+	wxASSERT_MSG(
+		name.Find(':') == wxNOT_FOUND, "Column name \"" + name + "\" contains invalid characters!");
+	wxASSERT_MSG(
+		name.Find(',') == wxNOT_FOUND, "Column name \"" + name + "\" contains invalid characters!");
+
+	// Check for uniqueness of names.
+	for (ColNameList::const_iterator uit = m_column_names.begin(); uit != m_column_names.end(); ++uit) {
+		if (name == uit->name) {
+			wxFAIL_MSG("Column name \"" + name + "\" is not unique!");
+		}
+	}
+#endif
+	ColNameList::iterator it = m_column_names.begin();
+	while (it != m_column_names.end() && it->index < index) {
+		++it;
+	}
+	m_column_names.insert(it, ColNameEntry(index, defaultWidth, name));
+	while (it != m_column_names.end()) {
+		++it;
+		++(it->index);
+	}
+}
+
+const wxString &CListColumnStore::GetColumnName(int index) const
+{
+	for (const ColNameEntry &entry : m_column_names) {
+		if (entry.index == index) {
+			return entry.name;
+		}
+	}
+	return EmptyString;
+}
+
+int CListColumnStore::GetColumnDefaultWidth(int index) const
+{
+	for (const ColNameEntry &entry : m_column_names) {
+		if (entry.index == index) {
+			return entry.defaultWidth;
+		}
+	}
+	return -1; // wxLIST_AUTOSIZE
+}
+
+int CListColumnStore::GetColumnIndex(const wxString &name) const
+{
+	for (const ColNameEntry &entry : m_column_names) {
+		if (entry.name == name) {
+			return entry.index;
+		}
+	}
+	return -1;
+}
+
+int CListColumnStore::GetCachedWidth(int index) const
+{
+	return (index >= 0 && index < (int)m_column_sizes.size()) ? m_column_sizes[index] : 0;
+}
+
+void CListColumnStore::SetCachedWidth(int index, int width)
+{
+	if (index >= (int)m_column_sizes.size()) {
+		m_column_sizes.resize(index + 1, 0);
+	}
+	m_column_sizes[index] = width;
+}
+
+int CListColumnStore::GetNewColumnIndex(int oldindex, const wxString &oldColumnOrder) const
+{
+	wxStringTokenizer oldcolumns(oldColumnOrder, ",", wxTOKEN_RET_EMPTY_ALL);
+	while (oldcolumns.HasMoreTokens()) {
+		wxString name = oldcolumns.GetNextToken();
+		if (oldindex == 0) {
+			return GetColumnIndex(name);
+		}
+		--oldindex;
+	}
+	return -1;
+}
+
+void CListColumnStore::SaveSettings(const IColumnWidthProvider &widget, const CSortingList &sortOrders) const
+{
+	if (!HasTableName()) {
+		return;
+	}
+	wxConfigBase *cfg = wxConfigBase::Get();
+
+	// Save sorting, column and order
+	wxString sortOrder;
+	for (CSortingList::const_iterator it = sortOrders.begin(); it != sortOrders.end();) {
+		wxString columnName = GetColumnName(static_cast<int>(it->first));
+		if (!columnName.IsEmpty()) {
+			sortOrder += columnName;
+			sortOrder += ":";
+			sortOrder += it->second & CMuleListCtrl::SORT_DES ? "1" : "0";
+			sortOrder += ":";
+			sortOrder += it->second & CMuleListCtrl::SORT_ALT ? "1" : "0";
+			if (++it != sortOrders.end()) {
+				sortOrder += ",";
+			}
+		} else {
+			++it;
+		}
+	}
+	cfg->Write("/eMule/TableOrdering" + m_name, sortOrder);
+
+	// Save column widths. ATM this is also used to signify hidden columns.
+	wxString buffer;
+	for (int i = 0; i < widget.GetColumnCount(); ++i) {
+		wxString columnName = GetColumnName(i);
+		if (!columnName.IsEmpty()) {
+			if (!buffer.IsEmpty()) {
+				buffer << ",";
+			}
+			int currentwidth = widget.GetColumnWidth(i);
+			int savedsize = (m_column_sizes.size() && (i < (int)m_column_sizes.size()))
+						? m_column_sizes[i]
+						: 0;
+			buffer << columnName << ":" << ((currentwidth > 0) ? currentwidth : (-1 * savedsize));
+		}
+	}
+	cfg->Write("/eMule/TableWidths" + m_name, buffer);
+}
+
+void CListColumnStore::ParseOldConfigEntries(const wxString &sortOrders,
+	const wxString &columnWidths,
+	IColumnWidthProvider &widget,
+	const wxString &oldColumnOrder,
+	CSortingList &outSortOrders)
+{
+	// Set sort order (including sort column)
+	wxStringTokenizer tokens(sortOrders, ",");
+	while (tokens.HasMoreTokens()) {
+		wxString token = tokens.GetNextToken();
+
+		long column = 0;
+		unsigned long order = 0;
+
+		if (token.BeforeFirst(' ').Strip(wxString::both).ToLong(&column)) {
+			if (token.AfterFirst(' ').Strip(wxString::both).ToULong(&order)) {
+				column = GetNewColumnIndex(static_cast<int>(column), oldColumnOrder);
+				// Sanity checking, to avoid asserting if column count changes.
+				if (column >= 0 && column < widget.GetColumnCount()) {
+					// Sanity checking, to avoid asserting if data-format changes.
+					if ((order & ~CMuleListCtrl::SORTING_MASK) == 0) {
+						outSortOrders.emplace_back(column, order);
+					}
+				}
+			}
+		}
+	}
+
+	// Set column widths
+	int counter = 0;
+	wxStringTokenizer tokenizer(columnWidths, ",");
+	while (tokenizer.HasMoreTokens()) {
+		long idx = GetNewColumnIndex(counter++, oldColumnOrder);
+		long width = StrToLong(tokenizer.GetNextToken());
+		if (idx >= 0) {
+			widget.SetColumnWidth(static_cast<int>(idx), static_cast<int>(width));
+		}
+	}
+}
+
+void CListColumnStore::LoadSettings(
+	IColumnWidthProvider &widget, const wxString &oldColumnOrder, CSortingList &outSortOrders)
+{
+	outSortOrders.clear();
+	if (!HasTableName()) {
+		return;
+	}
+	wxConfigBase *cfg = wxConfigBase::Get();
+
+	wxString sortOrders = cfg->Read("/eMule/TableOrdering" + m_name, "");
+	wxString columnWidths = cfg->Read("/eMule/TableWidths" + m_name, "");
+
+	if (columnWidths.Find(':') == wxNOT_FOUND) {
+		// Old-style config entries...
+		ParseOldConfigEntries(sortOrders, columnWidths, widget, oldColumnOrder, outSortOrders);
+		return;
+	}
+
+	// Sort orders are stored in order primary, secondary, ...
+	// The caller applies them via SetSorting(), which treats the *last*
+	// call as primary, so hand them back in reverse (secondary, ..., primary).
+	wxStringTokenizer tokens(sortOrders, ",");
+	std::list<wxString> tokenList;
+	while (tokens.HasMoreTokens()) {
+		tokenList.push_front(tokens.GetNextToken());
+	}
+	for (const wxString &token : tokenList) {
+		wxString name = token.BeforeFirst(':');
+		long order = StrToLong(token.AfterFirst(':').BeforeLast(':'));
+		long alt = StrToLong(token.AfterLast(':'));
+		int col = GetColumnIndex(name);
+		if (col >= 0) {
+			outSortOrders.emplace_back(col,
+				(order ? CMuleListCtrl::SORT_DES : 0) | (alt ? CMuleListCtrl::SORT_ALT : 0));
+		}
+	}
+
+	// Column widths
+	wxStringTokenizer tkz(columnWidths, ",");
+	while (tkz.HasMoreTokens()) {
+		wxString token = tkz.GetNextToken();
+		wxString name = token.BeforeFirst(':');
+		long width = StrToLong(token.AfterFirst(':'));
+		int col = GetColumnIndex(name);
+		if (col >= 0) {
+			if (col >= (int)m_column_sizes.size()) {
+				m_column_sizes.resize(col + 1, 0);
+			}
+			m_column_sizes[col] = static_cast<int>(abs(width));
+			widget.SetColumnWidth(col, static_cast<int>((width > 0) ? width : 0));
+		}
+	}
+}

--- a/src/ListColumnStore.h
+++ b/src/ListColumnStore.h
@@ -1,0 +1,168 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef LISTCOLUMNSTORE_H
+#define LISTCOLUMNSTORE_H
+
+#include <wx/string.h>
+
+#include <list>
+#include <utility>
+#include <vector>
+
+/**
+ * The subset of a list widget's column API that column persistence needs.
+ * CMuleListCtrl already implements this exact signature set by inheriting
+ * wxGenericListCtrl, so it satisfies this interface for free (see its
+ * class declaration). A future wxDataViewCtrl-backed list only needs to
+ * forward these three calls to its own columns
+ * (GetColumnCount()/GetColumn(i)->GetWidth()/SetWidth()) to reuse
+ * CListColumnStore unchanged.
+ */
+class IColumnWidthProvider
+{
+public:
+	virtual ~IColumnWidthProvider() = default;
+	virtual int GetColumnCount() const = 0;
+	virtual int GetColumnWidth(int col) const = 0;
+	virtual bool SetColumnWidth(int col, int width) = 0;
+};
+
+/**
+ * Owns a list control's column-persistence state (the stable, translation-
+ * independent name/default-width per column, the last-known width cache,
+ * and (de)serialization to/from wxConfig) independently of which widget
+ * actually renders the columns.
+ *
+ * Extracted from CMuleListCtrl (see #675/#180 phase 2 discussion): the
+ * persisted format and config keys ("/eMule/TableOrdering<name>",
+ * "/eMule/TableWidths<name>") are unchanged, so existing user settings
+ * keep working across this refactor. Sort-order *mutation* deliberately
+ * stays out of this class -- applying a loaded sort order can have
+ * widget-specific side effects (e.g. CMuleListCtrl::SetSorting() also
+ * triggers a re-sort and validates against AltSortAllowed()), so
+ * LoadSettings() only decodes the stored order and hands it back to the
+ * caller to apply through whatever mechanism its own widget needs.
+ */
+class CListColumnStore
+{
+public:
+	//! A column index paired with its CMuleListCtrl::MLOrder flags.
+	typedef std::pair<unsigned, unsigned> CColPair;
+	typedef std::list<CColPair> CSortingList;
+
+	/**
+	 * Sets the persistence key prefix. Mirrors
+	 * CMuleListCtrl::SetTableName(): an empty name means "don't persist".
+	 */
+	void SetTableName(const wxString &name) { m_name = name; }
+	bool HasTableName() const { return !m_name.IsEmpty(); }
+
+	/**
+	 * Registers a column's persistence name and default width at the
+	 * given index. Called from the list's InsertColumn()-equivalent, the
+	 * same point CMuleListCtrl::InsertColumn() currently updates
+	 * m_column_names from.
+	 */
+	//! In debug builds, also asserts the name is free of ':'/',' (the
+	//! serialization format's own delimiters) and not already registered --
+	//! this store is the only thing that can check uniqueness now, so the
+	//! check moved here from CMuleListCtrl::InsertColumn().
+	void RegisterColumn(int index, int defaultWidth, const wxString &name);
+
+	//! Forgets all registered columns (mirrors CMuleListCtrl::ClearAll()).
+	void ClearColumns() { m_column_names.clear(); }
+
+	const wxString &GetColumnName(int index) const;
+	int GetColumnDefaultWidth(int index) const;
+	int GetColumnIndex(const wxString &name) const;
+
+	/**
+	 * Last-known width cache for a hidden column, keyed by column index.
+	 * Used by the hide/show-via-menu interaction (CMuleListCtrl::OnMenuSelected):
+	 * width is cached here when a column is hidden, so it can be restored
+	 * when the column is shown again in the same session. 0 if never cached.
+	 */
+	int GetCachedWidth(int index) const;
+	void SetCachedWidth(int index, int width);
+
+	/**
+	 * Writes the current column widths/visibility and the given sort
+	 * order out to wxConfig, under this store's table name. No-op if no
+	 * table name has been set.
+	 */
+	void SaveSettings(const IColumnWidthProvider &widget, const CSortingList &sortOrders) const;
+
+	/**
+	 * Reads column widths/visibility and sort order back from wxConfig,
+	 * applying widths directly via the given widget and returning the
+	 * decoded sort order (in the same primary-last order
+	 * CMuleListCtrl::LoadSettings() has always built it in, ready to be
+	 * applied via the caller's own SetSorting()). No-op (and clears
+	 * outSortOrders) if no table name has been set.
+	 *
+	 * @param oldColumnOrder Pre-2.2.2 column order, comma-separated, as
+	 * CMuleListCtrl::GetOldColumnOrder() provides; empty to skip that
+	 * migration path.
+	 */
+	void LoadSettings(
+		IColumnWidthProvider &widget, const wxString &oldColumnOrder, CSortingList &outSortOrders);
+
+private:
+	int GetNewColumnIndex(int oldindex, const wxString &oldColumnOrder) const;
+	void ParseOldConfigEntries(const wxString &sortOrders,
+		const wxString &columnWidths,
+		IColumnWidthProvider &widget,
+		const wxString &oldColumnOrder,
+		CSortingList &outSortOrders);
+
+	class ColNameEntry
+	{
+	public:
+		int index;
+		int defaultWidth;
+		wxString name;
+		ColNameEntry(int _index, int _defaultWidth, const wxString &_name)
+		: index(_index)
+		, defaultWidth(_defaultWidth)
+		, name(_name)
+		{
+		}
+	};
+	typedef std::list<ColNameEntry> ColNameList;
+
+	//! The persistence key prefix. Empty means "don't persist".
+	wxString m_name;
+
+	//! Column names, sorted by column index.
+	ColNameList m_column_names;
+
+	//! Cache of the columns' sizes (used to remember a hidden column's
+	//! last width, per CMuleListCtrl::SaveSettings' original comment).
+	typedef std::vector<int> ColSizeVector;
+	ColSizeVector m_column_sizes;
+};
+
+#endif // LISTCOLUMNSTORE_H
+// File_checked_for_headers

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -99,7 +99,7 @@ CMuleListCtrl::CMuleListCtrl(wxWindow *parent,
 
 CMuleListCtrl::~CMuleListCtrl()
 {
-	if (!m_name.IsEmpty()) {
+	if (m_columnStore.HasTableName()) {
 		SaveSettings();
 	}
 }
@@ -108,31 +108,7 @@ long CMuleListCtrl::InsertColumn(
 	long col, const wxString &heading, int format, int width, const wxString &name)
 {
 	if (!name.IsEmpty()) {
-#ifdef __DEBUG__
-		// Check for valid names
-		wxASSERT_MSG(name.Find(':') == wxNOT_FOUND,
-			"Column name \"" + name + "\" contains invalid characters!");
-		wxASSERT_MSG(name.Find(',') == wxNOT_FOUND,
-			"Column name \"" + name + "\" contains invalid characters!");
-
-		// Check for uniqueness of names.
-		for (ColNameList::const_iterator it = m_column_names.begin(); it != m_column_names.end();
-			++it) {
-			if (name == it->name) {
-				wxFAIL_MSG("Column name \"" + name + "\" is not unique!");
-			}
-		}
-#endif
-		// Insert name at position col.
-		ColNameList::iterator it = m_column_names.begin();
-		while (it != m_column_names.end() && it->index < col) {
-			++it;
-		}
-		m_column_names.insert(it, ColNameEntry(col, width, name));
-		while (it != m_column_names.end()) {
-			++it;
-			++(it->index);
-		}
+		m_columnStore.RegisterColumn(static_cast<int>(col), width, name);
 	}
 
 	return MuleExtern::wxGenericListCtrl::InsertColumn(col, heading, format, width);
@@ -140,141 +116,27 @@ long CMuleListCtrl::InsertColumn(
 
 void CMuleListCtrl::SaveSettings()
 {
-	wxCHECK_RET(!m_name.IsEmpty(), "Cannot save settings for unnamed list");
+	wxCHECK_RET(m_columnStore.HasTableName(), "Cannot save settings for unnamed list");
 
-	wxConfigBase *cfg = wxConfigBase::Get();
-
-	// Save sorting, column and order
-	wxString sortOrder;
-	for (CSortingList::iterator it = m_sort_orders.begin(); it != m_sort_orders.end();) {
-		wxString columnName = GetColumnName(it->first);
-		if (!columnName.IsEmpty()) {
-			sortOrder += columnName;
-			sortOrder += ":";
-			sortOrder += it->second & SORT_DES ? "1" : "0";
-			sortOrder += ":";
-			sortOrder += it->second & SORT_ALT ? "1" : "0";
-			if (++it != m_sort_orders.end()) {
-				sortOrder += ",";
-			}
-		} else {
-			++it;
-		}
-	}
-
-	cfg->Write("/eMule/TableOrdering" + m_name, sortOrder);
-
-	// Save column widths. ATM this is also used to signify hidden columns.
-	wxString buffer;
-	for (int i = 0; i < GetColumnCount(); ++i) {
-		wxString columnName = GetColumnName(i);
-		if (!columnName.IsEmpty()) {
-			if (!buffer.IsEmpty()) {
-				buffer << ",";
-			}
-			int currentwidth = GetColumnWidth(i);
-			int savedsize = (m_column_sizes.size() && (i < (int)m_column_sizes.size()))
-						? m_column_sizes[i]
-						: 0;
-			buffer << columnName << ":" << ((currentwidth > 0) ? currentwidth : (-1 * savedsize));
-		}
-	}
-
-	cfg->Write("/eMule/TableWidths" + m_name, buffer);
-}
-
-void CMuleListCtrl::ParseOldConfigEntries(const wxString &sortOrders, const wxString &columnWidths)
-{
-	// Set sort order (including sort column)
-	wxStringTokenizer tokens(sortOrders, ",");
-	while (tokens.HasMoreTokens()) {
-		wxString token = tokens.GetNextToken();
-
-		long column = 0;
-		unsigned long order = 0;
-
-		if (token.BeforeFirst(' ').Strip(wxString::both).ToLong(&column)) {
-			if (token.AfterFirst(' ').Strip(wxString::both).ToULong(&order)) {
-				column = GetNewColumnIndex(column);
-				// Sanity checking, to avoid asserting if column count changes.
-				if (column >= 0 && column < GetColumnCount()) {
-					// Sanity checking, to avoid asserting if data-format changes.
-					if ((order & ~SORTING_MASK) == 0) {
-						// SetSorting will take care of duplicate entries
-						SetSorting(column, order);
-					}
-				}
-			}
-		}
-	}
-
-	// Set column widths
-	int counter = 0;
-	wxStringTokenizer tokenizer(columnWidths, ",");
-	while (tokenizer.HasMoreTokens()) {
-		long idx = GetNewColumnIndex(counter++);
-		long width = StrToLong(tokenizer.GetNextToken());
-		if (idx >= 0) {
-			SetColumnWidth(idx, width);
-		}
-	}
+	m_columnStore.SaveSettings(*this, m_sort_orders);
 }
 
 void CMuleListCtrl::LoadSettings()
 {
-	wxCHECK_RET(!m_name.IsEmpty(), "Cannot load settings for unnamed list");
-
-	wxConfigBase *cfg = wxConfigBase::Get();
-
-	// Load sort order (including sort-column)
-	m_sort_orders.clear();
-	wxString sortOrders = cfg->Read("/eMule/TableOrdering" + m_name, "");
-	wxString columnWidths = cfg->Read("/eMule/TableWidths" + m_name, "");
+	wxCHECK_RET(m_columnStore.HasTableName(), "Cannot load settings for unnamed list");
 
 	// Prevent sorting from occurring when calling SetSorting
 	MuleListCtrlCompare sortFunc = m_sort_func;
 	m_sort_func = NULL;
 
-	if (columnWidths.Find(':') == wxNOT_FOUND) {
-		// Old-style config entries...
-		ParseOldConfigEntries(sortOrders, columnWidths);
-	} else {
-		// Sort orders
-		wxStringTokenizer tokens(sortOrders, ",");
-		// Sort orders are stored in order primary, secondary, ...
-		// We want to apply them with SetSorting(), so we have to apply them in reverse order,
-		// so that the primary order is applied last and wins.
-		// Read them with tokenizer and store them in a list in reverse order.
-		CStringList tokenList;
-		while (tokens.HasMoreTokens()) {
-			tokenList.push_front(tokens.GetNextToken());
-		}
-		for (CStringList::iterator it = tokenList.begin(); it != tokenList.end(); ++it) {
-			const wxString &token = *it;
-			wxString name = token.BeforeFirst(':');
-			long order = StrToLong(token.AfterFirst(':').BeforeLast(':'));
-			long alt = StrToLong(token.AfterLast(':'));
-			int col = GetColumnIndex(name);
-			if (col >= 0) {
-				SetSorting(col, (order ? SORT_DES : 0) | (alt ? SORT_ALT : 0));
-			}
-		}
+	CListColumnStore::CSortingList decodedSortOrders;
+	m_columnStore.LoadSettings(*this, GetOldColumnOrder(), decodedSortOrders);
 
-		// Column widths
-		wxStringTokenizer tkz(columnWidths, ",");
-		while (tkz.HasMoreTokens()) {
-			wxString token = tkz.GetNextToken();
-			wxString name = token.BeforeFirst(':');
-			long width = StrToLong(token.AfterFirst(':'));
-			int col = GetColumnIndex(name);
-			if (col >= 0) {
-				if (col >= (int)m_column_sizes.size()) {
-					m_column_sizes.resize(col + 1, 0);
-				}
-				m_column_sizes[col] = abs(width);
-				SetColumnWidth(col, (width > 0) ? width : 0);
-			}
-		}
+	m_sort_orders.clear();
+	for (CListColumnStore::CSortingList::const_iterator it = decodedSortOrders.begin();
+		it != decodedSortOrders.end();
+		++it) {
+		SetSorting(it->first, it->second);
 	}
 
 	// Must have at least one sort-order specified
@@ -285,50 +147,6 @@ void CMuleListCtrl::LoadSettings()
 	// Re-enable sorting and resort the contents (if any).
 	m_sort_func = sortFunc;
 	SortList();
-}
-
-const wxString &CMuleListCtrl::GetColumnName(int index) const
-{
-	for (ColNameList::const_iterator it = m_column_names.begin(); it != m_column_names.end(); ++it) {
-		if (it->index == index) {
-			return it->name;
-		}
-	}
-	return EmptyString;
-}
-
-int CMuleListCtrl::GetColumnDefaultWidth(int index) const
-{
-	for (ColNameList::const_iterator it = m_column_names.begin(); it != m_column_names.end(); ++it) {
-		if (it->index == index) {
-			return it->defaultWidth;
-		}
-	}
-	return wxLIST_AUTOSIZE;
-}
-
-int CMuleListCtrl::GetColumnIndex(const wxString &name) const
-{
-	for (ColNameList::const_iterator it = m_column_names.begin(); it != m_column_names.end(); ++it) {
-		if (it->name == name) {
-			return it->index;
-		}
-	}
-	return -1;
-}
-
-int CMuleListCtrl::GetNewColumnIndex(int oldindex) const
-{
-	wxStringTokenizer oldcolumns(GetOldColumnOrder(), ",", wxTOKEN_RET_EMPTY_ALL);
-
-	while (oldcolumns.HasMoreTokens()) {
-		wxString name = oldcolumns.GetNextToken();
-		if (oldindex == 0) {
-			return GetColumnIndex(name);
-		}
-		--oldindex;
-	}
-	return -1;
 }
 
 long CMuleListCtrl::GetInsertPos(wxUIntPtr data)
@@ -493,15 +311,11 @@ void CMuleListCtrl::OnMenuSelected(wxCommandEvent &evt)
 {
 	unsigned int col = evt.GetId() - MP_LISTCOL_1;
 
-	if (col >= m_column_sizes.size()) {
-		m_column_sizes.resize(col + 1, 0);
-	}
-
 	if (GetColumnWidth(col) > COL_SIZE_MIN) {
-		m_column_sizes[col] = GetColumnWidth(col);
+		m_columnStore.SetCachedWidth(static_cast<int>(col), GetColumnWidth(static_cast<int>(col)));
 		SetColumnWidth(col, 0);
 	} else {
-		int oldsize = m_column_sizes[col];
+		int oldsize = m_columnStore.GetCachedWidth(static_cast<int>(col));
 		SetColumnWidth(col, (oldsize > 0) ? oldsize : GetColumnDefaultWidth(col));
 	}
 }

--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -35,6 +35,7 @@
 
 #include <vector>
 #include <list>
+#include "ListColumnStore.h" // Needed for CListColumnStore, IColumnWidthProvider
 #include "Types.h"
 
 // Palette selector for custom-drawn text in list controls. Reads the
@@ -64,7 +65,7 @@ static inline bool IsListBackgroundDark(const wxWindow *w)
  *  - Loading and saving of column properties.
  *  - Selection of items by typing an initial part of the text (TTS).
  */
-class CMuleListCtrl : public MuleExtern::wxGenericListCtrl
+class CMuleListCtrl : public MuleExtern::wxGenericListCtrl, public IColumnWidthProvider
 {
 public:
 	/**
@@ -125,7 +126,7 @@ public:
 	 * Lets callers persist a list's layout without tripping the unnamed-list
 	 * assertion inside SaveSettings().
 	 */
-	bool HasStoredTableName() const { return !m_name.IsEmpty(); }
+	bool HasStoredTableName() const { return m_columnStore.HasTableName(); }
 
 	/**
 	 * Loads column settings.
@@ -236,7 +237,7 @@ public:
 	 */
 	void ClearAll()
 	{
-		m_column_names.clear();
+		m_columnStore.ClearColumns();
 		MuleExtern::wxGenericListCtrl::ClearAll();
 	}
 
@@ -255,6 +256,21 @@ public:
 	 * Indicates if we're in the process of sorting.
 	 */
 	bool IsSorting() const { return m_isSorting; }
+
+	// IColumnWidthProvider -- explicit forwarding overrides rather than
+	// relying on wxGenericListCtrl's identically-signatured methods to
+	// satisfy the interface implicitly: with two unrelated base classes,
+	// the compiler won't link one base's definition to the other's pure
+	// virtual on its own.
+	int GetColumnCount() const override { return MuleExtern::wxGenericListCtrl::GetColumnCount(); }
+	int GetColumnWidth(int col) const override
+	{
+		return MuleExtern::wxGenericListCtrl::GetColumnWidth(col);
+	}
+	bool SetColumnWidth(int col, int width) override
+	{
+		return MuleExtern::wxGenericListCtrl::SetColumnWidth(col, width);
+	}
 
 protected:
 	// True while sorting. Protected so a virtual-mode subclass that overrides
@@ -306,7 +322,7 @@ protected:
 	 * make use of the LoadSettings/SaveSettings functions. CMuleListCtrl
 	 * uses the name specified in this command to create unique keynames.
 	 */
-	void SetTableName(const wxString &name) { m_name = name; }
+	void SetTableName(const wxString &name) { m_columnStore.SetTableName(name); }
 
 	/**
 	 * Return old column order.
@@ -405,7 +421,7 @@ protected:
 	 *
 	 * @return The column index, or -1 in case the name was invalid.
 	 */
-	int GetColumnIndex(const wxString &name) const;
+	int GetColumnIndex(const wxString &name) const { return m_columnStore.GetColumnIndex(name); }
 
 	/**
 	 * Compares two items using the current (multi-column) sort sequence,
@@ -430,8 +446,10 @@ private:
 	 */
 	void SetColumnImage(unsigned col, int image);
 
-	//! The name of the table. Used to load/save settings.
-	wxString m_name;
+	//! Owns column persistence (names, width cache, wxConfig
+	//! serialization) independently of this being a wxListCtrl -- see
+	//! ListColumnStore.h.
+	CListColumnStore m_columnStore;
 
 	//! The sorter function needed by wxListCtrl.
 	MuleListCtrlCompare m_sort_func;
@@ -476,16 +494,6 @@ private:
 	CSortingList m_sort_orders;
 
 	/**
-	 * Get the column name by index.
-	 *
-	 * @param[in] column Index of the column whose name we're looking for.
-	 *
-	 * @return The column name or an empty string if index is invalid
-	 * (out of range), or the column name hasn't been set.
-	 */
-	const wxString &GetColumnName(int column) const;
-
-	/**
 	 * Get the column default width by index.
 	 *
 	 * @param[in] column Index of the column whose name we're looking for.
@@ -493,52 +501,7 @@ private:
 	 * @return The column default width or wx default width if index is invalid
 	 * (out of range), or the column name hasn't been set.
 	 */
-	int GetColumnDefaultWidth(int column) const;
-
-	/**
-	 * Find out the new index of the column by the old index.
-	 *
-	 * @param[in] oldindex Old column index which we want to turn into a
-	 * new index.
-	 *
-	 * @return The new index of the column, or -1 if an error occurred.
-	 */
-	int GetNewColumnIndex(int oldindex) const;
-
-	/**
-	 * Parses old config entries.
-	 *
-	 * @param[in] sortOrders	Old sort orders line.
-	 * @param[in] columnWidths	Old column widths line.
-	 */
-	void ParseOldConfigEntries(const wxString &sortOrders, const wxString &columnWidths);
-
-	/// This class contains a column index, its default width and its name.
-	class ColNameEntry
-	{
-	public:
-		int index;
-		int defaultWidth;
-		wxString name;
-		ColNameEntry(int _index, int _defaultWidth, const wxString &_name)
-		: index(_index)
-		, defaultWidth(_defaultWidth)
-		, name(_name)
-		{
-		}
-	};
-
-	/// This list contains the columns' names.
-	typedef std::list<ColNameEntry> ColNameList;
-
-	/// Container for column names, sorted by column index.
-	ColNameList m_column_names;
-
-	/// This vector contains a cache of the columns' sizes.
-	typedef std::vector<int> ColSizeVector;
-
-	/// Container for column sizes cache.
-	ColSizeVector m_column_sizes;
+	int GetColumnDefaultWidth(int column) const { return m_columnStore.GetColumnDefaultWidth(column); }
 
 	wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
## Summary

Extracts the column-name/width/sort-order persistence logic out of `CMuleListCtrl` into a new, widget-agnostic `CListColumnStore`, which talks to the list widget through a small `IColumnWidthProvider` interface (column count, get/set width by index).

This is prep work for #180 phase 2 (porting `CSearchListCtrl` to `wxDataViewCtrl` for accessibility, tracked under #675). @got3nks asked in the #180 discussion that this extraction land as its own, independently reviewable commit before the actual `wxDataViewCtrl` port, since the persistence logic — including the legacy pre-2.2.2 config migration path — must not be duplicated against `wxDataViewColumn`. The new search list control will reuse `CListColumnStore` unchanged instead of reimplementing it.

**No behaviour change.** Config keys (`/eMule/TableOrdering<name>`, `/eMule/TableWidths<name>`) and the on-disk format are unchanged, so existing user settings keep working. `CMuleListCtrl` keeps its full public API (`SaveSettings`/`LoadSettings`/`InsertColumn`/`SetTableName`/`GetColumnIndex`/...).

## Notes

- `CMuleListCtrl` now implements `IColumnWidthProvider` via explicit forwarding overrides (`GetColumnCount`/`GetColumnWidth`/`SetColumnWidth`) rather than relying on `wxGenericListCtrl`'s identically-signatured methods to satisfy the interface implicitly — with two unrelated base classes, the compiler won't link one base's definition to the other's pure virtual on its own.
- Sort-order *mutation* deliberately stays out of `CListColumnStore`: applying a loaded sort order has widget-specific side effects (`CMuleListCtrl::SetSorting()` also triggers a re-sort and validates against `AltSortAllowed()`), so `LoadSettings()` only decodes the stored order and hands it back to the caller to apply through its own `SetSorting()`.
- The last-known-width cache used by the hide/show-via-menu interaction (`CMuleListCtrl::OnMenuSelected`) moved into the store too (`GetCachedWidth`/`SetCachedWidth`), since it's part of the same per-column state.

## Test plan

- [x] Builds clean (macOS, full `amule` target)
- [x] `clang-format` v18 (pinned) applied
- [x] `clang-tidy` Tier-1 (whole-tree) and Tier-2 (changed-lines) both clean on the touched files
- [x] Launched the built app against an isolated test config (own ports, not the real app) and confirmed column widths/sort order/hidden columns load and save back correctly, matching pre-refactor behaviour
