### PR TITLE
fix(gui): spread the tray limit presets, and raise the stale capacity defaults

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2939,6 +2939,15 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3024,15 +3033,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:14+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2976,6 +2976,15 @@ msgstr "واضح"
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "بلا حدود"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3066,15 +3075,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "خروج"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "بلا حدود"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:15+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3032,6 +3032,15 @@ msgstr "Llimpiar"
 msgid "Select All"
 msgstr "Esbillar too"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Illimitáu"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3125,15 +3134,6 @@ msgstr "Anubrir aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Colar"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Illimitáu"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2970,6 +2970,15 @@ msgstr "Изчисти"
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "кБ/с"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "неограничен"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3060,15 +3069,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Изход"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "кБ/с"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "неограничен"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2938,6 +2938,15 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3023,15 +3032,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:15+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3022,6 +3022,15 @@ msgstr "Neteja"
 msgid "Select All"
 msgstr "Selecciona-ho tot"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Il·limitat"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3115,15 +3124,6 @@ msgstr "Amaga l'aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Surt"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Il·limitat"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:15+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3020,6 +3020,15 @@ msgstr "Vyprázdnit"
 msgid "Select All"
 msgstr "Označit vše"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Neomezený"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3113,15 +3122,6 @@ msgstr "Skrýt aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Ukončit"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Neomezený"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:16+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2984,6 +2984,15 @@ msgstr "Ryd"
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Ubegrænset"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3076,15 +3085,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Afslut"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Ubegrænset"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:16+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3027,6 +3027,15 @@ msgstr "Leeren"
 msgid "Select All"
 msgstr "Alles auswählen"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Unbegrenzt"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3113,15 +3122,6 @@ msgstr "Verstecke aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Schließen"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Unbegrenzt"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:16+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3043,6 +3043,15 @@ msgstr "Καθαρισμός"
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Απεριόριστο"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3136,15 +3145,6 @@ msgstr "Κρύψιμο aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Έξοδος"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Απεριόριστο"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2939,6 +2939,15 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3024,15 +3033,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:16+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3028,6 +3028,15 @@ msgstr "Limpiar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Ilimitado"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3114,15 +3123,6 @@ msgstr "Ocultar aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Salir"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3023,6 +3023,15 @@ msgstr "Puhasta"
 msgid "Select All"
 msgstr "Vali kõik"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Piiramatu"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3116,15 +3125,6 @@ msgstr "Peida aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Välju"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Piiramatu"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:17+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3024,6 +3024,15 @@ msgstr "Garbitu"
 msgid "Select All"
 msgstr "Hautatu dena"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Mugarik gabea"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3117,15 +3126,6 @@ msgstr "aMule ezkutatu"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Irten"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Mugarik gabea"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:17+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3024,6 +3024,15 @@ msgstr "Pyyhi"
 msgid "Select All"
 msgstr "Valitse kaikki"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "KB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Rajoittamaton"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3117,15 +3126,6 @@ msgstr "Piilota aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Sulje"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "KB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Rajoittamaton"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:18+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3026,6 +3026,15 @@ msgstr "Effacer"
 msgid "Select All"
 msgstr "Tout sélectionner"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "Ko/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Pas de limite"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k : "
@@ -3112,15 +3121,6 @@ msgstr "Cacher aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Quitter"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "Ko/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Pas de limite"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:18+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3040,6 +3040,15 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Ilimitado"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3126,15 +3135,6 @@ msgstr "Ocultar aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Saír"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:18+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2996,6 +2996,15 @@ msgstr "נקה"
 msgid "Select All"
 msgstr "בחר הכל"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "ק\"ב/ש"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3088,15 +3097,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "יציאה"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "ק\"ב/ש"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:19+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2994,6 +2994,15 @@ msgstr "Ocisti"
 msgid "Select All"
 msgstr "Izaberite sve"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Bezkrajno"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3087,15 +3096,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Izlaz"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Bezkrajno"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:19+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3009,6 +3009,15 @@ msgstr "Törlés"
 msgid "Select All"
 msgstr "Mindent kijelöl"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Korlátlan"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3095,15 +3104,6 @@ msgstr "aMule elrejtése"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Kilépés"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Korlátlan"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:19+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3037,6 +3037,15 @@ msgstr "Pulisci"
 msgid "Select All"
 msgstr "Seleziona tutto"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Illimitato"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3123,15 +3132,6 @@ msgstr "Nascondi aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Esci"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Illimitato"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3021,6 +3021,15 @@ msgstr "クリア"
 msgid "Select All"
 msgstr "全ての選択"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "無制限"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3113,15 +3122,6 @@ msgstr "aMuleを隠す"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "終了"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "無制限"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:20+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3042,6 +3042,15 @@ msgstr "깨끗이"
 msgid "Select All"
 msgstr "모두 선택"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "무제한"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3134,15 +3143,6 @@ msgstr "어뮬 숨기기"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "종료"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "무제한"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:20+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3056,6 +3056,15 @@ msgstr "Išvalyti"
 msgid "Select All"
 msgstr "Pažymėti viską"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Neribojama"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3149,15 +3158,6 @@ msgstr "Slėpti aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Baigti"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Neribojama"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:29+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2956,6 +2956,15 @@ msgstr "Notīrīt"
 msgid "Select All"
 msgstr "Atlasīt visas"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3042,15 +3051,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Iziet"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:20+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3026,6 +3026,15 @@ msgstr "Wissen"
 msgid "Select All"
 msgstr "Alles selecteren"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Onbegrensd"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3119,15 +3128,6 @@ msgstr "Verberg aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Afsluiten"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Onbegrensd"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:21+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3040,6 +3040,15 @@ msgstr "Frigjer plass"
 msgid "Select All"
 msgstr "Vél alle"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Ubegrensa"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3133,15 +3142,6 @@ msgstr "Gøyme aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Avslutt"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Ubegrensa"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:21+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3038,6 +3038,15 @@ msgstr "Wyczyść"
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Nielimitowane"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3131,15 +3140,6 @@ msgstr "Ukryj aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Wyjdź"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Nielimitowane"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:21+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3033,6 +3033,15 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Selecionar Tudo"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Ilimitado"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3119,15 +3128,6 @@ msgstr "Ocultar aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Sair"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:22+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3030,6 +3030,15 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Seleccionar tudo"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Ilimitado"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3123,15 +3132,6 @@ msgstr "Esconder"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Sair"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:22+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3033,6 +3033,15 @@ msgstr "Curăță"
 msgid "Select All"
 msgstr "Selectează tot"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Nelimitat"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3126,15 +3135,6 @@ msgstr "Ascunde aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Ieşire"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Nelimitat"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:23+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3053,6 +3053,15 @@ msgstr "Очистить"
 msgid "Select All"
 msgstr "Выделить все"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "КБ/с"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Неограниченно"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3139,15 +3148,6 @@ msgstr "Свернуть aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Выход"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "КБ/с"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Неограниченно"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:24+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3053,6 +3053,15 @@ msgstr "Počisti"
 msgid "Select All"
 msgstr "Izberi vse"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Neomejeno"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3146,15 +3155,6 @@ msgstr "Skrij aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Končaj"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Neomejeno"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:24+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3034,6 +3034,15 @@ msgstr "Pastro"
 msgid "Select All"
 msgstr "Zgjidhi te gjitha"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "E pakufijshme"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3126,15 +3135,6 @@ msgstr "Fshih aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Dlje"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "E pakufijshme"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:25+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3022,6 +3022,15 @@ msgstr "Töm"
 msgid "Select All"
 msgstr "Markera alla"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Obegränsad"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3115,15 +3124,6 @@ msgstr "Dölj aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Avsluta"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Obegränsad"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:29+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2938,6 +2938,15 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3023,15 +3032,6 @@ msgstr "அகோவேறுகழுதையை மறை"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3019,6 +3019,15 @@ msgstr "Temizle"
 msgid "Select All"
 msgstr "Tümünü Seç"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "kB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Sınırsız"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
@@ -3105,15 +3114,6 @@ msgstr "aMule'yi Gizle"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Çıkış"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Sınırsız"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:26+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3052,6 +3052,15 @@ msgstr "Очистити"
 msgid "Select All"
 msgstr "Вибрати всі"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "кбайт/с"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "Безмежно"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3145,15 +3154,6 @@ msgstr "Сховати aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "Вийти"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "кбайт/с"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "Безмежно"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2937,6 +2937,15 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr ""
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
@@ -3022,15 +3031,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:27+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3029,6 +3029,15 @@ msgstr "清除"
 msgid "Select All"
 msgstr "全选"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "KB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "无限制"
+
 #: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k： "
@@ -3115,15 +3124,6 @@ msgstr "隐藏 aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "退出"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "KB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "无限制"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-04 12:39+0200\n"
+"POT-Creation-Date: 2026-08-04 13:14+0200\n"
 "PO-Revision-Date: 2026-08-04 09:27+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3015,6 +3015,15 @@ msgstr "清除"
 msgid "Select All"
 msgstr "全選"
 
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
+msgid "kB/s"
+msgstr "KB/s"
+
+#: src/MuleTrayIcon.cpp
+msgid "Unlimited"
+msgstr "無限制"
+
 #: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
@@ -3108,15 +3117,6 @@ msgstr "隱藏 aMule"
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"
 msgstr "離開"
-
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "KB/s"
-
-#: src/MuleTrayIcon.cpp
-msgid "Unlimited"
-msgstr "無限制"
 
 #: src/MuleTrayIcon.cpp
 msgid "aMule Tray Menu"

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -174,6 +174,49 @@ void CMuleTrayIcon::DoSetDownloadLimit(long kBytesPerSec)
 #endif
 }
 
+// The limit presets both tray backends offer, and their labels.
+//
+// One ladder, one set of strings. The appindicator backend builds GtkWidgets
+// and the wx backend builds a wxMenu, but what goes in them is identical, and
+// it used to be written out twice -- which is how the GTK side ended up
+// showing "Unlimited" and "kB/s" untranslated while the wx side translated
+// both.
+//
+// The presets are fractions of the configured line capacity rather than of the
+// current limit. Scaling from the limit would mean the menu could only ever
+// lower it: with a 50 kB/s cap in force, every entry would be at or below 50
+// and there would be no way back up. Capacity is what the line can do, so
+// fifths of it span throttled to full speed in both directions.
+namespace
+{
+const int TRAY_SPEED_PRESETS = 5;
+
+// What to assume when the user has set their capacity to "unlimited": there is
+// nothing to take fractions of otherwise.
+const uint32 TRAY_FALLBACK_CAPACITY = 100;
+
+/// Fills @a speeds with the presets in descending order, highest first.
+void GetTraySpeedPresets(uint32 capacity, unsigned int (&speeds)[TRAY_SPEED_PRESETS])
+{
+	// A capacity of "unlimited" gives nothing to take fractions of, and one
+	// below the preset count would collapse the ladder to zeros.
+	if (capacity == UNLIMITED) {
+		capacity = TRAY_FALLBACK_CAPACITY;
+	} else if (capacity < TRAY_SPEED_PRESETS * 2) {
+		capacity = TRAY_SPEED_PRESETS * 2;
+	}
+	for (int i = 0; i < TRAY_SPEED_PRESETS; i++) {
+		speeds[i] = (unsigned int)((double)capacity / TRAY_SPEED_PRESETS) * (TRAY_SPEED_PRESETS - i);
+	}
+}
+
+/// The menu label for one preset, e.g. "2500 kB/s".
+wxString TraySpeedLabel(unsigned int kBytesPerSec)
+{
+	return CFormat("%u %s") % kBytesPerSec % _("kB/s");
+}
+} // namespace
+
 // =====================================================================
 // Backend selection — see MuleTrayIcon.h for rationale.
 // =====================================================================
@@ -255,13 +298,14 @@ GtkWidget *make_action_item(const char *label, TrayAction action, long arg, gpoi
 GtkWidget *make_speed_submenu(uint32 max_speed, TrayAction action, gpointer user_data)
 {
 	GtkWidget *submenu = gtk_menu_new();
-	gtk_menu_shell_append(GTK_MENU_SHELL(submenu), make_action_item("Unlimited", action, -1, user_data));
-	for (int i = 0; i < 5; i++) {
-		unsigned int spd = (unsigned int)((double)max_speed / 5) * (5 - i);
-		char label[64];
-		g_snprintf(label, sizeof(label), "%u kB/s", spd);
-		gtk_menu_shell_append(
-			GTK_MENU_SHELL(submenu), make_action_item(label, action, (long)spd, user_data));
+	gtk_menu_shell_append(GTK_MENU_SHELL(submenu),
+		make_action_item(wxString(_("Unlimited")).utf8_str(), action, -1, user_data));
+	unsigned int speeds[TRAY_SPEED_PRESETS];
+	GetTraySpeedPresets(max_speed, speeds);
+	for (int i = 0; i < TRAY_SPEED_PRESETS; i++) {
+		gtk_menu_shell_append(GTK_MENU_SHELL(submenu),
+			make_action_item(TraySpeedLabel(speeds[i]).utf8_str(), action, (long)speeds[i],
+				user_data));
 	}
 	gtk_widget_show_all(submenu);
 	return submenu;
@@ -445,11 +489,6 @@ void CMuleTrayIcon::RebuildMenu()
 	// Upload limit submenu
 	{
 		uint32 max_ul = thePrefs::GetMaxGraphUploadRate();
-		if (max_ul == UNLIMITED)
-			max_ul = 100;
-		else if (max_ul < 10)
-			max_ul = 10;
-
 		GtkWidget *sub = make_speed_submenu(max_ul, TRAY_ACTION_SET_UPLOAD_LIMIT, this);
 		GtkWidget *item = gtk_menu_item_new_with_label(_("Upload limit").utf8_str());
 		gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), sub);
@@ -459,11 +498,6 @@ void CMuleTrayIcon::RebuildMenu()
 	// Download limit submenu
 	{
 		uint32 max_dl = thePrefs::GetMaxGraphDownloadRate();
-		if (max_dl == UNLIMITED)
-			max_dl = 100;
-		else if (max_dl < 10)
-			max_dl = 10;
-
 		GtkWidget *sub = make_speed_submenu(max_dl, TRAY_ACTION_SET_DOWNLOAD_LIMIT, this);
 		GtkWidget *item = gtk_menu_item_new_with_label(_("Download limit").utf8_str());
 		gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), sub);
@@ -932,18 +966,10 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	{
 		UploadSpeedMenu->Append(UPLOAD_ITEM1, _("Unlimited"));
 
-		uint32 max_ul_speed = thePrefs::GetMaxGraphUploadRate();
-
-		if (max_ul_speed == UNLIMITED) {
-			max_ul_speed = 100;
-		} else if (max_ul_speed < 10) {
-			max_ul_speed = 10;
-		}
-
-		for (int i = 0; i < 5; i++) {
-			unsigned int tempspeed = (unsigned int)((double)max_ul_speed / 5) * (5 - i);
-			wxString temp = CFormat("%u %s") % tempspeed % _("kB/s");
-			UploadSpeedMenu->Append((int)UPLOAD_ITEM1 + i + 1, temp);
+		unsigned int speeds[TRAY_SPEED_PRESETS];
+		GetTraySpeedPresets(thePrefs::GetMaxGraphUploadRate(), speeds);
+		for (int i = 0; i < TRAY_SPEED_PRESETS; i++) {
+			UploadSpeedMenu->Append((int)UPLOAD_ITEM1 + i + 1, TraySpeedLabel(speeds[i]));
 		}
 	}
 	traymenu->Append(0, UploadSpeedMenu->GetTitle(), UploadSpeedMenu);
@@ -952,18 +978,10 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	{
 		DownloadSpeedMenu->Append(DOWNLOAD_ITEM1, _("Unlimited"));
 
-		uint32 max_dl_speed = thePrefs::GetMaxGraphDownloadRate();
-
-		if (max_dl_speed == UNLIMITED) {
-			max_dl_speed = 100;
-		} else if (max_dl_speed < 10) {
-			max_dl_speed = 10;
-		}
-
-		for (int i = 0; i < 5; i++) {
-			unsigned int tempspeed = (unsigned int)((double)max_dl_speed / 5) * (5 - i);
-			wxString temp = CFormat("%d %s") % tempspeed % _("kB/s");
-			DownloadSpeedMenu->Append((int)DOWNLOAD_ITEM1 + i + 1, temp);
+		unsigned int speeds[TRAY_SPEED_PRESETS];
+		GetTraySpeedPresets(thePrefs::GetMaxGraphDownloadRate(), speeds);
+		for (int i = 0; i < TRAY_SPEED_PRESETS; i++) {
+			DownloadSpeedMenu->Append((int)DOWNLOAD_ITEM1 + i + 1, TraySpeedLabel(speeds[i]));
 		}
 	}
 

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -189,7 +189,14 @@ void CMuleTrayIcon::DoSetDownloadLimit(long kBytesPerSec)
 // fifths of it span throttled to full speed in both directions.
 namespace
 {
-const int TRAY_SPEED_PRESETS = 5;
+// Divisors applied to the line capacity, descending. Not fifths: an even
+// ladder can only ever cover one order of magnitude, so on a fast line every
+// entry lands high and there is no way to throttle hard from the tray, while
+// on a slow one they bunch together near the top. Spacing them out covers
+// full speed down to a heavy throttle from the same capacity, which is what
+// makes one setting work for a 4 Mbit line and a 200 Mbit one alike.
+const unsigned int TRAY_SPEED_DIVISORS[] = { 1, 2, 4, 10, 50 };
+const int TRAY_SPEED_PRESETS = (int)(sizeof(TRAY_SPEED_DIVISORS) / sizeof(TRAY_SPEED_DIVISORS[0]));
 
 // What to assume when the user has set their capacity to "unlimited": there is
 // nothing to take fractions of otherwise.
@@ -198,15 +205,18 @@ const uint32 TRAY_FALLBACK_CAPACITY = 100;
 /// Fills @a speeds with the presets in descending order, highest first.
 void GetTraySpeedPresets(uint32 capacity, unsigned int (&speeds)[TRAY_SPEED_PRESETS])
 {
-	// A capacity of "unlimited" gives nothing to take fractions of, and one
-	// below the preset count would collapse the ladder to zeros.
 	if (capacity == UNLIMITED) {
 		capacity = TRAY_FALLBACK_CAPACITY;
-	} else if (capacity < TRAY_SPEED_PRESETS * 2) {
-		capacity = TRAY_SPEED_PRESETS * 2;
+	}
+	// Keep the smallest entry at 1 kB/s or more: a preset of 0 would read as
+	// a limit and act as "unlimited", which is the opposite of what picking
+	// the bottom of the list means.
+	const uint32 smallest = TRAY_SPEED_DIVISORS[TRAY_SPEED_PRESETS - 1];
+	if (capacity < smallest) {
+		capacity = smallest;
 	}
 	for (int i = 0; i < TRAY_SPEED_PRESETS; i++) {
-		speeds[i] = (unsigned int)((double)capacity / TRAY_SPEED_PRESETS) * (TRAY_SPEED_PRESETS - i);
+		speeds[i] = (unsigned int)(capacity / TRAY_SPEED_DIVISORS[i]);
 	}
 }
 
@@ -304,8 +314,8 @@ GtkWidget *make_speed_submenu(uint32 max_speed, TrayAction action, gpointer user
 	GetTraySpeedPresets(max_speed, speeds);
 	for (int i = 0; i < TRAY_SPEED_PRESETS; i++) {
 		gtk_menu_shell_append(GTK_MENU_SHELL(submenu),
-			make_action_item(TraySpeedLabel(speeds[i]).utf8_str(), action, (long)speeds[i],
-				user_data));
+			make_action_item(
+				TraySpeedLabel(speeds[i]).utf8_str(), action, (long)speeds[i], user_data));
 	}
 	gtk_widget_show_all(submenu);
 	return submenu;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1534,8 +1534,22 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	 **/
 	NewCfgItem(IDC_SLIDER, (MkCfg_Int("/eMule/StatGraphsInterval", s_trafficOMeterInterval, 3)));
 	NewCfgItem(IDC_SLIDER2, (MkCfg_Int("/eMule/statsInterval", s_statsInterval, 30)));
-	NewCfgItem(IDC_DOWNLOAD_CAP, (MkCfg_Int("/eMule/DownloadCapacity", s_maxGraphDownloadRate, 300)));
-	NewCfgItem(IDC_UPLOAD_CAP, (MkCfg_Int("/eMule/UploadCapacity", s_maxGraphUploadRate, 100)));
+	// Line capacity, in kB/s. Not a limit -- it is what the connection can
+	// do, and both the traffic graph's scale and the tray's limit presets are
+	// derived from it. The old 300/100 described a fast line when they were
+	// chosen and now describe almost nobody, which left the tray offering a
+	// top preset of 300 kB/s on a gigabit connection.
+	//
+	// 100/20 Mbit, converted at 1024. Asymmetric because consumer lines
+	// mostly are, and because upload is the side people actually throttle.
+	// A user whose line differs sets this on the Statistics page, or answers
+	// the first-run wizard, which computes it from the speeds they enter.
+	//
+	// Only new configurations see this. aMule writes every key on save, so an
+	// existing amule.conf already carries the old value and wxConfig applies
+	// a default only when the key is absent.
+	NewCfgItem(IDC_DOWNLOAD_CAP, (MkCfg_Int("/eMule/DownloadCapacity", s_maxGraphDownloadRate, 12500)));
+	NewCfgItem(IDC_UPLOAD_CAP, (MkCfg_Int("/eMule/UploadCapacity", s_maxGraphUploadRate, 2500)));
 	NewCfgItem(IDC_SLIDER3, (MkCfg_Int("/eMule/StatsAverageMinutes", s_statsAverageMinutes, 5)));
 	NewCfgItem(IDC_SLIDER4, (MkCfg_Int("/eMule/VariousStatisticsMaxValue", s_statsMax, 100)));
 	NewCfgItem(IDC_CLIENTVERSIONS, (MkCfg_Int("/Statistics/MaxClientVersions", s_maxClientVersions, 0)));


### PR DESCRIPTION
Fixes #788. The tray's Upload/Download limit submenus offered fifths of the configured line capacity, whose defaults are 300 and 100 kB/s. On any current connection the *top* entry is already a heavy throttle — which is what the report shows.

## The presets are no longer evenly spaced

Fifths span a single factor of five, so on a fast line every entry lands high and there's no way to throttle hard from the tray, while on a slow one they bunch near the top. Dividing by 1, 2, 4, 10 and 50 covers full speed down to a heavy throttle from the same capacity.

**This helps existing users without them changing anything.** At the current 300 default the ladder goes from `300/240/180/120/60` to `300/150/75/30/6` — same ceiling, far better reach downward.

## The capacity defaults move to 100/20 Mbit

Converted at 1024, that's 12500 and 2500 kB/s, giving `12500/6250/3125/1250/250` and `2500/1250/625/250/50`.

Capacity isn't a limit — it's what the line can do. The traffic graph scales from it, the status bar computes its percentage against it, and EC publishes it as `EC_TAG_CONN_UL_CAP`/`DL_CAP`. Asymmetric because consumer lines mostly are, and because upload is the side people actually throttle.

Only **new** configurations see this: aMule writes every key on save, so an existing `amule.conf` already carries the old value and `wxConfig` applies a default only when the key is absent. That's why the ladder change matters on its own — and anyone whose line differs sets it on the Statistics page, or answers the first-run wizard, which already computes it from the speeds entered.

## Why not derive from the configured limit

Considered and rejected: the menu could then only ever *lower* the limit, since every entry would be at or below the cap in force, and the shipped default of unlimited leaves nothing to scale from at all.

## Deduplication

The ladder was written out three times — once in the appindicator submenu builder, once each for upload and download in the wx builder — and the two backends had drifted. The appindicator one passes labels straight to GTK, so **"Unlimited" and "kB/s" were never translated there** while the wx one ran both through `_()`; one also formatted an unsigned with `%d`. One helper now produces the speeds and one the labels, so both backends show the same strings in the user's language. The clamp moved in with them, replacing two caller-side copies.

## Verification

Both backends built: macOS (wx) and Linux with `libayatana-appindicator 0.5.94` active, which is the only build that compiles the GTK path at all. clang-format 18 clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors, `ctest` 32/32. Catalogs regenerated — no msgids added or removed (1917 both sides), the entries only move position because xgettext orders by source location.

Not yet visually confirmed on either backend: the numbers above are computed, not seen. Worth a look before merge.

One trade-off worth stating: raising the download capacity also rescales the traffic graph, so a user on a slow line who takes the new default gets a graph where their traffic sits near the axis. That is inherent to one setting serving both, and is why the wizard path matters.
