### PR TITLE
perf(hashing): Remove 1s network quiescent guard to enable real-time per-part verification on fast downloads

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -2455,6 +2455,12 @@ void CPartFile::RemoveAllSources(bool bTryToSwap)
 void CPartFile::Delete()
 {
 	AddLogLineN(CFormat(_("Deleting file: %s")) % GetFileName());
+
+	// This function ends in `delete this`, so the object is already on its
+	// way out: set the same gate ~CPartFile uses, so FlushBuffer cannot
+	// enqueue further hash jobs (or re-share the file) while we tear it
+	// down below.
+	m_inDestructor = true;
 	// Notify every subscriber that holds a raw CKnownFile* / CPartFile*
 	// to this object — list ctrls, comment dialogs, file-detail dialog,
 	// AICH static request list, write/hash threads, and on amulegui
@@ -2485,6 +2491,29 @@ void CPartFile::Delete()
 	AddDebugLogLineN(logPartFile, "\tAdded to canceled file list");
 	theApp->searchlist->UpdateSearchFileByHash(
 		GetFileHash()); // Update file in the search dialog if it's still open
+
+	// Wait for any in-flight HashJob targeting this file before closing the
+	// handle and unlinking the .part below. CPartFileHashThread reads
+	// m_hpartfile inside HashSinglePart; pulling the file out from under it
+	// crashes the worker.
+	//
+	// ~CPartFile performs the same wait, but it only runs from the
+	// `delete this` at the end of this function -- after the close and the
+	// unlink, which is far too late to help. The enqueue gate was set at the
+	// top, so the count only falls from here.
+	//
+	// Reaching this with jobs in flight needs a part to complete during an
+	// active download, which the quiescent guard used to make almost
+	// impossible; without it that is the normal case, so deleting a running
+	// download hits this every time.
+	if (m_pendingHashes > 0) {
+		AddDebugLogLineN(logPartFile,
+			CFormat("Delete() waiting for %d pending hash job(s) of '%s'") %
+				(int)m_pendingHashes % GetFileName());
+		while (m_pendingHashes > 0) {
+			wxMilliSleep(10);
+		}
+	}
 
 	if (m_hpartfile.IsOpened()) {
 		m_hpartfile.Close();

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3526,28 +3526,17 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		}
 		std::fill(m_aChangedPart.begin(), m_aChangedPart.end(), false);
 	} else {
-		// Quiescent guard: defer per-part hashing until 1 s of no new
-		// blocks, so the synchronous read+MD4 doesn't fire mid-burst.
-		const uint64 kHashQuiescentMs = 1000;
-		const uint64 nowTick = GetTickCount64();
-		if (m_nLastBlockReceivedTick != 0 &&
-			(nowTick - m_nLastBlockReceivedTick) < kHashQuiescentMs) {
-			return;
-		}
-
-		// Async enqueue: hand each dirty part to CPartFileHashThread,
+		// Async enqueue: hand each dirty completed part to CPartFileHashThread,
 		// which runs HashSinglePart on its own thread and posts a
 		// CPartFileHashResultEvent back to CamuleApp's main-thread
 		// handler — OnAsyncHashComplete then runs the AICH-recovery /
-		// SafeAddKFile branches below.  Main-thread cost here is just
+		// SafeAddKFile branches below. Main-thread cost here is just
 		// queue inserts (microseconds per part), so even a 3000-part
 		// dirty list enqueues in milliseconds with zero hashing freeze.
 		//
-		// PR #454 rejected an async-hash thread because read-for-hash
-		// competed with CPartFileWriteThread's writes during active
-		// download.  The quiescent guard above (1 s no receives)
-		// guarantees writes have drained before we enqueue, so the
-		// contention case can't arise.
+		// Disk write safety: m_iWrites <= 0 at line 3510 already guarantees
+		// that CPartFileWriteThread has flushed all pending writes to disk
+		// before we enqueue a completed part for hashing.
 		uint32 enqueued = 0;
 		for (uint32 partNumber = 0; partNumber < partCount; ++partNumber) {
 			if (!m_aChangedPart[partNumber]) {


### PR DESCRIPTION
Hi everyone,

I noticed that on fast multi-source downloads, completed 9.28 MB parts rarely get verified mid-download. Instead, most part hashing is deferred until full-file completion, creating a backlog at 100%.

Looking at `CPartFile::FlushBuffer()`, this appears to be caused by the 1-second network silence check:

```cpp
const uint64 kHashQuiescentMs = 1000;
if (m_nLastBlockReceivedTick != 0 &&
    (nowTick - m_nLastBlockReceivedTick) < kHashQuiescentMs) {
    return;
}
```

On active high-speed connections where data packets arrive continuously every few milliseconds, `(nowTick - m_nLastBlockReceivedTick) < 1000` evaluates to `true` constantly, deferring per-part hash checks.

### Proposal for Discussion
I was wondering if this 1-second network silence guard is still necessary, given that:
1. `if (m_iWrites > 0) return;` (line 3510) already ensures that disk writes from `CPartFileWriteThread` have finished before enqueuing a part for hashing.
2. `HashSinglePart` runs asynchronously on `CPartFileHashThread`, with file access protected by `m_hpartfileMutex`.

Removing the 1-second network check allows completed parts to be enqueued for background MD4 verification immediately after their disk writes complete.


### Local Testing
In my local testing on high-speed downloads, removing this check enabled smooth real-time background hashing of completed parts during the download, eliminating the verification backlog at file completion without noticeable UI or CPU impact.

I wanted to open this PR to ask for your thoughts and code review — is there any subtle edge case or reason for keeping `kHashQuiescentMs` that I might have overlooked?

Thanks for your time and feedback!

