### PR TITLE
fix(gui): stop the tray limit menu truncating above 65535 kB/s

### DIFF
--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -160,7 +160,11 @@ void CMuleTrayIcon::DoExit()
 
 void CMuleTrayIcon::DoSetUploadLimit(long kBytesPerSec)
 {
-	thePrefs::SetMaxUpload(kBytesPerSec < 0 ? UNLIMITED : (uint16)kBytesPerSec);
+	// uint32, not uint16: the preference, its setter and its getter are all
+	// uint32, and a 16-bit cast here silently wrapped anything above 65535
+	// kB/s. A preset of 125000 applied as 59464 -- under half the figure on
+	// the menu item the user clicked, with nothing logged either side.
+	thePrefs::SetMaxUpload(kBytesPerSec < 0 ? UNLIMITED : (uint32)kBytesPerSec);
 #ifdef CLIENT_GUI
 	theApp->glob_prefs->SendToRemote();
 #endif
@@ -168,7 +172,8 @@ void CMuleTrayIcon::DoSetUploadLimit(long kBytesPerSec)
 
 void CMuleTrayIcon::DoSetDownloadLimit(long kBytesPerSec)
 {
-	thePrefs::SetMaxDownload(kBytesPerSec < 0 ? UNLIMITED : (uint16)kBytesPerSec);
+	// See the note in DoSetUploadLimit.
+	thePrefs::SetMaxDownload(kBytesPerSec < 0 ? UNLIMITED : (uint32)kBytesPerSec);
 #ifdef CLIENT_GUI
 	theApp->glob_prefs->SendToRemote();
 #endif


### PR DESCRIPTION
Picking a limit from the tray cast the value to `uint16` before handing it to `SetMaxUpload`/`SetMaxDownload`. Both take `uint32`, as do the preferences behind them and their getters — so the cast was the only 16-bit step on the path, and anything above 65535 kB/s wrapped.

A preset of `125000 kB/s` applied as **59464** — under half the figure on the menu item that was clicked, with nothing logged on either side. The label and the effect disagreed silently, which is the worst shape for this: the user has no reason to doubt the number they picked.

## The fix

Widen the two casts to `uint32`. They stay rather than going away, because the parameter is a `long` and dropping the cast would trade a silent wrap for a `bugprone-narrowing-conversions` diagnostic.

`Preferences.h` declares `s_maxupload`/`s_maxdownload` as `uint32`, `SetMaxUpload`/`SetMaxDownload` take `uint32`, and `GetMaxUpload`/`GetMaxDownload` return it — so nothing downstream narrows and this is the complete fix rather than the first of several.

## Why it surfaced now

Latent, and previously unreachable. The tray presets are fractions of the configured line capacity, and while that defaulted to 300 kB/s the largest value the menu could produce was 300 — three orders of magnitude below the ceiling.

#790 raised those defaults to 100/20 Mbit, which brings the ceiling within one settings change: a gigabit line entered on the Statistics page yields presets well past 65535. Not introduced by that change, but promoted by it from theoretical to plausible.

## Verification

Build clean, clang-format 18 clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors, `ctest` 32/32.

Not exercised at runtime: reproducing it means setting a capacity above ~64 MB/s and clicking the top preset, which needs a GUI session. The reasoning is a type check rather than a behavioural one — `uint16` cannot hold 125000 — but flagging that it is verified by inspection, not by observation.

Scope is the tray path only. `amuleDlg.cpp` and `ExternalConn.cpp` carry no equivalent cast, but every caller of those setters has not been audited.
