### PR TITLE
fix(ec): clear the peer-negotiated tag-count flag on reconnect

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -882,14 +882,16 @@ void CamuleRemoteGuiApp::AttemptReconnect()
 	// the EC packet-reassembly state (a stale mid-packet read left over from
 	// the drop would otherwise misparse the new session's first bytes and the
 	// login would fail) and a fresh asio socket on the SAME CRemoteConnect
-	// object (keeps every remote container's m_conn pointer valid). Capability
-	// flags persist on the object -- SetCapabilities is not called again here,
-	// and what this end can do has not changed -- so ConnectToCore re-runs the
-	// login handshake as on first connect. The one flag that is cleared is the
-	// one agreed with the *peer* rather than chosen locally; see
-	// CECSocket::ResetProtocolState.
+	// object (keeps every remote container's m_conn pointer valid). Locally
+	// chosen capability flags persist deliberately -- SetCapabilities is not
+	// called again here, and what this end can do has not changed -- so
+	// ConnectToCore re-runs the login handshake as on first connect. Flags
+	// agreed with the previous daemon are a different matter: the next one may
+	// not support them, so they are dropped here rather than inside
+	// ResetProtocolState, which other CECSocket users share.
 	m_connect->DiscardRequestQueue();
 	m_connect->ResetProtocolState();
+	m_connect->ClearPeerNegotiatedFlags();
 	m_connect->ResetForReconnect();
 
 	// Per-attempt watchdog so an attempt that hangs (host unreachable, SYN

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -883,8 +883,11 @@ void CamuleRemoteGuiApp::AttemptReconnect()
 	// the drop would otherwise misparse the new session's first bytes and the
 	// login would fail) and a fresh asio socket on the SAME CRemoteConnect
 	// object (keeps every remote container's m_conn pointer valid). Capability
-	// flags persist on the object, so ConnectToCore re-runs the login handshake
-	// as on first connect.
+	// flags persist on the object -- SetCapabilities is not called again here,
+	// and what this end can do has not changed -- so ConnectToCore re-runs the
+	// login handshake as on first connect. The one flag that is cleared is the
+	// one agreed with the *peer* rather than chosen locally; see
+	// CECSocket::ResetProtocolState.
 	m_connect->DiscardRequestQueue();
 	m_connect->ResetProtocolState();
 	m_connect->ResetForReconnect();

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -261,12 +261,6 @@ size_t CQueuedData::GetUnreadDataLength() const
 // CECSocket API - User interface functions
 //
 
-// The per-packet flags this end may send before anything is negotiated: only
-// the version-sanity bit, which every packet carries and ReadPacket checks for.
-// Capability bits are OR'd in as the handshake agrees them, and the
-// `flags &= m_my_flags` in WritePacket strips any the peer never confirmed.
-static const uint32_t EC_MY_FLAGS_INITIAL = 0x20;
-
 CECSocket::CECSocket(bool use_events)
 : m_use_events(use_events)
 , m_in_ptr(EC_SOCKET_BUFFER_SIZE)
@@ -283,7 +277,7 @@ CECSocket::CECSocket(bool use_events)
 m_bytes_needed(EC_HEADER_SIZE)
 , m_in_header(true)
 , m_curr_packet_len(0)
-, m_my_flags(EC_MY_FLAGS_INITIAL)
+, m_my_flags(0x20)
 , m_haveNotificationSupport(false)
 , m_isLocalPeer(false)
 {
@@ -296,6 +290,29 @@ CECSocket::~CECSocket()
 		m_output_queue.pop_front();
 		delete data;
 	}
+}
+
+// Deliberately not part of ResetProtocolState. m_my_flags mixes two kinds of
+// state: capabilities this end simply has, and capabilities agreed with the
+// peer. Only a caller that knows it is facing a *different* peer may drop the
+// second kind, and only that caller knows it -- CECMemSocket, for one, sets
+// EC_FLAG_LARGE_TAG_COUNT in its constructor as a local property of the wire
+// format it caches, and clearing it there would corrupt the cache.
+//
+// Today the sole caller is amulegui's reconnect path, which reuses one
+// CRemoteConnect across sessions.
+void CECSocket::ClearPeerNegotiatedFlags()
+{
+	// EC_FLAG_LARGE_TAG_COUNT is the only bit here whose value comes from the
+	// peer: it is set when the daemon echoes EC_TAG_CAN_LARGE_TAG_COUNT in
+	// AUTH_OK. Left set across a reconnect, a client that negotiated it with
+	// one daemon keeps sending the extended tag-count format to one that never
+	// advertised it, and that does not fail cleanly -- the receiver reads a
+	// differently-sized count field and misparses everything after it.
+	//
+	// EC_FLAG_ZLIB and EC_FLAG_UTF8_NUMBERS are chosen locally, through
+	// SetCapabilities, which the reconnect path does not call again. They stay.
+	m_my_flags &= ~(uint32_t)EC_FLAG_LARGE_TAG_COUNT;
 }
 
 void CECSocket::ResetProtocolState()
@@ -326,20 +343,6 @@ void CECSocket::ResetProtocolState()
 	m_bytes_needed = EC_HEADER_SIZE;
 	m_in_header = true;
 	m_curr_packet_len = 0;
-	// m_my_flags holds two different things: what this end is willing to do,
-	// and what the last peer agreed to. Only the second is stale here.
-	//
-	// EC_FLAG_ZLIB and EC_FLAG_UTF8_NUMBERS come from local preferences via
-	// SetCapabilities, which the reconnect path does not call again -- so
-	// they have to survive, and they are still true regardless of which peer
-	// answers next. EC_FLAG_LARGE_TAG_COUNT is the odd one out: it is set
-	// only when the daemon echoes EC_TAG_CAN_LARGE_TAG_COUNT in AUTH_OK, and
-	// the word is otherwise only ever OR'd into. Left set, a client that
-	// negotiated it with one daemon keeps sending the extended tag-count
-	// format after reconnecting to one that never advertised it, which does
-	// not fail cleanly: the receiver reads a differently-sized count field
-	// and misparses everything after it.
-	m_my_flags &= ~(uint32_t)EC_FLAG_LARGE_TAG_COUNT;
 	// Re-negotiated by the reconnected session's auth handshake.
 	m_haveNotificationSupport = false;
 }

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -261,6 +261,12 @@ size_t CQueuedData::GetUnreadDataLength() const
 // CECSocket API - User interface functions
 //
 
+// The per-packet flags this end may send before anything is negotiated: only
+// the version-sanity bit, which every packet carries and ReadPacket checks for.
+// Capability bits are OR'd in as the handshake agrees them, and the
+// `flags &= m_my_flags` in WritePacket strips any the peer never confirmed.
+static const uint32_t EC_MY_FLAGS_INITIAL = 0x20;
+
 CECSocket::CECSocket(bool use_events)
 : m_use_events(use_events)
 , m_in_ptr(EC_SOCKET_BUFFER_SIZE)
@@ -277,7 +283,7 @@ CECSocket::CECSocket(bool use_events)
 m_bytes_needed(EC_HEADER_SIZE)
 , m_in_header(true)
 , m_curr_packet_len(0)
-, m_my_flags(0x20)
+, m_my_flags(EC_MY_FLAGS_INITIAL)
 , m_haveNotificationSupport(false)
 , m_isLocalPeer(false)
 {
@@ -320,6 +326,20 @@ void CECSocket::ResetProtocolState()
 	m_bytes_needed = EC_HEADER_SIZE;
 	m_in_header = true;
 	m_curr_packet_len = 0;
+	// m_my_flags holds two different things: what this end is willing to do,
+	// and what the last peer agreed to. Only the second is stale here.
+	//
+	// EC_FLAG_ZLIB and EC_FLAG_UTF8_NUMBERS come from local preferences via
+	// SetCapabilities, which the reconnect path does not call again -- so
+	// they have to survive, and they are still true regardless of which peer
+	// answers next. EC_FLAG_LARGE_TAG_COUNT is the odd one out: it is set
+	// only when the daemon echoes EC_TAG_CAN_LARGE_TAG_COUNT in AUTH_OK, and
+	// the word is otherwise only ever OR'd into. Left set, a client that
+	// negotiated it with one daemon keeps sending the extended tag-count
+	// format after reconnecting to one that never advertised it, which does
+	// not fail cleanly: the receiver reads a differently-sized count field
+	// and misparses everything after it.
+	m_my_flags &= ~(uint32_t)EC_FLAG_LARGE_TAG_COUNT;
 	// Re-negotiated by the reconnected session's auth handshake.
 	m_haveNotificationSupport = false;
 }

--- a/src/libs/ec/cpp/ECSocket.h
+++ b/src/libs/ec/cpp/ECSocket.h
@@ -149,6 +149,14 @@ public:
 	// reconnected session's first bytes and the login handshake fails.
 	void ResetProtocolState();
 
+	/**
+	 * Drop the capability bits agreed with the previous peer, keeping the ones
+	 * this end chose locally. Only for a caller reusing this object against a
+	 * possibly different peer; see the definition for why it is separate from
+	 * ResetProtocolState.
+	 */
+	void ClearPeerNegotiatedFlags();
+
 	void CloseSocket() { InternalClose(); }
 
 	/**

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -53,6 +53,32 @@ target_link_libraries (ECIdDiffTest
 	mulecommon
 )
 
+add_executable (ECSocketFlagsTest
+	ECSocketFlagsTest.cpp
+	# As for ECIdDiffTest: libec.a references DoECLogLine / theLogger
+	# unconditionally in Debug, so the no-op definitions have to be linked in.
+	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+)
+
+add_test (NAME ECSocketFlagsTest
+	COMMAND ECSocketFlagsTest
+)
+
+target_include_directories (ECSocketFlagsTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs/ec/cpp
+)
+
+target_link_libraries (ECSocketFlagsTest
+	muleunit
+	ec
+	mulecommon
+)
+
 add_executable (CValueMapTest
 	CValueMapTest.cpp
 	# LoggerConsole.cpp provides the no-op DoECLogLine + theLogger symbols that

--- a/unittests/tests/ECSocketFlagsTest.cpp
+++ b/unittests/tests/ECSocketFlagsTest.cpp
@@ -1,0 +1,111 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include <ec/cpp/ECCodes.h>
+#include <ec/cpp/ECMemSocket.h>
+#include <ec/cpp/ECSocket.h>
+
+using namespace muleunit;
+
+// m_my_flags mixes two kinds of capability bit, and the difference decides
+// which ones a reconnect may drop:
+//
+//   - chosen locally (EC_FLAG_ZLIB, EC_FLAG_UTF8_NUMBERS), from preferences
+//     via SetCapabilities, which the reconnect path does not call again;
+//   - agreed with the peer (EC_FLAG_LARGE_TAG_COUNT), set only when the daemon
+//     echoes EC_TAG_CAN_LARGE_TAG_COUNT in AUTH_OK.
+//
+// Getting either half wrong is silent. Left set across a reconnect, the
+// negotiated bit makes the client keep sending the extended tag-count format
+// to a daemon that never advertised it, and the receiver misparses every tag
+// after the count. Clearing too much instead disables compression for the rest
+// of the session -- no error either way, just a broken or slow list.
+//
+// The transition is pure state, so it needs no daemon: CECMemSocket is a
+// concrete in-tree CECSocket whose constructor already sets both
+// EC_FLAG_UTF8_NUMBERS and EC_FLAG_LARGE_TAG_COUNT.
+
+namespace
+{
+
+// m_my_flags is protected, and deliberately so; a subclass is how the tree
+// itself reaches it (CECMemSocket's constructor does exactly this).
+class CFlagProbe : public CECMemSocket
+{
+public:
+	void Add(uint32_t flags) { m_my_flags |= flags; }
+	uint32_t Flags() const { return m_my_flags; }
+};
+
+} // namespace
+
+DECLARE_SIMPLE(ECSocketFlags)
+
+// The reason this was not a one-line clear of the whole word.
+TEST(ECSocketFlags, ClearPeerNegotiatedKeepsLocalCapabilities)
+{
+	CFlagProbe socket;
+	socket.Add(EC_FLAG_ZLIB);
+
+	// Precondition: all three bits set, as after a completed handshake.
+	ASSERT_TRUE((socket.Flags() & EC_FLAG_ZLIB) != 0);
+	ASSERT_TRUE((socket.Flags() & EC_FLAG_UTF8_NUMBERS) != 0);
+	ASSERT_TRUE((socket.Flags() & EC_FLAG_LARGE_TAG_COUNT) != 0);
+
+	socket.ClearPeerNegotiatedFlags();
+
+	// Only the negotiated bit goes.
+	ASSERT_TRUE((socket.Flags() & EC_FLAG_LARGE_TAG_COUNT) == 0);
+	ASSERT_TRUE((socket.Flags() & EC_FLAG_ZLIB) != 0);
+	ASSERT_TRUE((socket.Flags() & EC_FLAG_UTF8_NUMBERS) != 0);
+}
+
+// Every packet carries the version-sanity bit, and ReadPacket rejects one that
+// does not -- so the clear must not disturb it.
+TEST(ECSocketFlags, ClearPeerNegotiatedKeepsVersionBit)
+{
+	CFlagProbe socket;
+	const uint32_t versionBit = socket.Flags() & 0x60;
+
+	socket.ClearPeerNegotiatedFlags();
+
+	ASSERT_EQUALS(versionBit, socket.Flags() & 0x60);
+}
+
+// The clear lives outside ResetProtocolState on purpose. CECMemSocket sets
+// EC_FLAG_LARGE_TAG_COUNT as a local property of the wire format it caches,
+// not as something a peer agreed to, so a reset that dropped it would silently
+// downgrade the cache to the short tag-count format.
+TEST(ECSocketFlags, ResetProtocolStateLeavesCapabilitiesAlone)
+{
+	CFlagProbe socket;
+	socket.Add(EC_FLAG_ZLIB);
+	const uint32_t before = socket.Flags();
+
+	socket.ResetProtocolState();
+
+	ASSERT_EQUALS(before, socket.Flags());
+}


### PR DESCRIPTION
amulegui reuses one `CRemoteConnect` across reconnects — that is why `ResetProtocolState()` exists — so anything it does not clear carries into the next session. `EC_FLAG_LARGE_TAG_COUNT` was carrying.

It is set only when the daemon echoes `EC_TAG_CAN_LARGE_TAG_COUNT` in `AUTH_OK`. So a client that negotiated the extended tag-count format with one daemon kept sending it after reconnecting to a daemon that never advertised it. That does not fail cleanly: the receiver reads a differently-sized count field and misparses everything after it.

The comment at the point of negotiation already claimed the format "stays disabled in both directions for the duration of this connection". That is now true.

## Only that flag — and not inside `ResetProtocolState`

`m_my_flags` holds two different things: capabilities this end simply has, and capabilities agreed with a peer. Only the second is stale on reconnect.

`EC_FLAG_ZLIB` and `EC_FLAG_UTF8_NUMBERS` come from local preferences via `SetCapabilities()`, which `AttemptReconnect()` does **not** call again. Clearing the whole word would have dropped compression and UTF-8 numbers on every reconnect, with no path to restore them short of a restart.

The first version of this fix put the clear inside `ResetProtocolState()`. Review caught that this writes a rule into the base class that one of its own subclasses contradicts: `CECMemSocket`'s constructor also sets `EC_FLAG_LARGE_TAG_COUNT`, as a local property of the canonical wire format its response cache emits — exactly the category that must survive. That is safe today only because `ResetProtocolState()` is never called on that subclass, which is not a rule worth depending on. A future caller would silently drop the cache to the short tag-count format: this bug's mirror image.

So the clear now lives in its own `CECSocket::ClearPeerNegotiatedFlags()`, called from `AttemptReconnect()` beside the other two resets. The mechanism sits on the base class, where `m_my_flags` lives; the policy sits with the one caller that knows it may be facing a different daemon.

## Dropping the version-bit constant

An earlier commit here introduced `EC_MY_FLAGS_INITIAL` for the `0x20` in the constructor. That named one of four appearances of the same bit — `WritePacket()` still opens with a bare `0x20` twice, and `ReadPacket()` still tests `0x60`/`0x20` — so a reader meeting the constant could not tell whether it was the same bit, and the name described the use ("initial my_flags") rather than the thing. It is reverted. Naming the protocol version bit belongs with the other flag values in `ECCodes.abstract`, as its own change.

## Tests

`ECSocketFlagsTest`, three cases. The transition is pure state and `CECMemSocket` is a concrete in-tree `CECSocket`, so it needs no daemon and no GUI:

- the negotiated bit is cleared and the locally chosen ones survive — the reason this was not a one-line clear of the whole word;
- the version-sanity bit survives, since every packet carries it and `ReadPacket()` rejects one that does not;
- `ResetProtocolState()` leaves `m_my_flags` alone — which is what pins the placement decision above.

Mutation-checked in three directions: over-clearing (`m_my_flags = 0x20`), not clearing at all, and clearing the wrong bit. Each fails on the assertion you would expect; unmutated passes.

## Scope

Narrow: it needs one amulegui *process* to reconnect to a peer of different vintage — an older daemon, a different host, or the same host downgraded. Same-daemon reconnects, the common case, were never affected, because re-ORing a bit that is already set is a no-op.

## Verification

Build clean across monolithic, amulegui, amuled and amulecmd; clang-format 18 clean; Tier-2 clang-tidy clean on the diff with 0 compiler errors; `ctest` 33/33.

Not reproduced at runtime. Triggering the original bug needs two daemons that disagree about the capability, and the only code path that calls the reconnect sequence needs a GUI session. The check worth doing before merge is therefore the *common* path rather than the rare one: connect amulegui, force a reconnect to the same daemon, and confirm the file list still populates and compression is still active.
