### PR TITLE
fix(ec): report why a login was refused instead of letting it time out

### DIFF
--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -651,6 +651,14 @@ void CRemoteConnect::DiscardRequestQueue()
 	m_req_count = 0;
 }
 
+void CRemoteConnect::NotifyConnectionResult(bool connected)
+{
+	if (m_notifier) {
+		wxECSocketEvent event(wxEVT_EC_CONNECTION, connected, m_server_reply);
+		m_notifier->AddPendingEvent(event);
+	}
+}
+
 bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 {
 	bool result = false;
@@ -686,6 +694,7 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 							    "settings.");
 					m_ec_state = EC_FAIL;
 					CloseSocket();
+					NotifyConnectionResult(false);
 					return false;
 				}
 				wxString saltHash = MD5Sum(CFormat("%lX") % passwordSalt->GetInt()).GetHash();
@@ -711,6 +720,7 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 						   "knows the password. Connection closed.");
 				m_ec_state = EC_FAIL;
 				CloseSocket();
+				NotifyConnectionResult(false);
 				return false;
 			}
 			m_ec_state = EC_OK;
@@ -791,10 +801,7 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			CloseSocket();
 		}
 	}
-	if (m_notifier) {
-		wxECSocketEvent event(wxEVT_EC_CONNECTION, result, m_server_reply);
-		m_notifier->AddPendingEvent(event);
-	}
+	NotifyConnectionResult(result);
 	return result;
 }
 

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -621,6 +621,19 @@ public:
 private:
 	virtual const CECPacket *OnPacketReceived(const CECPacket *packet, uint32 trueSize);
 	bool ProcessAuthPacket(const CECPacket *reply);
+
+	/**
+	 * Hand the outcome of a login attempt to the GUI, carrying whatever
+	 * m_server_reply currently explains.
+	 *
+	 * Every path that ends a login attempt must call this. Plain CloseSocket()
+	 * does not dispatch OnLost (see the note on CloseAndDispatchLost in
+	 * ECSocket.h) precisely because ProcessAuthPacket is expected to notify for
+	 * itself, so a path that closes and returns without calling this leaves
+	 * amulegui waiting on its connect-timeout watchdog instead of showing the
+	 * reason.
+	 */
+	void NotifyConnectionResult(bool connected);
 };
 
 wxDECLARE_EVENT(wxEVT_EC_CONNECTION, wxEvent);


### PR DESCRIPTION
Connecting a current amulegui to a core that predates #785 fails — correctly, since the core cannot negotiate an encrypted session and falling back to the password-keyed derivation is the downgrade #785 exists to prevent. But it fails as a **timeout**, several seconds later, with a message that is wrong in every particular:

> Unable to reach `<host>:<port>` within the allotted time. Please check the host, port and that aMule is running with External Connections enabled.

The host is reachable, aMule is running, and External Connections are enabled. Meanwhile the accurate message — that the core did not negotiate encryption, and how to turn encryption off if the user wants to connect anyway — was already written and never shown.

## Why nothing was reported

The two encryption checks added in #785 end a login attempt by setting `m_server_reply`, closing the socket and returning `false`. Both return *before* the tail of `ProcessAuthPacket`, which is the only place that fires `wxEVT_EC_CONNECTION` — so the GUI is never told the attempt ended, and waits for its connect-timeout watchdog instead.

Nothing else covers for them. Plain `CloseSocket()` deliberately does not dispatch `OnLost`, and the note on `CloseAndDispatchLost` in `ECSocket.h` says exactly why:

> Sites that already have their own UI-facing notification (`CRemoteConnect::ProcessAuthPacket` fires `wxEVT_EC_CONNECTION` directly) keep using plain `CloseSocket`.

That precondition is what the new returns broke. `CAsioSocketImpl::Close` also sets `m_closed`, which suppresses the asio-side lost path, so no notification arrives from any direction.

This is the normal upgrade order — the GUI updated before the daemon — so it is what a user hits first, and the misleading text sends them to check the one thing that is not wrong.

## The fix

All three terminal paths now go through a single `NotifyConnectionResult` helper rather than repeating the event block. The mid-handshake `EC_SALT_RECEIVED` return still does not notify, which is correct: that attempt has not ended. An audit of every `return` in the function confirms those four are all of them.

## Verification

Verified against a real pre-#785 core: the client now reports the encryption refusal instead of timing out.

Build clean across monolithic, amulegui, amuled and amulecmd; clang-format 18 clean; Tier-2 clang-tidy clean on the diff with 0 compiler errors; `ctest` 33/33.

No unit test. Unlike the pure state transition in #794, `ProcessAuthPacket` needs a live socket and an event handler to reach, so the return-path audit above is what stands in for one, and it is weaker — it shows every exit notifies, not that the event carries the right payload to the GUI.
