### PR TITLE
perf: prefer AES for EC if both the server and client have hardware support

### DIFF
--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -149,6 +149,8 @@ the offer is refused rather than answered with a weaker derivation.
 | `1` | AES-128-GCM (mandatory) | when both sides have hardware support for AES |
 | `2` | ChaCha20-Poly1305 (optional) | when both sides have ChaCha20 and at least one lacks hardware support for AES |
 
+Please note Crypto++ (as of version 8.9.0), detects hardware AES on x86 and
+Linux ARM only, so macOS and Windows stays on ChaCha20 despite the hardware.
 
 **Keys.** Both sides derive from the X25519 shared secret, and from nothing
 else. In particular *not* from the password: a key derived from something that

--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -144,10 +144,11 @@ The public key is not optional. A peer that offers `EC_TAG_CAN_AEAD` without one
 is malformed, not old — encryption and the key exchange shipped together — and
 the offer is refused rather than answered with a weaker derivation.
 
-| id | cipher |
-| -- | ------ |
-| `1` | AES-128-GCM (mandatory) |
-| `2` | ChaCha20-Poly1305 (optional; preferred where both sides have it) |
+| id | cipher | preferred |
+| -- | ------ | -- |
+| `1` | AES-128-GCM (mandatory) | when both sides have hardware support for AES |
+| `2` | ChaCha20-Poly1305 (optional) | when both sides have ChaCha20 and at least one lacks hardware support for AES |
+
 
 **Keys.** Both sides derive from the X25519 shared secret, and from nothing
 else. In particular *not* from the password: a key derived from something that

--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -149,8 +149,13 @@ the offer is refused rather than answered with a weaker derivation.
 | `1` | AES-128-GCM (mandatory) | when both sides have hardware support for AES |
 | `2` | ChaCha20-Poly1305 (optional) | when both sides have ChaCha20 and at least one lacks hardware support for AES |
 
-Please note Crypto++ (as of version 8.9.0), detects hardware AES on x86 and
-Linux ARM only, so macOS and Windows stays on ChaCha20 despite the hardware.
+Note that Crypto++ (as of 8.9.0) only detects hardware AES on x86 and on Linux
+ARM. On macOS and Windows ARM builds the check comes up empty even where the
+CPU has the instructions, so those peers offer ChaCha20 first and the channel
+settles on it. That is the right outcome while it lasts: the same flag decides
+whether Crypto++ itself uses the AES instructions, so a peer that preferred AES
+there would get the table-based implementation, which is slower than ChaCha20
+and not constant-time.
 
 **Keys.** Both sides derive from the X25519 shared secret, and from nothing
 else. In particular *not* from the password: a key derived from something that

--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -80,37 +80,11 @@
 // what the peer can do, not what this build has.
 #include CRYPTO_HEADER(chachapoly.h)
 #include CRYPTO_HEADER(xed25519.h)
-
-#endif /* CRYPTOPP_INC_NEED_AEAD */
-
-// check hardware support for AES
-// if both the client and the daemon have it, prefer AES over ChaCha20
+// Runtime CPU feature probes, for picking the cipher the hardware is fastest
+// at. In the AEAD block for the same reason as the rest: only the EC layer
+// asks, and this header reaches most of the tree through MD5Sum.h.
 #include CRYPTO_HEADER(cpu.h)
-namespace ECCrypt
-{
-#if defined(CRYPTOPP_AESNI_AVAILABLE)
-inline bool HasHardwareAES()
-{
-	return CryptoPP::HasAESNI();
-}
-#elif defined(CRYPTOPP_ARM_AES_AVAILABLE)
-inline bool HasHardwareAES()
-{
-	return CryptoPP::HasAES();
-}
-#elif defined(CRYPTOPP_POWER8_AES_AVAILABLE)
-inline bool HasHardwareAES()
-{
-	return CryptoPP::HasAES();
-}
-#else
-inline bool HasHardwareAES()
-{
-	return false;
-}
 #endif
-} // namespace ECCrypt
-using ECCrypt::HasHardwareAES;
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -80,7 +80,21 @@
 // what the peer can do, not what this build has.
 #include CRYPTO_HEADER(chachapoly.h)
 #include CRYPTO_HEADER(xed25519.h)
+
+// check hardware support for AES
+// if both the client and the daemon have it, prefer AES over ChaCha20
+#include CRYPTO_HEADER(cpu.h)
+#if defined(CRYPTOPP_AESNI_AVAILABLE)
+#define HasHardwareAES() CryptoPP::HasAESNI()
+#elif defined(CRYPTOPP_ARM_AES_AVAILABLE)
+#define HasHardwareAES() CryptoPP::HasAES()
+#elif defined(CRYPTOPP_POWER8_AES_AVAILABLE)
+#define HasHardwareAES() CryptoPP::HasAES()
+#else
+#define HasHardwareAES() (false)
 #endif
+
+#endif /* CRYPTOPP_INC_NEED_AEAD */
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -81,20 +81,36 @@
 #include CRYPTO_HEADER(chachapoly.h)
 #include CRYPTO_HEADER(xed25519.h)
 
+#endif /* CRYPTOPP_INC_NEED_AEAD */
+
 // check hardware support for AES
 // if both the client and the daemon have it, prefer AES over ChaCha20
 #include CRYPTO_HEADER(cpu.h)
+namespace ECCrypt
+{
 #if defined(CRYPTOPP_AESNI_AVAILABLE)
-#define HasHardwareAES() CryptoPP::HasAESNI()
+inline bool HasHardwareAES()
+{
+	return CryptoPP::HasAESNI();
+}
 #elif defined(CRYPTOPP_ARM_AES_AVAILABLE)
-#define HasHardwareAES() CryptoPP::HasAES()
+inline bool HasHardwareAES()
+{
+	return CryptoPP::HasAES();
+}
 #elif defined(CRYPTOPP_POWER8_AES_AVAILABLE)
-#define HasHardwareAES() CryptoPP::HasAES()
+inline bool HasHardwareAES()
+{
+	return CryptoPP::HasAES();
+}
 #else
-#define HasHardwareAES() (false)
+inline bool HasHardwareAES()
+{
+	return false;
+}
 #endif
-
-#endif /* CRYPTOPP_INC_NEED_AEAD */
+} // namespace ECCrypt
+using ECCrypt::HasHardwareAES;
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -703,20 +703,27 @@ void CECServerSocket::NegotiateAEAD(const CECPacket *request, CECPacket *respons
 	const uint8_t *offered = (const uint8_t *)offer->GetTagData();
 	const uint16_t offeredLen = offer->GetTagDataLen();
 
-	// Our list is in preference order, so take our first mutual entry rather
-	// than the client's -- the daemon decides what it would rather run.
-	const std::vector<uint8_t> ours = ECCrypt::SupportedCiphers();
-	for (size_t i = 0; i < ours.size() && m_aeadCipher == ECCrypt::Cipher_None; ++i) {
-		for (uint16_t j = 0; j < offeredLen; ++j) {
-			if (offered[j] == ours[i]) {
-				m_aeadCipher = ours[i];
-				break;
+	// the client prefers Cipher_ChaCha20_Poly1305, probably because it doesn't support
+	// hardware AES, let's make our client happy
+	if (offeredLen && offered[0] == ECCrypt::Cipher_ChaCha20_Poly1305 &&
+		ECCrypt::IsCipherSupported(ECCrypt::Cipher_ChaCha20_Poly1305))
+		m_aeadCipher = ECCrypt::Cipher_ChaCha20_Poly1305;
+	else {
+		// Our list is in preference order, so take our first mutual entry rather
+		// than the client's -- the daemon decides what it would rather run.
+		const std::vector<uint8_t> ours = ECCrypt::SupportedCiphers();
+		for (size_t i = 0; i < ours.size() && m_aeadCipher == ECCrypt::Cipher_None; ++i) {
+			for (uint16_t j = 0; j < offeredLen; ++j) {
+				if (offered[j] == ours[i]) {
+					m_aeadCipher = ours[i];
+					break;
+				}
 			}
 		}
-	}
-	if (m_aeadCipher == ECCrypt::Cipher_None) {
-		AddDebugLogLineN(logEC, "AEAD: no cipher in common with this client");
-		return;
+		if (m_aeadCipher == ECCrypt::Cipher_None) {
+			AddDebugLogLineN(logEC, "AEAD: no cipher in common with this client");
+			return;
+		}
 	}
 
 	m_aeadServerNonce = ECCrypt::RandomBytes(ECCrypt::NONCE_TAG_LEN);

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -26,8 +26,6 @@
 
 #include "config.h" // Needed for VERSION
 
-#include "CryptoPP_Inc.h" // Needed for HasHardwareAES
-
 #include <set>       // Needed for std::set (m_lastSentSharedFileIds)
 #include <list>      // Needed for std::list (multi-search LRU ring)
 #include <algorithm> // Needed for std::find (multi-search LRU ring)

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -26,6 +26,8 @@
 
 #include "config.h" // Needed for VERSION
 
+#include "CryptoPP_Inc.h" // Needed for HasHardwareAES
+
 #include <set>       // Needed for std::set (m_lastSentSharedFileIds)
 #include <list>      // Needed for std::list (multi-search LRU ring)
 #include <algorithm> // Needed for std::find (multi-search LRU ring)
@@ -703,14 +705,16 @@ void CECServerSocket::NegotiateAEAD(const CECPacket *request, CECPacket *respons
 	const uint8_t *offered = (const uint8_t *)offer->GetTagData();
 	const uint16_t offeredLen = offer->GetTagDataLen();
 
-	// the client prefers Cipher_ChaCha20_Poly1305, probably because it doesn't support
-	// hardware AES, let's make our client happy
+	// The client prefers Cipher_ChaCha20_Poly1305, probably because it doesn't support
+	// hardware AES, let's make our client happy.
+	// If a third cipher is ever added, please update all the logic below and SupportedCiphers()
+	// to make sure you send and select the intended ciphers
 	if (offeredLen && offered[0] == ECCrypt::Cipher_ChaCha20_Poly1305 &&
 		ECCrypt::IsCipherSupported(ECCrypt::Cipher_ChaCha20_Poly1305))
 		m_aeadCipher = ECCrypt::Cipher_ChaCha20_Poly1305;
 	else {
-		// Our list is in preference order, so take our first mutual entry rather
-		// than the client's -- the daemon decides what it would rather run.
+		// if the client didn't ask for ChaCha20, we will check our own list
+		// in preference order, so take our first mutual entry.
 		const std::vector<uint8_t> ours = ECCrypt::SupportedCiphers();
 		for (size_t i = 0; i < ours.size() && m_aeadCipher == ECCrypt::Cipher_None; ++i) {
 			for (uint16_t j = 0; j < offeredLen; ++j) {

--- a/src/libs/ec/cpp/ECCrypt.cpp
+++ b/src/libs/ec/cpp/ECCrypt.cpp
@@ -87,11 +87,11 @@ std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher> MakeCipher(uint8_t ciphe
 
 } // namespace
 
-std::vector<uint8_t> SupportedCiphers()
+std::vector<uint8_t> SupportedCiphers(bool preferAES)
 {
 	std::vector<uint8_t> out;
 	// Preferred cipher first, but the final choice is made by the server
-	if (HasHardwareAES()) {
+	if (preferAES) {
 		out.push_back(Cipher_AES128_GCM);
 		out.push_back(Cipher_ChaCha20_Poly1305);
 	} else {

--- a/src/libs/ec/cpp/ECCrypt.cpp
+++ b/src/libs/ec/cpp/ECCrypt.cpp
@@ -87,6 +87,25 @@ std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher> MakeCipher(uint8_t ciphe
 
 } // namespace
 
+bool HasHardwareAES()
+{
+	// The availability macros say whether this build has the code path at all;
+	// the Has* calls say whether the running CPU has the instructions. Both
+	// have to hold, and cryptopp dispatches on the same answer we read here.
+#if defined(CRYPTOPP_AESNI_AVAILABLE)
+	return CryptoPP::HasAESNI();
+#elif defined(CRYPTOPP_ARM_AES_AVAILABLE) || defined(CRYPTOPP_POWER8_AES_AVAILABLE)
+	return CryptoPP::HasAES();
+#else
+	return false;
+#endif
+}
+
+std::vector<uint8_t> SupportedCiphers()
+{
+	return SupportedCiphers(HasHardwareAES());
+}
+
 std::vector<uint8_t> SupportedCiphers(bool preferAES)
 {
 	std::vector<uint8_t> out;

--- a/src/libs/ec/cpp/ECCrypt.cpp
+++ b/src/libs/ec/cpp/ECCrypt.cpp
@@ -90,9 +90,14 @@ std::unique_ptr<CryptoPP::AuthenticatedSymmetricCipher> MakeCipher(uint8_t ciphe
 std::vector<uint8_t> SupportedCiphers()
 {
 	std::vector<uint8_t> out;
-	// Preferred first: the server picks the first entry the client also has.
-	out.push_back(Cipher_ChaCha20_Poly1305);
-	out.push_back(Cipher_AES128_GCM);
+	// Preferred cipher first, but the final choice is made by the server
+	if (HasHardwareAES()) {
+		out.push_back(Cipher_AES128_GCM);
+		out.push_back(Cipher_ChaCha20_Poly1305);
+	} else {
+		out.push_back(Cipher_ChaCha20_Poly1305);
+		out.push_back(Cipher_AES128_GCM);
+	}
 	return out;
 }
 

--- a/src/libs/ec/cpp/ECCrypt.h
+++ b/src/libs/ec/cpp/ECCrypt.h
@@ -74,9 +74,10 @@ const size_t NONCE_TAG_LEN = 32;
 /// AEAD tag appended to every sealed body.
 const size_t AEAD_TAG_LEN = 16;
 
+bool HasHardwareAES(); // defined in CryptoPP_Inc.h
 /// Ciphers this build can actually do, strongest/fastest first. The server
 /// picks the first entry the client also offered.
-std::vector<uint8_t> SupportedCiphers();
+std::vector<uint8_t> SupportedCiphers(bool preferAES = HasHardwareAES());
 
 /// Whether this build can do @a cipher at all.
 bool IsCipherSupported(uint8_t cipher);

--- a/src/libs/ec/cpp/ECCrypt.h
+++ b/src/libs/ec/cpp/ECCrypt.h
@@ -74,10 +74,22 @@ const size_t NONCE_TAG_LEN = 32;
 /// AEAD tag appended to every sealed body.
 const size_t AEAD_TAG_LEN = 16;
 
-bool HasHardwareAES(); // defined in CryptoPP_Inc.h
+/// Whether this CPU runs AES in hardware *and* cryptopp will dispatch to it.
+/// Both halves matter: where cryptopp's detection comes up empty it also falls
+/// back to table-based AES, so asking the CPU directly would have us prefer a
+/// cipher the library then runs in software.
+bool HasHardwareAES();
+
 /// Ciphers this build can actually do, strongest/fastest first. The server
-/// picks the first entry the client also offered.
-std::vector<uint8_t> SupportedCiphers(bool preferAES = HasHardwareAES());
+/// picks the first entry the client also offered. AES leads when it is
+/// hardware-backed, ChaCha20 otherwise -- see HasHardwareAES().
+std::vector<uint8_t> SupportedCiphers();
+
+/// SupportedCiphers() with the hardware question answered explicitly, so both
+/// orderings are testable on any machine. Kept as an overload rather than a
+/// defaulted argument: a default would make every caller's translation unit
+/// need HasHardwareAES()'s definition, and cryptopp stays out of this header.
+std::vector<uint8_t> SupportedCiphers(bool preferAES);
 
 /// Whether this build can do @a cipher at all.
 bool IsCipherSupported(uint8_t cipher);

--- a/unittests/tests/ECCryptTest.cpp
+++ b/unittests/tests/ECCryptTest.cpp
@@ -32,6 +32,9 @@
 
 #include <muleunit/test.h>
 
+#define CRYPTOPP_INC_NEED_AEAD
+#include <../src/CryptoPP_Inc.h> //needed for HasHardwareAES
+
 #include "ECCrypt.h"
 
 #include <cstdlib>
@@ -144,11 +147,11 @@ TEST(ECCrypt, AesGcmIsAlwaysAvailable)
 
 TEST(ECCrypt, PreferredCipherComesFirst)
 {
-	// The daemon picks the first mutually supported entry, so ordering is the
-	// preference. Where ChaCha exists it must outrank AES: without hardware
-	// AES it is substantially faster, which is the Raspberry Pi case.
+	// As a general rule, from fastest to slowest:
+	// AES (with hardware support) > ChaCha20 > AES (without hardware support)
+	// The preferred cipher is the fastest, and it shall come first
 	const std::vector<uint8_t> ciphers = SupportedCiphers();
-	if (IsCipherSupported(Cipher_ChaCha20_Poly1305)) {
+	if (IsCipherSupported(Cipher_ChaCha20_Poly1305) && !HasHardwareAES()) {
 		ASSERT_EQUALS((int)Cipher_ChaCha20_Poly1305, (int)ciphers[0]);
 	} else {
 		ASSERT_EQUALS((int)Cipher_AES128_GCM, (int)ciphers[0]);

--- a/unittests/tests/ECCryptTest.cpp
+++ b/unittests/tests/ECCryptTest.cpp
@@ -32,9 +32,7 @@
 
 #include <muleunit/test.h>
 
-#define CRYPTOPP_INC_NEED_AEAD
-#include <../src/CryptoPP_Inc.h> //needed for HasHardwareAES
-
+#include "CryptoPP_Inc.h" //needed for HasHardwareAES
 #include "ECCrypt.h"
 
 #include <cstdlib>
@@ -147,14 +145,28 @@ TEST(ECCrypt, AesGcmIsAlwaysAvailable)
 
 TEST(ECCrypt, PreferredCipherComesFirst)
 {
-	// As a general rule, from fastest to slowest:
-	// AES (with hardware support) > ChaCha20 > AES (without hardware support)
-	// The preferred cipher is the fastest, and it shall come first
-	const std::vector<uint8_t> ciphers = SupportedCiphers();
-	if (IsCipherSupported(Cipher_ChaCha20_Poly1305) && !HasHardwareAES()) {
+	// Case 1: preferAES = false
+	// ChaCha20 shall come first if supported, AES otherwise
+	const std::vector<uint8_t> ciphers = SupportedCiphers(false);
+	if (IsCipherSupported(Cipher_ChaCha20_Poly1305)) {
 		ASSERT_EQUALS((int)Cipher_ChaCha20_Poly1305, (int)ciphers[0]);
 	} else {
 		ASSERT_EQUALS((int)Cipher_AES128_GCM, (int)ciphers[0]);
+	}
+
+	// Case 2: preferAES = true
+	// AES shall always come first, as supporting it is mandatory
+	const std::vector<uint8_t> ciphers2 = SupportedCiphers(true);
+	ASSERT_EQUALS((int)Cipher_AES128_GCM, (int)ciphers2[0]);
+
+	// Case 3: preferAES = HasHardwareAES()
+	// ChaCha20 shall come first if supported and no hardware support for AES
+	// Otherwise, AES shall come first
+	const std::vector<uint8_t> ciphers3 = SupportedCiphers();
+	if (IsCipherSupported(Cipher_ChaCha20_Poly1305) && !HasHardwareAES()) {
+		ASSERT_EQUALS((int)Cipher_ChaCha20_Poly1305, (int)ciphers3[0]);
+	} else {
+		ASSERT_EQUALS((int)Cipher_AES128_GCM, (int)ciphers3[0]);
 	}
 }
 

--- a/unittests/tests/ECCryptTest.cpp
+++ b/unittests/tests/ECCryptTest.cpp
@@ -32,7 +32,6 @@
 
 #include <muleunit/test.h>
 
-#include "CryptoPP_Inc.h" //needed for HasHardwareAES
 #include "ECCrypt.h"
 
 #include <cstdlib>


### PR DESCRIPTION
What do you think of this optimization?

In #714 the encryption for EC included both AES and ChaCha20, and chose ChaCha20 whenever available because it is faster when there is no hardware support for AES. After bumping the minimum CryptoPP version, ChaCha20 shall always be available, and therefore the only chosen cipher in the aMule suite (unless someone develops an external client supporting only AES).

This PR uses a runtime check from CryptoPP library to check if there is hardware support for AES. If so, it is chosen as the first option. If both sides have hardware support, it is chosen as the cipher for the channel. Otherwise, the previous logic applies. So the priorities will be:
1. AES if both sides have hardware support
2. ChaCha20 if both sides implement it
3. AES as a final fallback option

For the above priorities to hold, both the EC client and the server must be running an updated version.