### PR TITLE
GetHTML wxString progresscolor[] bug

### DIFF
--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1261,7 +1261,7 @@ CDynProgressImage::CDynProgressImage(int width, int height, wxString &tmpl, Down
 
 wxString CDynProgressImage::GetHTML()
 {
-	static const wxString progresscolor[12] = { "transparent.gif",
+	static const wxString progresscolor[12] = { wxS("transparent.gif"),
 		wxS("black.gif"),
 		wxS("yellow.gif"),
 		wxS("red.gif"),
@@ -1272,7 +1272,7 @@ wxString CDynProgressImage::GetHTML()
 		wxS("blue5.gif"),
 		wxS("blue6.gif"),
 		wxS("green.gif"),
-		wxS("greenpercent.gif")	};
+		wxS("greenpercent.gif") };
 
 	CreateSpan();
 

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1261,18 +1261,19 @@ CDynProgressImage::CDynProgressImage(int width, int height, wxString &tmpl, Down
 
 wxString CDynProgressImage::GetHTML()
 {
-	static wxChar *progresscolor[12] = { "transparent.gif",
-		"black.gif",
-		"yellow.gif",
-		"red.gif",
-		"blue1.gif",
-		"blue2.gif",
-		"blue3.gif",
-		"blue4.gif",
-		"blue5.gif",
-		"blue6.gif",
-		"green.gif",
-		"greenpercent.gif" };
+		static const wxString progresscolor[] = {
+		wxS("black.gif"),
+		wxS("yellow.gif"),
+		wxS("red.gif"),
+		wxS("blue1.gif"),
+		wxS("blue2.gif"),
+		wxS("blue3.gif"),
+		wxS("blue4.gif"),
+		wxS("blue5.gif"),
+		wxS("blue6.gif"),
+		wxS("green.gif"),
+		wxS("greenpercent.gif")
+	};
 
 	CreateSpan();
 

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1261,7 +1261,7 @@ CDynProgressImage::CDynProgressImage(int width, int height, wxString &tmpl, Down
 
 wxString CDynProgressImage::GetHTML()
 {
-		static const wxString progresscolor[] = {
+	static const wxString progresscolor[12] = { "transparent.gif",
 		wxS("black.gif"),
 		wxS("yellow.gif"),
 		wxS("red.gif"),
@@ -1272,8 +1272,7 @@ wxString CDynProgressImage::GetHTML()
 		wxS("blue5.gif"),
 		wxS("blue6.gif"),
 		wxS("green.gif"),
-		wxS("greenpercent.gif")
-	};
+		wxS("greenpercent.gif")	};
 
 	CreateSpan();
 


### PR DESCRIPTION
## Summary

Bug compiling the web server:
```
cmake -B build \
  -DBUILD_MONOLITHIC=OFF \
  -DBUILD_DAEMON=ON \
  -DBUILD_AMULECMD=ON \
  -DBUILD_WEBSERVER=ON \
  -DBUILD_ED2K=ON \
  -DBUILD_REMOTEGUI=OFF
```
```
cmake --build build
```
```
...
/home/projects/amule/src/webserver/src/WebServer.cpp: In member function ‘virtual wxString CDynProgressImage::GetHTML()’:
/home/projects/amule/src/webserver/src/WebServer.cpp:1264:46: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1264 |         static wxChar *progresscolor[12] = { "transparent.gif",
      |                                              ^~~~~~~~~~~~~~~~~
      |                                              |
      |                                              const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1265:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1265 |                 "black.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1266:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1266 |                 "yellow.gif",
      |                 ^~~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1267:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1267 |                 "red.gif",
      |                 ^~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1268:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1268 |                 "blue1.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1269:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1269 |                 "blue2.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1270:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1270 |                 "blue3.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1271:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1271 |                 "blue4.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1272:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1272 |                 "blue5.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1273:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1273 |                 "blue6.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1274:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1274 |                 "green.gif",
      |                 ^~~~~~~~~~~
      |                 |
      |                 const char*
/home/projects/amule/src/webserver/src/WebServer.cpp:1275:17: error: cannot convert ‘const char*’ to ‘wxChar*’ {aka ‘wchar_t*’} in initialization
 1275 |                 "greenpercent.gif" };
      |                 ^~~~~~~~~~~~~~~~~~
      |                 |
      |                 const char*
gmake[2]: *** [src/webserver/src/CMakeFiles/amuleweb.dir/build.make:247: src/webserver/src/CMakeFiles/amuleweb.dir/WebServer.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:762: src/webserver/src/CMakeFiles/amuleweb.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```


## Test plan

```
iban@garapenaeus /home/projects/amule (master)> cmake --build build
[  0%] Built target amule_metainfo
[ 18%] Built target pofiles_1
[ 23%] Built target mulecommon
[ 23%] Built target pofiles
[ 24%] Built target mulesocket
[ 25%] Built target generate_ECTagTypes.h
[ 25%] Built target generate_ECCodes.h
[ 30%] Built target ec
[ 33%] Built target amulecmd
[ 42%] Built target muleappcommon
[ 47%] Built target webcommon
[ 59%] Built target muleappcore
[ 91%] Built target amuled
[ 93%] Built target ed2k
[ 93%] Building CXX object src/webserver/src/CMakeFiles/amuleweb.dir/WebServer.cpp.o
[ 94%] Building CXX object src/webserver/src/CMakeFiles/amuleweb.dir/WebSocket.cpp.o
[ 94%] Linking CXX executable amuleweb
[100%] Built target amuleweb
```
