### PR TITLE
fix(search): restore the column show/hide menu and shift+page selection

### DIFF
--- a/src/ListColumnStore.h
+++ b/src/ListColumnStore.h
@@ -32,6 +32,22 @@
 #include <vector>
 
 /**
+ * Width at or below which a column counts as hidden.
+ *
+ * wxGTK reserves a few pixels for the header grip and won't shrink a column
+ * below that, so "hidden" can't mean literally zero there.  Shared by every
+ * list that offers the header's show/hide menu, so the threshold and the
+ * width written to the config stay in agreement.
+ */
+#ifdef __WXGTK__
+constexpr int COL_SIZE_MIN = 10;
+#elif defined(__WINDOWS__) || defined(__WXMAC__) || defined(__WXCOCOA__)
+constexpr int COL_SIZE_MIN = 0;
+#else
+#error Need to define COL_SIZE_MIN for your OS
+#endif
+
+/**
  * The subset of a list widget's column API that column persistence needs.
  * CMuleListCtrl already implements this exact signature set by inheriting
  * wxGenericListCtrl, so it satisfies this interface for free (see its

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -39,15 +39,6 @@
 
 #include <wx/artprov.h> // Needed for wxArtProvider::GetBitmap
 
-// Global constants
-#ifdef __WXGTK__
-const int COL_SIZE_MIN = 10;
-#elif defined(__WINDOWS__) || defined(__WXMAC__) || defined(__WXCOCOA__)
-const int COL_SIZE_MIN = 0;
-#else
-#error Need to define COL_SIZE_MIN for your OS
-#endif
-
 wxBEGIN_EVENT_TABLE(CMuleListCtrl, MuleExtern::wxGenericListCtrl)
 	EVT_LIST_COL_CLICK(-1, CMuleListCtrl::OnColumnLClick)
 	EVT_LIST_COL_RIGHT_CLICK(-1, CMuleListCtrl::OnColumnRClick)

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -183,6 +183,21 @@ CSearchListCtrl::CSearchListCtrl(
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 
+#ifdef __WXOSX__
+	// Not registered with the column store and not offered in the header
+	// menu: it exists only to absorb the trailing-column sizing described
+	// on CSearchListModel::COL_SPACER.
+	// Resizable is load-bearing: macOS hands the leftover space to the last
+	// *resizable* column, so a fixed spacer cannot shrink and the collapse
+	// falls through to the last real column instead.
+	AppendTextColumn(wxEmptyString,
+		CSearchListModel::COL_SPACER,
+		wxDATAVIEW_CELL_INERT,
+		1,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE);
+#endif
+
 	m_columnStore.RegisterColumn(CSearchListModel::COL_NAME, 500, "N");
 	m_columnStore.RegisterColumn(CSearchListModel::COL_SIZE, 100, "Z");
 	m_columnStore.RegisterColumn(CSearchListModel::COL_SOURCES, 50, "u");
@@ -197,7 +212,7 @@ CSearchListCtrl::CSearchListCtrl(
 
 	// Sized before LoadColumnSettings(), which restores hidden columns through
 	// the width adapter and therefore writes into this.
-	m_columnHidden.assign(GetColumnCount(), false);
+	m_columnHidden.assign(RealColumnCount(), false);
 
 	// Default sort is by name, ascending.
 	m_sort_orders.emplace_back(CSearchListModel::COL_NAME, 0);
@@ -212,7 +227,7 @@ CSearchListCtrl::CSearchListCtrl(
 		SyncLists(s_lists.front(), this);
 	}
 
-	for (int i = 0; i < GetColumnCount(); ++i) {
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
 		m_lastKnownWidths.push_back(GetColumn(i)->GetWidth());
 	}
 
@@ -551,8 +566,8 @@ void CSearchListCtrl::ApplySorting(unsigned column, unsigned order)
 
 	// Unmark the previous sort column (only one wxDataViewColumn can be the
 	// active sort key at a time; SetSortOrder() below moves the mark).
-	for (int i = 0; i < GetColumnCount(); ++i) {
-		if ((unsigned)i != column && GetColumn(i)->IsSortKey()) {
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
+		if (i != column && GetColumn(i)->IsSortKey()) {
 			GetColumn(i)->UnsetAsSortKey();
 		}
 	}
@@ -604,7 +619,7 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 {
 	wxCHECK_RET(src && dst, "NULL argument in SyncLists");
 
-	for (int i = 0; i < src->GetColumnCount(); ++i) {
+	for (unsigned i = 0; i < src->RealColumnCount(); ++i) {
 		// Hidden state has to travel with the width: copying width alone
 		// would leave the other tabs showing a column this one has hidden.
 		const bool hidden = src->IsColumnHidden(i);
@@ -622,8 +637,8 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 		dst->m_sort_orders = src->m_sort_orders;
 		if (!dst->m_sort_orders.empty()) {
 			const CColPair &primary = dst->m_sort_orders.front();
-			for (int i = 0; i < dst->GetColumnCount(); ++i) {
-				if ((unsigned)i != primary.first && dst->GetColumn(i)->IsSortKey()) {
+			for (unsigned i = 0; i < dst->RealColumnCount(); ++i) {
+				if (i != primary.first && dst->GetColumn(i)->IsSortKey()) {
 					dst->GetColumn(i)->UnsetAsSortKey();
 				}
 			}
@@ -695,7 +710,7 @@ void CSearchListCtrl::OnIdle(wxIdleEvent &event)
 	// directly (unlike wxListCtrl's EVT_LIST_COL_END_DRAG), so a drag-resize
 	// is detected here by simply comparing against the last-seen widths.
 	bool changed = false;
-	for (int i = 0; i < GetColumnCount() && i < (int)m_lastKnownWidths.size(); ++i) {
+	for (int i = 0; i < (int)RealColumnCount() && i < (int)m_lastKnownWidths.size(); ++i) {
 		const int width = GetColumn(i)->GetWidth();
 		if (width != m_lastKnownWidths[i]) {
 			m_lastKnownWidths[i] = width;
@@ -751,11 +766,9 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
 {
 	// Show/hide menu, as CMuleListCtrl::OnColumnRClick offered on every
-	// other list. A column is "shown" when it is wider than COL_SIZE_MIN,
-	// which is also how the state reaches the config: hiding writes a
-	// zero-ish width that CListColumnStore persists like any other.
+	// other list.
 	wxMenu menu;
-	const unsigned columns = std::min<unsigned>(GetColumnCount(), MP_LISTCOL_15 - MP_LISTCOL_1 + 1);
+	const unsigned columns = std::min<unsigned>(RealColumnCount(), MP_LISTCOL_15 - MP_LISTCOL_1 + 1);
 	for (unsigned i = 0; i < columns; ++i) {
 		const wxDataViewColumn *col = GetColumn(i);
 		menu.AppendCheckItem(static_cast<int>(i) + MP_LISTCOL_1, col->GetTitle());
@@ -766,6 +779,16 @@ void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
 	event.Skip();
 }
 
+unsigned CSearchListCtrl::RealColumnCount() const
+{
+	const unsigned columns = GetColumnCount();
+#ifdef __WXOSX__
+	return (columns > 0) ? columns - 1 : 0;
+#else
+	return columns;
+#endif
+}
+
 bool CSearchListCtrl::IsColumnHidden(int col) const
 {
 	return (col >= 0) && (static_cast<size_t>(col) < m_columnHidden.size()) && m_columnHidden[col];
@@ -773,11 +796,11 @@ bool CSearchListCtrl::IsColumnHidden(int col) const
 
 void CSearchListCtrl::SetColumnHidden(int col, bool hidden, int width)
 {
-	if (col < 0 || static_cast<unsigned>(col) >= GetColumnCount()) {
+	if (col < 0 || static_cast<unsigned>(col) >= RealColumnCount()) {
 		return;
 	}
 	if (static_cast<size_t>(col) >= m_columnHidden.size()) {
-		m_columnHidden.resize(GetColumnCount(), false);
+		m_columnHidden.resize(RealColumnCount(), false);
 	}
 
 	m_columnHidden[col] = hidden;
@@ -794,7 +817,7 @@ void CSearchListCtrl::UpdateExpanderColumn()
 	// that currently owns it would take the group triangles with it and
 	// leave children unreachable, and re-showing a column to its left has
 	// to take them back rather than stranding them mid-row.
-	for (unsigned i = 0; i < GetColumnCount(); ++i) {
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
 		if (!IsColumnHidden(static_cast<int>(i))) {
 			wxDataViewColumn *column = GetColumn(i);
 			if (GetExpanderColumn() != column) {
@@ -808,7 +831,7 @@ void CSearchListCtrl::UpdateExpanderColumn()
 void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
 {
 	const int col = evt.GetId() - MP_LISTCOL_1;
-	if (col < 0 || static_cast<unsigned>(col) >= GetColumnCount()) {
+	if (col < 0 || static_cast<unsigned>(col) >= RealColumnCount()) {
 		return;
 	}
 
@@ -935,17 +958,44 @@ void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) con
 	// current sort. GetItemByRow()/GetRowByItem() would be the direct
 	// route but exist only in wx's generic implementation, not on GTK or
 	// macOS.
+	const auto byDisplayOrder = [this](const CSearchFile *f1, const CSearchFile *f2) {
+		return CompareFiles(f1, f2) < 0;
+	};
+
 	wxDataViewItemArray roots;
 	m_model->GetChildren(wxDataViewItem(), roots);
 
-	ordered.clear();
-	ordered.reserve(roots.GetCount());
+	std::vector<CSearchFile *> parents;
+	parents.reserve(roots.GetCount());
 	for (size_t i = 0; i < roots.GetCount(); ++i) {
-		ordered.push_back(CSearchListModel::ToFile(roots[i]));
+		parents.push_back(CSearchListModel::ToFile(roots[i]));
 	}
-	std::sort(ordered.begin(), ordered.end(), [this](const CSearchFile *f1, const CSearchFile *f2) {
-		return CompareFiles(f1, f2) < 0;
-	});
+	std::sort(parents.begin(), parents.end(), byDisplayOrder);
+
+	// An expanded group's children occupy rows of their own, so they belong
+	// here too: callers count rows against what is on screen (a page is
+	// GetCountPerPage() rows, children included) and select ranges of them.
+	// Leaving them out made a page overshoot and skipped every child inside
+	// the range.
+	ordered.clear();
+	ordered.reserve(parents.size());
+	for (CSearchFile *parent : parents) {
+		ordered.push_back(parent);
+
+		const wxDataViewItem item = CSearchListModel::ToItem(parent);
+		if (!IsExpanded(item)) {
+			continue;
+		}
+		wxDataViewItemArray kids;
+		m_model->GetChildren(item, kids);
+		std::vector<CSearchFile *> children;
+		children.reserve(kids.GetCount());
+		for (size_t i = 0; i < kids.GetCount(); ++i) {
+			children.push_back(CSearchListModel::ToFile(kids[i]));
+		}
+		std::sort(children.begin(), children.end(), byDisplayOrder);
+		ordered.insert(ordered.end(), children.begin(), children.end());
+	}
 }
 
 #ifdef __WXOSX__

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -245,6 +245,10 @@ void CSearchListCtrl::LoadColumnSettings()
 	CListColumnStore::CSortingList decoded;
 	m_columnStore.LoadSettings(m_widthAdapter, "N,Z,u,Y,I,S", decoded);
 
+	// Restored widths can leave the default expander column hidden, which
+	// would strand the group triangles on a column nobody can see.
+	UpdateExpanderColumn();
+
 	// LoadSettings() returns the orders primary-LAST: CMuleListCtrl applied
 	// them by calling SetSorting() on each in turn, and each call pushes to
 	// the front, so the last one processed ends up primary. ApplySorting()
@@ -751,6 +755,23 @@ void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
 	event.Skip();
 }
 
+void CSearchListCtrl::UpdateExpanderColumn()
+{
+	// The expander belongs on the leftmost visible column: hiding the column
+	// that currently owns it would take the group triangles with it and
+	// leave children unreachable, and re-showing a column to its left has
+	// to take them back rather than stranding them mid-row.
+	for (unsigned i = 0; i < GetColumnCount(); ++i) {
+		wxDataViewColumn *column = GetColumn(i);
+		if (!column->IsHidden()) {
+			if (GetExpanderColumn() != column) {
+				SetExpanderColumn(column);
+			}
+			return;
+		}
+	}
+}
+
 void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
 {
 	const int col = evt.GetId() - MP_LISTCOL_1;
@@ -764,21 +785,12 @@ void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
 		// exactly as CMuleListCtrl::OnMenuSelected did.
 		m_columnStore.SetCachedWidth(col, column->GetWidth());
 		column->SetHidden(true);
-		// The expander lives on one specific column; hiding that one would
-		// take the group triangles with it and leave children unreachable.
-		if (GetExpanderColumn() == column) {
-			for (unsigned i = 0; i < GetColumnCount(); ++i) {
-				if (!GetColumn(i)->IsHidden()) {
-					SetExpanderColumn(GetColumn(i));
-					break;
-				}
-			}
-		}
 	} else {
 		const int cached = m_columnStore.GetCachedWidth(col);
 		column->SetHidden(false);
 		column->SetWidth(cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
 	}
+	UpdateExpanderColumn();
 	SaveColumnSettings();
 }
 

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -53,10 +53,12 @@
 wxBEGIN_EVENT_TABLE(CSearchListCtrl, wxDataViewCtrl)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CSearchListCtrl::OnRightClick)
 	EVT_DATAVIEW_COLUMN_HEADER_CLICK(wxID_ANY, CSearchListCtrl::OnColumnHeaderClick)
+	EVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK(wxID_ANY, CSearchListCtrl::OnColumnHeaderRightClick)
 	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CSearchListCtrl::OnItemActivated)
 	EVT_DATAVIEW_SELECTION_CHANGED(wxID_ANY, CSearchListCtrl::OnSelectionChanged)
 	EVT_IDLE(CSearchListCtrl::OnIdle)
 	EVT_CHAR(CSearchListCtrl::OnChar)
+	EVT_KEY_DOWN(CSearchListCtrl::OnKeyDown)
 
 	EVT_MENU(MP_GETED2KLINK, CSearchListCtrl::OnPopupGetUrl)
 	EVT_MENU(MP_RAZORSTATS, CSearchListCtrl::OnRazorStatsCheck)
@@ -64,6 +66,7 @@ wxBEGIN_EVENT_TABLE(CSearchListCtrl, wxDataViewCtrl)
 	EVT_MENU(MP_GETCOMMENTS, CSearchListCtrl::OnGetComments)
 	EVT_MENU(MP_RESUME, CSearchListCtrl::OnPopupDownload)
 	EVT_MENU_RANGE(MP_ASSIGNCAT, MP_ASSIGNCAT + 99, CSearchListCtrl::OnPopupDownload)
+	EVT_MENU_RANGE(MP_LISTCOL_1, MP_LISTCOL_15, CSearchListCtrl::OnColumnMenuSelected)
 wxEND_EVENT_TABLE()
 
 std::list<CSearchListCtrl *> CSearchListCtrl::s_lists;
@@ -730,6 +733,44 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 	}
 }
 
+void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
+{
+	// Show/hide menu, as CMuleListCtrl::OnColumnRClick offered on every
+	// other list. A column is "shown" when it is wider than COL_SIZE_MIN,
+	// which is also how the state reaches the config: hiding writes a
+	// zero-ish width that CListColumnStore persists like any other.
+	wxMenu menu;
+	const unsigned columns = std::min<unsigned>(GetColumnCount(), MP_LISTCOL_15 - MP_LISTCOL_1 + 1);
+	for (unsigned i = 0; i < columns; ++i) {
+		const wxDataViewColumn *col = GetColumn(i);
+		menu.AppendCheckItem(static_cast<int>(i) + MP_LISTCOL_1, col->GetTitle());
+		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, col->GetWidth() > COL_SIZE_MIN);
+	}
+
+	PopupMenu(&menu);
+	event.Skip();
+}
+
+void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
+{
+	const int col = evt.GetId() - MP_LISTCOL_1;
+	if (col < 0 || static_cast<unsigned>(col) >= GetColumnCount()) {
+		return;
+	}
+
+	wxDataViewColumn *column = GetColumn(static_cast<unsigned>(col));
+	if (column->GetWidth() > COL_SIZE_MIN) {
+		// Remember the width so re-showing restores what the user had,
+		// exactly as CMuleListCtrl::OnMenuSelected did.
+		m_columnStore.SetCachedWidth(col, column->GetWidth());
+		column->SetWidth(COL_SIZE_MIN);
+	} else {
+		const int cached = m_columnStore.GetCachedWidth(col);
+		column->SetWidth(cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
+	}
+	SaveColumnSettings();
+}
+
 void CSearchListCtrl::OnItemActivated(wxDataViewEvent &event)
 {
 	CSearchFile *file = CSearchListModel::ToFile(event.GetItem());
@@ -831,6 +872,94 @@ namespace
 const uint64 kTypeAheadResetMs = 1500;
 } // namespace
 
+void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) const
+{
+	// The model yields top-level rows in arrival order, so they are put
+	// through this list's own comparator -- the one CSearchListModel::
+	// Compare() uses -- to match what is actually on screen under the
+	// current sort. GetItemByRow()/GetRowByItem() would be the direct
+	// route but exist only in wx's generic implementation, not on GTK or
+	// macOS.
+	wxDataViewItemArray roots;
+	m_model->GetChildren(wxDataViewItem(), roots);
+
+	ordered.clear();
+	ordered.reserve(roots.GetCount());
+	for (size_t i = 0; i < roots.GetCount(); ++i) {
+		ordered.push_back(CSearchListModel::ToFile(roots[i]));
+	}
+	std::sort(ordered.begin(), ordered.end(), [this](const CSearchFile *f1, const CSearchFile *f2) {
+		return CompareFiles(f1, f2) < 0;
+	});
+}
+
+#ifdef __WXOSX__
+void CSearchListCtrl::PageExtendSelection(bool down)
+{
+	std::vector<CSearchFile *> ordered;
+	BuildDisplayOrder(ordered);
+	if (ordered.empty()) {
+		return;
+	}
+
+	const wxDataViewItem currentItem = GetCurrentItem();
+	CSearchFile *currentFile = currentItem.IsOk() ? CSearchListModel::ToFile(currentItem) : nullptr;
+	const auto found = std::find(ordered.begin(), ordered.end(), currentFile);
+	const int current = (found == ordered.end())
+				    ? (down ? -1 : static_cast<int>(ordered.size()))
+				    : static_cast<int>(std::distance(ordered.begin(), found));
+
+	// A page is however many rows fit, less one so the row at the edge
+	// stays visible -- the same overlap the other ports scroll by.
+	int rowHeight = 0;
+	if (currentItem.IsOk()) {
+		rowHeight = GetItemRect(currentItem).height;
+	}
+	if (rowHeight <= 0) {
+		rowHeight = GetItemRect(CSearchListModel::ToItem(ordered.front())).height;
+	}
+	const int rows = (rowHeight > 0) ? std::max(1, (GetClientSize().y / rowHeight) - 1) : 1;
+
+	const int last = static_cast<int>(ordered.size()) - 1;
+	const int target = std::min(last, std::max(0, current + (down ? rows : -rows)));
+
+	// Grow the existing selection to cover everything between where the
+	// cursor was and where it lands, so repeated presses keep extending.
+	wxDataViewItemArray selection;
+	GetSelections(selection);
+	const int from = std::min(current < 0 ? target : current, target);
+	const int to = std::max(current > last ? target : current, target);
+	for (int i = std::max(0, from); i <= std::min(last, to); ++i) {
+		const wxDataViewItem item = CSearchListModel::ToItem(ordered[i]);
+		if (selection.Index(item) == wxNOT_FOUND) {
+			selection.Add(item);
+		}
+	}
+
+	const wxDataViewItem targetItem = CSearchListModel::ToItem(ordered[target]);
+	SetSelections(selection);
+	SetCurrentItem(targetItem);
+	EnsureVisible(targetItem);
+}
+#endif // __WXOSX__
+
+void CSearchListCtrl::OnKeyDown(wxKeyEvent &evt)
+{
+#ifdef __WXOSX__
+	// NSOutlineView pages the view without touching the selection, so
+	// shift+page-up/down -- which extends the selection on GTK and MSW --
+	// does nothing at all here. Plain page-up/down is deliberately left to
+	// the platform, which scrolls without moving the selection by
+	// convention; only the shifted form is handled.
+	const int key = evt.GetKeyCode();
+	if (evt.ShiftDown() && (key == WXK_PAGEUP || key == WXK_PAGEDOWN)) {
+		PageExtendSelection(key == WXK_PAGEDOWN);
+		return;
+	}
+#endif
+	evt.Skip();
+}
+
 void CSearchListCtrl::OnChar(wxKeyEvent &evt)
 {
 	int key = evt.GetKeyCode();
@@ -879,20 +1008,11 @@ void CSearchListCtrl::OnChar(wxKeyEvent &evt)
 	// than a second ordering that could disagree with what is on screen.
 	// (GetItemByRow()/GetRowByItem() would be the direct route but exist
 	// only in wx's generic implementation, not on GTK or macOS.)
-	wxDataViewItemArray roots;
-	m_model->GetChildren(wxDataViewItem(), roots);
-	if (roots.IsEmpty()) {
+	std::vector<CSearchFile *> ordered;
+	BuildDisplayOrder(ordered);
+	if (ordered.empty()) {
 		return;
 	}
-
-	std::vector<CSearchFile *> ordered;
-	ordered.reserve(roots.GetCount());
-	for (size_t i = 0; i < roots.GetCount(); ++i) {
-		ordered.push_back(CSearchListModel::ToFile(roots[i]));
-	}
-	std::sort(ordered.begin(), ordered.end(), [this](const CSearchFile *f1, const CSearchFile *f2) {
-		return CompareFiles(f1, f2) < 0;
-	});
 
 	// A fresh single keystroke starts one past the current match so that
 	// tapping the same letter cycles; further keystrokes refine in place.

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -195,6 +195,10 @@ CSearchListCtrl::CSearchListCtrl(
 	m_columnStore.RegisterColumn(CSearchListModel::COL_CODEC, 80, "C");
 	m_columnStore.RegisterColumn(CSearchListModel::COL_DIRECTORY, 280, "D");
 
+	// Sized before LoadColumnSettings(), which restores hidden columns through
+	// the width adapter and therefore writes into this.
+	m_columnHidden.assign(GetColumnCount(), false);
+
 	// Default sort is by name, ascending.
 	m_sort_orders.emplace_back(CSearchListModel::COL_NAME, 0);
 	GetColumn(CSearchListModel::COL_NAME)->SetSortOrder(true);
@@ -601,18 +605,14 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 	wxCHECK_RET(src && dst, "NULL argument in SyncLists");
 
 	for (int i = 0; i < src->GetColumnCount(); ++i) {
-		wxDataViewColumn *from = src->GetColumn(i);
-		wxDataViewColumn *to = dst->GetColumn(i);
-		// Hidden state has to travel with the width: a hidden column reports
-		// a width of zero, so copying width alone would leave the other tabs
-		// with a zero-width column that still counts as visible -- invisible
-		// in the list, but ticked in the header menu and impossible to
-		// restore from there.
-		if (to->IsHidden() != from->IsHidden()) {
-			to->SetHidden(from->IsHidden());
+		// Hidden state has to travel with the width: copying width alone
+		// would leave the other tabs showing a column this one has hidden.
+		const bool hidden = src->IsColumnHidden(i);
+		if (dst->IsColumnHidden(i) != hidden) {
+			dst->SetColumnHidden(i, hidden, src->GetColumn(i)->GetWidth());
 		}
-		if (!from->IsHidden() && to->GetWidth() != from->GetWidth()) {
-			to->SetWidth(from->GetWidth());
+		if (!hidden && dst->GetColumn(i)->GetWidth() != src->GetColumn(i)->GetWidth()) {
+			dst->GetColumn(i)->SetWidth(src->GetColumn(i)->GetWidth());
 		}
 	}
 	dst->UpdateExpanderColumn();
@@ -759,11 +759,33 @@ void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
 	for (unsigned i = 0; i < columns; ++i) {
 		const wxDataViewColumn *col = GetColumn(i);
 		menu.AppendCheckItem(static_cast<int>(i) + MP_LISTCOL_1, col->GetTitle());
-		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, !col->IsHidden());
+		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, !IsColumnHidden(static_cast<int>(i)));
 	}
 
 	PopupMenu(&menu);
 	event.Skip();
+}
+
+bool CSearchListCtrl::IsColumnHidden(int col) const
+{
+	return (col >= 0) && (static_cast<size_t>(col) < m_columnHidden.size()) && m_columnHidden[col];
+}
+
+void CSearchListCtrl::SetColumnHidden(int col, bool hidden, int width)
+{
+	if (col < 0 || static_cast<unsigned>(col) >= GetColumnCount()) {
+		return;
+	}
+	if (static_cast<size_t>(col) >= m_columnHidden.size()) {
+		m_columnHidden.resize(GetColumnCount(), false);
+	}
+
+	m_columnHidden[col] = hidden;
+	wxDataViewColumn *column = GetColumn(static_cast<unsigned>(col));
+	column->SetHidden(hidden);
+	if (!hidden && width > COL_SIZE_MIN) {
+		column->SetWidth(width);
+	}
 }
 
 void CSearchListCtrl::UpdateExpanderColumn()
@@ -773,8 +795,8 @@ void CSearchListCtrl::UpdateExpanderColumn()
 	// leave children unreachable, and re-showing a column to its left has
 	// to take them back rather than stranding them mid-row.
 	for (unsigned i = 0; i < GetColumnCount(); ++i) {
-		wxDataViewColumn *column = GetColumn(i);
-		if (!column->IsHidden()) {
+		if (!IsColumnHidden(static_cast<int>(i))) {
+			wxDataViewColumn *column = GetColumn(i);
 			if (GetExpanderColumn() != column) {
 				SetExpanderColumn(column);
 			}
@@ -790,16 +812,14 @@ void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
 		return;
 	}
 
-	wxDataViewColumn *column = GetColumn(static_cast<unsigned>(col));
-	if (!column->IsHidden()) {
+	if (!IsColumnHidden(col)) {
 		// Remember the width so re-showing restores what the user had,
 		// exactly as CMuleListCtrl::OnMenuSelected did.
-		m_columnStore.SetCachedWidth(col, column->GetWidth());
-		column->SetHidden(true);
+		m_columnStore.SetCachedWidth(col, GetColumn(static_cast<unsigned>(col))->GetWidth());
+		SetColumnHidden(col, true, 0);
 	} else {
 		const int cached = m_columnStore.GetCachedWidth(col);
-		column->SetHidden(false);
-		column->SetWidth(cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
+		SetColumnHidden(col, false, cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
 	}
 	UpdateExpanderColumn();
 	SyncOtherLists(this);

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -622,9 +622,10 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 	for (unsigned i = 0; i < src->RealColumnCount(); ++i) {
 		// Hidden state has to travel with the width: copying width alone
 		// would leave the other tabs showing a column this one has hidden.
-		const bool hidden = src->IsColumnHidden(i);
-		if (dst->IsColumnHidden(i) != hidden) {
-			dst->SetColumnHidden(i, hidden, src->GetColumn(i)->GetWidth());
+		const int col = static_cast<int>(i);
+		const bool hidden = src->IsColumnHidden(col);
+		if (dst->IsColumnHidden(col) != hidden) {
+			dst->SetColumnHidden(col, hidden, src->GetColumn(i)->GetWidth());
 		}
 		if (!hidden && dst->GetColumn(i)->GetWidth() != src->GetColumn(i)->GetWidth()) {
 			dst->GetColumn(i)->SetWidth(src->GetColumn(i)->GetWidth());

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -744,7 +744,7 @@ void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
 	for (unsigned i = 0; i < columns; ++i) {
 		const wxDataViewColumn *col = GetColumn(i);
 		menu.AppendCheckItem(static_cast<int>(i) + MP_LISTCOL_1, col->GetTitle());
-		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, col->GetWidth() > COL_SIZE_MIN);
+		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, !col->IsHidden());
 	}
 
 	PopupMenu(&menu);
@@ -759,13 +759,24 @@ void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
 	}
 
 	wxDataViewColumn *column = GetColumn(static_cast<unsigned>(col));
-	if (column->GetWidth() > COL_SIZE_MIN) {
+	if (!column->IsHidden()) {
 		// Remember the width so re-showing restores what the user had,
 		// exactly as CMuleListCtrl::OnMenuSelected did.
 		m_columnStore.SetCachedWidth(col, column->GetWidth());
-		column->SetWidth(COL_SIZE_MIN);
+		column->SetHidden(true);
+		// The expander lives on one specific column; hiding that one would
+		// take the group triangles with it and leave children unreachable.
+		if (GetExpanderColumn() == column) {
+			for (unsigned i = 0; i < GetColumnCount(); ++i) {
+				if (!GetColumn(i)->IsHidden()) {
+					SetExpanderColumn(GetColumn(i));
+					break;
+				}
+			}
+		}
 	} else {
 		const int cached = m_columnStore.GetCachedWidth(col);
+		column->SetHidden(false);
 		column->SetWidth(cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
 	}
 	SaveColumnSettings();
@@ -894,7 +905,7 @@ void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) con
 }
 
 #ifdef __WXOSX__
-void CSearchListCtrl::PageExtendSelection(bool down)
+void CSearchListCtrl::PageExtendSelection(PageMotion motion)
 {
 	std::vector<CSearchFile *> ordered;
 	BuildDisplayOrder(ordered);
@@ -905,23 +916,38 @@ void CSearchListCtrl::PageExtendSelection(bool down)
 	const wxDataViewItem currentItem = GetCurrentItem();
 	CSearchFile *currentFile = currentItem.IsOk() ? CSearchListModel::ToFile(currentItem) : nullptr;
 	const auto found = std::find(ordered.begin(), ordered.end(), currentFile);
+	const bool forward = (motion == PageMotion::PageDown) || (motion == PageMotion::End);
 	const int current = (found == ordered.end())
-				    ? (down ? -1 : static_cast<int>(ordered.size()))
+				    ? (forward ? -1 : static_cast<int>(ordered.size()))
 				    : static_cast<int>(std::distance(ordered.begin(), found));
 
-	// A page is however many rows fit, less one so the row at the edge
-	// stays visible -- the same overlap the other ports scroll by.
-	int rowHeight = 0;
-	if (currentItem.IsOk()) {
-		rowHeight = GetItemRect(currentItem).height;
-	}
-	if (rowHeight <= 0) {
-		rowHeight = GetItemRect(CSearchListModel::ToItem(ordered.front())).height;
-	}
-	const int rows = (rowHeight > 0) ? std::max(1, (GetClientSize().y / rowHeight) - 1) : 1;
-
 	const int last = static_cast<int>(ordered.size()) - 1;
-	const int target = std::min(last, std::max(0, current + (down ? rows : -rows)));
+
+	int target = 0;
+	switch (motion) {
+	case PageMotion::Home:
+		target = 0;
+		break;
+	case PageMotion::End:
+		target = last;
+		break;
+	default: {
+		// GetCountPerPage() is implemented by the native macOS backend;
+		// GetItemRect() is not a substitute, since it returns an empty rect
+		// for rows that aren't currently on screen and the resulting height
+		// of zero collapses a page to a single row.
+		int rows = GetCountPerPage();
+		if (rows <= 0) {
+			rows = 10;
+		} else {
+			// Leave one row of overlap, as the other ports scroll.
+			rows = std::max(1, rows - 1);
+		}
+		const int delta = (motion == PageMotion::PageDown) ? rows : -rows;
+		target = std::min(last, std::max(0, current + delta));
+		break;
+	}
+	}
 
 	// Grow the existing selection to cover everything between where the
 	// cursor was and where it lands, so repeated presses keep extending.
@@ -946,15 +972,28 @@ void CSearchListCtrl::PageExtendSelection(bool down)
 void CSearchListCtrl::OnKeyDown(wxKeyEvent &evt)
 {
 #ifdef __WXOSX__
-	// NSOutlineView pages the view without touching the selection, so
-	// shift+page-up/down -- which extends the selection on GTK and MSW --
-	// does nothing at all here. Plain page-up/down is deliberately left to
-	// the platform, which scrolls without moving the selection by
-	// convention; only the shifted form is handled.
-	const int key = evt.GetKeyCode();
-	if (evt.ShiftDown() && (key == WXK_PAGEUP || key == WXK_PAGEDOWN)) {
-		PageExtendSelection(key == WXK_PAGEDOWN);
-		return;
+	// NSOutlineView moves the view without touching the selection, so the
+	// shifted navigation keys -- which extend the selection on GTK and MSW
+	// -- do nothing at all here. The unshifted forms are deliberately left
+	// to the platform, which scrolls without moving the selection by
+	// convention.
+	if (evt.ShiftDown()) {
+		switch (evt.GetKeyCode()) {
+		case WXK_PAGEUP:
+			PageExtendSelection(PageMotion::PageUp);
+			return;
+		case WXK_PAGEDOWN:
+			PageExtendSelection(PageMotion::PageDown);
+			return;
+		case WXK_HOME:
+			PageExtendSelection(PageMotion::Home);
+			return;
+		case WXK_END:
+			PageExtendSelection(PageMotion::End);
+			return;
+		default:
+			break;
+		}
 	}
 #endif
 	evt.Skip();

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -601,10 +601,21 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 	wxCHECK_RET(src && dst, "NULL argument in SyncLists");
 
 	for (int i = 0; i < src->GetColumnCount(); ++i) {
-		if (dst->GetColumn(i)->GetWidth() != src->GetColumn(i)->GetWidth()) {
-			dst->GetColumn(i)->SetWidth(src->GetColumn(i)->GetWidth());
+		wxDataViewColumn *from = src->GetColumn(i);
+		wxDataViewColumn *to = dst->GetColumn(i);
+		// Hidden state has to travel with the width: a hidden column reports
+		// a width of zero, so copying width alone would leave the other tabs
+		// with a zero-width column that still counts as visible -- invisible
+		// in the list, but ticked in the header menu and impossible to
+		// restore from there.
+		if (to->IsHidden() != from->IsHidden()) {
+			to->SetHidden(from->IsHidden());
+		}
+		if (!from->IsHidden() && to->GetWidth() != from->GetWidth()) {
+			to->SetWidth(from->GetWidth());
 		}
 	}
+	dst->UpdateExpanderColumn();
 
 	if (dst->m_sort_orders.empty() || src->m_sort_orders.empty() ||
 		dst->m_sort_orders.front() != src->m_sort_orders.front()) {
@@ -791,6 +802,7 @@ void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
 		column->SetWidth(cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
 	}
 	UpdateExpanderColumn();
+	SyncOtherLists(this);
 	SaveColumnSettings();
 }
 

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -357,14 +357,16 @@ protected:
 
 public:
 	/**
-	 * Whether a column is hidden, tracked here rather than read back from
-	 * wxDataViewColumn::IsHidden().
+	 * Whether a column is hidden, tracked here rather than derived from the
+	 * control.
 	 *
-	 * The macOS backend overrides both SetHidden() and IsHidden(), but they
-	 * disagree: the column does disappear, while IsHidden() keeps reporting
-	 * it as shown. Reading it back would leave the header menu ticking
-	 * columns that aren't there and unable to bring them back, so this
-	 * class owns the answer and only ever writes to the control.
+	 * A hidden wxDataViewColumn keeps reporting its old width, so width
+	 * alone can't answer the question, and the width is what
+	 * CListColumnStore persists (as a negative entry carrying the size to
+	 * restore). Keeping the state here means the header menu, the
+	 * expander's leftmost-visible search, the persisted width and the
+	 * cross-tab sync all read one answer that this class controls, instead
+	 * of each re-deriving it.
 	 */
 	bool IsColumnHidden(int col) const;
 	//! Hide or show a column; width is the one to restore when showing.

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -218,7 +218,7 @@ protected:
 		: m_ctrl(ctrl)
 		{
 		}
-		int GetColumnCount() const override { return static_cast<int>(m_ctrl->GetColumnCount()); }
+		int GetColumnCount() const override { return static_cast<int>(m_ctrl->RealColumnCount()); }
 		// A hidden column reads as zero-width so CListColumnStore persists
 		// the hidden state through the width it already saves, with no
 		// second mechanism.
@@ -231,15 +231,13 @@ protected:
 			if (width > 0) {
 				return width;
 			}
-			// macOS sizes the trailing column to whatever space is left
-			// over, so once the columns are wider than the control it
-			// reports zero -- while still being a perfectly visible column
-			// the user can scroll to. CListColumnStore treats any width
-			// <= 0 as hidden and persists it as a negative entry, so
-			// letting that through marks the last column hidden on every
-			// shutdown, and the next launch does the same to whichever
-			// column then ends up last: one lost per restart. Fall back to
-			// what the column is known to be worth instead.
+			// A visible column should never report zero -- the spacer
+			// appended on macOS exists so the trailing-column sizing lands
+			// there instead. This is the backstop if it ever does anyway:
+			// CListColumnStore reads a width <= 0 as hidden and persists it
+			// negative, so a stray zero would hide a real column on the
+			// next launch, then do the same to whichever column became last
+			// -- one lost per restart, which is what this used to do.
 			const int cached = m_ctrl->m_columnStore.GetCachedWidth(col);
 			return (cached > 0) ? cached : m_ctrl->m_columnStore.GetColumnDefaultWidth(col);
 		}
@@ -362,15 +360,21 @@ protected:
 
 	/**
 	 * Header right-click: the column show/hide menu every other list gets
-	 * from CMuleListCtrl::OnColumnRClick(). Hiding is a zero-width column
-	 * rather than wxDataViewColumn::SetHidden(), so the state round-trips
-	 * through CListColumnStore's existing width persistence.
+	 * from CMuleListCtrl::OnColumnRClick(). Hiding calls SetHidden() and
+	 * records it in m_columnHidden; the persisted form stays a width of
+	 * zero, which CListColumnStore already understands.
 	 */
 	void OnColumnHeaderRightClick(wxDataViewEvent &event);
 	void OnColumnMenuSelected(wxCommandEvent &evt);
 
 	//! Keeps the group expander on the leftmost visible column.
 	void UpdateExpanderColumn();
+
+	/**
+	 * Columns the user owns, excluding the macOS spacer, which must stay
+	 * out of the header menu, the persisted widths and the cross-tab sync.
+	 */
+	unsigned RealColumnCount() const;
 
 public:
 	/**

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -219,10 +219,25 @@ protected:
 		{
 		}
 		int GetColumnCount() const override { return static_cast<int>(m_ctrl->GetColumnCount()); }
-		int GetColumnWidth(int col) const override { return m_ctrl->GetColumn(col)->GetWidth(); }
+		// A hidden column reads as zero-width so CListColumnStore persists
+		// the hidden state through the width it already saves, with no
+		// second mechanism. wxDataViewCtrl won't shrink a column to nothing
+		// -- a header stub survives -- so hiding has to go through
+		// SetHidden() rather than SetWidth(0).
+		int GetColumnWidth(int col) const override
+		{
+			const wxDataViewColumn *column = m_ctrl->GetColumn(col);
+			return column->IsHidden() ? 0 : column->GetWidth();
+		}
 		bool SetColumnWidth(int col, int width) override
 		{
-			m_ctrl->GetColumn(col)->SetWidth(width);
+			wxDataViewColumn *column = m_ctrl->GetColumn(col);
+			if (width <= COL_SIZE_MIN) {
+				column->SetHidden(true);
+			} else {
+				column->SetHidden(false);
+				column->SetWidth(width);
+			}
 			return true;
 		}
 
@@ -356,8 +371,9 @@ protected:
 	void OnChar(wxKeyEvent &evt);
 
 	/**
-	 * Navigation keys. Only shift+page-up/down on macOS is handled (see
-	 * PageExtendSelection); everything else goes to the backend.
+	 * Navigation keys. Only shifted page-up/down and home/end on macOS are
+	 * handled (see PageExtendSelection); everything else goes to the
+	 * backend.
 	 */
 	void OnKeyDown(wxKeyEvent &evt);
 
@@ -366,11 +382,19 @@ protected:
 
 #ifdef __WXOSX__
 	/**
-	 * Extends the selection by one page. GTK and MSW get this from their
-	 * backends; NSOutlineView pages the view without moving the selection,
-	 * so it is done by hand to keep the three ports consistent.
+	 * Extends the selection by a page, or to the start/end of the list.
+	 * GTK and MSW get this from their backends; NSOutlineView moves the
+	 * view without touching the selection, so it is done by hand to keep
+	 * the three ports consistent.
 	 */
-	void PageExtendSelection(bool down);
+	enum class PageMotion
+	{
+		PageUp,
+		PageDown,
+		Home,
+		End
+	};
+	void PageExtendSelection(PageMotion motion);
 #endif
 
 	//! Keystrokes accumulated so far, lowercased; reset after kTypeAheadResetMs.

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -335,6 +335,15 @@ protected:
 	void OnPopupDownload(wxCommandEvent &event);
 
 	/**
+	 * Header right-click: the column show/hide menu every other list gets
+	 * from CMuleListCtrl::OnColumnRClick(). Hiding is a zero-width column
+	 * rather than wxDataViewColumn::SetHidden(), so the state round-trips
+	 * through CListColumnStore's existing width persistence.
+	 */
+	void OnColumnHeaderRightClick(wxDataViewEvent &event);
+	void OnColumnMenuSelected(wxCommandEvent &evt);
+
+	/**
 	 * Type-to-select, reimplemented for wxDataViewCtrl.
 	 *
 	 * CMuleListCtrl::OnChar() gave every list this behaviour: typing jumps
@@ -345,6 +354,24 @@ protected:
 	 * here to keep the three ports behaving alike.
 	 */
 	void OnChar(wxKeyEvent &evt);
+
+	/**
+	 * Navigation keys. Only shift+page-up/down on macOS is handled (see
+	 * PageExtendSelection); everything else goes to the backend.
+	 */
+	void OnKeyDown(wxKeyEvent &evt);
+
+	//! Top-level rows in the order they are displayed under the current sort.
+	void BuildDisplayOrder(std::vector<CSearchFile *> &ordered) const;
+
+#ifdef __WXOSX__
+	/**
+	 * Extends the selection by one page. GTK and MSW get this from their
+	 * backends; NSOutlineView pages the view without moving the selection,
+	 * so it is done by hand to keep the three ports consistent.
+	 */
+	void PageExtendSelection(bool down);
+#endif
 
 	//! Keystrokes accumulated so far, lowercased; reset after kTypeAheadResetMs.
 	wxString m_ttsText;

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -214,37 +214,31 @@ protected:
 	class ColumnWidthAdapter : public IColumnWidthProvider
 	{
 	public:
-		explicit ColumnWidthAdapter(wxDataViewCtrl *ctrl)
+		explicit ColumnWidthAdapter(CSearchListCtrl *ctrl)
 		: m_ctrl(ctrl)
 		{
 		}
 		int GetColumnCount() const override { return static_cast<int>(m_ctrl->GetColumnCount()); }
 		// A hidden column reads as zero-width so CListColumnStore persists
 		// the hidden state through the width it already saves, with no
-		// second mechanism. wxDataViewCtrl won't shrink a column to nothing
-		// -- a header stub survives -- so hiding has to go through
-		// SetHidden() rather than SetWidth(0).
+		// second mechanism.
 		int GetColumnWidth(int col) const override
 		{
-			const wxDataViewColumn *column = m_ctrl->GetColumn(col);
-			return column->IsHidden() ? 0 : column->GetWidth();
+			return m_ctrl->IsColumnHidden(col) ? 0 : m_ctrl->GetColumn(col)->GetWidth();
 		}
 		bool SetColumnWidth(int col, int width) override
 		{
-			wxDataViewColumn *column = m_ctrl->GetColumn(col);
-			if (width <= COL_SIZE_MIN) {
-				column->SetHidden(true);
-			} else {
-				column->SetHidden(false);
-				column->SetWidth(width);
-			}
+			m_ctrl->SetColumnHidden(col, width <= COL_SIZE_MIN, width);
 			return true;
 		}
 
 	private:
-		wxDataViewCtrl *m_ctrl;
+		CSearchListCtrl *m_ctrl;
 	};
 	ColumnWidthAdapter m_widthAdapter;
+
+	//! Per-column hidden state, indexed like the control's columns.
+	std::vector<bool> m_columnHidden;
 
 	typedef std::pair<unsigned, unsigned> CColPair;
 	typedef std::list<CColPair> CSortingList;
@@ -361,6 +355,22 @@ protected:
 	//! Keeps the group expander on the leftmost visible column.
 	void UpdateExpanderColumn();
 
+public:
+	/**
+	 * Whether a column is hidden, tracked here rather than read back from
+	 * wxDataViewColumn::IsHidden().
+	 *
+	 * The macOS backend overrides both SetHidden() and IsHidden(), but they
+	 * disagree: the column does disappear, while IsHidden() keeps reporting
+	 * it as shown. Reading it back would leave the header menu ticking
+	 * columns that aren't there and unable to bring them back, so this
+	 * class owns the answer and only ever writes to the control.
+	 */
+	bool IsColumnHidden(int col) const;
+	//! Hide or show a column; width is the one to restore when showing.
+	void SetColumnHidden(int col, bool hidden, int width);
+
+private:
 	/**
 	 * Type-to-select, reimplemented for wxDataViewCtrl.
 	 *

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -358,6 +358,9 @@ protected:
 	void OnColumnHeaderRightClick(wxDataViewEvent &event);
 	void OnColumnMenuSelected(wxCommandEvent &evt);
 
+	//! Keeps the group expander on the leftmost visible column.
+	void UpdateExpanderColumn();
+
 	/**
 	 * Type-to-select, reimplemented for wxDataViewCtrl.
 	 *

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -224,7 +224,24 @@ protected:
 		// second mechanism.
 		int GetColumnWidth(int col) const override
 		{
-			return m_ctrl->IsColumnHidden(col) ? 0 : m_ctrl->GetColumn(col)->GetWidth();
+			if (m_ctrl->IsColumnHidden(col)) {
+				return 0;
+			}
+			const int width = m_ctrl->GetColumn(col)->GetWidth();
+			if (width > 0) {
+				return width;
+			}
+			// macOS sizes the trailing column to whatever space is left
+			// over, so once the columns are wider than the control it
+			// reports zero -- while still being a perfectly visible column
+			// the user can scroll to. CListColumnStore treats any width
+			// <= 0 as hidden and persists it as a negative entry, so
+			// letting that through marks the last column hidden on every
+			// shutdown, and the next launch does the same to whichever
+			// column then ends up last: one lost per restart. Fall back to
+			// what the column is known to be worth instead.
+			const int cached = m_ctrl->m_columnStore.GetCachedWidth(col);
+			return (cached > 0) ? cached : m_ctrl->m_columnStore.GetColumnDefaultWidth(col);
 		}
 		bool SetColumnWidth(int col, int width) override
 		{

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -103,6 +103,12 @@ public:
 		COL_BITRATE,
 		COL_CODEC,
 		COL_DIRECTORY,
+		//! Always empty. macOS sizes the trailing column to the leftover
+		//! space, collapsing it to nothing once the columns are wider than
+		//! the control; a spacer at the end takes that role so no real
+		//! column is ever the one that disappears. Only appended there --
+		//! GTK and MSW lay the columns out without it.
+		COL_SPACER,
 		COL_COUNT
 	};
 


### PR DESCRIPTION
Two more behaviours the `wxDataViewCtrl` port left behind, both of which every list still on `wxListCtrl` inherits for free from `CMuleListCtrl`. Same class as the three restored in #796 (multi-selection, type-to-select, select-all) and the reason #801 argues for a shared base before the next list is ported.

## Column show/hide menu

Right-clicking a column header opened a check-menu of columns (`CMuleListCtrl::OnColumnRClick`/`OnMenuSelected`). The ported search list bound no header right-click handler at all, so there was no way to hide a column.

Restored on `CSearchListCtrl` with the original semantics: hiding sets the column to `COL_SIZE_MIN` and caches the previous width, so re-showing restores what the user had, and the state persists through `CListColumnStore`'s existing width handling instead of needing a second mechanism.

`COL_SIZE_MIN` moves from a file-local constant in `MuleListCtrl.cpp` to `ListColumnStore.h`, beside the column-width interface, so both lists read one threshold rather than keeping copies. It is 10 on wxGTK — which won't shrink a column past the header grip — and 0 elsewhere, so this touches the GTK build in particular.

## Shift+page-up/down on macOS

Shift+page-up/down extends the selection on GTK and MSW, whose backends implement it. On macOS it does nothing: `NSOutlineView` pages the view without touching the selection. Handled by hand under `__WXOSX__` so the three ports agree; repeated presses keep extending, since it grows the existing selection between the cursor's old and new position.

Plain page-up/down is deliberately left to the platform — macOS scrolls without moving the selection by convention (Finder, Mail) — and that behaviour is unchanged.

## Shared ordering

Both the existing type-ahead search and the new page handler need the top-level rows in displayed order, so that is factored into `BuildDisplayOrder()` and shared rather than written twice. It runs the rows through this list's own comparator because `GetItemByRow()`/`GetRowByItem()` exist only in wx's generic implementation, not on GTK or macOS.

## Testing

Built clean on macOS, Ubuntu 26.04 arm64 (wxGTK 3.2.9) and Windows 11 arm64; `clang-format` and both `clang-tidy` tiers clean on the diff.

Draft until the interactive pass on all three is done — specifically that a hidden column stays hidden across a restart, and that the macOS page size feels right.
