### PR TITLE
feat(gui): port CServerListCtrl to wxDataViewCtrl (#180, #801)

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -91,6 +91,7 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 		SearchListCtrl.cpp
 		SearchListModel.cpp
 		ServerListCtrl.cpp
+		ServerListModel.cpp
 		ServerWnd.cpp
 		SharedDirsApplyTask.cpp
 		SharedFilePeersListCtrl.cpp

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -66,6 +66,7 @@ src/ServerConnect.cpp
 src/Server.cpp
 src/ServerList.cpp
 src/ServerListCtrl.cpp
+src/ServerListModel.cpp
 src/ServerSocket.cpp
 src/ServerWnd.cpp
 src/SharedDirWatcher.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1313,17 +1313,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
@@ -2526,11 +2526,12 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr ""
 
@@ -6370,20 +6371,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr ""
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6391,15 +6380,23 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
+msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6424,6 +6421,10 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
+msgstr ""
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
 msgstr ""
 
 #: src/ServerSocket.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:28+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1337,17 +1337,17 @@ msgid "Very low"
 msgstr "متدني جدا"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "متدني"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "عادي"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "مرتفع"
 
@@ -2560,11 +2560,12 @@ msgstr "الرفع"
 msgid "None"
 msgstr "ﻻ احد"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "ﻻ"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "نعم"
 
@@ -6464,20 +6465,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr "خادمات (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "خادم"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6485,16 +6474,24 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "الغاء الخادم"
+msgid "Mark server as non-static"
+msgstr ""
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
+msgstr "الغاء الخادم"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "الغاء الخادم"
 
 #: src/ServerListCtrl.cpp
@@ -6522,6 +6519,10 @@ msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "خادم"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:29+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1354,17 +1354,17 @@ msgid "Very low"
 msgstr "Mui baxa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -2616,11 +2616,12 @@ msgstr "Xuba"
 msgid "None"
 msgstr "Dengún"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Sí"
 
@@ -6579,37 +6580,33 @@ msgstr "De xuru quies desaniciar el sirvidor fixu %s"
 msgid "Servers (%i)"
 msgstr "Sirvidores (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Sirvidor"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Coneutar al sirvidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Conseñar como sirvidor fixu"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Conseñar como sirvidor non-fixu"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Conseñar sirvidores como fixos"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Conseñar como sirvidor fixu"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Conseñar sirvidores como non-fixos"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Desaniciar sirvidor"
+msgid "Mark server as non-static"
+msgstr "Conseñar como sirvidor non-fixu"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Desaniciar sirvidores"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Desaniciar sirvidor"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6634,6 +6631,10 @@ msgstr "¿De xuru quies desaniciar el sirvidor seleicionáu?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "¿De xuru quies desaniciar los sirvidores seleicionaos?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Sirvidor"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:29+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1332,17 +1332,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ниско"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Нормален"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Високо"
 
@@ -2556,11 +2556,12 @@ msgstr "Качване"
 msgid "None"
 msgstr "никой"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Не"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Да"
 
@@ -6439,20 +6440,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr "Сървъри (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Сървър"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6460,16 +6449,24 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Премахване на сървър"
+msgid "Mark server as non-static"
+msgstr ""
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
+msgstr "Премахване на сървър"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "Премахване на сървър"
 
 #: src/ServerListCtrl.cpp
@@ -6497,6 +6494,10 @@ msgstr "Сигурни ли сте,че желаете да откажете с�
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Сървър"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1312,17 +1312,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
@@ -2525,11 +2525,12 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr ""
 
@@ -6369,20 +6370,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr ""
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6390,15 +6379,23 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
+msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6423,6 +6420,10 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
+msgstr ""
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
 msgstr ""
 
 #: src/ServerSocket.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:30+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1351,17 +1351,17 @@ msgid "Very low"
 msgstr "Molt baixa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -2607,11 +2607,12 @@ msgstr "Pujant"
 msgid "None"
 msgstr "Cap"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Sí"
 
@@ -6549,37 +6550,33 @@ msgstr "Esteu segur que voleu esborrar el servidor estàtic %s"
 msgid "Servers (%i)"
 msgstr "Servidors (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Servidor"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Connecta al servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marca el servidor com a estàtic"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Marca el servidor com a no estàtic"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marca els servidors com a estàtics"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marca el servidor com a estàtic"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marca els servidors com a no estàtics"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Esborra el servidor"
+msgid "Mark server as non-static"
+msgstr "Marca el servidor com a no estàtic"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Esborra els servidors"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Esborra el servidor"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6604,6 +6601,10 @@ msgstr "Esteu segur que voleu esborrar el servidor seleccionat?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Esteu segur que voleu esborrar els servidors seleccionats?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Servidor"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:30+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1356,17 +1356,17 @@ msgid "Very low"
 msgstr "Velmi nízká"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nízká"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normální"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Vysoká"
 
@@ -2597,11 +2597,12 @@ msgstr "Odesílám"
 msgid "None"
 msgstr "Nic"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ano"
 
@@ -6558,37 +6559,33 @@ msgstr "Opravdu si přejete smazat stálý server %s?"
 msgid "Servers (%i)"
 msgstr "Servery (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Připojit k serveru"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Označit server jako stálý"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Označit server jako nestálý"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Označit servery jako stálé"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Označit server jako stálý"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Označit servery jako nestálé"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Odstranit server"
+msgid "Mark server as non-static"
+msgstr "Označit server jako nestálý"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Vzdálené servery"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Odstranit server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6615,6 +6612,10 @@ msgstr "Opravdu si přejete smazat vybrané servery?"
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Opravdu si přejete smazat vybrané servery?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:31+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1340,17 +1340,17 @@ msgid "Very low"
 msgstr "Meget lav"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Lav"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høj"
 
@@ -2566,11 +2566,12 @@ msgstr "Upload"
 msgid "None"
 msgstr "Ingen"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ja"
 
@@ -6480,20 +6481,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr "Servere (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6501,16 +6490,24 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Fjern server"
+msgid "Mark server as non-static"
+msgstr ""
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
+msgstr "Fjern server"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "Fjern server"
 
 #: src/ServerListCtrl.cpp
@@ -6538,6 +6535,10 @@ msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:31+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1360,17 +1360,17 @@ msgid "Very low"
 msgstr "Sehr niedrig"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niedrig"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoch"
 
@@ -2612,11 +2612,12 @@ msgstr "Hochladen"
 msgid "None"
 msgstr "Keine"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nein"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ja"
 
@@ -6545,37 +6546,33 @@ msgstr "Wirklich den statischen Server '%s' löschen?"
 msgid "Servers (%i)"
 msgstr "Server (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Verbinde mit Server"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Markiere den Server als statisch"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Markiere den Server als nicht statisch"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Markiere die Server als statisch"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Markiere den Server als statisch"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Markiere die Server als nicht statisch"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Entferne Server"
+msgid "Mark server as non-static"
+msgstr "Markiere den Server als nicht statisch"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Entferne die Server"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Entferne Server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6600,6 +6597,10 @@ msgstr "Wirklich den markierten Server löschen?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Wirklich die markierten Server löschen?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:32+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1362,17 +1362,17 @@ msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Χαμηλή"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Κανονική"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Υψηλή"
 
@@ -2625,11 +2625,12 @@ msgstr "Ανέβασμα"
 msgid "None"
 msgstr "Κανείς"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Όχι"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ναι"
 
@@ -6592,37 +6593,33 @@ msgstr "Είστε σίγουρος/η ότι θέλετε να διαγράψε
 msgid "Servers (%i)"
 msgstr "Διακομιστές (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Διακομιστής"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Σύνδεση σε διακομιστή"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Σημαδέψτε τον διακομιστή σαν στατικό"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Σημαδέψτε τον διακομιστή σαν μη στατικό"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Σημαδέψτε τους διακομιστές σαν στατικούς"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Σημαδέψτε τον διακομιστή σαν στατικό"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Σημαδέψτε τους διακομιστές σαν μη στατικούς"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Αφαίρεση διακομιστή"
+msgid "Mark server as non-static"
+msgstr "Σημαδέψτε τον διακομιστή σαν μη στατικό"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Αφαίρεση διακομιστών"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Αφαίρεση διακομιστή"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6647,6 +6644,10 @@ msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετ�
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε τους επιλεγμένους διακομιστές;"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Διακομιστής"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1313,17 +1313,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
@@ -2526,11 +2526,12 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr ""
 
@@ -6370,20 +6371,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr ""
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6391,15 +6380,23 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
+msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6424,6 +6421,10 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
+msgstr ""
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
 msgstr ""
 
 #: src/ServerSocket.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:33+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1363,17 +1363,17 @@ msgid "Very low"
 msgstr "Muy baja"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baja"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -2615,11 +2615,12 @@ msgstr "Subiendo"
 msgid "None"
 msgstr "Ninguno"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Sí"
 
@@ -6528,37 +6529,33 @@ msgstr "¿Seguro que quiere eliminar el servidor fijo %s?"
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Servidor"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectar al servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marcar el servidor como fijo"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Desmarcar el servidor como fijo"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar los servidores como fijos"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marcar el servidor como fijo"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Desmarcar los servidores como fijos"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Borrar el servidor"
+msgid "Mark server as non-static"
+msgstr "Desmarcar el servidor como fijo"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Borrar los servidores"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Borrar el servidor"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6583,6 +6580,10 @@ msgstr "¿Seguro que desea borrar el servidor seleccionado?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "¿Seguro que desea borrar los servidores seleccionados?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Servidor"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1352,17 +1352,17 @@ msgid "Very low"
 msgstr "Väga madal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Madal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Keskmine"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Kõrge"
 
@@ -2608,11 +2608,12 @@ msgstr "Saadan"
 msgid "None"
 msgstr "Mitte keegi"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Jah"
 
@@ -6555,37 +6556,33 @@ msgstr "Oled kindel et tahad kustutada staatilise serveri %s"
 msgid "Servers (%i)"
 msgstr "Servereid (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Ühendu serveriga"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Märgi server staatilisena"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Märgi server mittestaatilisena"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Märgi serverid staatilisena"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Märgi server staatilisena"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Märgi serverid mittestaatilisena"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Eemalda server"
+msgid "Mark server as non-static"
+msgstr "Märgi server mittestaatilisena"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Eemalda serverid"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Eemalda server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6610,6 +6607,10 @@ msgstr "Oled kindel et tahad valitud serveri kustutada?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Oled kindel et tahad valitud serverid kustutada?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:34+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1353,17 +1353,17 @@ msgid "Very low"
 msgstr "Oso txikia"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxua"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normala"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Altua"
 
@@ -2609,11 +2609,12 @@ msgstr "Igotzen"
 msgid "None"
 msgstr "Batez"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ez"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Bai"
 
@@ -6553,37 +6554,33 @@ msgstr "Ziur al zaude %s zerbitzari tinkoa ezabatu nahi duzula"
 msgid "Servers (%i)"
 msgstr "Zerbitzariak (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Zerbitzaria"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Zerbitzarira konektatu"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Zerbitzaria estatiko bezala markatu"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Zerbitzaria ez-estatiko bezala markatu"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Zerbitzariak estatiko bezala markatu"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Zerbitzaria estatiko bezala markatu"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Zerbitzariak ez-estatiko bezala markatu"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Ezabatu zerbitzaria"
+msgid "Mark server as non-static"
+msgstr "Zerbitzaria ez-estatiko bezala markatu"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Ezabatu zerbitzariak"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Ezabatu zerbitzaria"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6608,6 +6605,10 @@ msgstr "Ziur zaude aukeratutako zerbitzaria ezabatu nahi duzula?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ziur zaude aukeratutako zerbitzariak ezabatu nahi dituzula?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Zerbitzaria"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:34+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1353,17 +1353,17 @@ msgid "Very low"
 msgstr "Erittäin matala"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Matala"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaali"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Korkea"
 
@@ -2609,11 +2609,12 @@ msgstr "Lähettää"
 msgid "None"
 msgstr "Ei yhtään"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ei"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -6553,37 +6554,33 @@ msgstr "Oletko varma että haluat poistaa pysyvän palvelimen %s"
 msgid "Servers (%i)"
 msgstr "Palvelimet (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Palvelin"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Yhdistä palvelimelle"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Merkitse palvelin pysyväksi"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Poista palvelimen pysyvyysmerkintä"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Merkitse palvelimet pysyviksi"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Merkitse palvelin pysyväksi"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Poista palvelimien pysyvyysmerkintä"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Poista palvelin"
+msgid "Mark server as non-static"
+msgstr "Poista palvelimen pysyvyysmerkintä"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Poista palvelimet"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Poista palvelin"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6608,6 +6605,10 @@ msgstr "Oletko varma että haluat poistaa valitun palvelimen?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Oletko varma että haluat poistaa valitut palvelimet?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Palvelin"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:35+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1361,17 +1361,17 @@ msgid "Very low"
 msgstr "Très basse"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Basse"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Haute"
 
@@ -2613,11 +2613,12 @@ msgstr "Émission en cours"
 msgid "None"
 msgstr "Aucun"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Oui"
 
@@ -6520,37 +6521,33 @@ msgstr "Êtes-vous sûr de vouloir supprimer le serveur statique %s"
 msgid "Servers (%i)"
 msgstr "Serveurs (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Serveur"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Connexion au serveur"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marquer le serveur comme statique"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Marquer le serveur comme non statique"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marquer les serveurs comme statiques"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marquer le serveur comme statique"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marquer les serveurs comme non statiques"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Supprimer le serveur"
+msgid "Mark server as non-static"
+msgstr "Marquer le serveur comme non statique"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Supprimer les serveurs"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Supprimer le serveur"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6575,6 +6572,10 @@ msgstr "Êtes-vous sûr de vouloir supprimer le serveur sélectionné ?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Êtes-vous sûr de vouloir supprimer les serveurs sélectionnés ?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Serveur"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:36+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1373,17 +1373,17 @@ msgid "Very low"
 msgstr "Moi baixa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -2625,11 +2625,12 @@ msgstr "Enviando"
 msgid "None"
 msgstr "Ningún"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Non"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Si"
 
@@ -6559,37 +6560,33 @@ msgstr "Seguro de que quere borrar o servidor estático %s?"
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Servidor"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectarse ao servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marcar servidor como estático"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Marcar servidor como non estático"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar servidores como estáticos"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marcar servidor como estático"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcar servidores como non estáticos"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Borrar servidor"
+msgid "Mark server as non-static"
+msgstr "Marcar servidor como non estático"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Borrar servidores"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Borrar servidor"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6614,6 +6611,10 @@ msgstr "Está seguro de que quere borrar o servidor seleccionado?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Está seguro de que quere borrar os servidores seleccionados?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Servidor"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:36+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1343,17 +1343,17 @@ msgid "Very low"
 msgstr "מאוד נמוך"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "נמוך"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "רגיל"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "גבוה"
 
@@ -2578,11 +2578,12 @@ msgstr "ההעלאות"
 msgid "None"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "לא"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "כן"
 
@@ -6516,37 +6517,33 @@ msgstr "האם אתה בטוח שאתה רוצה למחוק את השרת הקב
 msgid "Servers (%i)"
 msgstr "שרתים (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "שרת"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "מחובר לשרת"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "סמן שרת בתור קבוע"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "סמן שרת בתור לא קבוע"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "סמן שרתים בתור קבועים"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "סמן שרת בתור קבוע"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "סמן שרתים בתור כאלה שאינם קבועים"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "הסר שרת"
+msgid "Mark server as non-static"
+msgstr "סמן שרת בתור לא קבוע"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "הסר שרתים"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "הסר שרת"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6571,6 +6568,10 @@ msgstr "האם אתה בטוח שאתה מעוניין למחוק את כל הש
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "האם אתה בטוח שאתה מעוניין למחוק את כל השרתים המסומנים?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "שרת"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:37+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1347,17 +1347,17 @@ msgid "Very low"
 msgstr "Vrlo nizak"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nisko"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalan"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoko"
 
@@ -2573,11 +2573,12 @@ msgstr "Prijenos"
 msgid "None"
 msgstr "Nijedno"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Da"
 
@@ -6509,20 +6510,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr "Serveri (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6530,16 +6519,24 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Odstrani servera"
+msgid "Mark server as non-static"
+msgstr ""
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
+msgstr "Odstrani servera"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "Odstrani servera"
 
 #: src/ServerListCtrl.cpp
@@ -6567,6 +6564,10 @@ msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1349,17 +1349,17 @@ msgid "Very low"
 msgstr "Nagyon alacsony"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Alacsony"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normál"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Magas"
 
@@ -2599,11 +2599,12 @@ msgstr "Feltöltés alatt"
 msgid "None"
 msgstr "Egyik sem"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nem"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Igen"
 
@@ -6522,37 +6523,33 @@ msgstr "Biztos, hogy törlöd az állandó %s kiszolgálót"
 msgid "Servers (%i)"
 msgstr "Kiszolgálók száma (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Kiszolgáló"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Kapcsolódás a kiszolgálóhoz"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Kiszolgáló megjelölése állandóként"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Kiszolgáló megjelölése nem állandóként"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Kiszolgálók megjelölése állandóként"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Kiszolgáló megjelölése állandóként"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Kiszolgálók megjelölése nem állandóként"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Kiszolgáló eltávolítása"
+msgid "Mark server as non-static"
+msgstr "Kiszolgáló megjelölése nem állandóként"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Kiszolgálók eltávolítása"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Kiszolgáló eltávolítása"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6577,6 +6574,10 @@ msgstr "Biztos, hogy törlöd a kiválasztott kiszolgálót?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Biztos, hogy törlöd a kiválasztott kiszolgálókat?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Kiszolgáló"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:38+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1363,17 +1363,17 @@ msgid "Very low"
 msgstr "Molto bassa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Bassa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -2625,11 +2625,12 @@ msgstr "Caricamento"
 msgid "None"
 msgstr "Nessuno"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "No"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Sì"
 
@@ -6517,37 +6518,33 @@ msgstr "Sei sicuro di voler eliminare il server statico %s"
 msgid "Servers (%i)"
 msgstr "Server (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Connetti al server"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Segna il server come statico"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Segna il server come non statico"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Segna i server come statici"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Segna il server come statico"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Segna i server come non statici"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Rimuovi il server"
+msgid "Mark server as non-static"
+msgstr "Segna il server come non statico"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Rimuovi i server"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Rimuovi il server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6572,6 +6569,10 @@ msgstr "Sei sicuro di voler eliminare il server selezionato?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Sei sicuro di voler eliminare i server selezionati?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1352,17 +1352,17 @@ msgid "Very low"
 msgstr "非常に低い"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低い"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高い"
 
@@ -2608,11 +2608,12 @@ msgstr "アップロード"
 msgid "None"
 msgstr "誰も許可しない"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "いいえ"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "はい"
 
@@ -6545,24 +6546,16 @@ msgstr "スタティックサーバ %s を本当に削除しますか？"
 msgid "Servers (%i)"
 msgstr "サーバ （%i）"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "サーバ"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "サーバへ接続する"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as static"
+msgid "Mark servers as static"
 msgstr "サーバをスタティックとしてマークする"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "サーバを非スタティックとしてマークする"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark servers as static"
+msgid "Mark server as static"
 msgstr "サーバをスタティックとしてマークする"
 
 #: src/ServerListCtrl.cpp
@@ -6570,11 +6563,15 @@ msgid "Mark servers as non-static"
 msgstr "サーバを非スタティックとしてマークする"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "サーバを削除する"
+msgid "Mark server as non-static"
+msgstr "サーバを非スタティックとしてマークする"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr "サーバを削除する"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "サーバを削除する"
 
 #: src/ServerListCtrl.cpp
@@ -6600,6 +6597,10 @@ msgstr "全ての選択されたサーバを本当に削除しますか？"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "全ての選択されたサーバを本当に削除しますか？"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "サーバ"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1361,17 +1361,17 @@ msgid "Very low"
 msgstr "매우 낮음"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "낮음"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "보통"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "높음"
 
@@ -2624,11 +2624,12 @@ msgstr "올려주기"
 msgid "None"
 msgstr "아무도"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "아니오"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "예"
 
@@ -6582,27 +6583,18 @@ msgstr "정적 서버 %s를 삭제하시겠습니까?"
 msgid "Servers (%i)"
 msgstr "서버 (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "서버"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "서버에 연결함"
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
-msgid "Mark server as static"
+msgid "Mark servers as static"
 msgstr "정적인 서버를 만듦"
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
-msgid "Mark server as non-static"
-msgstr "비정적인 서버를 만듦"
-
-#: src/ServerListCtrl.cpp
-#, fuzzy
-msgid "Mark servers as static"
+msgid "Mark server as static"
 msgstr "정적인 서버를 만듦"
 
 #: src/ServerListCtrl.cpp
@@ -6612,12 +6604,17 @@ msgstr "비정적인 서버를 만듦"
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
-msgid "Remove server"
-msgstr "서버를 삭제"
+msgid "Mark server as non-static"
+msgstr "비정적인 서버를 만듦"
 
 #: src/ServerListCtrl.cpp
 #, fuzzy
 msgid "Remove servers"
+msgstr "서버를 삭제"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "Remove server"
 msgstr "서버를 삭제"
 
 #: src/ServerListCtrl.cpp
@@ -6645,6 +6642,10 @@ msgstr "선택된 서버를 삭제하시겠습니까?"
 #, fuzzy
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "선택된 서버를 삭제하시겠습니까?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "서버"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1367,17 +1367,17 @@ msgid "Very low"
 msgstr "Labai žemas"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Žemas"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalus"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Aukštas"
 
@@ -2633,11 +2633,12 @@ msgstr "Išsiuntimas"
 msgid "None"
 msgstr "Niekas"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Taip"
 
@@ -6611,37 +6612,33 @@ msgstr "Ar tikrai norite pašalinti šį statišką serverį %s"
 msgid "Servers (%i)"
 msgstr "Serveriai (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Serveris"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Prisijungti prie serverio"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Pažymėti, kad serveris statiškas"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Pažymėti, kad serveris nestatiškas"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Pažymėti, kad serveriai statiški"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Pažymėti, kad serveris statiškas"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Pažymėti, kad serveriai nestatiški"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Pašalinti serverį"
+msgid "Mark server as non-static"
+msgstr "Pažymėti, kad serveris nestatiškas"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Pašalinti serverius"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Pašalinti serverį"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6666,6 +6663,10 @@ msgstr "Ar tikrai norite pašalinti pažymėtą serverį?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ar tikrai norite pašalinti pažymėtus serverius?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Serveris"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1327,17 +1327,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
@@ -2542,11 +2542,12 @@ msgstr "Augšupielādē"
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nē"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Jā"
 
@@ -6409,24 +6410,16 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr "Serveri (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Serveris"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Pieslēgties serverim"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "Mark server as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6434,12 +6427,16 @@ msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Noņemt atlasīto serveri"
+msgid "Mark server as non-static"
+msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Noņemt atlasītos serverus"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Noņemt atlasīto serveri"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6464,6 +6461,10 @@ msgstr "Vai tiešām dzēst atlasīto serveri?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Vai tiešām dzēst atlasītos serverus?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Serveris"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:40+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1353,17 +1353,17 @@ msgid "Very low"
 msgstr "Heel laag"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Laag"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoog"
 
@@ -2611,11 +2611,12 @@ msgstr "Aan het uploaden"
 msgid "None"
 msgstr "Geen"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nee"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ja"
 
@@ -6554,37 +6555,33 @@ msgstr "Weet u zeker dat u de statische server %s wilt verwijderen"
 msgid "Servers (%i)"
 msgstr "Servers (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Verbind met server"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Markeer server als statisch"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Markeer server als niet-statisch"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Markeer servers als statisch"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Markeer server als statisch"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Markeer servers als niet-statisch"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Verwijder server"
+msgid "Mark server as non-static"
+msgstr "Markeer server als niet-statisch"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Verwijder servers"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Verwijder server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6609,6 +6606,10 @@ msgstr "Weet u zeker dat u de geselecteerde server wilt verwijderen?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Weet u zeker dat u de geselecteerde servers wilt verwijderen?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1360,17 +1360,17 @@ msgid "Very low"
 msgstr "Svært låg"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Vanleg"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høg"
 
@@ -2622,11 +2622,12 @@ msgstr "Opplasting"
 msgid "None"
 msgstr "Ingen"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nei"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ja"
 
@@ -6583,37 +6584,33 @@ msgstr "Er du sikker på at du vil slette den statiske tenaren %s"
 msgid "Servers (%i)"
 msgstr "Tenarar (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Tenar"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Kople til tenar"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Merk tenar som statisk"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Merk tenar som ustatisk"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Merk tenarar som statiske"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Merk tenar som statisk"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Merk tenarar som ustatiske"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Ta bort tenar"
+msgid "Mark server as non-static"
+msgstr "Merk tenar som ustatisk"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Ta bort tenarar"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Ta bort tenar"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6638,6 +6635,10 @@ msgstr "Er du viss på at du vil slette den valde tenaren."
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Er du viss på at du vil slette dei valde tenarane?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Tenar"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:41+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1360,17 +1360,17 @@ msgid "Very low"
 msgstr "Bardzo niski"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niski"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalny"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Wysoki"
 
@@ -2618,11 +2618,12 @@ msgstr "Wysyłanie"
 msgid "None"
 msgstr "Brak"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nie"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Tak"
 
@@ -6590,37 +6591,33 @@ msgstr "Na pewno chcesz usunąć serwer statyczny %s"
 msgid "Servers (%i)"
 msgstr "Serwery (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Serwer"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Połącz z serwerem"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Oznacz serwer jako statyczny"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Oznacz serwer jako nie statyczny"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Oznacz serwery jako statyczne"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Oznacz serwer jako statyczny"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Oznacz serwery jako nie statyczne"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Usuń serwer"
+msgid "Mark server as non-static"
+msgstr "Oznacz serwer jako nie statyczny"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Usuń serwery"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Usuń serwer"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6645,6 +6642,10 @@ msgstr "Jesteś pewien, że chcesz usunąć wybrany serwer?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Jesteś pewien, że chcesz usunąć wybrane serwery?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Serwer"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1359,17 +1359,17 @@ msgid "Very low"
 msgstr "Muito baixo"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixo"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alto"
 
@@ -2621,11 +2621,12 @@ msgstr "Enviando"
 msgid "None"
 msgstr "Nenhum"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Sim"
 
@@ -6514,37 +6515,33 @@ msgstr "Deseja remover o servidor estático %s"
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Servidor"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectar ao servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marcar servidor como fixo"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Marcar servidor como não-fixo"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar servidores como fixos"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marcar servidor como fixo"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcar servidores como não-fixos"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Apagar servidor"
+msgid "Mark server as non-static"
+msgstr "Marcar servidor como não-fixo"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Apagar servidores"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Apagar servidor"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6569,6 +6566,10 @@ msgstr "Deseja remover o servidor selecionado?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Deseja remover o servidores selecionados?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Servidor"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1359,17 +1359,17 @@ msgid "Very low"
 msgstr "Muito baixa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -2615,11 +2615,12 @@ msgstr "A Enviar"
 msgid "None"
 msgstr "Nenhum"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Não"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Sim"
 
@@ -6561,37 +6562,33 @@ msgstr "Tem a certeza que deseja eliminar o servidor estático %s"
 msgid "Servers (%i)"
 msgstr "Servidores (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Servidor"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Ligar ao servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marcar o servidor como estático"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Marcar o servidor como não estático"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcar os servidores como estáticos"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marcar o servidor como estático"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcar os servidores como não estáticos"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Remover o servidor"
+msgid "Mark server as non-static"
+msgstr "Marcar o servidor como não estático"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Remover os servidores"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Remover o servidor"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6616,6 +6613,10 @@ msgstr "Tem a certeza que deseja eliminar o servidor seleccionado?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Tem a certeza que deseja eliminar os servidores seleccionados?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Servidor"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:43+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1357,17 +1357,17 @@ msgid "Very low"
 msgstr "Foarte joasă"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Joasă"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Înaltă"
 
@@ -2613,11 +2613,12 @@ msgstr "Se încarcă"
 msgid "None"
 msgstr "Niciunul"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nu"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Da"
 
@@ -6572,37 +6573,33 @@ msgstr "Sigur doriți să ștergeți serverul static %s"
 msgid "Servers (%i)"
 msgstr "Servere (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Conectare la server"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Marcați serverul ca static"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Marcați serverul ca ne-static"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Marcați serverele ca statice"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Marcați serverul ca static"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Marcați serverele ca ne-statice"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Elimină server"
+msgid "Mark server as non-static"
+msgstr "Marcați serverul ca ne-static"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Elimină servere"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Elimină server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6627,6 +6624,10 @@ msgstr "Sigur doriți să ștergeți serverul selectat?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Sigur doriți să ștergeți serverele selectate?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:43+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1369,17 +1369,17 @@ msgid "Very low"
 msgstr "Очень низкий"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низкий"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Обычный"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Высокий"
 
@@ -2635,11 +2635,12 @@ msgstr "Отдаётся"
 msgid "None"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Нет"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Да"
 
@@ -6564,24 +6565,16 @@ msgstr "Уверены, что хотите удалить постоянный 
 msgid "Servers (%i)"
 msgstr "Серверы (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Сервер"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Подключиться к серверу"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as static"
+msgid "Mark servers as static"
 msgstr "Внести в список постоянных серверов"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Удалить из списка статических серверов"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark servers as static"
+msgid "Mark server as static"
 msgstr "Внести в список постоянных серверов"
 
 #: src/ServerListCtrl.cpp
@@ -6589,12 +6582,16 @@ msgid "Mark servers as non-static"
 msgstr "Удалить из списка статических серверов"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Удалить выбранный сервер"
+msgid "Mark server as non-static"
+msgstr "Удалить из списка статических серверов"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Удалить выбранные серверы"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Удалить выбранный сервер"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6619,6 +6616,10 @@ msgstr "Удалить выбранный сервер?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Удалить выбранные серверы?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Сервер"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:44+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1367,17 +1367,17 @@ msgid "Very low"
 msgstr "Zelo nizka"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nizka"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Običajna"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoka"
 
@@ -2628,11 +2628,12 @@ msgstr "Pošiljanje"
 msgid "None"
 msgstr "Brez"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ne"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Da"
 
@@ -6609,37 +6610,33 @@ msgstr "Ali res želite izbrisati statičen strežnik %s?"
 msgid "Servers (%i)"
 msgstr "Strežniki (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Strežnik"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Poveži se na strežnik"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Označi strežnik kot statičen"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Označi strežnik kot ne-statičen"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Označi strežnike kot statične"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Označi strežnik kot statičen"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Označi strežnike kot ne-statične"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Odstrani strežnik"
+msgid "Mark server as non-static"
+msgstr "Označi strežnik kot ne-statičen"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Odstrani strežnike"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Odstrani strežnik"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6664,6 +6661,10 @@ msgstr "Ali res želite izbrisati izbrani strežnik?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ali res želite izbrisati izbrane strežnike?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Strežnik"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:44+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1357,17 +1357,17 @@ msgid "Very low"
 msgstr "Shume ngadale"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ngadale"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "E larte"
 
@@ -2616,11 +2616,12 @@ msgstr "Ngarkim"
 msgid "None"
 msgstr "Asnjeri"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Jo"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Po"
 
@@ -6573,37 +6574,33 @@ msgstr "Jeni te sigurte qe doni te fshini kete server te qendrueshem %s"
 msgid "Servers (%i)"
 msgstr "Serverat (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Serveri"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Lidhu ne Server"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Shenoje Serverin si te qendrueshem"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Shenoje Serverin si te Jo-Qendrueshem"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Shenoji Serverat si te qendrueshem"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Shenoje Serverin si te qendrueshem"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Shenoji Serverat si te Jo-Qendrueshem"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Hiq Server"
+msgid "Mark server as non-static"
+msgstr "Shenoje Serverin si te Jo-Qendrueshem"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Hiq Serverat"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Hiq Server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6628,6 +6625,10 @@ msgstr "Jeni te sigurte qe deshironi te fshini te gjithe serverin e perzgjedhur?
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Jeni te sigurte qe deshironi te fshini serverat e zgjedhur?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Serveri"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:45+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1351,17 +1351,17 @@ msgid "Very low"
 msgstr "Mycket låg"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hög"
 
@@ -2607,11 +2607,12 @@ msgstr "Skickar"
 msgid "None"
 msgstr "Ingen"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Nej"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Ja"
 
@@ -6549,37 +6550,33 @@ msgstr "Är du säker på att du vill ta bort den statiska servern %s"
 msgid "Servers (%i)"
 msgstr "Servrar (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Server"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Anslut till server"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Markera servern som statisk"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Markera servern som icke-statisk"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Markera servrar som statiska"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Markera servern som statisk"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Markera servrar som icke-statiska"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Ta bort server"
+msgid "Mark server as non-static"
+msgstr "Markera servern som icke-statisk"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Ta bort servrar"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Ta bort server"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6604,6 +6601,10 @@ msgstr "Är du säker på att du vill ta bort vald server?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Är du säker på att du vill ta bort valda servrar?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Server"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1312,17 +1312,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
@@ -2525,11 +2525,12 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr ""
 
@@ -6369,20 +6370,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr ""
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6390,15 +6379,23 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
+msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6423,6 +6420,10 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
+msgstr ""
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
 msgstr ""
 
 #: src/ServerSocket.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1354,17 +1354,17 @@ msgid "Very low"
 msgstr "Çok düşük"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Düşük"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Yüksek"
 
@@ -2606,11 +2606,12 @@ msgstr "Gönderiliyor"
 msgid "None"
 msgstr "Yok"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Hayır"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Evet"
 
@@ -6513,37 +6514,33 @@ msgstr "Statik sunucu %s'i silmek istediğinizden emin misiniz"
 msgid "Servers (%i)"
 msgstr "Sunucular (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Sunucu"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "Sunucuya bağlan"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Sunucuyu statik olarak işaretle"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Sunucuyu statik olmayan olarak işaretle"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Sunucuları statik olarak işaretle"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Sunucuyu statik olarak işaretle"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Sunucuları statik olmayan olarak işaretle"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Sunucuyu kaldır"
+msgid "Mark server as non-static"
+msgstr "Sunucuyu statik olmayan olarak işaretle"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Sunucuları kaldır"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Sunucuyu kaldır"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6568,6 +6565,10 @@ msgstr "Seçili sunucuyu silmek istediğinizden emin misiniz?"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Seçili sunucuları silmek istediğinizden emin misiniz?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Sunucu"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:46+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1362,17 +1362,17 @@ msgid "Very low"
 msgstr "Дуже низька"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низька"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Звичайна"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Висока"
 
@@ -2628,11 +2628,12 @@ msgstr "Вивантаження"
 msgid "None"
 msgstr "Жоден"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "Ні"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "Так"
 
@@ -6614,37 +6615,33 @@ msgstr "Ви впевнені, що хочете видалити постійн
 msgid "Servers (%i)"
 msgstr "Сервери (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "Сервер"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "З'єднатися з сервером"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr "Позначити сервер як постійний"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "Позначити сервер як непостійний"
 
 #: src/ServerListCtrl.cpp
 msgid "Mark servers as static"
 msgstr "Позначити сервери як постійні"
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr "Позначити сервер як постійний"
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr "Позначити сервери як непостійні"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "Видалити сервер"
+msgid "Mark server as non-static"
+msgstr "Позначити сервер як непостійний"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
 msgstr "Видалити сервери"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
+msgstr "Видалити сервер"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
@@ -6669,6 +6666,10 @@ msgstr "Ви впевнені, що хочете видалити вибрани
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "Ви впевнені, що хочете видалити вибрані сервери?"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "Сервер"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1311,17 +1311,17 @@ msgid "Very low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr ""
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr ""
 
@@ -2524,11 +2524,12 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr ""
 
@@ -6368,20 +6369,8 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr ""
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as static"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6389,15 +6378,23 @@ msgid "Mark servers as static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
+msgid "Mark server as static"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
 msgid "Mark servers as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
+msgid "Mark server as non-static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -6422,6 +6419,10 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
+msgstr ""
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
 msgstr ""
 
 #: src/ServerSocket.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:47+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1355,17 +1355,17 @@ msgid "Very low"
 msgstr "极低"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
@@ -2617,11 +2617,12 @@ msgstr "正在上传"
 msgid "None"
 msgstr "没有"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "是"
 
@@ -6510,24 +6511,16 @@ msgstr "您确定要删除静态服务器 %s ?"
 msgid "Servers (%i)"
 msgstr "服务器（%i）"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "服务器"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "连接到服务器"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as static"
+msgid "Mark servers as static"
 msgstr "标记服务器为静态"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "标记服务器为非静态"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark servers as static"
+msgid "Mark server as static"
 msgstr "标记服务器为静态"
 
 #: src/ServerListCtrl.cpp
@@ -6535,11 +6528,15 @@ msgid "Mark servers as non-static"
 msgstr "标记服务器为非静态"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "删除服务器"
+msgid "Mark server as non-static"
+msgstr "标记服务器为非静态"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr "删除服务器"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "删除服务器"
 
 #: src/ServerListCtrl.cpp
@@ -6565,6 +6562,10 @@ msgstr "您确定要删除已选的服务器吗？"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "您确定要删除已选的服务器吗？"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "服务器"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-05 18:19+0200\n"
 "PO-Revision-Date: 2026-08-04 15:47+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1351,17 +1351,17 @@ msgid "Very low"
 msgstr "極低"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ServerListCtrl.cpp src/ServerListModel.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
@@ -2605,11 +2605,12 @@ msgstr "正在上傳"
 msgid "None"
 msgstr "無"
 
-#: src/GenericClientListCtrl.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/ServerListModel.cpp
 msgid "No"
 msgstr "否"
 
-#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp src/ServerListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PrefsUnifiedDlg.cpp
+#: src/ServerListModel.cpp
 msgid "Yes"
 msgstr "是"
 
@@ -6532,24 +6533,16 @@ msgstr "您確定要刪除靜態伺服器 %s"
 msgid "Servers (%i)"
 msgstr "伺服器 (%i)"
 
-#: src/ServerListCtrl.cpp src/ServerSocket.cpp src/ServerWnd.cpp
-msgid "Server"
-msgstr "伺服器"
-
 #: src/ServerListCtrl.cpp
 msgid "Connect to server"
 msgstr "連線到伺服器"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as static"
+msgid "Mark servers as static"
 msgstr "標記爲靜態伺服器"
 
 #: src/ServerListCtrl.cpp
-msgid "Mark server as non-static"
-msgstr "標記爲非靜態伺服器"
-
-#: src/ServerListCtrl.cpp
-msgid "Mark servers as static"
+msgid "Mark server as static"
 msgstr "標記爲靜態伺服器"
 
 #: src/ServerListCtrl.cpp
@@ -6557,11 +6550,15 @@ msgid "Mark servers as non-static"
 msgstr "標記爲非靜態伺服器"
 
 #: src/ServerListCtrl.cpp
-msgid "Remove server"
-msgstr "移除伺服器"
+msgid "Mark server as non-static"
+msgstr "標記爲非靜態伺服器"
 
 #: src/ServerListCtrl.cpp
 msgid "Remove servers"
+msgstr "移除伺服器"
+
+#: src/ServerListCtrl.cpp
+msgid "Remove server"
 msgstr "移除伺服器"
 
 #: src/ServerListCtrl.cpp
@@ -6587,6 +6584,10 @@ msgstr "您確定要刪除選取的伺服器嗎？"
 #: src/ServerListCtrl.cpp
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr "您確定要刪除選取的伺服器嗎？"
+
+#: src/ServerSocket.cpp src/ServerWnd.cpp
+msgid "Server"
+msgstr "伺服器"
 
 #: src/ServerSocket.cpp
 #, c-format

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -25,37 +25,46 @@
 
 #include "ServerListCtrl.h" // Interface declarations
 
-#include <algorithm> // Needed for std::max
+#include <algorithm> // Needed for std::find, std::max, std::sort
 #include <vector>    // Needed for std::vector
 
 #include <common/MenuIDs.h>
 
+#include <wx/dcclient.h> // Needed for wxClientDC
 #include <wx/menu.h>
-#include <wx/stattext.h>
 #include <wx/msgdlg.h>
+#include <wx/stattext.h>
 
 #include "amule.h"         // Needed for theApp
 #include "DownloadQueue.h" // Needed for CDownloadQueue
 #ifdef GEOIP_GUI
-#include "CountryFlags.h"   // Needed for CCountryFlags (flag bitmaps)
-#include "CountryDisplay.h" // Needed for GetDisplayCountryCode
+#include "CountryFlags.h" // Needed for CCountryFlags (flag bitmaps)
 #endif
-#include "ServerList.h"    // Needed for CServerList
-#include "ServerConnect.h" // Needed for CServerConnect
-#include "Server.h"        // Needed for CServer and SRV_PR_*
-#include "Logger.h"
-#include <common/Format.h> // Needed for CFormat
+#include "GetTickCount.h"    // Needed for GetTickCount64()
+#include "Server.h"          // Needed for CServer and SRV_PR_*
+#include "ServerConnect.h"   // Needed for CServerConnect
+#include "ServerList.h"      // Needed for CServerList
+#include "ServerListModel.h" // Needed for CServerListModel
+#include <common/Format.h>   // Needed for CFormat
 
-#include <wx/dcclient.h> // Needed for wxClientDC
-
-// One fixed size for everything in the control's small image list. Set by the
-// 16x16 header sort arrows; the bundled country flags are 16x11 and get padded
-// onto a transparent cell of this size (see FlagImage).
+// One fixed size for the country flags, padded onto a transparent cell of
+// this size (see FlagIcon).
 static const int LIST_IMAGE_SIZE = 16;
 
-wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleVirtualListCtrl)
-	EVT_LIST_ITEM_RIGHT_CLICK(-1, CServerListCtrl::OnItemRightClicked)
-	EVT_LIST_ITEM_ACTIVATED(-1, CServerListCtrl::OnItemActivated)
+// MLOrder-compatible bit value, reused from CMuleListCtrl so the persisted
+// "TableOrderingServer" config entries stay wire-compatible (see
+// ListColumnStore.cpp, which already hardcodes this same value).
+namespace
+{
+const unsigned SORT_DES = 0x1000;
+} // namespace
+
+wxBEGIN_EVENT_TABLE(CServerListCtrl, wxDataViewCtrl)
+	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CServerListCtrl::OnRightClick)
+	EVT_DATAVIEW_COLUMN_HEADER_CLICK(wxID_ANY, CServerListCtrl::OnColumnHeaderClick)
+	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CServerListCtrl::OnItemActivated)
+	EVT_IDLE(CServerListCtrl::OnIdle)
+	EVT_CHAR(CServerListCtrl::OnChar)
 
 	EVT_MENU(MP_PRIOLOW, CServerListCtrl::OnPriorityChange)
 	EVT_MENU(MP_PRIONORMAL, CServerListCtrl::OnPriorityChange)
@@ -70,63 +79,134 @@ wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleVirtualListCtrl)
 	EVT_MENU(MP_REMOVEALL, CServerListCtrl::OnRemoveServers)
 
 	EVT_MENU(MP_GETED2KLINK, CServerListCtrl::OnGetED2kURL)
-
-	EVT_CHAR(CServerListCtrl::OnKeyPressed)
 wxEND_EVENT_TABLE()
 
-CServerListCtrl::CServerListCtrl(wxWindow *parent,
-	wxWindowID winid,
-	const wxPoint &pos,
-	const wxSize &size,
-	long style,
-	const wxValidator &validator,
-	const wxString &name)
-: CMuleVirtualListCtrl(parent, winid, pos, size, style, validator, name)
-, m_images(LIST_IMAGE_SIZE, LIST_IMAGE_SIZE, true, 0)
+CServerListCtrl::CServerListCtrl(
+	wxWindow *parent, wxWindowID winid, const wxPoint &pos, const wxSize &size, const wxString &name)
+: wxDataViewCtrl(parent, winid, pos, size, wxDV_ROW_LINES | wxDV_MULTIPLE, wxDefaultValidator, name)
+, m_widthAdapter(this)
+, m_connected(nullptr)
 {
-	// Setting the sorter function.
-	SetSortFunc(SortProc);
+	// See CSearchListCtrl's ctor for why this is required for OnIdle to fire.
+	SetExtraStyle(GetExtraStyle() | wxWS_EX_PROCESS_IDLE);
 
-	// Set the table-name (for loading and saving preferences).
-	SetTableName("Server");
+	m_model = new CServerListModel(this);
+	AssociateModel(m_model);
+	m_model->DecRef(); // the control now holds the only reference
 
-	m_connected = 0;
+	AppendIconTextColumn(_("Server Name"),
+		CServerListModel::COL_NAME,
+		wxDATAVIEW_CELL_INERT,
+		150,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Address"),
+		CServerListModel::COL_ADDR,
+		wxDATAVIEW_CELL_INERT,
+		140,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Port"),
+		CServerListModel::COL_PORT,
+		wxDATAVIEW_CELL_INERT,
+		25,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Description"),
+		CServerListModel::COL_DESC,
+		wxDATAVIEW_CELL_INERT,
+		150,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Ping"),
+		CServerListModel::COL_PING,
+		wxDATAVIEW_CELL_INERT,
+		25,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Users"),
+		CServerListModel::COL_USERS,
+		wxDATAVIEW_CELL_INERT,
+		40,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Files"),
+		CServerListModel::COL_FILES,
+		wxDATAVIEW_CELL_INERT,
+		45,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Priority"),
+		CServerListModel::COL_PRIO,
+		wxDATAVIEW_CELL_INERT,
+		60,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Failed"),
+		CServerListModel::COL_FAILS,
+		wxDATAVIEW_CELL_INERT,
+		40,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Static"),
+		CServerListModel::COL_STATIC,
+		wxDATAVIEW_CELL_INERT,
+		40,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("Version"),
+		CServerListModel::COL_VERSION,
+		wxDATAVIEW_CELL_INERT,
+		80,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 
-	// Take over the small image list from the one every CMuleListCtrl shares:
-	// the country flags are added to it on demand and have no business showing
-	// up in the other lists' indices. The sort arrows have to come first, at
-	// the indices SetSorting() uses.
-	AddSortArrows(m_images);
-	SetImageList(&m_images, wxIMAGE_LIST_SMALL);
-
-	wxFont bold = GetFont();
-	bold.SetWeight(wxFONTWEIGHT_BOLD);
-	m_boldAttr.SetFont(bold);
-
-	InsertColumn(COLUMN_SERVER_NAME, _("Server Name"), wxLIST_FORMAT_LEFT, 150, "N");
-	InsertColumn(COLUMN_SERVER_ADDR, _("Address"), wxLIST_FORMAT_LEFT, 140, "A");
-	InsertColumn(COLUMN_SERVER_PORT, _("Port"), wxLIST_FORMAT_LEFT, 25, "P");
-	InsertColumn(COLUMN_SERVER_DESC, _("Description"), wxLIST_FORMAT_LEFT, 150, "D");
-	InsertColumn(COLUMN_SERVER_PING, _("Ping"), wxLIST_FORMAT_LEFT, 25, "p");
-	InsertColumn(COLUMN_SERVER_USERS, _("Users"), wxLIST_FORMAT_LEFT, 40, "U");
-	InsertColumn(COLUMN_SERVER_FILES, _("Files"), wxLIST_FORMAT_LEFT, 45, "F");
-	InsertColumn(COLUMN_SERVER_PRIO, _("Priority"), wxLIST_FORMAT_LEFT, 60, "r");
-	InsertColumn(COLUMN_SERVER_FAILS, _("Failed"), wxLIST_FORMAT_LEFT, 40, "f");
-	InsertColumn(COLUMN_SERVER_STATIC, _("Static"), wxLIST_FORMAT_LEFT, 40, "S");
-	InsertColumn(COLUMN_SERVER_VERSION, _("Version"), wxLIST_FORMAT_LEFT, 80, "V");
+	m_columnStore.RegisterColumn(CServerListModel::COL_NAME, 150, "N");
+	m_columnStore.RegisterColumn(CServerListModel::COL_ADDR, 140, "A");
+	m_columnStore.RegisterColumn(CServerListModel::COL_PORT, 25, "P");
+	m_columnStore.RegisterColumn(CServerListModel::COL_DESC, 150, "D");
+	m_columnStore.RegisterColumn(CServerListModel::COL_PING, 25, "p");
+	m_columnStore.RegisterColumn(CServerListModel::COL_USERS, 40, "U");
+	m_columnStore.RegisterColumn(CServerListModel::COL_FILES, 45, "F");
+	m_columnStore.RegisterColumn(CServerListModel::COL_PRIO, 60, "r");
+	m_columnStore.RegisterColumn(CServerListModel::COL_FAILS, 40, "f");
+	m_columnStore.RegisterColumn(CServerListModel::COL_STATIC, 40, "S");
+	m_columnStore.RegisterColumn(CServerListModel::COL_VERSION, 80, "V");
 
 #if !defined(CLIENT_GUI)
-	InsertColumn(COLUMN_SERVER_TCPFLAGS, _("TCP Flags"), wxLIST_FORMAT_LEFT, 80, "t");
-	InsertColumn(COLUMN_SERVER_UDPFLAGS, _("UDP Flags"), wxLIST_FORMAT_LEFT, 80, "u");
+	AppendTextColumn(_("TCP Flags"),
+		CServerListModel::COL_TCPFLAGS,
+		wxDATAVIEW_CELL_INERT,
+		80,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AppendTextColumn(_("UDP Flags"),
+		CServerListModel::COL_UDPFLAGS,
+		wxDATAVIEW_CELL_INERT,
+		80,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	m_columnStore.RegisterColumn(CServerListModel::COL_TCPFLAGS, 80, "t");
+	m_columnStore.RegisterColumn(CServerListModel::COL_UDPFLAGS, 80, "u");
 #if !defined(__DEBUG__)
-	// InsertColumn created the columns with their default 80 width, which is required to unhide
-	// them on the context menu. Now, for Release builds, we will hide them by default
-	SetColumnWidth(GetColumnIndex("t"), 0);
-	SetColumnWidth(GetColumnIndex("u"), 0);
+	// Created with their default 80 width above, which is required to unhide
+	// them on the context menu. Now, for Release builds, hide them by default.
+	GetColumn(CServerListModel::COL_TCPFLAGS)->SetHidden(true);
+	GetColumn(CServerListModel::COL_UDPFLAGS)->SetHidden(true);
 #endif
 #endif
 
-	LoadSettings();
+	// Default sort is by name, ascending.
+	m_sort_orders.emplace_back(CServerListModel::COL_NAME, 0);
+	GetColumn(CServerListModel::COL_NAME)->SetSortOrder(true);
+
+	m_columnStore.SetTableName("Server");
+	LoadColumnSettings();
+}
+
+CServerListCtrl::~CServerListCtrl()
+{
+	SaveColumnSettings();
 }
 
 wxString CServerListCtrl::GetOldColumnOrder() const
@@ -134,7 +214,33 @@ wxString CServerListCtrl::GetOldColumnOrder() const
 	return "N,A,P,D,p,U,F,r,f,S,V,t,u";
 }
 
-CServerListCtrl::~CServerListCtrl() {}
+void CServerListCtrl::LoadColumnSettings()
+{
+	if (!m_columnStore.HasTableName()) {
+		return;
+	}
+
+	CListColumnStore::CSortingList decoded;
+	m_columnStore.LoadSettings(m_widthAdapter, GetOldColumnOrder(), decoded);
+
+	// LoadSettings() returns the orders primary-LAST -- see
+	// CSearchListCtrl::LoadColumnSettings for the full explanation.
+	m_sort_orders.clear();
+	for (const CListColumnStore::CColPair &pair : decoded) {
+		ApplySorting(pair.first, pair.second);
+	}
+	if (m_sort_orders.empty()) {
+		ApplySorting(CServerListModel::COL_NAME, 0);
+	}
+}
+
+void CServerListCtrl::SaveColumnSettings()
+{
+	if (!m_columnStore.HasTableName()) {
+		return;
+	}
+	m_columnStore.SaveSettings(m_widthAdapter, m_sort_orders);
+}
 
 void CServerListCtrl::AddServer(CServer *toadd)
 {
@@ -147,34 +253,37 @@ void CServerListCtrl::AddServer(CServer *toadd)
 
 void CServerListCtrl::RemoveServer(CServer *server)
 {
-	const wxUIntPtr ptr = reinterpret_cast<wxUIntPtr>(server);
-	if (!HasItemData(ptr)) {
+	if (!m_model->HasServer(server)) {
 		return;
 	}
 	if (server == m_connected) {
 		m_connected = nullptr;
 	}
-	RemoveItemData(ptr);
+	m_model->RemoveServer(server);
 	ShowServerCount();
 }
 
-void CServerListCtrl::RemoveAllServers(int state)
+void CServerListCtrl::RemoveAllServers(bool selectedOnly)
 {
-	// Collect first, delete second: the rows are a view onto the model, so
-	// removing one renumbers every row below it -- and the confirmations below
-	// run a nested event loop, during which the list can be updated underneath
-	// a row index but never underneath a server pointer.
+	// Collect first, delete second: the confirmations below run a nested
+	// event loop, during which the list can be updated underneath a server
+	// pointer but the pointer itself stays a stable identity to check.
 	std::vector<CServer *> candidates;
-	for (long pos = GetNextItem(-1, wxLIST_NEXT_ALL, state); pos != -1;
-		pos = GetNextItem(pos, wxLIST_NEXT_ALL, state)) {
-		candidates.push_back(reinterpret_cast<CServer *>(ItemAt(pos)));
+	if (selectedOnly) {
+		wxDataViewItemArray selections;
+		GetSelections(selections);
+		for (const wxDataViewItem &item : selections) {
+			candidates.push_back(CServerListModel::ToServer(item));
+		}
+	} else {
+		candidates = m_model->GetServers();
 	}
 
 	const bool connected = theApp->IsConnectedED2K() || theApp->serverconnect->IsConnecting();
 
 	for (CServer *server : candidates) {
 		// May have gone away while a message box was up.
-		if (!HasItemData(reinterpret_cast<wxUIntPtr>(server))) {
+		if (!m_model->HasServer(server)) {
 			continue;
 		}
 
@@ -213,173 +322,38 @@ void CServerListCtrl::RemoveAllServers(int state)
 	ShowServerCount();
 }
 
+void CServerListCtrl::DeleteAllItems()
+{
+	m_connected = nullptr;
+	m_model->ClearAll();
+	ShowServerCount();
+}
+
 void CServerListCtrl::RefreshServer(CServer *server)
 {
 	// Can't really refresh a NULL server
 	if (!server) {
 		return;
 	}
-
-	const wxUIntPtr ptr = reinterpret_cast<wxUIntPtr>(server);
-	if (HasItemData(ptr)) {
-		// The cells are rendered from the server on demand, so a refresh is
-		// just a repaint -- plus, when sorted by a column whose value just
-		// changed, the re-sort the base class coalesces for us.
-		RefreshItemData(ptr);
-	} else {
-		// We are not sure that the server isn't in the list, so we can re-add
-		AddItemData(ptr);
-	}
+	m_model->RefreshServer(server);
 }
 
-wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, long column) const
+wxIcon CServerListCtrl::FlagIcon(const wxString &code) const
 {
-	const CServer *server = reinterpret_cast<const CServer *>(item);
-
-	switch (column) {
-	case COLUMN_SERVER_NAME:
-		// The host country is the flag icon on this column, not a text
-		// prefix -- see OnGetItemColumnImage().
-		return server->GetListName();
-
-	case COLUMN_SERVER_ADDR:
-		return server->GetAddress();
-
-	case COLUMN_SERVER_PORT:
-		if (server->GetAuxPortsList().IsEmpty()) {
-			return CFormat("%u") % server->GetPort();
-		}
-		return CFormat("%u (%s)") % server->GetPort() % server->GetAuxPortsList();
-
-	case COLUMN_SERVER_DESC:
-		return server->GetDescription();
-
-	case COLUMN_SERVER_PING:
-		if (!server->GetPing()) {
-			return wxEmptyString;
-		}
-		return CastSecondsToHM(server->GetPing() / 1000, server->GetPing() % 1000);
-
-	case COLUMN_SERVER_USERS:
-		if (!server->GetUsers()) {
-			return wxEmptyString;
-		}
-		return CFormat("%u") % server->GetUsers();
-
-	case COLUMN_SERVER_FILES:
-		if (!server->GetFiles()) {
-			return wxEmptyString;
-		}
-		return CFormat("%u") % server->GetFiles();
-
-	case COLUMN_SERVER_PRIO:
-		switch (server->GetPreferences()) {
-		case SRV_PR_LOW:
-			return _("Low");
-		case SRV_PR_NORMAL:
-			return _("Normal");
-		case SRV_PR_HIGH:
-			return _("High");
-		default:
-			return "---"; // this should never happen
-		}
-
-	case COLUMN_SERVER_FAILS:
-		return CFormat("%u") % server->GetFailedCount();
-
-	case COLUMN_SERVER_STATIC:
-		return server->IsStaticMember() ? _("Yes") : _("No");
-
-	case COLUMN_SERVER_VERSION:
-		return server->GetVersion();
-
-#if !defined(CLIENT_GUI)
-	case COLUMN_SERVER_TCPFLAGS: {
-		wxString flags;
-		if (server->GetTCPFlags() & SRV_TCPFLG_COMPRESSION) {
-			flags += "c";
-		}
-		if (server->GetTCPFlags() & SRV_TCPFLG_NEWTAGS) {
-			flags += "n";
-		}
-		if (server->GetTCPFlags() & SRV_TCPFLG_UNICODE) {
-			flags += "u";
-		}
-		if (server->GetTCPFlags() & SRV_TCPFLG_RELATEDSEARCH) {
-			flags += "r";
-		}
-		if (server->GetTCPFlags() & SRV_TCPFLG_TYPETAGINTEGER) {
-			flags += "t";
-		}
-		if (server->GetTCPFlags() & SRV_TCPFLG_LARGEFILES) {
-			flags += "l";
-		}
-		if (server->GetTCPFlags() & SRV_TCPFLG_TCPOBFUSCATION) {
-			flags += "o";
-		}
-		return flags;
-	}
-
-	case COLUMN_SERVER_UDPFLAGS: {
-		wxString flags;
-		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES) {
-			flags += "g";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETFILES) {
-			flags += "f";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_NEWTAGS) {
-			flags += "n";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_UNICODE) {
-			flags += "u";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES2) {
-			flags += "G";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_LARGEFILES) {
-			flags += "l";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_UDPOBFUSCATION) {
-			flags += "o";
-		}
-		if (server->GetUDPFlags() & SRV_UDPFLG_TCPOBFUSCATION) {
-			flags += "O";
-		}
-		return flags;
-	}
-#endif
-
-	default:
-		return wxEmptyString;
-	}
-}
-
-// Gated with its only caller (OnGetItemColumnImage below): this reaches
-// theApp->GetCountryFlags(), which only exists under GEOIP_GUI, so compiling it
-// unconditionally broke the monolithic build at -DENABLE_IP2COUNTRY=NO.
-//
-// Only the definition is gated, not the declaration: GEOIP_GUI is #defined in
-// amule.h, which this file includes but ServerListCtrl.h does not -- so the
-// header cannot see the macro and gating it there would compile the
-// declaration out from under this definition. A member function that is
-// declared, never called and never defined is fine.
-#ifdef GEOIP_GUI
-int CServerListCtrl::FlagImage(const wxString &code) const
-{
-	const auto it = m_flagImages.find(code);
-	if (it != m_flagImages.end()) {
+	const auto it = m_flagIcons.find(code);
+	if (it != m_flagIcons.end()) {
 		return it->second;
 	}
 
+#ifdef GEOIP_GUI
 	const wxImage &flag = theApp->GetCountryFlags()->GetFlag(code);
 	if (!flag.IsOk()) {
-		m_flagImages[code] = -1;
-		return -1;
+		m_flagIcons[code] = wxIcon();
+		return wxIcon();
 	}
 
-	// Centre the 16x11 flag on the image list's square cell. Adding it at its
-	// own size instead would leave wxImageList to stretch it to the cell.
+	// Centre the 16x11 flag on a square cell. Adding it at its own size
+	// instead would leave it non-uniform against the other rows' icons.
 	wxImage cell = flag;
 	if (!cell.HasAlpha()) {
 		// Size() only pads with transparent pixels when there is an alpha
@@ -389,57 +363,21 @@ int CServerListCtrl::FlagImage(const wxString &code) const
 	cell = cell.Size(wxSize(LIST_IMAGE_SIZE, LIST_IMAGE_SIZE),
 		wxPoint((LIST_IMAGE_SIZE - cell.GetWidth()) / 2, (LIST_IMAGE_SIZE - cell.GetHeight()) / 2));
 
-	const int index = m_images.Add(wxBitmap(cell));
-	m_flagImages[code] = index;
-	return index;
-}
-#endif // GEOIP_GUI
-
-int CServerListCtrl::OnGetItemColumnImage(long item, long column) const
-{
-	if (column != COLUMN_SERVER_NAME) {
-		return -1;
-	}
-#ifdef GEOIP_GUI
-	// Host country as a flag icon, matching the peer list: no icon at all for
-	// an unresolved server, rather than the "? - " prefix this used to show.
-	const CServer *server = reinterpret_cast<const CServer *>(ItemAt(item));
-	wxString code;
-	if (GetDisplayCountryCode(
-		    server->IsCountryFromCore(), server->GetCountryCode(), server->GetIP(), code) &&
-		!code.IsEmpty()) {
-		return FlagImage(code);
-	}
+	wxIcon icon;
+	icon.CopyFromBitmap(wxBitmap(cell));
+	m_flagIcons[code] = icon;
+	return icon;
 #else
-	wxUnusedVar(item);
+	m_flagIcons[code] = wxIcon();
+	return wxIcon();
 #endif // GEOIP_GUI
-	return -1;
-}
-
-wxListItemAttr *CServerListCtrl::OnGetItemAttr(long item) const
-{
-	if (m_connected && reinterpret_cast<const CServer *>(ItemAt(item)) == m_connected) {
-		return &m_boldAttr;
-	}
-	return nullptr;
-}
-
-bool CServerListCtrl::IsLiveSortColumn() const
-{
-	switch (static_cast<int>(GetSortColumn())) {
-	case COLUMN_SERVER_PING:
-	case COLUMN_SERVER_USERS:
-	case COLUMN_SERVER_FILES:
-		return true;
-	default:
-		return false;
-	}
 }
 
 void CServerListCtrl::HighlightServer(const CServer *server, bool highlight)
 {
-	// The bold font is handed out by OnGetItemAttr(), so all this has to do is
-	// move m_connected and repaint the rows either side of the change.
+	// The bold attribute is handed out by CServerListModel::GetAttr(), so
+	// all this has to do is move m_connected and repaint the rows either
+	// side of the change.
 	const CServer *previous = m_connected;
 
 	if (highlight) {
@@ -451,11 +389,11 @@ void CServerListCtrl::HighlightServer(const CServer *server, bool highlight)
 	if (previous == m_connected) {
 		return;
 	}
-	if (previous) {
-		RefreshItemData(reinterpret_cast<wxUIntPtr>(previous));
+	if (previous && m_model->HasServer(const_cast<CServer *>(previous))) {
+		m_model->RefreshServer(const_cast<CServer *>(previous));
 	}
-	if (m_connected) {
-		RefreshItemData(reinterpret_cast<wxUIntPtr>(m_connected));
+	if (m_connected && m_model->HasServer(const_cast<CServer *>(m_connected))) {
+		m_model->RefreshServer(const_cast<CServer *>(m_connected));
 	}
 }
 
@@ -464,7 +402,7 @@ void CServerListCtrl::ShowServerCount()
 	wxStaticText *label = CastByName("serverListLabel", GetParent(), wxStaticText);
 
 	if (label) {
-		label->SetLabel(CFormat(_("Servers (%i)")) % GetItemCount());
+		label->SetLabel(CFormat(_("Servers (%i)")) % m_model->GetCount());
 		label->GetParent()->Layout();
 	}
 }
@@ -475,319 +413,133 @@ void CServerListCtrl::FitColumnsToContent()
 	// long (full forum URLs etc.), so cap it rather than let one row blow
 	// the column out. The other columns hold short, bounded values.
 	const int descMaxWidth = 300;
-
-	// wxLIST_AUTOSIZE is a no-op on a virtual control -- it has no native items
-	// to measure and just hands back a default width -- so the content side is
-	// measured here against the model. wxLIST_AUTOSIZE_USEHEADER measures the
-	// header text and works either way, so that half is left to it.
-	//
-	// The two constants and the arithmetic below reproduce what the non-virtual
-	// wxLIST_AUTOSIZE did, so column widths come out where they used to: the
-	// margin is the starting floor and is added once to the finished column
-	// (NOT per cell), and a cell carrying an image counts the image plus the
-	// narrower in-row image margin. Both live in listctrl.cpp as file-statics,
-	// hence the copies.
-	const int autosizeMargin = 10; // AUTOSIZE_COL_MARGIN
-	const int imageMargin = 5;     // IMAGE_MARGIN_IN_REPORT_MODE
+	const int autosizeMargin = 10;
+	const int imageMargin = 5;
 
 	wxClientDC dc(this);
 	dc.SetFont(GetFont());
 
-	const long rows = ItemDataCount();
+	// m_model->GetServers() is measured directly rather than waiting for a
+	// pending Cleared() to flush: the vector itself is mutated eagerly by
+	// AddServer/RemoveServer/RefreshServer, only the control's own
+	// notification is idle-deferred, so this is already up to date even
+	// right after a Freeze()/bulk-AddServer()/Thaw() reload.
+	const std::vector<CServer *> &servers = m_model->GetServers();
 
 	Freeze();
 	for (int col = 0; col < GetColumnCount(); ++col) {
-		// Leave hidden columns (width 0, e.g. the TCP/UDP flag columns or
-		// ones the user hid via the header menu) hidden.
-		if (GetColumnWidth(col) == 0) {
+		wxDataViewColumn *column = GetColumn(col);
+		if (column->IsHidden()) {
 			continue;
 		}
 
 		int contentWidth = autosizeMargin;
-		for (long row = 0; row < rows; ++row) {
-			wxCoord textWidth = 0;
-			dc.GetTextExtent(GetItemColumnText(ItemAt(row), col), &textWidth, nullptr);
-			int cellWidth = textWidth;
-			if (OnGetItemColumnImage(row, col) != -1) {
-				cellWidth += LIST_IMAGE_SIZE + imageMargin;
+		for (CServer *server : servers) {
+			wxVariant value;
+			m_model->GetValue(value, CServerListModel::ToItem(server), col);
+
+			wxString text;
+			int extraWidth = 0;
+			if (col == CServerListModel::COL_NAME) {
+				wxDataViewIconText iconText;
+				iconText << value;
+				text = iconText.GetText();
+				if (iconText.GetIcon().IsOk()) {
+					extraWidth = LIST_IMAGE_SIZE + imageMargin;
+				}
+			} else {
+				text = value.GetString();
 			}
+
+			wxCoord textWidth = 0;
+			dc.GetTextExtent(text, &textWidth, nullptr);
+			int cellWidth = textWidth + extraWidth;
 			if (cellWidth > contentWidth) {
 				contentWidth = cellWidth;
 			}
 		}
 		contentWidth += autosizeMargin;
 
-		SetColumnWidth(col, wxLIST_AUTOSIZE_USEHEADER);
-		const int headerWidth = GetColumnWidth(col);
+		wxCoord headerTextWidth = 0;
+		dc.GetTextExtent(column->GetTitle(), &headerTextWidth, nullptr);
+		const int headerWidth = headerTextWidth + 2 * autosizeMargin; // padding + sort-arrow room
 
 		int width = std::max(contentWidth, headerWidth);
-		if (col == COLUMN_SERVER_DESC && width > descMaxWidth) {
+		if (col == CServerListModel::COL_DESC && width > descMaxWidth) {
 			width = descMaxWidth;
 		}
-		SetColumnWidth(col, width);
+		column->SetWidth(width);
 	}
 	Thaw();
 }
 
-void CServerListCtrl::OnItemActivated(wxListEvent &event)
+void CServerListCtrl::OnIdle(wxIdleEvent &event)
 {
-	// Unselect all items but the activated one
-	long item = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	while (item > -1) {
-		SetItemState(item, 0, wxLIST_STATE_SELECTED);
+	event.Skip();
 
-		item = GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	}
+	// One coalesced rebuild per idle -- see CSearchListCtrl::OnIdle for the
+	// full rationale. There is no expand state to preserve here (flat list),
+	// only selection.
+	if (m_model->HasPending()) {
+		wxDataViewItemArray selected;
+		GetSelections(selected);
 
-	SetItemState(event.GetIndex(), wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+		m_model->FlushPending();
 
-	wxCommandEvent nulEvt;
-	OnConnectToServer(nulEvt);
-}
-
-void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
-{
-	// Check if clicked item is selected. If not, unselect all and select it.
-	long index = CheckSelection(event);
-
-	bool enable_reconnect = false;
-	bool enable_static_on = false;
-	bool enable_static_off = false;
-
-	// Gather information on the selected items
-	while (index > -1) {
-		CServer *server = reinterpret_cast<CServer *>(ItemAt(index));
-
-		// The current server is selected, so we might display the reconnect option
-		if (server == m_connected) {
-			enable_reconnect = true;
-		}
-
-		// We want to know which options should be enabled, either one or both
-		enable_static_on |= !server->IsStaticMember();
-		enable_static_off |= server->IsStaticMember();
-
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	}
-
-	wxMenu *serverMenu = new wxMenu(_("Server"));
-	wxMenu *serverPrioMenu = new wxMenu();
-	serverPrioMenu->Append(MP_PRIOLOW, _("Low"));
-	serverPrioMenu->Append(MP_PRIONORMAL, _("Normal"));
-	serverPrioMenu->Append(MP_PRIOHIGH, _("High"));
-	serverMenu->Append(MP_CONNECTTO, _("Connect to server"));
-	serverMenu->Append(12345, _("Priority"), serverPrioMenu);
-
-	serverMenu->AppendSeparator();
-
-	if (GetSelectedItemCount() == 1) {
-		serverMenu->Append(MP_ADDTOSTATIC, _("Mark server as static"));
-		serverMenu->Append(MP_REMOVEFROMSTATIC, _("Mark server as non-static"));
-	} else {
-		serverMenu->Append(MP_ADDTOSTATIC, _("Mark servers as static"));
-		serverMenu->Append(MP_REMOVEFROMSTATIC, _("Mark servers as non-static"));
-	}
-
-	serverMenu->AppendSeparator();
-
-	if (GetSelectedItemCount() == 1) {
-		serverMenu->Append(MP_REMOVE, _("Remove server"));
-	} else {
-		serverMenu->Append(MP_REMOVE, _("Remove servers"));
-	}
-	serverMenu->Append(MP_REMOVEALL, _("Remove all servers"));
-
-	serverMenu->AppendSeparator();
-
-	if (GetSelectedItemCount() == 1) {
-		serverMenu->Append(MP_GETED2KLINK, _("Copy eD2k link to clipboard"));
-	} else {
-		serverMenu->Append(MP_GETED2KLINK, _("Copy eD2k links to clipboard"));
-	}
-
-	serverMenu->Enable(MP_REMOVEFROMSTATIC, enable_static_off);
-	serverMenu->Enable(MP_ADDTOSTATIC, enable_static_on);
-
-	if (GetSelectedItemCount() == 1) {
-		if (enable_reconnect)
-			serverMenu->SetLabel(MP_CONNECTTO, _("Reconnect to server"));
-	} else {
-		serverMenu->Enable(MP_CONNECTTO, false);
-	}
-
-	PopupMenu(serverMenu, event.GetPoint());
-	delete serverMenu;
-}
-
-void CServerListCtrl::OnPriorityChange(wxCommandEvent &event)
-{
-	uint32 priority = 0;
-
-	switch (event.GetId()) {
-	case MP_PRIOLOW:
-		priority = SRV_PR_LOW;
-		break;
-	case MP_PRIONORMAL:
-		priority = SRV_PR_NORMAL;
-		break;
-	case MP_PRIOHIGH:
-		priority = SRV_PR_HIGH;
-		break;
-
-	default:
-		return;
-	}
-
-	ItemDataList items = GetSelectedItems();
-
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		CServer *server = reinterpret_cast<CServer *>(items[i]);
-		theApp->serverlist->SetServerPrio(server, priority);
-	}
-}
-
-void CServerListCtrl::OnStaticChange(wxCommandEvent &event)
-{
-	bool isStatic = (event.GetId() == MP_ADDTOSTATIC);
-
-	ItemDataList items = GetSelectedItems();
-
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		CServer *server = reinterpret_cast<CServer *>(items[i]);
-
-		// Only update items that have the wrong setting
-		if (server->IsStaticMember() != isStatic) {
-			theApp->serverlist->SetStaticServer(server, isStatic);
-		}
-	}
-}
-
-void CServerListCtrl::OnConnectToServer(wxCommandEvent &WXUNUSED(event))
-{
-	int item = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	if (item > -1) {
-		if (theApp->IsConnectedED2K()) {
-			theApp->serverconnect->Disconnect();
-		}
-
-		theApp->serverconnect->ConnectToServer(reinterpret_cast<CServer *>(ItemAt(item)));
-	}
-}
-
-void CServerListCtrl::OnGetED2kURL(wxCommandEvent &WXUNUSED(event))
-{
-	int pos = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	wxString URL;
-
-	while (pos != -1) {
-		CServer *server = reinterpret_cast<CServer *>(ItemAt(pos));
-
-		URL += CFormat("ed2k://|server|%s|%d|/\n") % server->GetFullIP() % server->GetPort();
-
-		pos = GetNextItem(pos, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	}
-
-	URL.RemoveLast();
-
-	theApp->CopyTextToClipboard(URL);
-}
-
-void CServerListCtrl::OnRemoveServers(wxCommandEvent &event)
-{
-	if (event.GetId() == MP_REMOVEALL) {
-		if (GetItemCount()) {
-			wxString question = _("Are you sure that you wish to delete all servers?");
-
-			if (wxMessageBox(
-				    question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) ==
-				wxYES) {
-				if (theApp->serverconnect->IsConnecting()) {
-					theApp->downloadqueue->StopUDPRequests();
-					theApp->serverconnect->StopConnectionTry();
-					theApp->serverconnect->Disconnect();
-				}
-
-				RemoveAllServers(wxLIST_STATE_DONTCARE);
+		wxDataViewItemArray live;
+		m_model->GetChildren(wxDataViewItem(), live);
+		wxDataViewItemArray restore;
+		for (size_t i = 0; i < selected.GetCount(); ++i) {
+			if (live.Index(selected[i]) != wxNOT_FOUND) {
+				restore.Add(selected[i]);
 			}
 		}
-	} else if (event.GetId() == MP_REMOVE) {
-		if (GetSelectedItemCount()) {
-			wxString question;
-			if (GetSelectedItemCount() == 1) {
-				question = _("Are you sure that you wish to delete the selected server?");
-			} else {
-				question = _("Are you sure that you wish to delete the selected servers?");
-			}
-
-			if (wxMessageBox(
-				    question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) ==
-				wxYES) {
-				RemoveAllServers(wxLIST_STATE_SELECTED);
-			}
+		if (!restore.IsEmpty()) {
+			SetSelections(restore);
 		}
 	}
 }
 
-void CServerListCtrl::OnKeyPressed(wxKeyEvent &event)
+int CServerListCtrl::CompareByColumn(
+	const CServer *s1, const CServer *s2, unsigned column, int modifier) const
 {
-	// Check if delete was pressed
-	if ((event.GetKeyCode() == WXK_DELETE) || (event.GetKeyCode() == WXK_NUMPAD_DELETE)) {
-		wxCommandEvent evt;
-		evt.SetId(MP_REMOVE);
-		OnRemoveServers(evt);
-	} else {
-		event.Skip();
-	}
-}
+	switch (column) {
+	case CServerListModel::COL_NAME:
+		return modifier * s1->GetListName().CmpNoCase(s2->GetListName());
 
-int CServerListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
-{
-	CServer *server1 = reinterpret_cast<CServer *>(item1);
-	CServer *server2 = reinterpret_cast<CServer *>(item2);
-
-	int mode = (sortData & CMuleListCtrl::SORT_DES) ? -1 : 1;
-
-	switch (sortData & CMuleListCtrl::COLUMN_MASK) {
-	// Sort by server-name
-	case COLUMN_SERVER_NAME:
-		return mode * server1->GetListName().CmpNoCase(server2->GetListName());
-
-	// Sort by address
-	case COLUMN_SERVER_ADDR: {
-		if (server1->HasDynIP() && server2->HasDynIP()) {
-			return mode * server1->GetDynIP().CmpNoCase(server2->GetDynIP());
-		} else if (server1->HasDynIP()) {
-			return mode * -1;
-		} else if (server2->HasDynIP()) {
-			return mode * 1;
+	case CServerListModel::COL_ADDR: {
+		if (s1->HasDynIP() && s2->HasDynIP()) {
+			return modifier * s1->GetDynIP().CmpNoCase(s2->GetDynIP());
+		} else if (s1->HasDynIP()) {
+			return modifier * -1;
+		} else if (s2->HasDynIP()) {
+			return modifier * 1;
 		} else {
-			uint32 a = wxUINT32_SWAP_ALWAYS(server1->GetIP());
-			uint32 b = wxUINT32_SWAP_ALWAYS(server2->GetIP());
-			return mode * CmpAny(a, b);
+			uint32 a = wxUINT32_SWAP_ALWAYS(s1->GetIP());
+			uint32 b = wxUINT32_SWAP_ALWAYS(s2->GetIP());
+			return modifier * CmpAny(a, b);
 		}
 	}
-	// Sort by port
-	case COLUMN_SERVER_PORT:
-		return mode * CmpAny(server1->GetPort(), server2->GetPort());
-	// Sort by description
-	case COLUMN_SERVER_DESC:
-		return mode * server1->GetDescription().CmpNoCase(server2->GetDescription());
-	// Sort by Ping
+
+	case CServerListModel::COL_PORT:
+		return modifier * CmpAny(s1->GetPort(), s2->GetPort());
+
+	case CServerListModel::COL_DESC:
+		return modifier * s1->GetDescription().CmpNoCase(s2->GetDescription());
+
 	// The -1 ensures that a value of zero (no ping known) is sorted last.
-	case COLUMN_SERVER_PING:
-		return mode * CmpAny(server1->GetPing() - 1, server2->GetPing() - 1);
-	// Sort by user-count
-	case COLUMN_SERVER_USERS:
-		return mode * CmpAny(server1->GetUsers(), server2->GetUsers());
-	// Sort by file-count
-	case COLUMN_SERVER_FILES:
-		return mode * CmpAny(server1->GetFiles(), server2->GetFiles());
-	// Sort by priority
-	case COLUMN_SERVER_PRIO: {
-		uint32 srv_pr1 = server1->GetPreferences();
-		uint32 srv_pr2 = server2->GetPreferences();
+	case CServerListModel::COL_PING:
+		return modifier * CmpAny(s1->GetPing() - 1, s2->GetPing() - 1);
+
+	case CServerListModel::COL_USERS:
+		return modifier * CmpAny(s1->GetUsers(), s2->GetUsers());
+
+	case CServerListModel::COL_FILES:
+		return modifier * CmpAny(s1->GetFiles(), s2->GetFiles());
+
+	case CServerListModel::COL_PRIO: {
+		uint32 srv_pr1 = s1->GetPreferences();
+		uint32 srv_pr2 = s2->GetPreferences();
 		switch (srv_pr1) {
 		case SRV_PR_HIGH:
 			srv_pr1 = SRV_PR_MAX;
@@ -814,21 +566,348 @@ int CServerListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortDat
 		default:
 			return 0;
 		}
-		return mode * CmpAny(srv_pr1, srv_pr2);
+		return modifier * CmpAny(srv_pr1, srv_pr2);
 	}
-	// Sort by failure-count
-	case COLUMN_SERVER_FAILS:
-		return mode * CmpAny(server1->GetFailedCount(), server2->GetFailedCount());
-	// Sort by static servers
-	case COLUMN_SERVER_STATIC: {
-		return mode * CmpAny(server2->IsStaticMember(), server1->IsStaticMember());
-	}
-	// Sort by version
-	case COLUMN_SERVER_VERSION:
-		return mode * FuzzyStrCmp(server1->GetVersion(), server2->GetVersion());
+
+	case CServerListModel::COL_FAILS:
+		return modifier * CmpAny(s1->GetFailedCount(), s2->GetFailedCount());
+
+	case CServerListModel::COL_STATIC:
+		return modifier * CmpAny(s2->IsStaticMember(), s1->IsStaticMember());
+
+	case CServerListModel::COL_VERSION:
+		return modifier * FuzzyStrCmp(s1->GetVersion(), s2->GetVersion());
 
 	default:
 		return 0;
+	}
+}
+
+int CServerListCtrl::CompareServers(const CServer *s1, const CServer *s2) const
+{
+	for (const CColPair &entry : m_sort_orders) {
+		const unsigned column = entry.first;
+		const unsigned order = entry.second;
+		const int modifier = (order & SORT_DES) ? -1 : 1;
+
+		int result = CompareByColumn(s1, s2, column, modifier);
+		if (result != 0) {
+			return result;
+		}
+	}
+	return 0;
+}
+
+void CServerListCtrl::ApplySorting(unsigned column, unsigned order)
+{
+	CSortingList::iterator it = m_sort_orders.begin();
+	for (; it != m_sort_orders.end(); ++it) {
+		if (it->first == column) {
+			m_sort_orders.erase(it);
+			break;
+		}
+	}
+	m_sort_orders.emplace_front(column, order);
+
+	// Unmark the previous sort column (only one wxDataViewColumn can be the
+	// active sort key at a time; SetSortOrder() below moves the mark).
+	for (int i = 0; i < GetColumnCount(); ++i) {
+		if ((unsigned)i != column && GetColumn(i)->IsSortKey()) {
+			GetColumn(i)->UnsetAsSortKey();
+		}
+	}
+	GetColumn(column)->SetSortOrder(!(order & SORT_DES));
+	GetModel()->Resort();
+}
+
+void CServerListCtrl::OnColumnHeaderClick(wxDataViewEvent &event)
+{
+	wxDataViewColumn *col = event.GetDataViewColumn();
+	if (!col) {
+		event.Skip();
+		return;
+	}
+	const unsigned column = static_cast<unsigned>(col->GetModelColumn());
+
+	// Same column clicked again flips ascending<->descending; there is no
+	// alt-criterion cycle for any Servers column (AltSortAllowed() is always
+	// false here), so a third click just restarts ascending.
+	unsigned sort_order = 0;
+	if (!m_sort_orders.empty() && m_sort_orders.front().first == column) {
+		sort_order = m_sort_orders.front().second;
+		sort_order = (sort_order & SORT_DES) ? 0 : SORT_DES;
+	} else {
+		for (CSortingList::const_iterator it = m_sort_orders.begin(); it != m_sort_orders.end();
+			++it) {
+			if (it->first == column) {
+				sort_order = it->second;
+				break;
+			}
+		}
+	}
+
+	ApplySorting(column, sort_order);
+}
+
+void CServerListCtrl::OnRightClick(wxDataViewEvent &event)
+{
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+	if (selections.empty()) {
+		event.Skip();
+		return;
+	}
+
+	bool enable_reconnect = false;
+	bool enable_static_on = false;
+	bool enable_static_off = false;
+
+	for (const wxDataViewItem &item : selections) {
+		CServer *server = CServerListModel::ToServer(item);
+		if (server == m_connected) {
+			enable_reconnect = true;
+		}
+		enable_static_on |= !server->IsStaticMember();
+		enable_static_off |= server->IsStaticMember();
+	}
+
+	// No title -- see CSearchListCtrl::OnRightClick's identical rationale
+	// (wxMenu's title parameter renders inconsistently across platforms).
+	wxMenu serverMenu;
+	wxMenu *serverPrioMenu = new wxMenu();
+	serverPrioMenu->Append(MP_PRIOLOW, _("Low"));
+	serverPrioMenu->Append(MP_PRIONORMAL, _("Normal"));
+	serverPrioMenu->Append(MP_PRIOHIGH, _("High"));
+	serverMenu.Append(MP_CONNECTTO, _("Connect to server"));
+	serverMenu.Append(12345, _("Priority"), serverPrioMenu);
+
+	serverMenu.AppendSeparator();
+
+	const bool multi = (selections.size() != 1);
+	serverMenu.Append(MP_ADDTOSTATIC, multi ? _("Mark servers as static") : _("Mark server as static"));
+	serverMenu.Append(MP_REMOVEFROMSTATIC,
+		multi ? _("Mark servers as non-static") : _("Mark server as non-static"));
+
+	serverMenu.AppendSeparator();
+
+	serverMenu.Append(MP_REMOVE, multi ? _("Remove servers") : _("Remove server"));
+	serverMenu.Append(MP_REMOVEALL, _("Remove all servers"));
+
+	serverMenu.AppendSeparator();
+
+	serverMenu.Append(
+		MP_GETED2KLINK, multi ? _("Copy eD2k links to clipboard") : _("Copy eD2k link to clipboard"));
+
+	serverMenu.Enable(MP_REMOVEFROMSTATIC, enable_static_off);
+	serverMenu.Enable(MP_ADDTOSTATIC, enable_static_on);
+
+	if (!multi) {
+		if (enable_reconnect) {
+			serverMenu.SetLabel(MP_CONNECTTO, _("Reconnect to server"));
+		}
+	} else {
+		serverMenu.Enable(MP_CONNECTTO, false);
+	}
+
+	PopupMenu(&serverMenu);
+}
+
+void CServerListCtrl::OnItemActivated(wxDataViewEvent &event)
+{
+	CServer *server = CServerListModel::ToServer(event.GetItem());
+	if (!server) {
+		return;
+	}
+
+	if (theApp->IsConnectedED2K()) {
+		theApp->serverconnect->Disconnect();
+	}
+	theApp->serverconnect->ConnectToServer(server);
+}
+
+void CServerListCtrl::OnPriorityChange(wxCommandEvent &event)
+{
+	uint32 priority = 0;
+
+	switch (event.GetId()) {
+	case MP_PRIOLOW:
+		priority = SRV_PR_LOW;
+		break;
+	case MP_PRIONORMAL:
+		priority = SRV_PR_NORMAL;
+		break;
+	case MP_PRIOHIGH:
+		priority = SRV_PR_HIGH;
+		break;
+
+	default:
+		return;
+	}
+
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+	for (const wxDataViewItem &item : selections) {
+		theApp->serverlist->SetServerPrio(CServerListModel::ToServer(item), priority);
+	}
+}
+
+void CServerListCtrl::OnStaticChange(wxCommandEvent &event)
+{
+	bool isStatic = (event.GetId() == MP_ADDTOSTATIC);
+
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+	for (const wxDataViewItem &item : selections) {
+		CServer *server = CServerListModel::ToServer(item);
+		// Only update items that have the wrong setting
+		if (server->IsStaticMember() != isStatic) {
+			theApp->serverlist->SetStaticServer(server, isStatic);
+		}
+	}
+}
+
+void CServerListCtrl::OnConnectToServer(wxCommandEvent &WXUNUSED(event))
+{
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+	if (selections.empty()) {
+		return;
+	}
+
+	if (theApp->IsConnectedED2K()) {
+		theApp->serverconnect->Disconnect();
+	}
+	theApp->serverconnect->ConnectToServer(CServerListModel::ToServer(selections[0]));
+}
+
+void CServerListCtrl::OnGetED2kURL(wxCommandEvent &WXUNUSED(event))
+{
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+	if (selections.empty()) {
+		return;
+	}
+
+	wxString URL;
+	for (const wxDataViewItem &item : selections) {
+		CServer *server = CServerListModel::ToServer(item);
+		URL += CFormat("ed2k://|server|%s|%d|/\n") % server->GetFullIP() % server->GetPort();
+	}
+	URL.RemoveLast();
+
+	theApp->CopyTextToClipboard(URL);
+}
+
+void CServerListCtrl::OnRemoveServers(wxCommandEvent &event)
+{
+	if (event.GetId() == MP_REMOVEALL) {
+		if (m_model->GetCount()) {
+			wxString question = _("Are you sure that you wish to delete all servers?");
+
+			if (wxMessageBox(
+				    question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) ==
+				wxYES) {
+				if (theApp->serverconnect->IsConnecting()) {
+					theApp->downloadqueue->StopUDPRequests();
+					theApp->serverconnect->StopConnectionTry();
+					theApp->serverconnect->Disconnect();
+				}
+
+				RemoveAllServers(false);
+			}
+		}
+	} else if (event.GetId() == MP_REMOVE) {
+		wxDataViewItemArray selections;
+		GetSelections(selections);
+		if (!selections.empty()) {
+			wxString question = (selections.size() == 1)
+						    ? wxString(_("Are you sure that you wish to delete the "
+								 "selected server?"))
+						    : wxString(_("Are you sure that you wish to delete the "
+								 "selected servers?"));
+
+			if (wxMessageBox(
+				    question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) ==
+				wxYES) {
+				RemoveAllServers(true);
+			}
+		}
+	}
+}
+
+namespace
+{
+//! How long a pause resets the accumulated type-ahead string, in ms.
+const uint64 kTypeAheadResetMs = 1500;
+} // namespace
+
+void CServerListCtrl::OnChar(wxKeyEvent &evt)
+{
+	if ((evt.GetKeyCode() == WXK_DELETE) || (evt.GetKeyCode() == WXK_NUMPAD_DELETE)) {
+		wxCommandEvent removeEvt;
+		removeEvt.SetId(MP_REMOVE);
+		OnRemoveServers(removeEvt);
+		return;
+	}
+
+	int key = evt.GetKeyCode();
+	if (key == 0) {
+		// GetUnicodeKey() returns wxChar -- a signed char in wx's UTF-8 build
+		// but wchar_t in the wide build, so an unsigned-char cast would
+		// truncate the wide case; the widening to int is deliberate.
+		// NOLINTNEXTLINE(bugprone-signed-char-misuse,bugprone-narrowing-conversions)
+		key = evt.GetUnicodeKey();
+	} else if (key >= WXK_START) {
+		evt.Skip();
+		return;
+	}
+
+	if (evt.AltDown() || evt.ControlDown() || evt.MetaDown()) {
+		const int plain = wxTolower(evt.GetKeyCode());
+		if (evt.CmdDown() && (evt.GetKeyCode() == 0x01 || plain == 'a')) {
+			SelectAll();
+			return;
+		}
+		evt.Skip();
+		return;
+	}
+
+	const uint64 now = GetTickCount64();
+	if (m_ttsTime + kTypeAheadResetMs < now) {
+		m_ttsText.Clear();
+	}
+	m_ttsTime = now;
+	m_ttsText.Append(wxTolower(static_cast<wxChar>(key)));
+
+	std::vector<CServer *> ordered = m_model->GetServers();
+	if (ordered.empty()) {
+		return;
+	}
+	std::sort(ordered.begin(), ordered.end(), [this](const CServer *s1, const CServer *s2) {
+		return CompareServers(s1, s2) < 0;
+	});
+
+	size_t start = 0;
+	const auto current = std::find(ordered.begin(), ordered.end(), m_ttsItem);
+	if (current != ordered.end()) {
+		start = static_cast<size_t>(std::distance(ordered.begin(), current));
+		if (m_ttsText.length() == 1) {
+			++start;
+		}
+	}
+
+	const size_t count = ordered.size();
+	for (size_t i = 0; i < count; ++i) {
+		CServer *server = ordered[(start + i) % count];
+		if (server->GetListName().Lower().StartsWith(m_ttsText)) {
+			const wxDataViewItem item = CServerListModel::ToItem(server);
+			m_ttsItem = server;
+			UnselectAll();
+			Select(item);
+			SetCurrentItem(item);
+			EnsureVisible(item);
+			return;
+		}
 	}
 }
 // File_checked_for_headers

--- a/src/ServerListCtrl.h
+++ b/src/ServerListCtrl.h
@@ -26,53 +26,40 @@
 #ifndef SERVERLISTCTRL_H
 #define SERVERLISTCTRL_H
 
-#include "MuleVirtualListCtrl.h" // Needed for CMuleVirtualListCtrl (and wxListItemAttr)
+#include <wx/dataview.h> // Needed for wxDataViewCtrl
 
+#include "ListColumnStore.h" // Needed for CListColumnStore, IColumnWidthProvider
+#include "Types.h"           // Needed for uint64
+
+#include <list>
 #include <map>
-
-#define COLUMN_SERVER_NAME 0
-#define COLUMN_SERVER_ADDR 1
-#define COLUMN_SERVER_PORT 2
-#define COLUMN_SERVER_DESC 3
-#define COLUMN_SERVER_PING 4
-#define COLUMN_SERVER_USERS 5
-#define COLUMN_SERVER_FILES 6
-#define COLUMN_SERVER_PRIO 7
-#define COLUMN_SERVER_FAILS 8
-#define COLUMN_SERVER_STATIC 9
-#define COLUMN_SERVER_VERSION 10
-#define COLUMN_SERVER_TCPFLAGS 11
-#define COLUMN_SERVER_UDPFLAGS 12
+#include <utility>
 
 class CServer;
-class CServerList;
-class wxListEvent;
-class wxCommandEvent;
+class CServerListModel;
 
 /**
  * The CServerListCtrl is used to display the list of servers which the user
- * can connect to and which we request sources from. It is a permanently sorted
- * list in that it always ensure that the items are sorted in the correct order.
+ * can connect to and which we request sources from. It is a permanently
+ * sorted list in that it always ensures that the items are sorted in the
+ * correct order.
  *
- * The rows are text-rendered from the model (GetItemColumnText), not
- * owner-drawn: the only graphic is the country flag in the Server Name column,
- * which a virtual list can supply through OnGetItemColumnImage.
+ * Backed by a wxDataViewCtrl (native control) rather than a wxListCtrl, for
+ * screen-reader accessibility (#180/#801). The list is flat -- every server
+ * is a top-level row, no grouping -- so CServerListModel is a plain
+ * pointer-keyed table rather than a tree, unlike CSearchListModel.
  */
-class CServerListCtrl : public CMuleVirtualListCtrl
+class CServerListCtrl : public wxDataViewCtrl
 {
 public:
 	/**
 	 * Constructor.
-	 *
-	 * @see CMuleListCtrl::CMuleListCtrl
 	 */
 	CServerListCtrl(wxWindow *parent,
 		wxWindowID winid = -1,
 		const wxPoint &pos = wxDefaultPosition,
 		const wxSize &size = wxDefaultSize,
-		long style = wxLC_ICON,
-		const wxValidator &validator = wxDefaultValidator,
-		const wxString &name = "mulelistctrl");
+		const wxString &name = "serverlistctrl");
 
 	/**
 	 * Destructor.
@@ -82,7 +69,7 @@ public:
 	/**
 	 * Adds a server to the list.
 	 *
-	 * @param A pointer to the new server.
+	 * @param toadd A pointer to the new server.
 	 *
 	 * Internally this function calls RefreshServer and ShowServerCount, with
 	 * the result that it is legal to add servers already in the list, though
@@ -96,23 +83,30 @@ public:
 	void RemoveServer(CServer *server);
 
 	/**
-	 * Removes all servers with the specified state.
+	 * Removes all servers, or only the currently selected ones.
 	 *
-	 * @param state All items with this state will be removed, default being all.
+	 * @param selectedOnly If true, only the selected servers are removed.
 	 */
-	void RemoveAllServers(int state = wxLIST_STATE_DONTCARE);
+	void RemoveAllServers(bool selectedOnly = false);
+
+	/**
+	 * Removes every row without the confirmation/static-server checks
+	 * RemoveAllServers() does -- used when the core's own list is reset out
+	 * from under this control (e.g. a full server.met reload).
+	 */
+	void DeleteAllItems();
 
 	/**
 	 * Updates the displayed information on a server.
 	 *
 	 * @param server The server to be updated.
 	 *
-	 * This function will not only update the displayed information, it will also
-	 * reposition the item should it be nescecarry to enforce the current sorting.
-	 * Also note that this function does not require that the server actually is
-	 * on the list already, since AddServer makes use of it, but this should
-	 * generally be avoided, since it will result in the server-count getting
-	 * skewed until the next AddServer call.
+	 * This function will not only update the displayed information, it will
+	 * also reposition the item should it be necessary to enforce the current
+	 * sorting. Also note that this function does not require that the server
+	 * actually is on the list already, since AddServer makes use of it, but
+	 * this should generally be avoided, since it will result in the
+	 * server-count getting skewed until the next AddServer call.
 	 */
 	void RefreshServer(CServer *server);
 
@@ -128,6 +122,9 @@ public:
 	 */
 	void HighlightServer(const CServer *server, bool highlight);
 
+	//! True if `server` is the one currently highlighted via HighlightServer().
+	bool IsConnected(const CServer *server) const { return server && server == m_connected; }
+
 	/**
 	 * This function updates the server-count in the server-wnd.
 	 */
@@ -141,106 +138,110 @@ public:
 	 */
 	void FitColumnsToContent();
 
+	/**
+	 * Full comparison of two servers according to this list's current sort
+	 * column/direction. Used by CServerListModel::Compare().
+	 */
+	int CompareServers(const CServer *s1, const CServer *s2) const;
+
+	/**
+	 * Index of `code`'s flag, loading the bitmap on first use. Returns an
+	 * invalid wxIcon for a code with no bundled flag.
+	 */
+	wxIcon FlagIcon(const wxString &code) const;
+
 protected:
 	/// Return old column order.
 	wxString GetOldColumnOrder() const;
 
-	/// Text of one cell, rendered on demand by the virtual control.
-	virtual wxString GetItemColumnText(wxUIntPtr item, long column) const;
-
 	/**
-	 * Image index for one cell: the host-country flag on the Server Name
-	 * column, none anywhere else.
+	 * Adapts this control to IColumnWidthProvider for CListColumnStore. See
+	 * CSearchListCtrl::ColumnWidthAdapter for why this is a separate object
+	 * rather than multiple inheritance.
 	 */
-	virtual int OnGetItemColumnImage(long item, long column) const;
+	class ColumnWidthAdapter : public IColumnWidthProvider
+	{
+	public:
+		explicit ColumnWidthAdapter(wxDataViewCtrl *ctrl)
+		: m_ctrl(ctrl)
+		{
+		}
+		int GetColumnCount() const override { return static_cast<int>(m_ctrl->GetColumnCount()); }
+		int GetColumnWidth(int col) const override { return m_ctrl->GetColumn(col)->GetWidth(); }
+		bool SetColumnWidth(int col, int width) override
+		{
+			m_ctrl->GetColumn(col)->SetWidth(width);
+			return true;
+		}
 
-	/// Bold attribute for the server we are connected to, none for the rest.
-	virtual wxListItemAttr *OnGetItemAttr(long item) const;
+	private:
+		wxDataViewCtrl *m_ctrl;
+	};
+	ColumnWidthAdapter m_widthAdapter;
 
-	/**
-	 * Ping, Users and Files change while the list is up, so sorting by one of
-	 * them enables the inherited live auto-sort.
-	 */
-	virtual bool IsLiveSortColumn() const;
+	typedef std::pair<unsigned, unsigned> CColPair;
+	typedef std::list<CColPair> CSortingList;
 
-private:
-	/**
-	 * Event-handler for handling item activation (connect).
-	 */
-	void OnItemActivated(wxListEvent &event);
+	//! Sort chain: front() is the primary sort column/order. Order values
+	//! reuse CMuleListCtrl::SORT_DES's bit value so the persisted config
+	//! stays wire-compatible (see ListColumnStore.cpp).
+	CSortingList m_sort_orders;
 
-	/**
-	 * Event-handler for displaying the popup-menu.
-	 */
-	void OnItemRightClicked(wxListEvent &event);
+	//! Single-column comparison, ported from the old CServerListCtrl::SortProc.
+	//! No column offers an alternate tie-break criterion here (unlike
+	//! Search's Sources column) -- the old SortProc never consulted a
+	//! SORT_ALT bit for any Servers column, so there is no `alt`/AltSortAllowed
+	//! parameter to thread through.
+	int CompareByColumn(const CServer *s1, const CServer *s2, unsigned column, int modifier) const;
 
-	/**
-	 * Event-handler for priority changes.
-	 */
+	CListColumnStore m_columnStore;
+	void LoadColumnSettings();
+	void SaveColumnSettings();
+	//! Applies `order` to `column`, moving it to the front of the sort
+	//! chain, sets the native column header sort indicator, and re-sorts.
+	void ApplySorting(unsigned column, unsigned order);
+
+	CServerListModel *m_model;
+
+	void OnIdle(wxIdleEvent &event);
+	void OnColumnHeaderClick(wxDataViewEvent &event);
+	void OnRightClick(wxDataViewEvent &event);
+	void OnItemActivated(wxDataViewEvent &event);
+
 	void OnPriorityChange(wxCommandEvent &event);
-
-	/**
-	 * Event-handler for static changes.
-	 */
 	void OnStaticChange(wxCommandEvent &event);
-
-	/**
-	 * Event-handler for server connections.
-	 */
 	void OnConnectToServer(wxCommandEvent &event);
-
-	/**
-	 * Event-handler for copying server-urls to the clipboard.
-	 */
 	void OnGetED2kURL(wxCommandEvent &event);
-
-	/**
-	 * Event-handler for server removal.
-	 */
 	void OnRemoveServers(wxCommandEvent &event);
 
 	/**
-	 * Event-handler for deleting servers when the delete-key is pressed.
+	 * Type-to-select plus Delete-to-remove, reimplemented for
+	 * wxDataViewCtrl -- see CSearchListCtrl::OnChar for the full rationale
+	 * (none of the backends provide type-ahead-jump the way CMuleListCtrl's
+	 * did). The Delete-key handling that used to be CServerListCtrl's own
+	 * separate EVT_CHAR handler (OnKeyPressed) is folded in here rather than
+	 * kept as a second binding.
 	 */
-	void OnKeyPressed(wxKeyEvent &event);
+	void OnChar(wxKeyEvent &evt);
 
-	/**
-	 * Sorter function.
-	 *
-	 * @see wxListCtrl::SortItems
-	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
-
-	/**
-	 * Index of @a code's flag in m_images, adding the bitmap on first use.
-	 * Returns -1 for a code with no bundled flag.
-	 */
-	int FlagImage(const wxString &code) const;
+	//! Keystrokes accumulated so far, lowercased; reset after kTypeAheadResetMs.
+	wxString m_ttsText;
+	//! GetTickCount64() of the last accepted keystroke.
+	uint64 m_ttsTime = 0;
+	//! Result the last match landed on, so repeats cycle to the next one.
+	CServer *m_ttsItem = nullptr;
 
 	//! Used to keep track of the last high-lighted item.
 	const CServer *m_connected;
 
-	/**
-	 * This control's own small image list: the header sort arrows first (the
-	 * indices CMuleListCtrl::SetSorting() uses), then one entry per country
-	 * flag actually seen. It replaces the list shared by every CMuleListCtrl
-	 * so the flags stay out of every other list in the app.
-	 *
-	 * Mutable because the flags are filled in lazily from
-	 * OnGetItemColumnImage(), which the virtual control calls to paint a row
-	 * and is therefore const. Loading all ~250 flags up front instead would
-	 * decode a PNG for every country nobody is connected to.
-	 */
-	mutable wxImageList m_images;
-
-	//! ISO code -> index into m_images.
-	mutable std::map<wxString, int> m_flagImages;
-
-	//! Returned by OnGetItemAttr() for the connected server; see HighlightServer().
-	mutable wxListItemAttr m_boldAttr;
+	//! ISO code -> flag icon, filled in lazily from GetValue()'s COL_NAME
+	//! case in CServerListModel (which is otherwise const, hence mutable).
+	//! Loading all ~250 flags up front instead would decode a PNG for every
+	//! country nobody is connected to.
+	mutable std::map<wxString, wxIcon> m_flagIcons;
 
 	wxDECLARE_EVENT_TABLE();
 };
 
-#endif
+#endif // SERVERLISTCTRL_H
 // File_checked_for_headers

--- a/src/ServerListModel.cpp
+++ b/src/ServerListModel.cpp
@@ -1,0 +1,304 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ServerListModel.h"
+
+#include <algorithm> // Needed for std::find
+
+#ifdef GEOIP_GUI
+#include "CountryDisplay.h" // Needed for GetDisplayCountryCode
+#endif
+#include <common/Format.h> // Needed for CFormat
+
+#include "OtherFunctions.h" // Needed for CastSecondsToHM
+#include "Server.h"         // Needed for CServer and SRV_PR_*
+#include "ServerListCtrl.h" // Needed for CServerListCtrl
+
+CServerListModel::CServerListModel(CServerListCtrl *owner)
+: m_owner(owner)
+{
+}
+
+void CServerListModel::AddServer(CServer *server)
+{
+	if (!server || m_index.count(server)) {
+		return;
+	}
+	m_servers.push_back(server);
+	m_index.insert(server);
+	MarkDirty();
+}
+
+void CServerListModel::RemoveServer(CServer *server)
+{
+	if (!server || !m_index.erase(server)) {
+		return;
+	}
+	m_servers.erase(std::find(m_servers.begin(), m_servers.end(), server));
+	MarkDirty();
+}
+
+void CServerListModel::RefreshServer(CServer *server)
+{
+	if (!server) {
+		return;
+	}
+	if (!m_index.count(server)) {
+		AddServer(server);
+		return;
+	}
+	MarkDirty();
+}
+
+void CServerListModel::ClearAll()
+{
+	if (m_servers.empty()) {
+		return;
+	}
+	m_servers.clear();
+	m_index.clear();
+	MarkDirty();
+}
+
+bool CServerListModel::HasServer(CServer *server) const
+{
+	return server && m_index.count(server) != 0;
+}
+
+bool CServerListModel::FlushPending()
+{
+	if (!m_pendingReset) {
+		return false;
+	}
+	m_pendingReset = false;
+	Cleared();
+	return true;
+}
+
+unsigned int CServerListModel::GetColumnCount() const
+{
+	return COL_COUNT;
+}
+
+wxString CServerListModel::GetColumnType(unsigned int col) const
+{
+	return (col == COL_NAME) ? wxString("wxDataViewIconText") : wxString("string");
+}
+
+void CServerListModel::GetValue(wxVariant &variant, const wxDataViewItem &item, unsigned int col) const
+{
+	const CServer *server = ToServer(item);
+
+	switch (col) {
+	case COL_NAME: {
+		wxIcon icon;
+#ifdef GEOIP_GUI
+		// Host country as a flag icon: no icon at all for an unresolved
+		// server, rather than the "? - " prefix this used to show.
+		wxString code;
+		if (GetDisplayCountryCode(
+			    server->IsCountryFromCore(), server->GetCountryCode(), server->GetIP(), code) &&
+			!code.IsEmpty()) {
+			icon = m_owner->FlagIcon(code);
+		}
+#endif // GEOIP_GUI
+		variant << wxDataViewIconText(server->GetListName(), icon);
+		break;
+	}
+
+	case COL_ADDR:
+		variant = server->GetAddress();
+		break;
+
+	case COL_PORT:
+		if (server->GetAuxPortsList().IsEmpty()) {
+			variant = wxString(CFormat("%u") % server->GetPort());
+		} else {
+			variant =
+				wxString(CFormat("%u (%s)") % server->GetPort() % server->GetAuxPortsList());
+		}
+		break;
+
+	case COL_DESC:
+		variant = server->GetDescription();
+		break;
+
+	case COL_PING:
+		variant = server->GetPing()
+				  ? CastSecondsToHM(server->GetPing() / 1000, server->GetPing() % 1000)
+				  : wxString();
+		break;
+
+	case COL_USERS:
+		variant = server->GetUsers() ? wxString(CFormat("%u") % server->GetUsers()) : wxString();
+		break;
+
+	case COL_FILES:
+		variant = server->GetFiles() ? wxString(CFormat("%u") % server->GetFiles()) : wxString();
+		break;
+
+	case COL_PRIO:
+		switch (server->GetPreferences()) {
+		case SRV_PR_LOW:
+			variant = wxString(_("Low"));
+			break;
+		case SRV_PR_NORMAL:
+			variant = wxString(_("Normal"));
+			break;
+		case SRV_PR_HIGH:
+			variant = wxString(_("High"));
+			break;
+		default:
+			variant = wxString("---"); // this should never happen
+			break;
+		}
+		break;
+
+	case COL_FAILS:
+		variant = wxString(CFormat("%u") % server->GetFailedCount());
+		break;
+
+	case COL_STATIC:
+		variant = server->IsStaticMember() ? wxString(_("Yes")) : wxString(_("No"));
+		break;
+
+	case COL_VERSION:
+		variant = server->GetVersion();
+		break;
+
+#if !defined(CLIENT_GUI)
+	case COL_TCPFLAGS: {
+		wxString flags;
+		if (server->GetTCPFlags() & SRV_TCPFLG_COMPRESSION) {
+			flags += "c";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_NEWTAGS) {
+			flags += "n";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_UNICODE) {
+			flags += "u";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_RELATEDSEARCH) {
+			flags += "r";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_TYPETAGINTEGER) {
+			flags += "t";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_LARGEFILES) {
+			flags += "l";
+		}
+		if (server->GetTCPFlags() & SRV_TCPFLG_TCPOBFUSCATION) {
+			flags += "o";
+		}
+		variant = flags;
+		break;
+	}
+
+	case COL_UDPFLAGS: {
+		wxString flags;
+		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES) {
+			flags += "g";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETFILES) {
+			flags += "f";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_NEWTAGS) {
+			flags += "n";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_UNICODE) {
+			flags += "u";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES2) {
+			flags += "G";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_LARGEFILES) {
+			flags += "l";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_UDPOBFUSCATION) {
+			flags += "o";
+		}
+		if (server->GetUDPFlags() & SRV_UDPFLG_TCPOBFUSCATION) {
+			flags += "O";
+		}
+		variant = flags;
+		break;
+	}
+#endif
+
+	default:
+		break;
+	}
+}
+
+bool CServerListModel::SetValue(
+	const wxVariant &WXUNUSED(variant), const wxDataViewItem &WXUNUSED(item), unsigned int WXUNUSED(col))
+{
+	// Every column is read-only; values only ever change from the core
+	// side, via RefreshServer().
+	return false;
+}
+
+bool CServerListModel::GetAttr(
+	const wxDataViewItem &item, unsigned int WXUNUSED(col), wxDataViewItemAttr &attr) const
+{
+	if (m_owner->IsConnected(ToServer(item))) {
+		attr.SetBold(true);
+		return true;
+	}
+	return false;
+}
+
+wxDataViewItem CServerListModel::GetParent(const wxDataViewItem &WXUNUSED(item)) const
+{
+	// Flat list: every server is a top-level row.
+	return wxDataViewItem();
+}
+
+bool CServerListModel::IsContainer(const wxDataViewItem &item) const
+{
+	return !item.IsOk(); // invisible root only -- no row ever has children
+}
+
+unsigned int CServerListModel::GetChildren(const wxDataViewItem &item, wxDataViewItemArray &children) const
+{
+	if (item.IsOk()) {
+		return 0;
+	}
+	for (CServer *server : m_servers) {
+		children.Add(ToItem(server));
+	}
+	return static_cast<unsigned int>(m_servers.size());
+}
+
+int CServerListModel::Compare(const wxDataViewItem &item1,
+	const wxDataViewItem &item2,
+	unsigned int WXUNUSED(column),
+	bool WXUNUSED(ascending)) const
+{
+	// The requested (column, ascending) pair reflects only the native
+	// header click; the full sort state (including any tie-break chain)
+	// is tracked on the control and applied here regardless -- see
+	// CServerListCtrl::CompareServers.
+	return m_owner->CompareServers(ToServer(item1), ToServer(item2));
+}

--- a/src/ServerListModel.h
+++ b/src/ServerListModel.h
@@ -1,0 +1,125 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef SERVERLISTMODEL_H
+#define SERVERLISTMODEL_H
+
+#include <wx/dataview.h>
+
+#include <unordered_set>
+#include <vector>
+
+class CServer;
+class CServerListCtrl;
+
+/**
+ * wxDataViewModel backing a CServerListCtrl. Flat (no grouping, unlike
+ * CSearchListModel's parent/child forest): every server is a top-level row,
+ * keyed by CServer* identity so the control's existing pointer-based API
+ * (AddServer(CServer*), RemoveServer(CServer*), HighlightServer(const
+ * CServer*, bool)) carries over without a row-index translation layer.
+ *
+ * Unlike CSearchListModel, this model owns its row set directly rather than
+ * querying a live core-side collection: CServerListCtrl has always kept its
+ * own displayed snapshot independent of CServerList's storage (see
+ * RemoveAllServers()'s "drop the row before asking for removal" comment),
+ * and that decoupling is preserved here.
+ *
+ * All mutations (AddServer/RemoveServer/RefreshServer/ClearAll) just mark
+ * the model dirty; the control flushes one Cleared() per idle
+ * (CServerListCtrl::OnIdle), same as CSearchListModel -- mixing incremental
+ * Item* notifications with a full reset left wxGTK/wxMSW's tree
+ * inconsistent for CSearchListCtrl (got3nks, PR #796 review), and a flat
+ * list is exposed to the exact same backends.
+ */
+class CServerListModel : public wxDataViewModel
+{
+public:
+	explicit CServerListModel(CServerListCtrl *owner);
+
+	//! Adds `server` if not already present, else a no-op (AddServer() on
+	//! the control has always tolerated re-adding a listed server).
+	void AddServer(CServer *server);
+	void RemoveServer(CServer *server);
+	//! Value-only change (no shape change) -- still funnels through the
+	//! same dirty-flag/idle-flush path as Add/Remove, see class comment.
+	void RefreshServer(CServer *server);
+	void ClearAll();
+	bool HasServer(CServer *server) const;
+	size_t GetCount() const { return m_servers.size(); }
+	const std::vector<CServer *> &GetServers() const { return m_servers; }
+
+	void MarkDirty() { m_pendingReset = true; }
+	bool FlushPending();
+	bool HasPending() const { return m_pendingReset; }
+
+	static CServer *ToServer(const wxDataViewItem &item) { return static_cast<CServer *>(item.GetID()); }
+	static wxDataViewItem ToItem(const CServer *server)
+	{
+		return wxDataViewItem(const_cast<CServer *>(server));
+	}
+
+	//! Column indices, matching the wxDataViewColumn order set up by
+	//! CServerListCtrl -- shared with CServerListCtrl::CompareServers().
+	enum Column
+	{
+		COL_NAME = 0,
+		COL_ADDR,
+		COL_PORT,
+		COL_DESC,
+		COL_PING,
+		COL_USERS,
+		COL_FILES,
+		COL_PRIO,
+		COL_FAILS,
+		COL_STATIC,
+		COL_VERSION,
+		COL_TCPFLAGS,
+		COL_UDPFLAGS,
+		COL_COUNT
+	};
+
+	// wxDataViewModel interface
+	unsigned int GetColumnCount() const wxOVERRIDE;
+	wxString GetColumnType(unsigned int col) const wxOVERRIDE;
+	void GetValue(wxVariant &variant, const wxDataViewItem &item, unsigned int col) const wxOVERRIDE;
+	bool SetValue(const wxVariant &variant, const wxDataViewItem &item, unsigned int col) wxOVERRIDE;
+	bool GetAttr(const wxDataViewItem &item, unsigned int col, wxDataViewItemAttr &attr) const wxOVERRIDE;
+	wxDataViewItem GetParent(const wxDataViewItem &item) const wxOVERRIDE;
+	bool IsContainer(const wxDataViewItem &item) const wxOVERRIDE;
+	unsigned int GetChildren(const wxDataViewItem &item, wxDataViewItemArray &children) const wxOVERRIDE;
+	int Compare(const wxDataViewItem &item1,
+		const wxDataViewItem &item2,
+		unsigned int column,
+		bool ascending) const wxOVERRIDE;
+
+private:
+	CServerListCtrl *m_owner;
+	std::vector<CServer *> m_servers;
+	std::unordered_set<CServer *> m_index;
+	bool m_pendingReset = false;
+};
+
+#endif // SERVERLISTMODEL_H
+// File_checked_for_headers

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2516,7 +2516,7 @@ wxSizer *serverListDlgUp( wxWindow *parent, bool call_fit, bool set_sizer )
     // Top border: without it this row sits flush against the tab strip
     // (issue #402 review: "too close to the borders of the tab container").
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
-    CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxSize(200, 100), wxLC_REPORT|wxSUNKEN_BORDER );
+    CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxSize(200, 100) );
     item0->Add( item15, wxSizerFlags(1).Expand().CenterVertical() );
     wxBoxSizer *item5 = new wxBoxSizer( wxHORIZONTAL );
 


### PR DESCRIPTION
## Context

#180 is the accessibility bug: `CMuleListCtrl`/`CMuleVirtualListCtrl` wrap the vendored `wxGenericListCtrl`, owner-drawn with no native backing, so VoiceOver/Orca can't see it. PR #796 fixed this for the search results list by porting to `wxDataViewCtrl`. #801 tracks the remaining lists still on the old base; this is the first of those ports.

`CServerListCtrl` was chosen as the smallest *valid* proof-of-concept among the `CMuleVirtualListCtrl` candidates: it's purely text-rendered (no `CBarShader` progress/availability bars, unlike Downloads/SharedFiles) and has the smallest external blast radius. No shared base class is extracted yet — per got3nks's own suggestion on #801, that generalization is deferred until 2+ of these lists are ported and the common shape is empirically clear.

## What changed

- New `CServerListModel`: a flat `wxDataViewModel` (not wx's `wxDataViewVirtualListModel`, which is row-index addressed and would force a translation layer at the control's existing `CServer*`-identity call sites like `RemoveServer(CServer*)`/`HighlightServer(const CServer*, bool)`). Reuses the dirty-flag + idle-coalesced `Cleared()` notification pattern #796 converged on after its own GTK/MSW structural-notification regressions.
- `CServerListCtrl` rewritten to inherit `wxDataViewCtrl` directly. Public API (`AddServer`, `RemoveServer`, `RefreshServer`, `HighlightServer`, `DeleteAllItems`, `ShowServerCount`, `FitColumnsToContent`) kept name/signature-stable so `ServerWnd.cpp`/`GuiEvents.cpp`/`amule-remote-gui.cpp` needed no changes beyond recompiling. `RemoveAllServers` dropped its `wxLIST_STATE_*` parameter for a plain `bool selectedOnly` (internal-only, no external callers).
- Guarded proactively against every regression class #796's review already found once:
  - `wxDV_MULTIPLE` explicit (the control defaults to single-select).
  - Type-to-select and Cmd/Ctrl+A reimplemented in `OnChar` — no `wxDataViewCtrl` backend provides them the way the old list did.
  - `wxDATAVIEW_COL_SORTABLE` on every column (otherwise sort works but no header caret).
  - All row mutations funnel through `MarkDirty()`/idle-flushed `Cleared()`, never incremental `ItemAdded`/`ItemDeleted`/`ItemChanged`.
- `IsLiveSortColumn()`'s bespoke live-resort machinery is gone entirely: `RefreshServer()`'s `MarkDirty()` → idle `Cleared()` already re-sorts against `Compare()` for free, a genuine simplification versus the base being replaced.
- `CListColumnStore`/`IColumnWidthProvider` (#787) carries over unchanged via the same `ColumnWidthAdapter` pattern `CSearchListCtrl` already proved.
- `muuli_wdr.cpp`'s construction call updated for the new ctor (dropped the unused `wxLC_*` style parameter, same as Search's port).

## Verification

- Builds clean (monolithic macOS target).
- `clang-format` v18 (pinned Docker image) applied.
- clang-tidy Tier-1 (whole-tree) and Tier-2 (changed-lines, `.clang-tidy-new-code`) both clean via a local CI replica — caught and fixed one real `bugprone-narrowing-conversions` hit in `OnChar` along the way.
- Launched against an isolated test config (non-default ports): starts clean, loads `server.met` (9 servers), connects and starts Kad, no crashes in the log.
- **Not yet verified interactively** (screenshots aren't attachable from this environment, same as #796): sort persistence across restart, multi-select context-menu actions, Cmd/Ctrl+A, type-to-select jump, live Ping/Users/Files updates while sorted by one of them, bulk reload auto-sizing, country flags (light/dark themes), and — the actual point of this port — a VoiceOver spot-check confirming rows are now announced. Happy to have this checked before merge, or after if that's easier.