### PR TITLE
feat(gui): shared wxDataViewCtrl base, and port CServerListCtrl onto it (#180, #801)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -953,6 +953,8 @@ if (NEED_LIB_MULEAPPGUI)
 		ListColumnStore.cpp
 		MuleColour.cpp
 		MuleGifCtrl.cpp
+		MuleDataViewCtrl.cpp
+		MuleVirtualDataViewCtrl.cpp
 		MuleListCtrl.cpp
 		MuleVirtualListCtrl.cpp
 		MuleNotebook.cpp

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -1,0 +1,500 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include "MuleDataViewCtrl.h" // Interface declarations
+
+#include <wx/menu.h> // Needed for wxMenu (header show/hide menu)
+
+#include <algorithm> // Needed for std::find, std::sort, std::min, std::max
+#include <vector>    // Needed for std::vector
+
+#include <common/MenuIDs.h> // Needed for MP_LISTCOL_1 .. MP_LISTCOL_15
+
+#include "GetTickCount.h" // Needed for GetTickCount64()
+
+namespace
+{
+//! How long a pause resets the accumulated type-ahead string, in ms.
+const uint64 kTypeAheadResetMs = 1500;
+} // namespace
+
+wxBEGIN_EVENT_TABLE(CMuleDataViewCtrl, wxDataViewCtrl)
+	EVT_DATAVIEW_COLUMN_HEADER_CLICK(wxID_ANY, CMuleDataViewCtrl::OnColumnHeaderClick)
+	EVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK(wxID_ANY, CMuleDataViewCtrl::OnColumnHeaderRightClick)
+	EVT_MENU_RANGE(MP_LISTCOL_1, MP_LISTCOL_15, CMuleDataViewCtrl::OnColumnMenuSelected)
+	EVT_IDLE(CMuleDataViewCtrl::OnIdle)
+	EVT_CHAR(CMuleDataViewCtrl::OnChar)
+	EVT_KEY_DOWN(CMuleDataViewCtrl::OnKeyDown)
+wxEND_EVENT_TABLE()
+
+CMuleDataViewCtrl::CMuleDataViewCtrl(wxWindow *parent,
+	wxWindowID winid,
+	const wxPoint &pos,
+	const wxSize &size,
+	long style,
+	const wxString &name)
+: wxDataViewCtrl(parent, winid, pos, size, style | wxDV_MULTIPLE | wxDV_ROW_LINES, wxDefaultValidator, name)
+, m_widthAdapter(this)
+{
+	// amuleDlg sets wxIdleEvent::SetMode(wxIDLE_PROCESS_SPECIFIED), so only
+	// windows carrying this style are sent idle events at all -- without it
+	// OnIdle() never runs.
+	SetExtraStyle(GetExtraStyle() | wxWS_EX_PROCESS_IDLE);
+}
+
+CMuleDataViewCtrl::~CMuleDataViewCtrl() = default;
+
+int CMuleDataViewCtrl::ColumnWidthAdapter::GetColumnWidth(int col) const
+{
+	if (m_ctrl->IsColumnHidden(col)) {
+		return 0;
+	}
+	const int width = m_ctrl->GetColumn(col)->GetWidth();
+	if (width > 0) {
+		return width;
+	}
+	// A visible column should never report zero -- the spacer appended on
+	// macOS exists so the trailing-column sizing lands there instead. This
+	// is the backstop if it ever does anyway: CListColumnStore reads a width
+	// <= 0 as hidden and persists it negative, so a stray zero would hide a
+	// real column on the next launch, then do the same to whichever column
+	// became last, losing one per restart.
+	const int cached = m_ctrl->m_columnStore.GetCachedWidth(col);
+	return (cached > 0) ? cached : m_ctrl->m_columnStore.GetColumnDefaultWidth(col);
+}
+
+void CMuleDataViewCtrl::AppendSpacerColumn(unsigned modelColumn)
+{
+#ifdef __WXOSX__
+	// Resizable is load-bearing: macOS hands the leftover space to the last
+	// *resizable* column, so a fixed spacer cannot shrink and the collapse
+	// falls through to the last real column instead.
+	AppendTextColumn(
+		wxEmptyString, modelColumn, wxDATAVIEW_CELL_INERT, 1, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+	m_hasSpacer = true;
+#else
+	(void)modelColumn;
+#endif
+}
+
+unsigned CMuleDataViewCtrl::RealColumnCount() const
+{
+	const unsigned columns = GetColumnCount();
+	if (m_hasSpacer && columns > 0) {
+		return columns - 1;
+	}
+	return columns;
+}
+
+void CMuleDataViewCtrl::InitColumnState()
+{
+	m_columnHidden.resize(RealColumnCount(), false);
+	m_lastKnownWidths.clear();
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
+		m_lastKnownWidths.push_back(GetColumn(i)->GetWidth());
+	}
+}
+
+bool CMuleDataViewCtrl::IsColumnHidden(int col) const
+{
+	return (col >= 0) && (static_cast<size_t>(col) < m_columnHidden.size()) && m_columnHidden[col];
+}
+
+void CMuleDataViewCtrl::SetColumnHidden(int col, bool hidden, int width)
+{
+	if (col < 0 || static_cast<unsigned>(col) >= RealColumnCount()) {
+		return;
+	}
+	if (static_cast<size_t>(col) >= m_columnHidden.size()) {
+		m_columnHidden.resize(RealColumnCount(), false);
+	}
+
+	m_columnHidden[col] = hidden;
+	wxDataViewColumn *column = GetColumn(static_cast<unsigned>(col));
+	column->SetHidden(hidden);
+	if (!hidden && width > COL_SIZE_MIN) {
+		column->SetWidth(width);
+	}
+}
+
+void CMuleDataViewCtrl::UpdateExpanderColumn()
+{
+	// The expander belongs on the leftmost visible column: hiding the column
+	// that currently owns it would take any group triangles with it, and
+	// re-showing a column to its left has to take them back.
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
+		if (!IsColumnHidden(static_cast<int>(i))) {
+			wxDataViewColumn *column = GetColumn(i);
+			if (GetExpanderColumn() != column) {
+				SetExpanderColumn(column);
+			}
+			return;
+		}
+	}
+}
+
+int CMuleDataViewCtrl::CompareItems(const wxDataViewItem &item1, const wxDataViewItem &item2) const
+{
+	for (const CColPair &entry : m_sort_orders) {
+		const unsigned column = entry.first;
+		const unsigned order = entry.second;
+		const int modifier = (order & SORT_DES) ? -1 : 1;
+		const bool alt = (order & SORT_ALT) != 0;
+
+		const int result = CompareByColumn(item1, item2, column, alt, modifier);
+		if (result != 0) {
+			return result;
+		}
+	}
+	return 0;
+}
+
+void CMuleDataViewCtrl::ApplySorting(unsigned column, unsigned order)
+{
+	// Push to the front: the most recently clicked column is primary, the
+	// rest stay as tie-breakers, matching CMuleListCtrl::SetSorting().
+	for (CSortingList::iterator it = m_sort_orders.begin(); it != m_sort_orders.end(); ++it) {
+		if (it->first == column) {
+			m_sort_orders.erase(it);
+			break;
+		}
+	}
+	m_sort_orders.emplace_front(column, order);
+
+	if (column < RealColumnCount()) {
+		for (unsigned i = 0; i < RealColumnCount(); ++i) {
+			if (i != column && GetColumn(i)->IsSortKey()) {
+				GetColumn(i)->UnsetAsSortKey();
+			}
+		}
+		GetColumn(column)->SetSortOrder(!(order & SORT_DES));
+	}
+
+	OnSortingChanged();
+}
+
+void CMuleDataViewCtrl::LoadColumnSettings()
+{
+	if (!m_columnStore.HasTableName()) {
+		return;
+	}
+
+	CListColumnStore::CSortingList decoded;
+	m_columnStore.LoadSettings(m_widthAdapter, GetOldColumnOrder(), decoded);
+
+	// Restored widths can leave the default expander column hidden.
+	UpdateExpanderColumn();
+
+	// LoadSettings() returns the orders primary-LAST: CMuleListCtrl applied
+	// them by calling SetSorting() on each in turn, and each call pushes to
+	// the front, so the last one processed ends up primary. ApplySorting()
+	// has the same semantics, so replaying them in order reproduces it.
+	m_sort_orders.clear();
+	for (const CListColumnStore::CColPair &pair : decoded) {
+		ApplySorting(pair.first, pair.second);
+	}
+}
+
+void CMuleDataViewCtrl::SaveColumnSettings()
+{
+	if (!m_columnStore.HasTableName()) {
+		return;
+	}
+	m_columnStore.SaveSettings(m_widthAdapter, m_sort_orders);
+}
+
+void CMuleDataViewCtrl::OnColumnHeaderClick(wxDataViewEvent &event)
+{
+	wxDataViewColumn *col = event.GetDataViewColumn();
+	if (!col) {
+		event.Skip();
+		return;
+	}
+	const unsigned column = static_cast<unsigned>(col->GetModelColumn());
+
+	// Mirrors CMuleListCtrl::OnColumnLClick's cycle: the same column clicked
+	// again flips ascending<->descending, and once descending, a further
+	// click on an alt-eligible column flips to ascending with the alt
+	// criterion toggled instead of clearing the sort.
+	unsigned sort_order = 0;
+	if (!m_sort_orders.empty() && m_sort_orders.front().first == column) {
+		sort_order = m_sort_orders.front().second;
+		if (sort_order & SORT_DES) {
+			if (AltSortAllowed(column)) {
+				sort_order = (~sort_order) & SORT_ALT;
+			} else {
+				sort_order = 0;
+			}
+		} else {
+			sort_order = SORT_DES | (sort_order & SORT_ALT);
+		}
+	} else {
+		// Clicking back to a column that is still in the chain resumes the
+		// direction it was last sorted by, rather than starting over.
+		for (const CColPair &entry : m_sort_orders) {
+			if (entry.first == column) {
+				sort_order = entry.second;
+				break;
+			}
+		}
+	}
+
+	ApplySorting(column, sort_order);
+	SaveColumnSettings();
+}
+
+void CMuleDataViewCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
+{
+	// Show/hide menu, as CMuleListCtrl::OnColumnRClick offered on every
+	// list built on the old base.
+	wxMenu menu;
+	const unsigned columns = std::min<unsigned>(RealColumnCount(), MP_LISTCOL_15 - MP_LISTCOL_1 + 1);
+	for (unsigned i = 0; i < columns; ++i) {
+		menu.AppendCheckItem(static_cast<int>(i) + MP_LISTCOL_1, GetColumn(i)->GetTitle());
+		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, !IsColumnHidden(static_cast<int>(i)));
+	}
+
+	PopupMenu(&menu);
+	event.Skip();
+}
+
+void CMuleDataViewCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
+{
+	const int col = evt.GetId() - MP_LISTCOL_1;
+	if (col < 0 || static_cast<unsigned>(col) >= RealColumnCount()) {
+		return;
+	}
+
+	if (!IsColumnHidden(col)) {
+		// Remember the width so re-showing restores what the user had.
+		m_columnStore.SetCachedWidth(col, GetColumn(static_cast<unsigned>(col))->GetWidth());
+		SetColumnHidden(col, true, 0);
+	} else {
+		const int cached = m_columnStore.GetCachedWidth(col);
+		SetColumnHidden(col, false, cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
+	}
+	UpdateExpanderColumn();
+	OnColumnVisibilityChanged();
+	SaveColumnSettings();
+}
+
+void CMuleDataViewCtrl::OnIdle(wxIdleEvent &event)
+{
+	event.Skip();
+
+	// No portable wxDataViewCtrl "column resized" event exists to hook
+	// directly (unlike wxListCtrl's EVT_LIST_COL_END_DRAG), so a drag-resize
+	// is detected by comparing against the last-seen widths.
+	bool changed = false;
+	for (int i = 0;
+		i < static_cast<int>(RealColumnCount()) && i < static_cast<int>(m_lastKnownWidths.size());
+		++i) {
+		const int width = GetColumn(i)->GetWidth();
+		if (width != m_lastKnownWidths[i]) {
+			m_lastKnownWidths[i] = width;
+			changed = true;
+		}
+	}
+	if (changed) {
+		OnColumnWidthsChanged();
+	}
+
+	OnIdleHook();
+}
+
+void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
+{
+	// The list gets first refusal on every key. Doing this before the
+	// WXK_START test is deliberate: WXK_DELETE is 127, well below it, so a
+	// delete-key handler placed after that test would never see it, while
+	// WXK_NUMPAD_DELETE (above it) would be skipped to the backend instead.
+	if (OnListKey(evt)) {
+		return;
+	}
+
+	int key = evt.GetKeyCode();
+	if (key == 0) {
+		// GetKeyCode() returns 0 for characters it can't map; the unicode
+		// key is the fallback. GetUnicodeKey() returns wxChar -- a signed
+		// char in wx's UTF-8 build but wchar_t in the wide build, so an
+		// unsigned-char cast would truncate the wide case.
+		// NOLINTNEXTLINE(bugprone-signed-char-misuse)
+		key = evt.GetUnicodeKey();
+	} else if (key >= WXK_START) {
+		// Navigation keys belong to the backend's own cursor handling.
+		evt.Skip();
+		return;
+	}
+
+	if (evt.AltDown() || evt.ControlDown() || evt.MetaDown()) {
+		// Cmd/Ctrl+A: only wxGTK's backend selects all by itself, so do it
+		// here for all three. A control-modified 'a' arrives as SOH on most
+		// ports, but not universally, so accept the letter too.
+		const int plain = wxTolower(evt.GetKeyCode());
+		if (evt.CmdDown() && (evt.GetKeyCode() == 0x01 || plain == 'a')) {
+			SelectAll();
+			return;
+		}
+		evt.Skip();
+		return;
+	}
+
+	const uint64 now = GetTickCount64();
+	if (m_ttsTime + kTypeAheadResetMs < now) {
+		m_ttsText.Clear();
+	}
+	m_ttsTime = now;
+	m_ttsText.Append(wxTolower(static_cast<wxChar>(key)));
+
+	wxDataViewItemArray ordered;
+	GetDisplayOrder(ordered);
+	const size_t count = ordered.GetCount();
+	if (count == 0) {
+		return;
+	}
+
+	// A fresh single keystroke starts one past the current match so that
+	// tapping the same letter cycles; further keystrokes refine in place.
+	size_t start = 0;
+	for (size_t i = 0; i < count; ++i) {
+		if (ordered[i].GetID() == m_ttsItem) {
+			start = i;
+			if (m_ttsText.length() == 1) {
+				++start;
+			}
+			break;
+		}
+	}
+
+	for (size_t i = 0; i < count; ++i) {
+		const wxDataViewItem item = ordered[(start + i) % count];
+		if (GetRowLabel(item).Lower().StartsWith(m_ttsText)) {
+			m_ttsItem = item.GetID();
+			UnselectAll();
+			Select(item);
+			SetCurrentItem(item);
+			EnsureVisible(item);
+			return;
+		}
+	}
+	// No match: the accumulated text is kept (so a typo can be corrected by
+	// continuing to type) but the selection stays where it is.
+}
+
+void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
+{
+#ifdef __WXOSX__
+	// NSOutlineView moves the view without touching the selection, so the
+	// shifted navigation keys -- which extend the selection on GTK and MSW
+	// -- do nothing at all here. The unshifted forms are deliberately left
+	// to the platform, which scrolls without moving the selection by
+	// convention.
+	if (evt.ShiftDown()) {
+		switch (evt.GetKeyCode()) {
+		case WXK_PAGEUP:
+			PageExtendSelection(PageMotion::PageUp);
+			return;
+		case WXK_PAGEDOWN:
+			PageExtendSelection(PageMotion::PageDown);
+			return;
+		case WXK_HOME:
+			PageExtendSelection(PageMotion::Home);
+			return;
+		case WXK_END:
+			PageExtendSelection(PageMotion::End);
+			return;
+		default:
+			break;
+		}
+	}
+#endif
+	evt.Skip();
+}
+
+#ifdef __WXOSX__
+void CMuleDataViewCtrl::PageExtendSelection(PageMotion motion)
+{
+	wxDataViewItemArray ordered;
+	GetDisplayOrder(ordered);
+	const size_t rowCount = ordered.GetCount();
+	if (rowCount == 0) {
+		return;
+	}
+
+	const wxDataViewItem currentItem = GetCurrentItem();
+	const int last = static_cast<int>(rowCount) - 1;
+	const bool forward = (motion == PageMotion::PageDown) || (motion == PageMotion::End);
+
+	int current = forward ? -1 : static_cast<int>(rowCount);
+	if (currentItem.IsOk()) {
+		const int found = ordered.Index(currentItem);
+		if (found != wxNOT_FOUND) {
+			current = found;
+		}
+	}
+
+	int target = 0;
+	switch (motion) {
+	case PageMotion::Home:
+		target = 0;
+		break;
+	case PageMotion::End:
+		target = last;
+		break;
+	default: {
+		// GetCountPerPage() is implemented by the native macOS backend;
+		// GetItemRect() is not a substitute, since it returns an empty rect
+		// for rows that aren't currently on screen and the resulting height
+		// of zero collapses a page to a single row.
+		int rows = GetCountPerPage();
+		if (rows <= 0) {
+			rows = 10;
+		} else {
+			// Leave one row of overlap, as the other ports scroll.
+			rows = std::max(1, rows - 1);
+		}
+		const int delta = (motion == PageMotion::PageDown) ? rows : -rows;
+		target = std::min(last, std::max(0, current + delta));
+		break;
+	}
+	}
+
+	// Grow the existing selection to cover everything between where the
+	// cursor was and where it lands, so repeated presses keep extending.
+	wxDataViewItemArray selection;
+	GetSelections(selection);
+	const int from = std::min(current < 0 ? target : current, target);
+	const int to = std::max(current > last ? target : current, target);
+	for (int i = std::max(0, from); i <= std::min(last, to); ++i) {
+		if (selection.Index(ordered[i]) == wxNOT_FOUND) {
+			selection.Add(ordered[i]);
+		}
+	}
+
+	const wxDataViewItem targetItem = ordered[target];
+	SetSelections(selection);
+	SetCurrentItem(targetItem);
+	EnsureVisible(targetItem);
+}
+#endif // __WXOSX__

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -1,0 +1,253 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#ifndef MULEDATAVIEWCTRL_H
+#define MULEDATAVIEWCTRL_H
+
+#include <wx/dataview.h>
+
+#include "ListColumnStore.h" // Needed for CListColumnStore, IColumnWidthProvider, COL_SIZE_MIN
+#include "Types.h"           // Needed for uint64
+
+#include <list>
+#include <utility>
+#include <vector>
+
+/**
+ * Shared behaviour for aMule's wxDataViewCtrl-backed lists.
+ *
+ * This is the wxDataViewCtrl counterpart of CMuleListCtrl: the chrome every
+ * list needs and no list should implement twice -- column widths and their
+ * persistence, the show/hide menu, the multi-column sort chain, type-ahead
+ * selection, and the per-platform compensation the ports have had to grow.
+ *
+ * It owns no data. A subclass supplies its rows through GetDisplayOrder(),
+ * their label through GetRowLabel(), and how two of them compare on a given
+ * column through CompareByColumn(); everything else here is written in terms
+ * of those three.
+ *
+ * Lists with a flat, row-addressed model should derive from
+ * CMuleVirtualDataViewCtrl instead, which adds the item-identity bookkeeping
+ * on top of this.
+ */
+class CMuleDataViewCtrl : public wxDataViewCtrl
+{
+public:
+	CMuleDataViewCtrl(wxWindow *parent,
+		wxWindowID winid = wxID_ANY,
+		const wxPoint &pos = wxDefaultPosition,
+		const wxSize &size = wxDefaultSize,
+		long style = 0,
+		const wxString &name = "muledataviewctrl");
+
+	~CMuleDataViewCtrl() override;
+
+	//! Sort-order bits, matching CMuleListCtrl so the persisted config stays
+	//! wire-compatible across both list families.
+	enum
+	{
+		SORT_DES = 0x1,
+		SORT_ALT = 0x2,
+		SORTING_MASK = 0x3
+	};
+
+	/**
+	 * Whether a column is hidden.
+	 *
+	 * Tracked here rather than derived from the control: a hidden
+	 * wxDataViewColumn keeps reporting its previous width, so width alone
+	 * cannot answer the question, and the width is what CListColumnStore
+	 * persists (as a negative entry carrying the size to restore).
+	 */
+	bool IsColumnHidden(int col) const;
+	//! Hide or show a column; width is the one to restore when showing.
+	void SetColumnHidden(int col, bool hidden, int width);
+
+	/**
+	 * Columns the user owns, excluding the macOS spacer (see the
+	 * constructor), which must stay out of the header menu, the persisted
+	 * widths and any cross-list synchronisation.
+	 */
+	unsigned RealColumnCount() const;
+
+protected:
+	typedef std::pair<unsigned, unsigned> CColPair;
+	typedef std::list<CColPair> CSortingList;
+
+	// --- what a subclass must provide -------------------------------------
+
+	/**
+	 * The rows as displayed, addressed by position.
+	 *
+	 * Built once per operation (a keystroke, a page key) rather than probed
+	 * per row: a list that derives its order has to walk its data to answer
+	 * at all, so per-row access would repeat that walk for every row.
+	 * Implementations must include the children of expanded containers where
+	 * they have them, since the callers measure against what is on screen.
+	 */
+	virtual void GetDisplayOrder(wxDataViewItemArray &ordered) const = 0;
+
+	//! Text a row is matched against when the user types to select.
+	virtual wxString GetRowLabel(const wxDataViewItem &item) const = 0;
+
+	/**
+	 * Single-column comparison, without the chain or the direction: the
+	 * caller applies `modifier` (-1 when descending) to the result.
+	 */
+	virtual int CompareByColumn(const wxDataViewItem &item1,
+		const wxDataViewItem &item2,
+		unsigned column,
+		bool alt,
+		int modifier) const = 0;
+
+	//! Whether a column offers a secondary "alt" sort criterion.
+	virtual bool AltSortAllowed(unsigned WXUNUSED(column)) const { return false; }
+
+	//! Column-name string for migrating pre-CListColumnStore config entries.
+	virtual wxString GetOldColumnOrder() const { return wxEmptyString; }
+
+	/**
+	 * First refusal on every key, before type-ahead or the backend sees it.
+	 * Return true to swallow it; the default claims nothing.
+	 */
+	virtual bool OnListKey(wxKeyEvent &WXUNUSED(evt)) { return false; }
+
+	//! Called once per idle after the base has done its own housekeeping.
+	virtual void OnIdleHook() {}
+
+	//! Called after a column is shown or hidden from the header menu.
+	virtual void OnColumnVisibilityChanged() {}
+
+	//! Called from idle when a drag-resize changed one or more widths.
+	virtual void OnColumnWidthsChanged() {}
+
+	//! Called after the sort chain changes; the list re-orders its rows here.
+	virtual void OnSortingChanged() {}
+
+	// --- services for subclasses ------------------------------------------
+
+	//! Full chain comparison: primary column first, then the tie-breakers.
+	int CompareItems(const wxDataViewItem &item1, const wxDataViewItem &item2) const;
+
+	//! Pushes a column to the front of the sort chain and applies the caret.
+	void ApplySorting(unsigned column, unsigned order);
+
+	void LoadColumnSettings();
+	void SaveColumnSettings();
+
+	//! Keeps the expander on the leftmost visible column.
+	void UpdateExpanderColumn();
+
+	/**
+	 * Appends the trailing spacer column on macOS.
+	 *
+	 * Must be called by the subclass after its own columns are appended and
+	 * before LoadColumnSettings(): macOS sizes the last *resizable* column
+	 * to the leftover space, collapsing it to nothing once the columns are
+	 * wider than the control, so a spacer takes that role instead of a
+	 * column the user cares about. `modelColumn` is an always-empty column
+	 * the subclass' model must answer for.
+	 */
+	void AppendSpacerColumn(unsigned modelColumn);
+
+	/**
+	 * Sizes the per-column state and snapshots the current widths. Call
+	 * after the columns exist and after LoadColumnSettings(): it preserves
+	 * any hidden flags already restored through the width adapter.
+	 */
+	void InitColumnState();
+
+	/**
+	 * Adapts this control to IColumnWidthProvider for CListColumnStore.
+	 * A separate object rather than multiple inheritance: wxDataViewCtrl's
+	 * own GetColumnCount() is virtual and returns unsigned, which isn't
+	 * override-compatible with the interface's int.
+	 */
+	class ColumnWidthAdapter : public IColumnWidthProvider
+	{
+	public:
+		explicit ColumnWidthAdapter(CMuleDataViewCtrl *ctrl)
+		: m_ctrl(ctrl)
+		{
+		}
+		int GetColumnCount() const override { return static_cast<int>(m_ctrl->RealColumnCount()); }
+		//! A hidden column reads as zero-width, which is how
+		//! CListColumnStore already persists hidden state.
+		int GetColumnWidth(int col) const override;
+		bool SetColumnWidth(int col, int width) override
+		{
+			m_ctrl->SetColumnHidden(col, width <= COL_SIZE_MIN, width);
+			return true;
+		}
+
+	private:
+		CMuleDataViewCtrl *m_ctrl;
+	};
+
+	CListColumnStore m_columnStore;
+	ColumnWidthAdapter m_widthAdapter;
+	CSortingList m_sort_orders;
+
+	void OnColumnHeaderClick(wxDataViewEvent &event);
+	void OnColumnHeaderRightClick(wxDataViewEvent &event);
+	void OnColumnMenuSelected(wxCommandEvent &evt);
+	void OnIdle(wxIdleEvent &event);
+	void OnChar(wxKeyEvent &evt);
+	void OnKeyDown(wxKeyEvent &evt);
+
+private:
+	//! Per-column hidden state, indexed like the control's columns.
+	std::vector<bool> m_columnHidden;
+
+	//! Last-seen widths, for detecting a drag-resize (no portable event).
+	std::vector<int> m_lastKnownWidths;
+
+	//! True once AppendSpacerColumn() has run (macOS only).
+	bool m_hasSpacer = false;
+
+	// Type-ahead state.
+	wxString m_ttsText;
+	uint64 m_ttsTime = 0;
+	void *m_ttsItem = nullptr;
+
+#ifdef __WXOSX__
+	enum class PageMotion
+	{
+		PageUp,
+		PageDown,
+		Home,
+		End
+	};
+	/**
+	 * Extends the selection by a page, or to the start/end of the list.
+	 * GTK and MSW get this from their backends; NSOutlineView moves the
+	 * view without touching the selection.
+	 */
+	void PageExtendSelection(PageMotion motion);
+#endif
+
+	wxDECLARE_EVENT_TABLE();
+};
+
+#endif // MULEDATAVIEWCTRL_H

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -1,0 +1,481 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include "MuleVirtualDataViewCtrl.h" // Interface declarations
+
+#include <algorithm> // Needed for std::sort, std::lower_bound, std::remove
+
+#include <wx/utils.h> // Needed for wxGetMouseState()
+
+#include "Preferences.h" // Needed for thePrefs::LiveListSort()
+
+namespace
+{
+//! Retry cadence while the user is interacting, in ms.
+const int kResortRetryMs = 250;
+const int kResortTimerId = wxID_HIGHEST + 1201;
+} // namespace
+
+wxBEGIN_EVENT_TABLE(CMuleVirtualDataViewCtrl, CMuleDataViewCtrl)
+	EVT_TIMER(kResortTimerId, CMuleVirtualDataViewCtrl::OnResortTimer)
+wxEND_EVENT_TABLE()
+
+/**
+ * The row-addressed view onto the control's item vector.
+ *
+ * Deliberately minimal: it holds no data of its own and answers every
+ * question by indexing into the owner's m_items. Nothing here is virtual for
+ * subclasses to touch -- they see the wxUIntPtr-based hooks instead.
+ */
+class CMuleVirtualDataViewCtrl::VirtualModel : public wxDataViewIndexListModel
+{
+public:
+	explicit VirtualModel(CMuleVirtualDataViewCtrl *owner)
+	: m_owner(owner)
+	{
+	}
+
+	unsigned int GetColumnCount() const override { return m_owner->GetColumnCount(); }
+
+	//! Taken from the column's own renderer, so a list can mix plain text and
+	//! icon+text columns without telling the model about it separately.
+	wxString GetColumnType(unsigned int col) const override
+	{
+		if (col >= m_owner->GetColumnCount()) {
+			return "string";
+		}
+		return m_owner->GetColumn(col)->GetRenderer()->GetVariantType();
+	}
+
+	void GetValueByRow(wxVariant &variant, unsigned row, unsigned col) const override
+	{
+		const bool iconText = (GetColumnType(col) == "wxDataViewIconText");
+		if (row >= m_owner->m_items.size() || col >= m_owner->RealColumnCount()) {
+			// Out of range, or the trailing spacer column, which is always
+			// empty by construction.
+			if (iconText) {
+				variant << wxDataViewIconText(wxEmptyString, wxIcon());
+			} else {
+				variant = wxString();
+			}
+			return;
+		}
+
+		const wxUIntPtr data = m_owner->m_items[row];
+		const wxString text = m_owner->GetItemColumnText(data, col);
+		if (!iconText) {
+			variant = text;
+			return;
+		}
+		wxIcon icon;
+		m_owner->GetItemIcon(data, col, icon);
+		variant << wxDataViewIconText(text, icon);
+	}
+
+	bool SetValueByRow(const wxVariant &, unsigned, unsigned) override { return false; }
+
+	/**
+	 * Keeps wx's own sorting in step with ours instead of letting it invent
+	 * an order.
+	 *
+	 * The columns are sortable so the header caret is drawn, which also means
+	 * wx sorts on a header click -- and wxDataViewModel::Compare() defaults
+	 * to comparing the rendered strings, so "10" would land before "9" and
+	 * the list's own comparator would never be consulted. Answering in terms
+	 * of the row order the control already holds makes wx's sort reproduce
+	 * m_items exactly, which the type-ahead and page keys rely on.
+	 *
+	 * The ascending flag is ignored on purpose. SortList() has already put
+	 * m_items in the requested direction, so honouring it here would invert
+	 * a second time and the list would snap back to where it started -- the
+	 * order only appearing to change on the very first click.
+	 */
+	int Compare(const wxDataViewItem &item1,
+		const wxDataViewItem &item2,
+		unsigned int WXUNUSED(column),
+		bool WXUNUSED(ascending)) const override
+	{
+		return static_cast<int>(GetRow(item1)) - static_cast<int>(GetRow(item2));
+	}
+
+	bool HasDefaultCompare() const override { return true; }
+
+	bool GetAttrByRow(unsigned row, unsigned col, wxDataViewItemAttr &attr) const override
+	{
+		if (row >= m_owner->m_items.size()) {
+			return false;
+		}
+		return m_owner->GetItemAttr(m_owner->m_items[row], col, attr);
+	}
+
+private:
+	CMuleVirtualDataViewCtrl *m_owner;
+};
+
+CMuleVirtualDataViewCtrl::CMuleVirtualDataViewCtrl(wxWindow *parent,
+	wxWindowID winid,
+	const wxPoint &pos,
+	const wxSize &size,
+	long style,
+	const wxString &name)
+: CMuleDataViewCtrl(parent, winid, pos, size, style, name)
+, m_virtualModel(new VirtualModel(this))
+{
+	m_resortTimer.SetOwner(this, kResortTimerId);
+}
+
+CMuleVirtualDataViewCtrl::~CMuleVirtualDataViewCtrl()
+{
+	m_virtualModel->DecRef();
+}
+
+void CMuleVirtualDataViewCtrl::AssociateVirtualModel()
+{
+	AssociateModel(m_virtualModel);
+}
+
+long CMuleVirtualDataViewCtrl::RowOfData(wxUIntPtr data) const
+{
+	const auto it = m_rowOf.find(data);
+	return (it == m_rowOf.end()) ? -1 : it->second;
+}
+
+wxUIntPtr CMuleVirtualDataViewCtrl::ItemAt(long row) const
+{
+	if (row < 0 || static_cast<size_t>(row) >= m_items.size()) {
+		return 0;
+	}
+	return m_items[static_cast<size_t>(row)];
+}
+
+void CMuleVirtualDataViewCtrl::RebuildRowIndex()
+{
+	m_rowOf.clear();
+	m_rowOf.reserve(m_items.size());
+	for (size_t i = 0; i < m_items.size(); ++i) {
+		m_rowOf[m_items[i]] = static_cast<long>(i);
+	}
+}
+
+int CMuleVirtualDataViewCtrl::CompareItemsFull(wxUIntPtr data1, wxUIntPtr data2) const
+{
+	// Walks the sort chain the base maintains: primary column first, then
+	// the tie-breakers left by earlier header clicks.
+	for (const CColPair &entry : m_sort_orders) {
+		const int modifier = (entry.second & SORT_DES) ? -1 : 1;
+		const bool alt = (entry.second & SORT_ALT) != 0;
+		const int result = CompareItemData(data1, data2, entry.first, alt, modifier);
+		if (result != 0) {
+			return result;
+		}
+	}
+	return 0;
+}
+
+long CMuleVirtualDataViewCtrl::InsertPos(wxUIntPtr data) const
+{
+	const auto at =
+		std::lower_bound(m_items.begin(), m_items.end(), data, [this](wxUIntPtr lhs, wxUIntPtr rhs) {
+			return CompareItemsFull(lhs, rhs) < 0;
+		});
+	return static_cast<long>(std::distance(m_items.begin(), at));
+}
+
+std::vector<wxUIntPtr> CMuleVirtualDataViewCtrl::GetSelectedItemData() const
+{
+	wxDataViewItemArray selection;
+	const_cast<CMuleVirtualDataViewCtrl *>(this)->GetSelections(selection);
+
+	std::vector<wxUIntPtr> data;
+	data.reserve(selection.GetCount());
+	for (size_t i = 0; i < selection.GetCount(); ++i) {
+		const unsigned row = m_virtualModel->GetRow(selection[i]);
+		if (row < m_items.size()) {
+			data.push_back(m_items[row]);
+		}
+	}
+	return data;
+}
+
+void CMuleVirtualDataViewCtrl::SetSelectedItemData(const std::vector<wxUIntPtr> &data)
+{
+	wxDataViewItemArray selection;
+	for (wxUIntPtr item : data) {
+		const long row = RowOfData(item);
+		if (row >= 0) {
+			selection.Add(m_virtualModel->GetItem(static_cast<unsigned>(row)));
+		}
+	}
+	SetSelections(selection);
+}
+
+void CMuleVirtualDataViewCtrl::AddItemData(wxUIntPtr data)
+{
+	if (!data || HasItemData(data)) {
+		return;
+	}
+	const long pos = InsertPos(data);
+
+	// Selection is re-resolved rather than kept: a wxDataViewItem from a
+	// row-addressed model would silently point at a different row once
+	// everything below the insertion shifts down. Rows above the insertion
+	// don't move, and an empty selection has nothing to preserve, so both
+	// cases skip the round-trip -- it is O(selection) and this path runs per
+	// arriving item.
+	const bool shifts = (static_cast<size_t>(pos) < m_items.size());
+	const std::vector<wxUIntPtr> selected =
+		(shifts && HasSelection()) ? GetSelectedItemData() : std::vector<wxUIntPtr>();
+
+	m_items.insert(m_items.begin() + pos, data);
+	RebuildRowIndex();
+	m_virtualModel->RowInserted(static_cast<unsigned>(pos));
+
+	if (!selected.empty()) {
+		SetSelectedItemData(selected);
+	}
+}
+
+void CMuleVirtualDataViewCtrl::AppendItemData(wxUIntPtr data)
+{
+	if (!data || HasItemData(data)) {
+		return;
+	}
+	m_items.push_back(data);
+	m_rowOf[data] = static_cast<long>(m_items.size()) - 1;
+}
+
+void CMuleVirtualDataViewCtrl::AppendItemDataNow(wxUIntPtr data)
+{
+	if (!data || HasItemData(data)) {
+		return;
+	}
+	m_items.push_back(data);
+	m_rowOf[data] = static_cast<long>(m_items.size()) - 1;
+	// Appending at the end leaves every other row where it was, so no
+	// selection round-trip is needed here.
+	m_virtualModel->RowInserted(static_cast<unsigned>(m_items.size()) - 1);
+}
+
+void CMuleVirtualDataViewCtrl::RemoveItemDataBatch(const std::vector<wxUIntPtr> &data)
+{
+	wxArrayInt rows;
+	for (wxUIntPtr item : data) {
+		const long row = RowOfData(item);
+		if (row >= 0) {
+			rows.Add(static_cast<int>(row));
+		}
+	}
+	if (rows.IsEmpty()) {
+		return;
+	}
+
+	std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	for (wxUIntPtr item : data) {
+		selected.erase(std::remove(selected.begin(), selected.end(), item), selected.end());
+	}
+
+	// Erase from the highest row down so the earlier indices stay valid.
+	wxArrayInt ordered(rows);
+	ordered.Sort([](int *a, int *b) { return *b - *a; });
+	for (size_t i = 0; i < ordered.GetCount(); ++i) {
+		m_items.erase(m_items.begin() + ordered[i]);
+	}
+	RebuildRowIndex();
+	// One notification for the whole set, and sent before the caller frees
+	// anything these point at.
+	m_virtualModel->RowsDeleted(rows);
+
+	SetSelectedItemData(selected);
+}
+
+void CMuleVirtualDataViewCtrl::FinishBulkLoad()
+{
+	SortList();
+}
+
+void CMuleVirtualDataViewCtrl::RemoveItemData(wxUIntPtr data)
+{
+	const long pos = RowOfData(data);
+	if (pos < 0) {
+		return;
+	}
+	std::vector<wxUIntPtr> selected = HasSelection() ? GetSelectedItemData() : std::vector<wxUIntPtr>();
+	selected.erase(std::remove(selected.begin(), selected.end(), data), selected.end());
+
+	m_items.erase(m_items.begin() + pos);
+	RebuildRowIndex();
+	// Told before the caller frees whatever `data` points at: the control
+	// must not be left holding a row for an object that no longer exists.
+	m_virtualModel->RowDeleted(static_cast<unsigned>(pos));
+
+	if (!selected.empty()) {
+		SetSelectedItemData(selected);
+	}
+}
+
+void CMuleVirtualDataViewCtrl::RefreshItemData(wxUIntPtr data)
+{
+	const long row = RowOfData(data);
+	if (row < 0) {
+		return;
+	}
+	m_virtualModel->RowChanged(static_cast<unsigned>(row));
+
+	// The value that just changed may be the one the list is sorted by, in
+	// which case the row has to move. Scheduled rather than done here: an
+	// update burst refreshes many rows, and re-sorting on each would be
+	// quadratic. Gated by the same preference CMuleVirtualListCtrl checks.
+	if (thePrefs::LiveListSort() && IsLiveSortColumn()) {
+		m_resortPending = true;
+		ScheduleResort();
+	}
+}
+
+void CMuleVirtualDataViewCtrl::ClearItemData()
+{
+	m_items.clear();
+	m_rowOf.clear();
+	m_virtualModel->Reset(0);
+}
+
+void CMuleVirtualDataViewCtrl::SortList()
+{
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+
+	std::sort(m_items.begin(), m_items.end(), [this](wxUIntPtr lhs, wxUIntPtr rhs) {
+		return CompareItemsFull(lhs, rhs) < 0;
+	});
+	RebuildRowIndex();
+	// Reset() rather than a per-row notification: with nothing materialised
+	// per row this only re-reads what is on screen.
+	m_virtualModel->Reset(static_cast<unsigned>(m_items.size()));
+
+	// Reset() drops the selection on wxGTK (it survives on macOS), so it is
+	// re-applied from the item data either way.
+	SetSelectedItemData(selected);
+}
+
+void CMuleVirtualDataViewCtrl::GetDisplayOrder(wxDataViewItemArray &ordered) const
+{
+	// m_items is already the display order, so this is a straight copy.
+	ordered.Clear();
+	ordered.Alloc(m_items.size());
+	for (size_t i = 0; i < m_items.size(); ++i) {
+		ordered.Add(m_virtualModel->GetItem(static_cast<unsigned>(i)));
+	}
+}
+
+wxString CMuleVirtualDataViewCtrl::GetRowLabel(const wxDataViewItem &item) const
+{
+	const unsigned row = m_virtualModel->GetRow(item);
+	if (row >= m_items.size()) {
+		return wxEmptyString;
+	}
+	return GetItemColumnText(m_items[row], 0);
+}
+
+int CMuleVirtualDataViewCtrl::CompareByColumn(const wxDataViewItem &item1,
+	const wxDataViewItem &item2,
+	unsigned column,
+	bool alt,
+	int modifier) const
+{
+	const unsigned row1 = m_virtualModel->GetRow(item1);
+	const unsigned row2 = m_virtualModel->GetRow(item2);
+	if (row1 >= m_items.size() || row2 >= m_items.size()) {
+		return 0;
+	}
+	return CompareItemData(m_items[row1], m_items[row2], column, alt, modifier);
+}
+
+void CMuleVirtualDataViewCtrl::OnSortingChanged()
+{
+	SortList();
+}
+
+void CMuleVirtualDataViewCtrl::SetFilterText(const wxString &text)
+{
+	const wxString lower = text.Lower();
+	if (lower == m_filterText) {
+		return;
+	}
+	m_filterText = lower;
+	RebuildFilteredView();
+}
+
+bool CMuleVirtualDataViewCtrl::MatchesFilter(const wxString &name) const
+{
+	if (m_filterText.IsEmpty()) {
+		return true;
+	}
+	// m_filterText is already lower-cased by SetFilterText().
+	return name.Lower().Contains(m_filterText);
+}
+
+void CMuleVirtualDataViewCtrl::ScheduleResort()
+{
+	if (m_resortScheduled) {
+		return; // one CallAfter coalesces the whole update burst
+	}
+	m_resortScheduled = true;
+	CallAfter(&CMuleVirtualDataViewCtrl::MaybeResortNow);
+}
+
+void CMuleVirtualDataViewCtrl::MaybeResortNow()
+{
+	m_resortScheduled = false;
+	if (!m_resortPending) {
+		return;
+	}
+	// The user may have switched to a static column since this was scheduled.
+	if (!IsLiveSortColumn()) {
+		m_resortPending = false;
+		return;
+	}
+	// Hold off while interacting; the retry timer polls (only during
+	// interaction) until idle.
+	if (IsInteracting()) {
+		if (!m_resortTimer.IsRunning()) {
+			m_resortTimer.Start(kResortRetryMs, wxTIMER_ONE_SHOT);
+		}
+		return;
+	}
+	m_resortPending = false;
+	SortList();
+}
+
+void CMuleVirtualDataViewCtrl::OnResortTimer(wxTimerEvent &WXUNUSED(evt))
+{
+	MaybeResortNow();
+}
+
+bool CMuleVirtualDataViewCtrl::IsInteracting() const
+{
+	// A context menu is open, or the user is holding the mouse (click /
+	// drag-select): defer the reorder so rows don't slide under the pointer.
+	if (IsMenuOpen()) {
+		return true;
+	}
+	return wxGetMouseState().LeftIsDown();
+}

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -1,0 +1,222 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#ifndef MULEVIRTUALDATAVIEWCTRL_H
+#define MULEVIRTUALDATAVIEWCTRL_H
+
+#include "MuleDataViewCtrl.h" // Needed for CMuleDataViewCtrl
+
+#include <wx/timer.h> // Needed for wxTimer (deferred live re-sort)
+
+#include <unordered_map>
+#include <vector>
+
+/**
+ * A CMuleDataViewCtrl holding a flat, model-owned list of items.
+ *
+ * The wxDataViewCtrl counterpart of CMuleVirtualListCtrl, and virtual in the
+ * same sense: the control materialises nothing per row. Rows are addressed by
+ * index through a wxDataViewIndexListModel, and cell text is pulled from the
+ * subclass on demand for the cells actually drawn.
+ *
+ * Two consequences are worth knowing before deriving from this.
+ *
+ * The list owns the order. Sorting is done here, over m_items, rather than by
+ * wx calling wxDataViewModel::Compare() -- the columns are marked sortable so
+ * the header caret appears, but wx is never asked to reorder anything.
+ *
+ * Item identity is not row identity. A wxDataViewItem from a row-addressed
+ * model encodes the row number, so removing a row silently moves what any
+ * previously-held item refers to. Everything below therefore speaks in
+ * wxUIntPtr item data, and selection is preserved across mutations by
+ * re-resolving that data to rows -- never by holding wxDataViewItems.
+ */
+class CMuleVirtualDataViewCtrl : public CMuleDataViewCtrl
+{
+public:
+	CMuleVirtualDataViewCtrl(wxWindow *parent,
+		wxWindowID winid = wxID_ANY,
+		const wxPoint &pos = wxDefaultPosition,
+		const wxSize &size = wxDefaultSize,
+		long style = 0,
+		const wxString &name = "mulevirtualdataviewctrl");
+
+	~CMuleVirtualDataViewCtrl() override;
+
+	//! Inserts in sorted position and tells the control about that row only.
+	void AddItemData(wxUIntPtr data);
+	//! Appends without sorting; pair with FinishBulkLoad().
+	void AppendItemData(wxUIntPtr data);
+	/**
+	 * Appends one item and shows it immediately, without sorting.
+	 *
+	 * For the single add that has to appear while a popup menu is up: the
+	 * batch path defers its work, and idle events don't run inside a modal
+	 * loop, so the row would otherwise not appear until the menu closed.
+	 */
+	void AppendItemDataNow(wxUIntPtr data);
+	//! Sorts and refreshes once, after a run of AppendItemData().
+	void FinishBulkLoad();
+	//! Drops the row, keeping the selection on the items that remain.
+	void RemoveItemData(wxUIntPtr data);
+	/**
+	 * Drops many rows as one operation.
+	 *
+	 * A loop of RemoveItemData() costs an index rebuild and a selection
+	 * round-trip per item; this pays each once, and tells the control about
+	 * the whole set in a single notification.
+	 */
+	void RemoveItemDataBatch(const std::vector<wxUIntPtr> &data);
+	//! Repaints just this row, re-sorting only if it moved under the sort.
+	void RefreshItemData(wxUIntPtr data);
+	void ClearItemData();
+	//! Name-compatible with the wxListCtrl API the ported lists were written
+	//! against, so their callers don't have to change.
+	bool DeleteAllItems()
+	{
+		ClearItemData();
+		return true;
+	}
+
+	bool HasItemData(wxUIntPtr data) const { return m_rowOf.count(data) != 0; }
+	long RowOfData(wxUIntPtr data) const;
+	wxUIntPtr ItemAt(long row) const;
+	long ItemDataCount() const { return static_cast<long>(m_items.size()); }
+
+	//! Cheap "is anything selected" test, avoiding a full selection copy.
+	bool HasSelection() const
+	{
+		return const_cast<CMuleVirtualDataViewCtrl *>(this)->GetSelectedItemsCount() > 0;
+	}
+
+	//! Item data of every selected row, in display order.
+	std::vector<wxUIntPtr> GetSelectedItemData() const;
+	//! Selects exactly these items, ignoring any that are no longer present.
+	void SetSelectedItemData(const std::vector<wxUIntPtr> &data);
+
+	//! Re-sorts the whole list, preserving the selection.
+	void SortList();
+
+	/**
+	 * Live text filter. Setting it calls RebuildFilteredView(), which the
+	 * list implements by re-populating itself from its own data source --
+	 * the filter is purely a GUI-side view, exactly as on
+	 * CMuleVirtualListCtrl.
+	 */
+	void SetFilterText(const wxString &text);
+
+protected:
+	// --- what a subclass must provide -------------------------------------
+
+	//! Text for a cell. Called only for cells being drawn.
+	virtual wxString GetItemColumnText(wxUIntPtr data, unsigned column) const = 0;
+
+	/**
+	 * Icon for a cell in a column appended as an icon+text column.
+	 * Return false to draw text alone.
+	 */
+	virtual bool GetItemIcon(
+		wxUIntPtr WXUNUSED(data), unsigned WXUNUSED(column), wxIcon &WXUNUSED(icon)) const
+	{
+		return false;
+	}
+
+	//! Per-row display attributes (bold, colour). Return false for default.
+	virtual bool GetItemAttr(
+		wxUIntPtr WXUNUSED(data), unsigned WXUNUSED(column), wxDataViewItemAttr &WXUNUSED(attr)) const
+	{
+		return false;
+	}
+
+	//! Single-column comparison of two items; the caller applies `modifier`.
+	virtual int CompareItemData(
+		wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const = 0;
+
+	/**
+	 * Whether the active sort column's values change while the list is up,
+	 * so a refreshed row may have to move. Gated by thePrefs::LiveListSort()
+	 * exactly as CMuleVirtualListCtrl gates it.
+	 */
+	virtual bool IsLiveSortColumn() const { return false; }
+
+	//! True while a context menu is up, so a reorder can be deferred.
+	virtual bool IsMenuOpen() const { return false; }
+
+	//! Re-populate the list for the current filter text.
+	virtual void RebuildFilteredView() {}
+
+	//! Whether `name` passes the current filter (case-insensitive contains).
+	bool MatchesFilter(const wxString &name) const;
+
+	// --- CMuleDataViewCtrl hooks ------------------------------------------
+
+	void GetDisplayOrder(wxDataViewItemArray &ordered) const override;
+	wxString GetRowLabel(const wxDataViewItem &item) const override;
+	int CompareByColumn(const wxDataViewItem &item1,
+		const wxDataViewItem &item2,
+		unsigned column,
+		bool alt,
+		int modifier) const override;
+	void OnSortingChanged() override;
+
+	//! Associates the internal model; call once the columns are appended.
+	void AssociateVirtualModel();
+
+private:
+	class VirtualModel;
+	friend class VirtualModel;
+
+	//! Full sort-chain comparison of two items.
+	int CompareItemsFull(wxUIntPtr data1, wxUIntPtr data2) const;
+	//! Where `data` belongs under the current sort.
+	long InsertPos(wxUIntPtr data) const;
+	//! m_rowOf is a cache of m_items; every structural change rebuilds it.
+	void RebuildRowIndex();
+
+	/**
+	 * Coalesces live re-sorts. A burst of RefreshItemData() calls schedules
+	 * exactly one reorder, and it is held off while the user is interacting
+	 * so rows don't slide out from under the pointer -- the same treatment
+	 * CMuleVirtualListCtrl gives it.
+	 */
+	void ScheduleResort();
+	void MaybeResortNow();
+	void OnResortTimer(wxTimerEvent &evt);
+	bool IsInteracting() const;
+
+	VirtualModel *m_virtualModel;
+
+	wxString m_filterText;
+	bool m_resortPending = false;
+	bool m_resortScheduled = false;
+	wxTimer m_resortTimer;
+
+	//! The rows, in display order. The single source of truth for ordering.
+	std::vector<wxUIntPtr> m_items;
+	std::unordered_map<wxUIntPtr, long> m_rowOf;
+
+	wxDECLARE_EVENT_TABLE();
+};
+
+#endif // MULEVIRTUALDATAVIEWCTRL_H

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -50,15 +50,10 @@
 #include "Preferences.h"    // Needed for thePrefs
 #include "GuiEvents.h"      // Needed for CoreNotify_Search_Add_Download
 
-wxBEGIN_EVENT_TABLE(CSearchListCtrl, wxDataViewCtrl)
+wxBEGIN_EVENT_TABLE(CSearchListCtrl, CMuleDataViewCtrl)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CSearchListCtrl::OnRightClick)
-	EVT_DATAVIEW_COLUMN_HEADER_CLICK(wxID_ANY, CSearchListCtrl::OnColumnHeaderClick)
-	EVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK(wxID_ANY, CSearchListCtrl::OnColumnHeaderRightClick)
 	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CSearchListCtrl::OnItemActivated)
 	EVT_DATAVIEW_SELECTION_CHANGED(wxID_ANY, CSearchListCtrl::OnSelectionChanged)
-	EVT_IDLE(CSearchListCtrl::OnIdle)
-	EVT_CHAR(CSearchListCtrl::OnChar)
-	EVT_KEY_DOWN(CSearchListCtrl::OnKeyDown)
 
 	EVT_MENU(MP_GETED2KLINK, CSearchListCtrl::OnPopupGetUrl)
 	EVT_MENU(MP_RAZORSTATS, CSearchListCtrl::OnRazorStatsCheck)
@@ -66,7 +61,6 @@ wxBEGIN_EVENT_TABLE(CSearchListCtrl, wxDataViewCtrl)
 	EVT_MENU(MP_GETCOMMENTS, CSearchListCtrl::OnGetComments)
 	EVT_MENU(MP_RESUME, CSearchListCtrl::OnPopupDownload)
 	EVT_MENU_RANGE(MP_ASSIGNCAT, MP_ASSIGNCAT + 99, CSearchListCtrl::OnPopupDownload)
-	EVT_MENU_RANGE(MP_LISTCOL_1, MP_LISTCOL_15, CSearchListCtrl::OnColumnMenuSelected)
 wxEND_EVENT_TABLE()
 
 std::list<CSearchListCtrl *> CSearchListCtrl::s_lists;
@@ -83,15 +77,10 @@ const unsigned SORTING_MASK = 0x3000;
 
 CSearchListCtrl::CSearchListCtrl(
 	wxWindow *parent, wxWindowID winid, const wxPoint &pos, const wxSize &size, const wxString &name)
-// wxDataViewCtrl defaults to single selection, while the wxListCtrl this
-// replaces was multi-select unless given wxLC_SINGLE_SEL -- without
-// wxDV_MULTIPLE every GetSelections() caller below (download, copy links,
-// category assign, ...) can only ever act on one result.
-: wxDataViewCtrl(parent, winid, pos, size, wxDV_ROW_LINES | wxDV_MULTIPLE, wxDefaultValidator, name)
+: CMuleDataViewCtrl(parent, winid, pos, size, 0, name)
 , m_nResultsID(0)
 , m_browseEcid(0)
 , m_browseStatus(0)
-, m_widthAdapter(this)
 , m_filterKnown(false)
 , m_invert(false)
 , m_filterEnabled(false)
@@ -183,20 +172,9 @@ CSearchListCtrl::CSearchListCtrl(
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 
-#ifdef __WXOSX__
-	// Not registered with the column store and not offered in the header
-	// menu: it exists only to absorb the trailing-column sizing described
-	// on CSearchListModel::COL_SPACER.
-	// Resizable is load-bearing: macOS hands the leftover space to the last
-	// *resizable* column, so a fixed spacer cannot shrink and the collapse
-	// falls through to the last real column instead.
-	AppendTextColumn(wxEmptyString,
-		CSearchListModel::COL_SPACER,
-		wxDATAVIEW_CELL_INERT,
-		1,
-		wxALIGN_LEFT,
-		wxDATAVIEW_COL_RESIZABLE);
-#endif
+	// Absorbs the macOS trailing-column sizing; the model answers COL_SPACER
+	// with an empty string.
+	AppendSpacerColumn(CSearchListModel::COL_SPACER);
 
 	m_columnStore.RegisterColumn(CSearchListModel::COL_NAME, 500, "N");
 	m_columnStore.RegisterColumn(CSearchListModel::COL_SIZE, 100, "Z");
@@ -209,10 +187,6 @@ CSearchListCtrl::CSearchListCtrl(
 	m_columnStore.RegisterColumn(CSearchListModel::COL_BITRATE, 80, "B");
 	m_columnStore.RegisterColumn(CSearchListModel::COL_CODEC, 80, "C");
 	m_columnStore.RegisterColumn(CSearchListModel::COL_DIRECTORY, 280, "D");
-
-	// Sized before LoadColumnSettings(), which restores hidden columns through
-	// the width adapter and therefore writes into this.
-	m_columnHidden.assign(RealColumnCount(), false);
 
 	// Default sort is by name, ascending.
 	m_sort_orders.emplace_back(CSearchListModel::COL_NAME, 0);
@@ -227,9 +201,7 @@ CSearchListCtrl::CSearchListCtrl(
 		SyncLists(s_lists.front(), this);
 	}
 
-	for (unsigned i = 0; i < RealColumnCount(); ++i) {
-		m_lastKnownWidths.push_back(GetColumn(i)->GetWidth());
-	}
+	InitColumnState();
 
 	s_lists.push_back(this);
 }
@@ -253,42 +225,6 @@ CSearchListCtrl::~CSearchListCtrl()
 		m_columnStore.SetTableName("Search");
 		SaveColumnSettings();
 	}
-}
-
-void CSearchListCtrl::LoadColumnSettings()
-{
-	if (!m_columnStore.HasTableName()) {
-		return;
-	}
-
-	CListColumnStore::CSortingList decoded;
-	m_columnStore.LoadSettings(m_widthAdapter, "N,Z,u,Y,I,S", decoded);
-
-	// Restored widths can leave the default expander column hidden, which
-	// would strand the group triangles on a column nobody can see.
-	UpdateExpanderColumn();
-
-	// LoadSettings() returns the orders primary-LAST: CMuleListCtrl applied
-	// them by calling SetSorting() on each in turn, and each call pushes to
-	// the front, so the last one processed ends up primary. ApplySorting()
-	// has the same push-to-front semantics, so replaying them in order
-	// reproduces that -- taking front() as the primary instead (as this
-	// used to) picks the least significant entry (got3nks, PR #796 review).
-	m_sort_orders.clear();
-	for (const CListColumnStore::CColPair &pair : decoded) {
-		ApplySorting(pair.first, pair.second);
-	}
-	if (m_sort_orders.empty()) {
-		ApplySorting(CSearchListModel::COL_NAME, 0);
-	}
-}
-
-void CSearchListCtrl::SaveColumnSettings()
-{
-	if (!m_columnStore.HasTableName()) {
-		return;
-	}
-	m_columnStore.SaveSettings(m_widthAdapter, m_sort_orders);
 }
 
 bool CSearchListCtrl::PassesFilter(const CSearchFile *file) const
@@ -423,7 +359,7 @@ int CSearchListCtrl::GetSelectedItemCount() const
 	return static_cast<int>(const_cast<CSearchListCtrl *>(this)->GetSelections(selections));
 }
 
-int CSearchListCtrl::CompareByColumn(
+int CSearchListCtrl::CompareFilesByColumn(
 	const CSearchFile *f1, const CSearchFile *f2, unsigned column, bool alt, int modifier) const
 {
 	switch (column) {
@@ -534,85 +470,12 @@ int CSearchListCtrl::CompareByColumn(
 
 int CSearchListCtrl::CompareFiles(const CSearchFile *f1, const CSearchFile *f2) const
 {
-	for (const CColPair &entry : m_sort_orders) {
-		const unsigned column = entry.first;
-		const unsigned order = entry.second;
-		const int modifier = (order & SORT_DES) ? -1 : 1;
-		const bool alt = (order & SORT_ALT) != 0;
-
-		int result = CompareByColumn(f1, f2, column, alt, modifier);
-		if (result != 0) {
-			return result;
-		}
-	}
-	return 0;
+	return CompareItems(CSearchListModel::ToItem(f1), CSearchListModel::ToItem(f2));
 }
 
 bool CSearchListCtrl::AltSortAllowed(unsigned column) const
 {
 	return column == CSearchListModel::COL_SOURCES;
-}
-
-void CSearchListCtrl::ApplySorting(unsigned column, unsigned order)
-{
-	CSortingList::iterator it = m_sort_orders.begin();
-	for (; it != m_sort_orders.end(); ++it) {
-		if (it->first == column) {
-			m_sort_orders.erase(it);
-			break;
-		}
-	}
-	m_sort_orders.emplace_front(column, order);
-
-	// Unmark the previous sort column (only one wxDataViewColumn can be the
-	// active sort key at a time; SetSortOrder() below moves the mark).
-	for (unsigned i = 0; i < RealColumnCount(); ++i) {
-		if (i != column && GetColumn(i)->IsSortKey()) {
-			GetColumn(i)->UnsetAsSortKey();
-		}
-	}
-	GetColumn(column)->SetSortOrder(!(order & SORT_DES));
-	GetModel()->Resort();
-
-	SyncOtherLists(this);
-}
-
-void CSearchListCtrl::OnColumnHeaderClick(wxDataViewEvent &event)
-{
-	wxDataViewColumn *col = event.GetDataViewColumn();
-	if (!col) {
-		event.Skip();
-		return;
-	}
-	const unsigned column = static_cast<unsigned>(col->GetModelColumn());
-
-	// Mirrors CMuleListCtrl::OnColumnLClick's cycle: same column clicked
-	// again flips ascending<->descending, and once descending, a further
-	// click on an alt-eligible column flips to ascending with the alt
-	// criterion toggled instead of clearing the sort.
-	unsigned sort_order = 0;
-	if (!m_sort_orders.empty() && m_sort_orders.front().first == column) {
-		sort_order = m_sort_orders.front().second;
-		if (sort_order & SORT_DES) {
-			if (AltSortAllowed(column)) {
-				sort_order = (~sort_order) & SORT_ALT;
-			} else {
-				sort_order = 0;
-			}
-		} else {
-			sort_order = SORT_DES | (sort_order & SORT_ALT);
-		}
-	} else {
-		for (CSortingList::const_iterator it = m_sort_orders.begin(); it != m_sort_orders.end();
-			++it) {
-			if (it->first == column) {
-				sort_order = it->second;
-				break;
-			}
-		}
-	}
-
-	ApplySorting(column, sort_order);
 }
 
 void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
@@ -658,10 +521,40 @@ void CSearchListCtrl::SyncOtherLists(CSearchListCtrl *src)
 	}
 }
 
-void CSearchListCtrl::OnIdle(wxIdleEvent &event)
+int CSearchListCtrl::CompareByColumn(const wxDataViewItem &item1,
+	const wxDataViewItem &item2,
+	unsigned column,
+	bool alt,
+	int modifier) const
 {
-	event.Skip();
+	return CompareFilesByColumn(
+		CSearchListModel::ToFile(item1), CSearchListModel::ToFile(item2), column, alt, modifier);
+}
 
+void CSearchListCtrl::GetDisplayOrder(wxDataViewItemArray &ordered) const
+{
+	std::vector<CSearchFile *> files;
+	BuildDisplayOrder(files);
+
+	ordered.Clear();
+	ordered.Alloc(files.size());
+	for (CSearchFile *file : files) {
+		ordered.Add(CSearchListModel::ToItem(file));
+	}
+}
+
+wxString CSearchListCtrl::GetRowLabel(const wxDataViewItem &item) const
+{
+	return CSearchListModel::ToFile(item)->GetFileName().GetPrintable();
+}
+
+wxString CSearchListCtrl::GetOldColumnOrder() const
+{
+	return "N,Z,u,Y,I,S";
+}
+
+void CSearchListCtrl::OnIdleHook()
+{
 	// One coalesced rebuild per idle for everything that arrived since the
 	// last one (got3nks, PR #796 review): mixing incremental Item*
 	// notifications with the full model reset a group formation needs left
@@ -706,21 +599,19 @@ void CSearchListCtrl::OnIdle(wxIdleEvent &event)
 			SetSelections(restore);
 		}
 	}
+}
 
-	// No portable wxDataViewCtrl "column resized" event exists to hook
-	// directly (unlike wxListCtrl's EVT_LIST_COL_END_DRAG), so a drag-resize
-	// is detected here by simply comparing against the last-seen widths.
-	bool changed = false;
-	for (int i = 0; i < (int)RealColumnCount() && i < (int)m_lastKnownWidths.size(); ++i) {
-		const int width = GetColumn(i)->GetWidth();
-		if (width != m_lastKnownWidths[i]) {
-			m_lastKnownWidths[i] = width;
-			changed = true;
-		}
+void CSearchListCtrl::OnColumnWidthsChanged()
+{
+	SyncOtherLists(this);
+}
+
+void CSearchListCtrl::OnSortingChanged()
+{
+	if (GetModel()) {
+		GetModel()->Resort();
 	}
-	if (changed) {
-		SyncOtherLists(this);
-	}
+	SyncOtherLists(this);
 }
 
 void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
@@ -762,92 +653,6 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 	} else {
 		event.Skip();
 	}
-}
-
-void CSearchListCtrl::OnColumnHeaderRightClick(wxDataViewEvent &event)
-{
-	// Show/hide menu, as CMuleListCtrl::OnColumnRClick offered on every
-	// other list.
-	wxMenu menu;
-	const unsigned columns = std::min<unsigned>(RealColumnCount(), MP_LISTCOL_15 - MP_LISTCOL_1 + 1);
-	for (unsigned i = 0; i < columns; ++i) {
-		const wxDataViewColumn *col = GetColumn(i);
-		menu.AppendCheckItem(static_cast<int>(i) + MP_LISTCOL_1, col->GetTitle());
-		menu.Check(static_cast<int>(i) + MP_LISTCOL_1, !IsColumnHidden(static_cast<int>(i)));
-	}
-
-	PopupMenu(&menu);
-	event.Skip();
-}
-
-unsigned CSearchListCtrl::RealColumnCount() const
-{
-	const unsigned columns = GetColumnCount();
-#ifdef __WXOSX__
-	return (columns > 0) ? columns - 1 : 0;
-#else
-	return columns;
-#endif
-}
-
-bool CSearchListCtrl::IsColumnHidden(int col) const
-{
-	return (col >= 0) && (static_cast<size_t>(col) < m_columnHidden.size()) && m_columnHidden[col];
-}
-
-void CSearchListCtrl::SetColumnHidden(int col, bool hidden, int width)
-{
-	if (col < 0 || static_cast<unsigned>(col) >= RealColumnCount()) {
-		return;
-	}
-	if (static_cast<size_t>(col) >= m_columnHidden.size()) {
-		m_columnHidden.resize(RealColumnCount(), false);
-	}
-
-	m_columnHidden[col] = hidden;
-	wxDataViewColumn *column = GetColumn(static_cast<unsigned>(col));
-	column->SetHidden(hidden);
-	if (!hidden && width > COL_SIZE_MIN) {
-		column->SetWidth(width);
-	}
-}
-
-void CSearchListCtrl::UpdateExpanderColumn()
-{
-	// The expander belongs on the leftmost visible column: hiding the column
-	// that currently owns it would take the group triangles with it and
-	// leave children unreachable, and re-showing a column to its left has
-	// to take them back rather than stranding them mid-row.
-	for (unsigned i = 0; i < RealColumnCount(); ++i) {
-		if (!IsColumnHidden(static_cast<int>(i))) {
-			wxDataViewColumn *column = GetColumn(i);
-			if (GetExpanderColumn() != column) {
-				SetExpanderColumn(column);
-			}
-			return;
-		}
-	}
-}
-
-void CSearchListCtrl::OnColumnMenuSelected(wxCommandEvent &evt)
-{
-	const int col = evt.GetId() - MP_LISTCOL_1;
-	if (col < 0 || static_cast<unsigned>(col) >= RealColumnCount()) {
-		return;
-	}
-
-	if (!IsColumnHidden(col)) {
-		// Remember the width so re-showing restores what the user had,
-		// exactly as CMuleListCtrl::OnMenuSelected did.
-		m_columnStore.SetCachedWidth(col, GetColumn(static_cast<unsigned>(col))->GetWidth());
-		SetColumnHidden(col, true, 0);
-	} else {
-		const int cached = m_columnStore.GetCachedWidth(col);
-		SetColumnHidden(col, false, cached > 0 ? cached : m_columnStore.GetColumnDefaultWidth(col));
-	}
-	UpdateExpanderColumn();
-	SyncOtherLists(this);
-	SaveColumnSettings();
 }
 
 void CSearchListCtrl::OnItemActivated(wxDataViewEvent &event)
@@ -945,12 +750,6 @@ void CSearchListCtrl::OnRelatedSearch(wxCommandEvent &WXUNUSED(event))
 	}
 }
 
-namespace
-{
-//! How long a pause resets the accumulated type-ahead string, in ms.
-const uint64 kTypeAheadResetMs = 1500;
-} // namespace
-
 void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) const
 {
 	// The model yields top-level rows in arrival order, so they are put
@@ -997,183 +796,6 @@ void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) con
 		std::sort(children.begin(), children.end(), byDisplayOrder);
 		ordered.insert(ordered.end(), children.begin(), children.end());
 	}
-}
-
-#ifdef __WXOSX__
-void CSearchListCtrl::PageExtendSelection(PageMotion motion)
-{
-	std::vector<CSearchFile *> ordered;
-	BuildDisplayOrder(ordered);
-	if (ordered.empty()) {
-		return;
-	}
-
-	const wxDataViewItem currentItem = GetCurrentItem();
-	CSearchFile *currentFile = currentItem.IsOk() ? CSearchListModel::ToFile(currentItem) : nullptr;
-	const auto found = std::find(ordered.begin(), ordered.end(), currentFile);
-	const bool forward = (motion == PageMotion::PageDown) || (motion == PageMotion::End);
-	const int current = (found == ordered.end())
-				    ? (forward ? -1 : static_cast<int>(ordered.size()))
-				    : static_cast<int>(std::distance(ordered.begin(), found));
-
-	const int last = static_cast<int>(ordered.size()) - 1;
-
-	int target = 0;
-	switch (motion) {
-	case PageMotion::Home:
-		target = 0;
-		break;
-	case PageMotion::End:
-		target = last;
-		break;
-	default: {
-		// GetCountPerPage() is implemented by the native macOS backend;
-		// GetItemRect() is not a substitute, since it returns an empty rect
-		// for rows that aren't currently on screen and the resulting height
-		// of zero collapses a page to a single row.
-		int rows = GetCountPerPage();
-		if (rows <= 0) {
-			rows = 10;
-		} else {
-			// Leave one row of overlap, as the other ports scroll.
-			rows = std::max(1, rows - 1);
-		}
-		const int delta = (motion == PageMotion::PageDown) ? rows : -rows;
-		target = std::min(last, std::max(0, current + delta));
-		break;
-	}
-	}
-
-	// Grow the existing selection to cover everything between where the
-	// cursor was and where it lands, so repeated presses keep extending.
-	wxDataViewItemArray selection;
-	GetSelections(selection);
-	const int from = std::min(current < 0 ? target : current, target);
-	const int to = std::max(current > last ? target : current, target);
-	for (int i = std::max(0, from); i <= std::min(last, to); ++i) {
-		const wxDataViewItem item = CSearchListModel::ToItem(ordered[i]);
-		if (selection.Index(item) == wxNOT_FOUND) {
-			selection.Add(item);
-		}
-	}
-
-	const wxDataViewItem targetItem = CSearchListModel::ToItem(ordered[target]);
-	SetSelections(selection);
-	SetCurrentItem(targetItem);
-	EnsureVisible(targetItem);
-}
-#endif // __WXOSX__
-
-void CSearchListCtrl::OnKeyDown(wxKeyEvent &evt)
-{
-#ifdef __WXOSX__
-	// NSOutlineView moves the view without touching the selection, so the
-	// shifted navigation keys -- which extend the selection on GTK and MSW
-	// -- do nothing at all here. The unshifted forms are deliberately left
-	// to the platform, which scrolls without moving the selection by
-	// convention.
-	if (evt.ShiftDown()) {
-		switch (evt.GetKeyCode()) {
-		case WXK_PAGEUP:
-			PageExtendSelection(PageMotion::PageUp);
-			return;
-		case WXK_PAGEDOWN:
-			PageExtendSelection(PageMotion::PageDown);
-			return;
-		case WXK_HOME:
-			PageExtendSelection(PageMotion::Home);
-			return;
-		case WXK_END:
-			PageExtendSelection(PageMotion::End);
-			return;
-		default:
-			break;
-		}
-	}
-#endif
-	evt.Skip();
-}
-
-void CSearchListCtrl::OnChar(wxKeyEvent &evt)
-{
-	int key = evt.GetKeyCode();
-	if (key == 0) {
-		// GetKeyCode() returns 0 for characters it can't map; the unicode
-		// key is the fallback (see CMuleListCtrl::OnChar for the history).
-		// GetUnicodeKey() returns wxChar -- a signed char in wx's UTF-8
-		// build but wchar_t in the wide build, so an unsigned-char cast
-		// would truncate the wide case and the widening is left as-is.
-		// NOLINTNEXTLINE(bugprone-signed-char-misuse)
-		key = evt.GetUnicodeKey();
-	} else if (key >= WXK_START) {
-		// Arrows, page up/down, home/end: the backend's own cursor handling
-		// owns these, and on macOS page keys deliberately scroll without
-		// moving the selection (platform convention).
-		evt.Skip();
-		return;
-	}
-
-	if (evt.AltDown() || evt.ControlDown() || evt.MetaDown()) {
-		// Cmd/Ctrl+A: only wxGTK's backend selects all by itself, so do it
-		// here for all three rather than leaving macOS and MSW without it
-		// (CMuleListCtrl::OnChar implemented it explicitly for the same
-		// reason). A control-modified 'a' arrives as SOH on most ports,
-		// but not universally, so accept the letter too.
-		const int plain = wxTolower(evt.GetKeyCode());
-		if (evt.CmdDown() && (evt.GetKeyCode() == 0x01 || plain == 'a')) {
-			SelectAll();
-			return;
-		}
-		// Every other shortcut belongs to the backend.
-		evt.Skip();
-		return;
-	}
-
-	const uint64 now = GetTickCount64();
-	if (m_ttsTime + kTypeAheadResetMs < now) {
-		m_ttsText.Clear();
-	}
-	m_ttsTime = now;
-	m_ttsText.Append(wxTolower(static_cast<wxChar>(key)));
-
-	// Match against the top-level rows in displayed order. The model yields
-	// them in arrival order, so they are sorted through the list's own
-	// comparator -- the same one CSearchListModel::Compare() uses -- rather
-	// than a second ordering that could disagree with what is on screen.
-	// (GetItemByRow()/GetRowByItem() would be the direct route but exist
-	// only in wx's generic implementation, not on GTK or macOS.)
-	std::vector<CSearchFile *> ordered;
-	BuildDisplayOrder(ordered);
-	if (ordered.empty()) {
-		return;
-	}
-
-	// A fresh single keystroke starts one past the current match so that
-	// tapping the same letter cycles; further keystrokes refine in place.
-	size_t start = 0;
-	const auto current = std::find(ordered.begin(), ordered.end(), m_ttsItem);
-	if (current != ordered.end()) {
-		start = static_cast<size_t>(std::distance(ordered.begin(), current));
-		if (m_ttsText.length() == 1) {
-			++start;
-		}
-	}
-
-	const size_t count = ordered.size();
-	for (size_t i = 0; i < count; ++i) {
-		CSearchFile *file = ordered[(start + i) % count];
-		if (file->GetFileName().GetPrintable().Lower().StartsWith(m_ttsText)) {
-			const wxDataViewItem item = CSearchListModel::ToItem(file);
-			m_ttsItem = file;
-			UnselectAll();
-			Select(item);
-			SetCurrentItem(item);
-			EnsureVisible(item);
-			return;
-		}
-	}
-	// No match: the accumulated text is kept (so a typo can be corrected by
-	// continuing to type) but the selection stays where it is.
 }
 
 void CSearchListCtrl::OnPopupDownload(wxCommandEvent &event)

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -26,9 +26,9 @@
 #ifndef SEARCHLISTCTRL_H
 #define SEARCHLISTCTRL_H
 
-#include <wx/colour.h>   // Needed for wxColour
-#include <wx/dataview.h> // Needed for wxDataViewCtrl
-#include <wx/regex.h>    // Needed for wxRegExp
+#include <wx/colour.h>        // Needed for wxColour
+#include "MuleDataViewCtrl.h" // Needed for CMuleDataViewCtrl
+#include <wx/regex.h>         // Needed for wxRegExp
 
 #include "ListColumnStore.h" // Needed for CListColumnStore, IColumnWidthProvider
 #include "Types.h"           // Needed for uint32
@@ -61,7 +61,7 @@ class CSearchListModel;
  * (IsExpanded()), unlike the old hand-drawn tree which faked it with
  * CSearchFile::ShowChildren()/SetShowChildren() plus manual row insertion.
  */
-class CSearchListCtrl : public wxDataViewCtrl
+class CSearchListCtrl : public CMuleDataViewCtrl
 {
 public:
 	/**
@@ -202,78 +202,26 @@ public:
 	int CompareFiles(const CSearchFile *f1, const CSearchFile *f2) const;
 
 protected:
-	/**
-	 * Adapts this control to IColumnWidthProvider for CListColumnStore.
-	 * A separate object rather than multiple inheritance (as
-	 * CMuleListCtrl does): wxDataViewCtrl::GetColumnCount() is itself
-	 * virtual and returns unsigned int, which isn't override-compatible
-	 * with IColumnWidthProvider::GetColumnCount()'s int return -- unlike
-	 * wxGenericListCtrl's (non-virtual) GetColumnCount(), there's no
-	 * name-hiding trick available here.
-	 */
-	class ColumnWidthAdapter : public IColumnWidthProvider
-	{
-	public:
-		explicit ColumnWidthAdapter(CSearchListCtrl *ctrl)
-		: m_ctrl(ctrl)
-		{
-		}
-		int GetColumnCount() const override { return static_cast<int>(m_ctrl->RealColumnCount()); }
-		// A hidden column reads as zero-width so CListColumnStore persists
-		// the hidden state through the width it already saves, with no
-		// second mechanism.
-		int GetColumnWidth(int col) const override
-		{
-			if (m_ctrl->IsColumnHidden(col)) {
-				return 0;
-			}
-			const int width = m_ctrl->GetColumn(col)->GetWidth();
-			if (width > 0) {
-				return width;
-			}
-			// A visible column should never report zero -- the spacer
-			// appended on macOS exists so the trailing-column sizing lands
-			// there instead. This is the backstop if it ever does anyway:
-			// CListColumnStore reads a width <= 0 as hidden and persists it
-			// negative, so a stray zero would hide a real column on the
-			// next launch, then do the same to whichever column became last
-			// -- one lost per restart, which is what this used to do.
-			const int cached = m_ctrl->m_columnStore.GetCachedWidth(col);
-			return (cached > 0) ? cached : m_ctrl->m_columnStore.GetColumnDefaultWidth(col);
-		}
-		bool SetColumnWidth(int col, int width) override
-		{
-			m_ctrl->SetColumnHidden(col, width <= COL_SIZE_MIN, width);
-			return true;
-		}
-
-	private:
-		CSearchListCtrl *m_ctrl;
-	};
-	ColumnWidthAdapter m_widthAdapter;
-
-	//! Per-column hidden state, indexed like the control's columns.
-	std::vector<bool> m_columnHidden;
-
-	typedef std::pair<unsigned, unsigned> CColPair;
-	typedef std::list<CColPair> CSortingList;
-
-	//! Sort chain: front() is the primary sort column/order, the rest are
-	//! secondary/tertiary tie-breakers from earlier column clicks. Order
-	//! values reuse CMuleListCtrl::SORT_DES / SORT_ALT bit values so the
-	//! persisted config stays wire-compatible (see ListColumnStore.cpp).
-	CSortingList m_sort_orders;
-
 	//! Single-column comparison (no chain, no direction), mirroring the old
 	//! CSearchListCtrl::SortProc switch minus the parent-recursion hack
 	//! (wxDataViewModel::Compare() is only ever asked to order true
 	//! siblings, so grouping is handled by the tree structure itself).
-	int CompareByColumn(
+	int CompareFilesByColumn(
 		const CSearchFile *f1, const CSearchFile *f2, unsigned column, bool alt, int modifier) const;
 
-	//! True if alternate sort criteria (secondary tie-break swap) are
-	//! offered for this column on repeated clicks.
-	bool AltSortAllowed(unsigned column) const;
+	// --- CMuleDataViewCtrl hooks ---
+	int CompareByColumn(const wxDataViewItem &item1,
+		const wxDataViewItem &item2,
+		unsigned column,
+		bool alt,
+		int modifier) const override;
+	bool AltSortAllowed(unsigned column) const override;
+	void GetDisplayOrder(wxDataViewItemArray &ordered) const override;
+	wxString GetRowLabel(const wxDataViewItem &item) const override;
+	wxString GetOldColumnOrder() const override;
+	void OnIdleHook() override;
+	void OnColumnWidthsChanged() override;
+	void OnSortingChanged() override;
 
 	/**
 	 * Returns true if the filename is filtered (i.e. passes the filter and
@@ -316,17 +264,6 @@ protected:
 	wxString m_browseName;
 	uint32 m_browseStatus;
 
-	//! Column persistence (widths, sort order) -- CSearchListCtrl no longer
-	//! inherits CMuleListCtrl (deliberately self-contained, see #180
-	//! discussion), so it owns this directly instead of getting it for free.
-	CListColumnStore m_columnStore;
-	void LoadColumnSettings();
-	void SaveColumnSettings();
-	//! Applies `order` to `column`, moving it to the front of the sort
-	//! chain (mirrors CMuleListCtrl::SetSorting's chain bookkeeping), sets
-	//! the native column header sort indicator, and re-sorts.
-	void ApplySorting(unsigned column, unsigned order);
-
 	//! The current filter reg-exp.
 	wxRegEx m_filter;
 	//! The text from which the filter is compiled.
@@ -342,12 +279,10 @@ protected:
 	//! no portable wxDataViewCtrl "column resized" event to hook directly)
 	//! so it can be propagated to the other open search tabs, same as the
 	//! old EVT_LIST_COL_END_DRAG-driven sync.
-	std::vector<int> m_lastKnownWidths;
 	void OnIdle(wxIdleEvent &event);
 
 	CSearchListModel *m_model;
 
-	void OnColumnHeaderClick(wxDataViewEvent &event);
 	void OnRightClick(wxDataViewEvent &event);
 	void OnItemActivated(wxDataViewEvent &event);
 	void OnSelectionChanged(wxDataViewEvent &event);
@@ -364,82 +299,19 @@ protected:
 	 * records it in m_columnHidden; the persisted form stays a width of
 	 * zero, which CListColumnStore already understands.
 	 */
-	void OnColumnHeaderRightClick(wxDataViewEvent &event);
-	void OnColumnMenuSelected(wxCommandEvent &evt);
 
 	//! Keeps the group expander on the leftmost visible column.
-	void UpdateExpanderColumn();
 
 	/**
 	 * Columns the user owns, excluding the macOS spacer, which must stay
 	 * out of the header menu, the persisted widths and the cross-tab sync.
 	 */
-	unsigned RealColumnCount() const;
 
 public:
-	/**
-	 * Whether a column is hidden, tracked here rather than derived from the
-	 * control.
-	 *
-	 * A hidden wxDataViewColumn keeps reporting its old width, so width
-	 * alone can't answer the question, and the width is what
-	 * CListColumnStore persists (as a negative entry carrying the size to
-	 * restore). Keeping the state here means the header menu, the
-	 * expander's leftmost-visible search, the persisted width and the
-	 * cross-tab sync all read one answer that this class controls, instead
-	 * of each re-deriving it.
-	 */
-	bool IsColumnHidden(int col) const;
-	//! Hide or show a column; width is the one to restore when showing.
-	void SetColumnHidden(int col, bool hidden, int width);
 
 private:
-	/**
-	 * Type-to-select, reimplemented for wxDataViewCtrl.
-	 *
-	 * CMuleListCtrl::OnChar() gave every list this behaviour: typing jumps
-	 * the selection to the first row whose name starts with what was typed,
-	 * accumulating keystrokes until a short pause resets it. None of the
-	 * wxDataViewCtrl backends provide it -- GTK pops up its own interactive
-	 * search box instead, macOS and MSW do nothing -- so it is implemented
-	 * here to keep the three ports behaving alike.
-	 */
-	void OnChar(wxKeyEvent &evt);
-
-	/**
-	 * Navigation keys. Only shifted page-up/down and home/end on macOS are
-	 * handled (see PageExtendSelection); everything else goes to the
-	 * backend.
-	 */
-	void OnKeyDown(wxKeyEvent &evt);
-
 	//! Top-level rows in the order they are displayed under the current sort.
 	void BuildDisplayOrder(std::vector<CSearchFile *> &ordered) const;
-
-#ifdef __WXOSX__
-	/**
-	 * Extends the selection by a page, or to the start/end of the list.
-	 * GTK and MSW get this from their backends; NSOutlineView moves the
-	 * view without touching the selection, so it is done by hand to keep
-	 * the three ports consistent.
-	 */
-	enum class PageMotion
-	{
-		PageUp,
-		PageDown,
-		Home,
-		End
-	};
-	void PageExtendSelection(PageMotion motion);
-#endif
-
-	//! Keystrokes accumulated so far, lowercased; reset after kTypeAheadResetMs.
-	wxString m_ttsText;
-	//! GetTickCount64() of the last accepted keystroke.
-	uint64 m_ttsTime = 0;
-	//! Result the last match landed on, so repeats cycle to the next one.
-	//! Compared by pointer against the live tree, never dereferenced blindly.
-	CSearchFile *m_ttsItem = nullptr;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -53,9 +53,9 @@
 // onto a transparent cell of this size (see FlagImage).
 static const int LIST_IMAGE_SIZE = 16;
 
-wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleVirtualListCtrl)
-	EVT_LIST_ITEM_RIGHT_CLICK(-1, CServerListCtrl::OnItemRightClicked)
-	EVT_LIST_ITEM_ACTIVATED(-1, CServerListCtrl::OnItemActivated)
+wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleVirtualDataViewCtrl)
+	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CServerListCtrl::OnItemRightClicked)
+	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CServerListCtrl::OnItemActivated)
 
 	EVT_MENU(MP_PRIOLOW, CServerListCtrl::OnPriorityChange)
 	EVT_MENU(MP_PRIONORMAL, CServerListCtrl::OnPriorityChange)
@@ -71,7 +71,6 @@ wxBEGIN_EVENT_TABLE(CServerListCtrl, CMuleVirtualListCtrl)
 
 	EVT_MENU(MP_GETED2KLINK, CServerListCtrl::OnGetED2kURL)
 
-	EVT_CHAR(CServerListCtrl::OnKeyPressed)
 wxEND_EVENT_TABLE()
 
 CServerListCtrl::CServerListCtrl(wxWindow *parent,
@@ -79,54 +78,72 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 	const wxPoint &pos,
 	const wxSize &size,
 	long style,
-	const wxValidator &validator,
 	const wxString &name)
-: CMuleVirtualListCtrl(parent, winid, pos, size, style, validator, name)
-, m_images(LIST_IMAGE_SIZE, LIST_IMAGE_SIZE, true, 0)
+: CMuleVirtualDataViewCtrl(parent, winid, pos, size, style, name)
 {
-	// Setting the sorter function.
-	SetSortFunc(SortProc);
-
-	// Set the table-name (for loading and saving preferences).
-	SetTableName("Server");
-
 	m_connected = 0;
 
-	// Take over the small image list from the one every CMuleListCtrl shares:
-	// the country flags are added to it on demand and have no business showing
-	// up in the other lists' indices. The sort arrows have to come first, at
-	// the indices SetSorting() uses.
-	AddSortArrows(m_images);
-	SetImageList(&m_images, wxIMAGE_LIST_SMALL);
-
-	wxFont bold = GetFont();
-	bold.SetWeight(wxFONTWEIGHT_BOLD);
-	m_boldAttr.SetFont(bold);
-
-	InsertColumn(COLUMN_SERVER_NAME, _("Server Name"), wxLIST_FORMAT_LEFT, 150, "N");
-	InsertColumn(COLUMN_SERVER_ADDR, _("Address"), wxLIST_FORMAT_LEFT, 140, "A");
-	InsertColumn(COLUMN_SERVER_PORT, _("Port"), wxLIST_FORMAT_LEFT, 25, "P");
-	InsertColumn(COLUMN_SERVER_DESC, _("Description"), wxLIST_FORMAT_LEFT, 150, "D");
-	InsertColumn(COLUMN_SERVER_PING, _("Ping"), wxLIST_FORMAT_LEFT, 25, "p");
-	InsertColumn(COLUMN_SERVER_USERS, _("Users"), wxLIST_FORMAT_LEFT, 40, "U");
-	InsertColumn(COLUMN_SERVER_FILES, _("Files"), wxLIST_FORMAT_LEFT, 45, "F");
-	InsertColumn(COLUMN_SERVER_PRIO, _("Priority"), wxLIST_FORMAT_LEFT, 60, "r");
-	InsertColumn(COLUMN_SERVER_FAILS, _("Failed"), wxLIST_FORMAT_LEFT, 40, "f");
-	InsertColumn(COLUMN_SERVER_STATIC, _("Static"), wxLIST_FORMAT_LEFT, 40, "S");
-	InsertColumn(COLUMN_SERVER_VERSION, _("Version"), wxLIST_FORMAT_LEFT, 80, "V");
+	// The name column carries the country flag, so it is icon+text; the rest
+	// are plain text. Sortable throughout, or wx draws no header caret.
+	const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+	AppendIconTextColumn(
+		_("Server Name"), COLUMN_SERVER_NAME, wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Address"), COLUMN_SERVER_ADDR, wxDATAVIEW_CELL_INERT, 140, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Port"), COLUMN_SERVER_PORT, wxDATAVIEW_CELL_INERT, 25, wxALIGN_LEFT, flags);
+	AppendTextColumn(
+		_("Description"), COLUMN_SERVER_DESC, wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Ping"), COLUMN_SERVER_PING, wxDATAVIEW_CELL_INERT, 25, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Users"), COLUMN_SERVER_USERS, wxDATAVIEW_CELL_INERT, 40, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Files"), COLUMN_SERVER_FILES, wxDATAVIEW_CELL_INERT, 45, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Priority"), COLUMN_SERVER_PRIO, wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Failed"), COLUMN_SERVER_FAILS, wxDATAVIEW_CELL_INERT, 40, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Static"), COLUMN_SERVER_STATIC, wxDATAVIEW_CELL_INERT, 40, wxALIGN_LEFT, flags);
+	AppendTextColumn(_("Version"), COLUMN_SERVER_VERSION, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, flags);
 
 #if !defined(CLIENT_GUI)
-	InsertColumn(COLUMN_SERVER_TCPFLAGS, _("TCP Flags"), wxLIST_FORMAT_LEFT, 80, "t");
-	InsertColumn(COLUMN_SERVER_UDPFLAGS, _("UDP Flags"), wxLIST_FORMAT_LEFT, 80, "u");
-#if !defined(__DEBUG__)
-	// InsertColumn created the columns with their default 80 width, which is required to unhide
-	// them on the context menu. Now, for Release builds, we will hide them by default
-	SetColumnWidth(GetColumnIndex("t"), 0);
-	SetColumnWidth(GetColumnIndex("u"), 0);
-#endif
+	AppendTextColumn(
+		_("TCP Flags"), COLUMN_SERVER_TCPFLAGS, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, flags);
+	AppendTextColumn(
+		_("UDP Flags"), COLUMN_SERVER_UDPFLAGS, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, flags);
 #endif
 
-	LoadSettings();
+	// Absorbs the macOS trailing-column sizing; the model answers any column
+	// past the real ones with an empty value.
+	AppendSpacerColumn(COLUMN_SERVER_SPACER);
+	AssociateVirtualModel();
+
+	m_columnStore.RegisterColumn(COLUMN_SERVER_NAME, 150, "N");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_ADDR, 140, "A");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_PORT, 25, "P");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_DESC, 150, "D");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_PING, 25, "p");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_USERS, 40, "U");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_FILES, 45, "F");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_PRIO, 60, "r");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_FAILS, 40, "f");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_STATIC, 40, "S");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_VERSION, 80, "V");
+#if !defined(CLIENT_GUI)
+	m_columnStore.RegisterColumn(COLUMN_SERVER_TCPFLAGS, 80, "t");
+	m_columnStore.RegisterColumn(COLUMN_SERVER_UDPFLAGS, 80, "u");
+#endif
+
+	// Default sort is by name, ascending; LoadColumnSettings() replaces it
+	// when the config has something saved.
+	ApplySorting(COLUMN_SERVER_NAME, 0);
+
+#if !defined(CLIENT_GUI) && !defined(__DEBUG__)
+	// Wire-flag columns are diagnostics: listed in the header menu so they
+	// can be switched on, hidden by default. Set before the settings are
+	// loaded, so anything the user saved wins -- the same ordering the old
+	// InsertColumn()/SetColumnWidth(0)/LoadSettings() sequence had.
+	SetColumnHidden(COLUMN_SERVER_TCPFLAGS, true, 0);
+	SetColumnHidden(COLUMN_SERVER_UDPFLAGS, true, 0);
+#endif
+
+	m_columnStore.SetTableName("Server");
+	LoadColumnSettings();
+	InitColumnState();
 }
 
 wxString CServerListCtrl::GetOldColumnOrder() const
@@ -158,16 +175,21 @@ void CServerListCtrl::RemoveServer(CServer *server)
 	ShowServerCount();
 }
 
-void CServerListCtrl::RemoveAllServers(int state)
+void CServerListCtrl::RemoveAllServers(bool selectedOnly)
 {
 	// Collect first, delete second: the rows are a view onto the model, so
 	// removing one renumbers every row below it -- and the confirmations below
 	// run a nested event loop, during which the list can be updated underneath
 	// a row index but never underneath a server pointer.
 	std::vector<CServer *> candidates;
-	for (long pos = GetNextItem(-1, wxLIST_NEXT_ALL, state); pos != -1;
-		pos = GetNextItem(pos, wxLIST_NEXT_ALL, state)) {
-		candidates.push_back(reinterpret_cast<CServer *>(ItemAt(pos)));
+	if (selectedOnly) {
+		for (wxUIntPtr data : GetSelectedItemData()) {
+			candidates.push_back(reinterpret_cast<CServer *>(data));
+		}
+	} else {
+		for (long row = 0; row < ItemDataCount(); ++row) {
+			candidates.push_back(reinterpret_cast<CServer *>(ItemAt(row)));
+		}
 	}
 
 	const bool connected = theApp->IsConnectedED2K() || theApp->serverconnect->IsConnecting();
@@ -232,7 +254,7 @@ void CServerListCtrl::RefreshServer(CServer *server)
 	}
 }
 
-wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, long column) const
+wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) const
 {
 	const CServer *server = reinterpret_cast<const CServer *>(item);
 
@@ -365,68 +387,67 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, long column) const
 // declaration out from under this definition. A member function that is
 // declared, never called and never defined is fine.
 #ifdef GEOIP_GUI
-int CServerListCtrl::FlagImage(const wxString &code) const
+const wxIcon &CServerListCtrl::FlagIcon(const wxString &code) const
 {
-	const auto it = m_flagImages.find(code);
-	if (it != m_flagImages.end()) {
+	static const wxIcon nullIcon;
+
+	const auto it = m_flagIcons.find(code);
+	if (it != m_flagIcons.end()) {
 		return it->second;
 	}
 
 	const wxImage &flag = theApp->GetCountryFlags()->GetFlag(code);
 	if (!flag.IsOk()) {
-		m_flagImages[code] = -1;
-		return -1;
+		// Cached as an invalid icon so an unknown code isn't looked up again.
+		return m_flagIcons.emplace(code, wxIcon()).first->second;
 	}
 
-	// Centre the 16x11 flag on the image list's square cell. Adding it at its
-	// own size instead would leave wxImageList to stretch it to the cell.
-	wxImage cell = flag;
-	if (!cell.HasAlpha()) {
-		// Size() only pads with transparent pixels when there is an alpha
-		// channel to be transparent in; without one it would pad with black.
-		cell.InitAlpha();
-	}
-	cell = cell.Size(wxSize(LIST_IMAGE_SIZE, LIST_IMAGE_SIZE),
-		wxPoint((LIST_IMAGE_SIZE - cell.GetWidth()) / 2, (LIST_IMAGE_SIZE - cell.GetHeight()) / 2));
-
-	const int index = m_images.Add(wxBitmap(cell));
-	m_flagImages[code] = index;
-	return index;
+	wxIcon icon;
+	icon.CopyFromBitmap(wxBitmap(flag));
+	return m_flagIcons.emplace(code, icon).first->second;
 }
 #endif // GEOIP_GUI
 
-int CServerListCtrl::OnGetItemColumnImage(long item, long column) const
+bool CServerListCtrl::GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const
 {
 	if (column != COLUMN_SERVER_NAME) {
-		return -1;
+		return false;
 	}
 #ifdef GEOIP_GUI
 	// Host country as a flag icon, matching the peer list: no icon at all for
 	// an unresolved server, rather than the "? - " prefix this used to show.
-	const CServer *server = reinterpret_cast<const CServer *>(ItemAt(item));
+	const CServer *server = reinterpret_cast<const CServer *>(item);
 	wxString code;
 	if (GetDisplayCountryCode(
 		    server->IsCountryFromCore(), server->GetCountryCode(), server->GetIP(), code) &&
 		!code.IsEmpty()) {
-		return FlagImage(code);
+		const wxIcon &flag = FlagIcon(code);
+		if (flag.IsOk()) {
+			icon = flag;
+			return true;
+		}
 	}
 #else
 	wxUnusedVar(item);
 #endif // GEOIP_GUI
-	return -1;
+	return false;
 }
 
-wxListItemAttr *CServerListCtrl::OnGetItemAttr(long item) const
+bool CServerListCtrl::GetItemAttr(wxUIntPtr item, unsigned WXUNUSED(column), wxDataViewItemAttr &attr) const
 {
-	if (m_connected && reinterpret_cast<const CServer *>(ItemAt(item)) == m_connected) {
-		return &m_boldAttr;
+	if (m_connected && reinterpret_cast<const CServer *>(item) == m_connected) {
+		attr.SetBold(true);
+		return true;
 	}
-	return nullptr;
+	return false;
 }
 
 bool CServerListCtrl::IsLiveSortColumn() const
 {
-	switch (static_cast<int>(GetSortColumn())) {
+	if (m_sort_orders.empty()) {
+		return false;
+	}
+	switch (static_cast<int>(m_sort_orders.front().first)) {
 	case COLUMN_SERVER_PING:
 	case COLUMN_SERVER_USERS:
 	case COLUMN_SERVER_FILES:
@@ -464,7 +485,7 @@ void CServerListCtrl::ShowServerCount()
 	wxStaticText *label = CastByName("serverListLabel", GetParent(), wxStaticText);
 
 	if (label) {
-		label->SetLabel(CFormat(_("Servers (%i)")) % GetItemCount());
+		label->SetLabel(CFormat(_("Servers (%i)")) % ItemDataCount());
 		label->GetParent()->Layout();
 	}
 }
@@ -476,19 +497,14 @@ void CServerListCtrl::FitColumnsToContent()
 	// the column out. The other columns hold short, bounded values.
 	const int descMaxWidth = 300;
 
-	// wxLIST_AUTOSIZE is a no-op on a virtual control -- it has no native items
-	// to measure and just hands back a default width -- so the content side is
-	// measured here against the model. wxLIST_AUTOSIZE_USEHEADER measures the
-	// header text and works either way, so that half is left to it.
-	//
-	// The two constants and the arithmetic below reproduce what the non-virtual
-	// wxLIST_AUTOSIZE did, so column widths come out where they used to: the
-	// margin is the starting floor and is added once to the finished column
-	// (NOT per cell), and a cell carrying an image counts the image plus the
-	// narrower in-row image margin. Both live in listctrl.cpp as file-statics,
-	// hence the copies.
-	const int autosizeMargin = 10; // AUTOSIZE_COL_MARGIN
-	const int imageMargin = 5;     // IMAGE_MARGIN_IN_REPORT_MODE
+	// Content is measured against the model rather than asked of the control:
+	// wxDataViewCtrl has no portable "size this column to its contents", and
+	// on a list that renders cells on demand there is nothing native to
+	// measure anyway. The margins reproduce what the old wxLIST_AUTOSIZE
+	// produced, so columns land where users are used to seeing them.
+	const int autosizeMargin = 10;
+	const int imageMargin = 5;
+	const int flagWidth = 16;
 
 	wxClientDC dc(this);
 	dc.SetFont(GetFont());
@@ -496,20 +512,22 @@ void CServerListCtrl::FitColumnsToContent()
 	const long rows = ItemDataCount();
 
 	Freeze();
-	for (int col = 0; col < GetColumnCount(); ++col) {
-		// Leave hidden columns (width 0, e.g. the TCP/UDP flag columns or
-		// ones the user hid via the header menu) hidden.
-		if (GetColumnWidth(col) == 0) {
+	for (unsigned col = 0; col < RealColumnCount(); ++col) {
+		// Leave hidden columns (the TCP/UDP flag columns, or ones the user
+		// hid from the header menu) hidden.
+		if (IsColumnHidden(static_cast<int>(col))) {
 			continue;
 		}
 
 		int contentWidth = autosizeMargin;
 		for (long row = 0; row < rows; ++row) {
+			const wxUIntPtr data = ItemAt(row);
 			wxCoord textWidth = 0;
-			dc.GetTextExtent(GetItemColumnText(ItemAt(row), col), &textWidth, nullptr);
+			dc.GetTextExtent(GetItemColumnText(data, col), &textWidth, nullptr);
 			int cellWidth = textWidth;
-			if (OnGetItemColumnImage(row, col) != -1) {
-				cellWidth += LIST_IMAGE_SIZE + imageMargin;
+			wxIcon icon;
+			if (GetItemIcon(data, col, icon)) {
+				cellWidth += flagWidth + imageMargin;
 			}
 			if (cellWidth > contentWidth) {
 				contentWidth = cellWidth;
@@ -517,46 +535,50 @@ void CServerListCtrl::FitColumnsToContent()
 		}
 		contentWidth += autosizeMargin;
 
-		SetColumnWidth(col, wxLIST_AUTOSIZE_USEHEADER);
-		const int headerWidth = GetColumnWidth(col);
+		wxCoord headerWidth = 0;
+		dc.GetTextExtent(GetColumn(col)->GetTitle(), &headerWidth, nullptr);
+		headerWidth += 2 * autosizeMargin;
 
-		int width = std::max(contentWidth, headerWidth);
+		int width = std::max(contentWidth, static_cast<int>(headerWidth));
 		if (col == COLUMN_SERVER_DESC && width > descMaxWidth) {
 			width = descMaxWidth;
 		}
-		SetColumnWidth(col, width);
+		GetColumn(col)->SetWidth(width);
 	}
 	Thaw();
 }
 
-void CServerListCtrl::OnItemActivated(wxListEvent &event)
+void CServerListCtrl::OnItemActivated(wxDataViewEvent &event)
 {
-	// Unselect all items but the activated one
-	long item = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	while (item > -1) {
-		SetItemState(item, 0, wxLIST_STATE_SELECTED);
-
-		item = GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	// Connect to the activated row alone, whatever else was selected.
+	if (event.GetItem().IsOk()) {
+		UnselectAll();
+		Select(event.GetItem());
 	}
-
-	SetItemState(event.GetIndex(), wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
 
 	wxCommandEvent nulEvt;
 	OnConnectToServer(nulEvt);
 }
 
-void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
+void CServerListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 {
-	// Check if clicked item is selected. If not, unselect all and select it.
-	long index = CheckSelection(event);
+	// Right-clicking a row outside the selection acts on that row alone.
+	if (event.GetItem().IsOk()) {
+		wxDataViewItemArray selection;
+		GetSelections(selection);
+		if (selection.Index(event.GetItem()) == wxNOT_FOUND) {
+			UnselectAll();
+			Select(event.GetItem());
+		}
+	}
 
 	bool enable_reconnect = false;
 	bool enable_static_on = false;
 	bool enable_static_off = false;
 
 	// Gather information on the selected items
-	while (index > -1) {
-		CServer *server = reinterpret_cast<CServer *>(ItemAt(index));
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CServer *server = reinterpret_cast<CServer *>(data);
 
 		// The current server is selected, so we might display the reconnect option
 		if (server == m_connected) {
@@ -566,8 +588,6 @@ void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
 		// We want to know which options should be enabled, either one or both
 		enable_static_on |= !server->IsStaticMember();
 		enable_static_off |= server->IsStaticMember();
-
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	}
 
 	wxMenu *serverMenu = new wxMenu(_("Server"));
@@ -580,7 +600,7 @@ void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
 
 	serverMenu->AppendSeparator();
 
-	if (GetSelectedItemCount() == 1) {
+	if (static_cast<int>(GetSelectedItemsCount()) == 1) {
 		serverMenu->Append(MP_ADDTOSTATIC, _("Mark server as static"));
 		serverMenu->Append(MP_REMOVEFROMSTATIC, _("Mark server as non-static"));
 	} else {
@@ -590,7 +610,7 @@ void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
 
 	serverMenu->AppendSeparator();
 
-	if (GetSelectedItemCount() == 1) {
+	if (static_cast<int>(GetSelectedItemsCount()) == 1) {
 		serverMenu->Append(MP_REMOVE, _("Remove server"));
 	} else {
 		serverMenu->Append(MP_REMOVE, _("Remove servers"));
@@ -599,7 +619,7 @@ void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
 
 	serverMenu->AppendSeparator();
 
-	if (GetSelectedItemCount() == 1) {
+	if (static_cast<int>(GetSelectedItemsCount()) == 1) {
 		serverMenu->Append(MP_GETED2KLINK, _("Copy eD2k link to clipboard"));
 	} else {
 		serverMenu->Append(MP_GETED2KLINK, _("Copy eD2k links to clipboard"));
@@ -608,14 +628,14 @@ void CServerListCtrl::OnItemRightClicked(wxListEvent &event)
 	serverMenu->Enable(MP_REMOVEFROMSTATIC, enable_static_off);
 	serverMenu->Enable(MP_ADDTOSTATIC, enable_static_on);
 
-	if (GetSelectedItemCount() == 1) {
+	if (static_cast<int>(GetSelectedItemsCount()) == 1) {
 		if (enable_reconnect)
 			serverMenu->SetLabel(MP_CONNECTTO, _("Reconnect to server"));
 	} else {
 		serverMenu->Enable(MP_CONNECTTO, false);
 	}
 
-	PopupMenu(serverMenu, event.GetPoint());
+	PopupMenu(serverMenu);
 	delete serverMenu;
 }
 
@@ -638,10 +658,10 @@ void CServerListCtrl::OnPriorityChange(wxCommandEvent &event)
 		return;
 	}
 
-	ItemDataList items = GetSelectedItems();
+	const std::vector<wxUIntPtr> items = GetSelectedItemData();
 
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		CServer *server = reinterpret_cast<CServer *>(items[i]);
+	for (wxUIntPtr data : items) {
+		CServer *server = reinterpret_cast<CServer *>(data);
 		theApp->serverlist->SetServerPrio(server, priority);
 	}
 }
@@ -650,10 +670,10 @@ void CServerListCtrl::OnStaticChange(wxCommandEvent &event)
 {
 	bool isStatic = (event.GetId() == MP_ADDTOSTATIC);
 
-	ItemDataList items = GetSelectedItems();
+	const std::vector<wxUIntPtr> items = GetSelectedItemData();
 
-	for (unsigned int i = 0; i < items.size(); ++i) {
-		CServer *server = reinterpret_cast<CServer *>(items[i]);
+	for (wxUIntPtr data : items) {
+		CServer *server = reinterpret_cast<CServer *>(data);
 
 		// Only update items that have the wrong setting
 		if (server->IsStaticMember() != isStatic) {
@@ -664,29 +684,25 @@ void CServerListCtrl::OnStaticChange(wxCommandEvent &event)
 
 void CServerListCtrl::OnConnectToServer(wxCommandEvent &WXUNUSED(event))
 {
-	int item = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
-	if (item > -1) {
+	if (!selected.empty()) {
 		if (theApp->IsConnectedED2K()) {
 			theApp->serverconnect->Disconnect();
 		}
 
-		theApp->serverconnect->ConnectToServer(reinterpret_cast<CServer *>(ItemAt(item)));
+		theApp->serverconnect->ConnectToServer(reinterpret_cast<CServer *>(selected.front()));
 	}
 }
 
 void CServerListCtrl::OnGetED2kURL(wxCommandEvent &WXUNUSED(event))
 {
-	int pos = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
 	wxString URL;
 
-	while (pos != -1) {
-		CServer *server = reinterpret_cast<CServer *>(ItemAt(pos));
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CServer *server = reinterpret_cast<CServer *>(data);
 
 		URL += CFormat("ed2k://|server|%s|%d|/\n") % server->GetFullIP() % server->GetPort();
-
-		pos = GetNextItem(pos, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	}
 
 	URL.RemoveLast();
@@ -697,7 +713,7 @@ void CServerListCtrl::OnGetED2kURL(wxCommandEvent &WXUNUSED(event))
 void CServerListCtrl::OnRemoveServers(wxCommandEvent &event)
 {
 	if (event.GetId() == MP_REMOVEALL) {
-		if (GetItemCount()) {
+		if (ItemDataCount()) {
 			wxString question = _("Are you sure that you wish to delete all servers?");
 
 			if (wxMessageBox(
@@ -709,13 +725,13 @@ void CServerListCtrl::OnRemoveServers(wxCommandEvent &event)
 					theApp->serverconnect->Disconnect();
 				}
 
-				RemoveAllServers(wxLIST_STATE_DONTCARE);
+				RemoveAllServers(false);
 			}
 		}
 	} else if (event.GetId() == MP_REMOVE) {
-		if (GetSelectedItemCount()) {
+		if (static_cast<int>(GetSelectedItemsCount())) {
 			wxString question;
-			if (GetSelectedItemCount() == 1) {
+			if (static_cast<int>(GetSelectedItemsCount()) == 1) {
 				question = _("Are you sure that you wish to delete the selected server?");
 			} else {
 				question = _("Are you sure that you wish to delete the selected servers?");
@@ -724,32 +740,34 @@ void CServerListCtrl::OnRemoveServers(wxCommandEvent &event)
 			if (wxMessageBox(
 				    question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) ==
 				wxYES) {
-				RemoveAllServers(wxLIST_STATE_SELECTED);
+				RemoveAllServers(true);
 			}
 		}
 	}
 }
 
-void CServerListCtrl::OnKeyPressed(wxKeyEvent &event)
+bool CServerListCtrl::OnListKey(wxKeyEvent &event)
 {
-	// Check if delete was pressed
+	// Delete removes the selected servers; everything else belongs to the
+	// control's own navigation.
 	if ((event.GetKeyCode() == WXK_DELETE) || (event.GetKeyCode() == WXK_NUMPAD_DELETE)) {
 		wxCommandEvent evt;
 		evt.SetId(MP_REMOVE);
 		OnRemoveServers(evt);
-	} else {
-		event.Skip();
+		return true;
 	}
+	return false;
 }
 
-int CServerListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
+int CServerListCtrl::CompareItemData(
+	wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool WXUNUSED(alt), int modifier) const
 {
-	CServer *server1 = reinterpret_cast<CServer *>(item1);
-	CServer *server2 = reinterpret_cast<CServer *>(item2);
+	const CServer *server1 = reinterpret_cast<const CServer *>(data1);
+	const CServer *server2 = reinterpret_cast<const CServer *>(data2);
 
-	int mode = (sortData & CMuleListCtrl::SORT_DES) ? -1 : 1;
+	const int mode = modifier;
 
-	switch (sortData & CMuleListCtrl::COLUMN_MASK) {
+	switch (column) {
 	// Sort by server-name
 	case COLUMN_SERVER_NAME:
 		return mode * server1->GetListName().CmpNoCase(server2->GetListName());

--- a/src/ServerListCtrl.h
+++ b/src/ServerListCtrl.h
@@ -26,7 +26,7 @@
 #ifndef SERVERLISTCTRL_H
 #define SERVERLISTCTRL_H
 
-#include "MuleVirtualListCtrl.h" // Needed for CMuleVirtualListCtrl (and wxListItemAttr)
+#include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
 
 #include <map>
 
@@ -43,6 +43,9 @@
 #define COLUMN_SERVER_VERSION 10
 #define COLUMN_SERVER_TCPFLAGS 11
 #define COLUMN_SERVER_UDPFLAGS 12
+//! Always empty. Absorbs the macOS trailing-column sizing; see
+//! CMuleDataViewCtrl::AppendSpacerColumn().
+#define COLUMN_SERVER_SPACER 13
 
 class CServer;
 class CServerList;
@@ -56,9 +59,9 @@ class wxCommandEvent;
  *
  * The rows are text-rendered from the model (GetItemColumnText), not
  * owner-drawn: the only graphic is the country flag in the Server Name column,
- * which a virtual list can supply through OnGetItemColumnImage.
+ * supplied through GetItemIcon().
  */
-class CServerListCtrl : public CMuleVirtualListCtrl
+class CServerListCtrl : public CMuleVirtualDataViewCtrl
 {
 public:
 	/**
@@ -67,12 +70,11 @@ public:
 	 * @see CMuleListCtrl::CMuleListCtrl
 	 */
 	CServerListCtrl(wxWindow *parent,
-		wxWindowID winid = -1,
+		wxWindowID winid = wxID_ANY,
 		const wxPoint &pos = wxDefaultPosition,
 		const wxSize &size = wxDefaultSize,
-		long style = wxLC_ICON,
-		const wxValidator &validator = wxDefaultValidator,
-		const wxString &name = "mulelistctrl");
+		long style = 0,
+		const wxString &name = "serverlistctrl");
 
 	/**
 	 * Destructor.
@@ -96,11 +98,11 @@ public:
 	void RemoveServer(CServer *server);
 
 	/**
-	 * Removes all servers with the specified state.
+	 * Removes servers from the list and from the core.
 	 *
-	 * @param state All items with this state will be removed, default being all.
+	 * @param selectedOnly Only the selected rows, rather than every server.
 	 */
-	void RemoveAllServers(int state = wxLIST_STATE_DONTCARE);
+	void RemoveAllServers(bool selectedOnly = false);
 
 	/**
 	 * Updates the displayed information on a server.
@@ -143,36 +145,37 @@ public:
 
 protected:
 	/// Return old column order.
-	wxString GetOldColumnOrder() const;
+	wxString GetOldColumnOrder() const override;
 
-	/// Text of one cell, rendered on demand by the virtual control.
-	virtual wxString GetItemColumnText(wxUIntPtr item, long column) const;
+	/// Text of one cell, pulled on demand for the cells being drawn.
+	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
 
-	/**
-	 * Image index for one cell: the host-country flag on the Server Name
-	 * column, none anywhere else.
-	 */
-	virtual int OnGetItemColumnImage(long item, long column) const;
+	/// Host-country flag on the Server Name column, nothing elsewhere.
+	bool GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const override;
 
-	/// Bold attribute for the server we are connected to, none for the rest.
-	virtual wxListItemAttr *OnGetItemAttr(long item) const;
+	/// Bold for the server we are connected to, default for the rest.
+	bool GetItemAttr(wxUIntPtr item, unsigned column, wxDataViewItemAttr &attr) const override;
 
 	/**
 	 * Ping, Users and Files change while the list is up, so sorting by one of
 	 * them enables the inherited live auto-sort.
 	 */
-	virtual bool IsLiveSortColumn() const;
+	bool IsLiveSortColumn() const override;
+
+	/// Single-column comparison for the base's sort chain.
+	int CompareItemData(
+		wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const override;
 
 private:
 	/**
 	 * Event-handler for handling item activation (connect).
 	 */
-	void OnItemActivated(wxListEvent &event);
+	void OnItemActivated(wxDataViewEvent &event);
 
 	/**
 	 * Event-handler for displaying the popup-menu.
 	 */
-	void OnItemRightClicked(wxListEvent &event);
+	void OnItemRightClicked(wxDataViewEvent &event);
 
 	/**
 	 * Event-handler for priority changes.
@@ -200,44 +203,28 @@ private:
 	void OnRemoveServers(wxCommandEvent &event);
 
 	/**
-	 * Event-handler for deleting servers when the delete-key is pressed.
+	 * Delete key removes the selected servers; see CMuleDataViewCtrl::OnListKey.
 	 */
-	void OnKeyPressed(wxKeyEvent &event);
+	bool OnListKey(wxKeyEvent &event) override;
 
 	/**
-	 * Sorter function.
-	 *
-	 * @see wxListCtrl::SortItems
+	 * @a code's flag, decoded on first use. An unknown code yields an
+	 * invalid icon, which draws as no icon at all.
 	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
-
-	/**
-	 * Index of @a code's flag in m_images, adding the bitmap on first use.
-	 * Returns -1 for a code with no bundled flag.
-	 */
-	int FlagImage(const wxString &code) const;
+	const wxIcon &FlagIcon(const wxString &code) const;
 
 	//! Used to keep track of the last high-lighted item.
 	const CServer *m_connected;
 
 	/**
-	 * This control's own small image list: the header sort arrows first (the
-	 * indices CMuleListCtrl::SetSorting() uses), then one entry per country
-	 * flag actually seen. It replaces the list shared by every CMuleListCtrl
-	 * so the flags stay out of every other list in the app.
+	 * ISO code -> flag icon, filled in lazily.
 	 *
-	 * Mutable because the flags are filled in lazily from
-	 * OnGetItemColumnImage(), which the virtual control calls to paint a row
-	 * and is therefore const. Loading all ~250 flags up front instead would
-	 * decode a PNG for every country nobody is connected to.
+	 * Mutable because the flags are decoded from GetItemIcon(), which the
+	 * control calls to paint a row and is therefore const. Loading all ~250
+	 * up front instead would decode a PNG for every country nobody is
+	 * connected to.
 	 */
-	mutable wxImageList m_images;
-
-	//! ISO code -> index into m_images.
-	mutable std::map<wxString, int> m_flagImages;
-
-	//! Returned by OnGetItemAttr() for the connected server; see HighlightServer().
-	mutable wxListItemAttr m_boldAttr;
+	mutable std::map<wxString, wxIcon> m_flagIcons;
 
 	wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
Answers the open question on #801 and ports the first list onto the result. **Supersedes #807**, whose port informed this one.

#801 asked whether the remaining lists should each be ported independently or share a base, and deferred deciding until the shape was clear from more than one list. #807 made it clear: it reimplemented type-to-select, select-all, the sort chain, the column-store adapter and the notification pattern from scratch, and — having been cut a few hours before #805 landed — arrived without the column show/hide menu, hidden-state tracking, the macOS trailing-column fix or the shifted navigation keys. A third port would have repeated it.

**`CMuleDataViewCtrl`** is the `wxDataViewCtrl` counterpart of `CMuleListCtrl`: column widths and persistence, the header show/hide menu, hidden state, the multi-column sort chain, type-to-select, Cmd/Ctrl+A, the macOS shifted page/home/end keys, the trailing-column spacer, drag-resize detection. It owns no data — a list supplies rows via `GetDisplayOrder()`, a label via `GetRowLabel()`, and ordering via `CompareByColumn()`.

**`CMuleVirtualDataViewCtrl`** is the counterpart of `CMuleVirtualListCtrl`, virtual in the same sense: rows addressed by index through a `wxDataViewIndexListModel`, nothing materialised per row. It carries the item-identity bookkeeping an identity-addressed model avoids — a `wxDataViewItem` from a row-addressed model encodes the row number, so a deletion silently retargets any item held across it. Verified with a standalone probe: selecting rows 1 and 3, deleting row 0, then re-reading the selection yields two *different* objects. Everything here therefore speaks in `wxUIntPtr` and re-resolves selection after each mutation. Also the legacy filter API, live re-sort coalesced through one `CallAfter` and deferred while the user interacts, bulk append, batch removal via `RowsDeleted`, and icon columns.

`CSearchListCtrl` moves onto the plain base and loses 499 lines.

**`CServerListCtrl`** is the first list on the virtual base. Its public API is unchanged, so `ServerWnd`, `GuiEvents` and the remote GUI needed nothing — the base offers the same `AddItemData`/`RemoveItemData`/`RefreshItemData` vocabulary as before. Removals notify the control *before* the core frees the server rather than deferring to idle: the row's identity is the object, so a repaint, a resort or a menu handler reading the selection in between would be reading freed memory (confirmed under ASAN on wxGTK 3.2.9 against the deferred variant). Live re-sort on Ping/Users/Files stays gated by `thePrefs::LiveListSort()`, and the TCP/UDP flag columns stay hidden by default in release builds — now through the header menu's hidden state rather than a zero width.

## Testing

Interactive pass on macOS, Ubuntu 26.04 arm64 (wxGTK 3.2.9) and Windows 11 arm64: both lists' sorting and its persistence, live re-sort, context menus, multi-select, delete, flags, the connected-server highlight, the column menu, type-to-select and select-all. `amule` and `amulegui` built separately on each. `clang-format` and both `clang-tidy` tiers clean.

Three bugs found only by running it, none visible to any gate: the search list's event table still named `wxDataViewCtrl` as its parent, so wx skipped the base's table entirely and `EVT_IDLE` never ran — no results appeared at all; the virtual model inverted descending sorts twice, so only the first header click did anything; and `WXK_DELETE` (127) sits below `WXK_START`, so the delete key fell through to type-ahead.

## Follow-up, deliberately not here

The country-flag icon cache is per-list, so Sources and Peers would each keep their own once ported. It belongs on `CCountryFlags` beside the existing `wxImage` cache — left out because it touches a shared class after the testing above was done.
