### PR TITLE
fix(gui): keep a sort chain when the config has none saved

### DIFF
--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -210,9 +210,24 @@ void CMuleDataViewCtrl::LoadColumnSettings()
 	// them by calling SetSorting() on each in turn, and each call pushes to
 	// the front, so the last one processed ends up primary. ApplySorting()
 	// has the same semantics, so replaying them in order reproduces it.
-	m_sort_orders.clear();
-	for (const CListColumnStore::CColPair &pair : decoded) {
-		ApplySorting(pair.first, pair.second);
+	// Only replace what the list installed for itself when the config actually
+	// has something stored. A profile with no saved TableOrdering for this list
+	// decodes to an empty list, and clearing unconditionally would throw away
+	// the default the list set before calling here -- CServerListCtrl sorts by
+	// name in exactly that way.
+	if (!decoded.empty()) {
+		m_sort_orders.clear();
+		for (const CListColumnStore::CColPair &pair : decoded) {
+			ApplySorting(pair.first, pair.second);
+		}
+	}
+
+	// A list that installs no default of its own (CSearchListCtrl) still has to
+	// end up with a sort chain: with none, CompareItems() answers 0 for every
+	// pair and nothing is ordered. CMuleListCtrl::LoadSettings() has always
+	// guaranteed at least one entry; keep that guarantee here.
+	if (m_sort_orders.empty()) {
+		ApplySorting(0, 0);
 	}
 }
 

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -195,6 +195,14 @@ int CMuleVirtualDataViewCtrl::CompareItemsFull(wxUIntPtr data1, wxUIntPtr data2)
 
 long CMuleVirtualDataViewCtrl::InsertPos(wxUIntPtr data) const
 {
+	// With no sort chain every comparison is equal, and lower_bound would
+	// answer begin() -- putting every arrival at the front, so the list fills
+	// in reverse. CMuleListCtrl::GetInsertPos() appends when it has no sorter;
+	// match it, so an unsorted list is at least in arrival order.
+	if (m_sort_orders.empty()) {
+		return static_cast<long>(m_items.size());
+	}
+
 	const auto at =
 		std::lower_bound(m_items.begin(), m_items.end(), data, [this](wxUIntPtr lhs, wxUIntPtr rhs) {
 			return CompareItemsFull(lhs, rhs) < 0;


### PR DESCRIPTION
On a profile with no saved column settings for a list, the list ends up with **no sort chain at all** — and for `CServerListCtrl` that means the server list fills in *reverse* arrival order, unsorted, with no header caret. Follow-up to #811.

## What happens

`CMuleDataViewCtrl::LoadColumnSettings()` cleared `m_sort_orders` and replayed whatever `LoadSettings()` decoded. With no saved `TableOrdering<name>`, `LoadSettings()` reads `""`, takes the old-style path, and its tokenizer yields nothing — so the clear stood and the chain was left empty.

`CServerListCtrl::Init()` installs `ApplySorting(COLUMN_SERVER_NAME, 0)` to prevent exactly this, but `SetTableName("Server")` runs *before* `LoadColumnSettings()`, so the `HasTableName()` early return did not protect it and the default was wiped.

An empty chain makes `CompareItemsFull()` answer 0 for every pair, and `InsertPos()`'s `std::lower_bound` then answers `begin()` — every `AddItemData()` lands at row 0. `CServerListCtrl` has a single add path (`RefreshServer` → `AddItemData`), so the initial `server.met` load goes the same way. `CSearchListCtrl` installs no default of its own and was left unsorted too.

It is only reachable without saved column settings, which is why an interactive pass on a developer profile never showed it — any machine that has run aMule before has `TableOrdering` stored.

`CMuleListCtrl::LoadSettings()` has always guaranteed at least one entry, and that guarantee was not carried across:

```cpp
// Must have at least one sort-order specified
if (m_sort_orders.empty()) {
    m_sort_orders.push_back(CColPair(0, 0));
}
```

## The fix

- Clear only when the config actually decoded something, so a list's *own* default survives rather than being replaced by a generic column 0.
- Keep the old floor for lists that install no default (`CSearchListCtrl`).
- `InsertPos()` appends when the chain is empty, as `CMuleListCtrl::GetInsertPos()` does. Without this an unsorted list fills backwards rather than in arrival order — this is what turned "unsorted" into "reversed".

## Test plan

Verified on an instrumented build (temporary `fprintf` in `LoadColumnSettings()` and `InsertPos()`, not part of this PR), macOS, wxOSX 3.3.3, against a config dir holding `server.met` with 6 servers. `Autoconnect=0`, `ConnectToKad=0` — the list populates from `server.met` without connecting anywhere.

Two configs, run against both the pre-fix and post-fix builds:

| build | `TableOrderingServer` | decoded | chain | insert positions |
|---|---|---|---|---|
| before | stripped | 0 | **0** | `0,0,0,0,0,0` |
| before | present  | 11 | 11 | `0,0,0,0,1,0` |
| after  | stripped | 0 | **1** | `0,0,1,3,2,2` |
| after  | present  | 11 | 11 | `0,0,0,0,1,0` |

Reading the rows:

- **before / stripped** is the bug: the chain is empty and every one of the six servers is inserted at row 0, so the list is in reverse arrival order.
- **after / stripped** is the fix: the chain is non-empty and the positions vary, i.e. real sorted insertion by name.
- **before / present vs after / present** are identical, so the saved-settings path — the one every existing profile takes — is unchanged.

The `present` rows are also the control: they show the probe responds to the variable rather than always reporting `pos=0`.

Read rather than run, for the paths the probe does not reach: `LoadColumnSettings()` early-returns when no table name is set, *before* the floor, so the floor only reaches lists that call it with a name. `CServerListCtrl` sets `"Server"` permanently and `CSearchListCtrl` sets `"Search"` around the call, so both are covered. Second and later search tabs take `SyncLists()` instead, which copies `m_sort_orders` wholesale whenever the destination is empty — so they inherit the floored chain. Before this change they inherited the empty one, and `SyncLists()`'s own `if (!dst->m_sort_orders.empty())` guard then skipped the resort, which is why every tab was affected rather than just the first.

Gates: build clean across monolithic, amulegui, amuled and amulecmd; `ctest` 33/33; clang-format 18 clean; Tier-2 clang-tidy clean on the diff with 0 compiler errors.

No unit test. `LoadColumnSettings()` and `InsertPos()` both need a realised `wxDataViewCtrl` with a column store attached, so unlike the pure state transition in #794 this does not reduce to something a `muleunit` fixture can construct. The instrumented run above is what stands in.
