### PR TITLE
fix(gui): translate the transfer rates shown in the window title

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1188,7 +1188,10 @@ void CamuleDlg::ShowTransferRate()
 
 	// Show upload/download speed in title
 	if (thePrefs::GetShowRatesOnTitle()) {
-		wxString UpDownSpeed = CFormat("Up: %.1f%s | Down: %.1f%s") % (showMBpsUp ? MBpsUp : kBpsUp) %
+		// Same msgid as the speed label above, so this reuses that translation
+		// rather than asking translators for the string twice.
+		wxString UpDownSpeed = CFormat(_("Up: %.1f%s | Down: %.1f%s")) %
+				       (showMBpsUp ? MBpsUp : kBpsUp) %
 				       (showMBpsUp ? _(" MB/s") : ((kBpsUp > 0) ? _(" kB/s") : "")) %
 				       (showMBpsDown ? MBpsDown : kBpsDown) %
 				       (showMBpsDown ? _(" MB/s") : ((kBpsDown > 0) ? _(" kB/s") : ""));


### PR DESCRIPTION
Closes #810.

With **Show transfer rates on title** enabled, the window title stays English — `Up: 1.2 kB/s | Down: 3.4 kB/s` — while the rest of the interface follows the chosen language. The speed label under the toolbar formats the same text and *does* translate, so the two disagree on screen at the same time.

## Cause

`CamuleDlg::ShowTransferRate()` builds the string twice. The label at `amuleDlg.cpp:1178` wraps it:

```cpp
buffer = CFormat(_("Up: %.1f%s | Down: %.1f%s")) % …
```

The title, thirteen lines below, did not:

```cpp
wxString UpDownSpeed = CFormat("Up: %.1f%s | Down: %.1f%s") % …
```

The `" MB/s"` and `" kB/s"` suffixes on that very statement were already wrapped in `_()`, which is why the units translated while the words around them did not.

## Nothing new for translators

The msgid already exists from the label, so no new string enters the catalogs and no Weblate round is needed — every language that already translated it there gets the title for free. Regenerating the catalogs changes only `POT-Creation-Date`, so no `po/` churn is included here.

Verified by looking the exact msgid up in the built `ru` catalog under a Russian locale: it resolves to `Отд: %.1f%s | Скач: %.1f%s`, with all four placeholders intact and in order, so `CFormat` substitutes exactly as before.

## Scope

Not a regression — the bare `CFormat` is present in the 3.0.0 and 3.0.1 tags and traces back past only mechanical touches (clang-format, the `wxT()` retirement).

Builds clean, clang-format 18 and both clang-tidy tiers clean on the diff.
