### PR TITLE
fix(download): re-download a completed file that was deleted from disk

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -386,7 +386,7 @@ void CDownloadQueue::AddDownload(CPartFile *file, bool paused, uint8 category)
 	AddLogLineC(CFormat(_("Downloading %s")) % file->GetFileName());
 }
 
-bool CDownloadQueue::IsFileExisting(const CMD4Hash &fileid, const wxString &requestedName) const
+bool CDownloadQueue::IsFileExisting(const CMD4Hash &fileid, const wxString &requestedName)
 {
 	if (CKnownFile *file = theApp->sharedfiles->GetFileByID(fileid)) {
 		if (file->IsPartFile()) {
@@ -417,6 +417,20 @@ bool CDownloadQueue::IsFileExisting(const CMD4Hash &fileid, const wxString &requ
 
 		return true;
 	} else if ((file = GetFileByID(fileid))) {
+		// GetFileByID() also returns finished downloads still lingering in
+		// m_completedDownloads (kept so a remote GUI can act on them). Such an
+		// entry is not an active download, so if its file was deleted from disk
+		// it must not keep blocking a re-download. The shared-file branch above
+		// already allows that, but a prior shares rescan removes the file from
+		// the shared list and leaves only this entry, which had no such check.
+		CPartFile *part = static_cast<CPartFile *>(file);
+		if (part->IsCompleted()) {
+			CPath fullpath = part->GetFilePath().JoinPaths(part->GetFileName());
+			if (!fullpath.FileExists()) {
+				ClearCompleted(ListOfUInts32(1, part->ECID()));
+				return false;
+			}
+		}
 		AddLogLineC(
 			CFormat(_("You are already trying to download the file %s")) % file->GetFileName());
 		return true;

--- a/src/DownloadQueue.h
+++ b/src/DownloadQueue.h
@@ -112,7 +112,7 @@ public:
 	 *                      filename) it is appended to the log line so the
 	 *                      message can be correlated with the download command.
 	 */
-	bool IsFileExisting(const CMD4Hash &fileid, const wxString &requestedName = wxEmptyString) const;
+	bool IsFileExisting(const CMD4Hash &fileid, const wxString &requestedName = wxEmptyString);
 
 	/**
 	 * Returns true if the specified file is on the download-queue.


### PR DESCRIPTION
Fixes #813.

**Problem**
When a completed download is deleted from disk and the user triggers a shared-files rescan, re-adding the same ed2k link is rejected with "You are already trying to download the file" and stays blocked until aMule is restarted.

**Cause**
A finished download stays in `m_completedDownloads` for the session (kept so a remote GUI can act on it). `GetFileByID()` searches that list as well as the active queue, so `IsFileExisting()` matches the completed entry and blocks the re-add. The completed-shared-file branch already unshares a missing file and allows re-download, but the rescan removes the file from the shared list first, so control falls through to the `m_completedDownloads` branch, which had no on-disk existence check. Only a restart (which clears the list) unblocked it. Confirmed on the current `develop` build, so this is not covered by any existing fix.

**Fix**
On the completed-download branch, mirror the shared-file logic: if the file no longer exists on disk, drop the stale `m_completedDownloads` entry via the existing `ClearCompleted()` and return false so the re-download proceeds. An in-progress part file still blocks as before.

**Testing**
Builds clean (macOS, monolithic + daemon); clang-format and diff-scoped clang-tidy (Tier-2) both clean.
