### PR TITLE
fix(gui): move Show/Hide aMule to the top of the tray menu

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2969,6 +2969,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3041,14 +3049,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:29+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3006,6 +3006,14 @@ msgid "Unlimited"
 msgstr "بلا حدود"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3083,14 +3091,6 @@ msgstr "فصل"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "إتصال"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:30+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3063,6 +3063,14 @@ msgid "Unlimited"
 msgstr "Illimitáu"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Amosar aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Anubrir aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3143,14 +3151,6 @@ msgstr "Desconeutar"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Coneutar"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Amosar aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Anubrir aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3000,6 +3000,14 @@ msgid "Unlimited"
 msgstr "неограничен"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3077,14 +3085,6 @@ msgstr "Разкачи"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Връзка"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2968,6 +2968,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3040,14 +3048,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:31+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3053,6 +3053,14 @@ msgid "Unlimited"
 msgstr "Il·limitat"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Mostra l'aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Amaga l'aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3133,14 +3141,6 @@ msgstr "Desconnecta"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Connecta"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Mostra l'aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Amaga l'aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:32+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3051,6 +3051,14 @@ msgid "Unlimited"
 msgstr "Neomezený"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Zobrazit aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Skrýt aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3131,14 +3139,6 @@ msgstr "Odpojit"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Připojit"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Zobrazit aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Skrýt aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:32+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3015,6 +3015,14 @@ msgid "Unlimited"
 msgstr "Ubegrænset"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3094,14 +3102,6 @@ msgstr "Afbryd"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Forbind"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:32+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3058,6 +3058,14 @@ msgid "Unlimited"
 msgstr "Unbegrenzt"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Zeige aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Verstecke aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3131,14 +3139,6 @@ msgstr "Trennen"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Verbinden"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Zeige aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Verstecke aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:33+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3074,6 +3074,14 @@ msgid "Unlimited"
 msgstr "Απεριόριστο"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Εμφάνιση aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Κρύψιμο aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3154,14 +3162,6 @@ msgstr "Αποσύνδεση"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Σύνδεση"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Εμφάνιση aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Κρύψιμο aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2969,6 +2969,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3041,14 +3049,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:34+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3059,6 +3059,14 @@ msgid "Unlimited"
 msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Mostrar aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Ocultar aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3132,14 +3140,6 @@ msgstr "Desconectar"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectar"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Mostrar aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Ocultar aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3054,6 +3054,14 @@ msgid "Unlimited"
 msgstr "Piiramatu"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Näita aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Peida aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3134,14 +3142,6 @@ msgstr "Ühendu lahti"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Ühenda"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Näita aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Peida aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:35+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3055,6 +3055,14 @@ msgid "Unlimited"
 msgstr "Mugarik gabea"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "aMule erakutsi"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "aMule ezkutatu"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3135,14 +3143,6 @@ msgstr "Deskonektatu"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Konektatu"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "aMule erakutsi"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "aMule ezkutatu"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:35+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3055,6 +3055,14 @@ msgid "Unlimited"
 msgstr "Rajoittamaton"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Näytä aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Piilota aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3135,14 +3143,6 @@ msgstr "Katkaise yhteys"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Yhdistä"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Näytä aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Piilota aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:36+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3057,6 +3057,14 @@ msgid "Unlimited"
 msgstr "Pas de limite"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Afficher aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Cacher aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k : "
 
@@ -3130,14 +3138,6 @@ msgstr "Déconnecter"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Se connecter"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Afficher aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Cacher aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:36+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3071,6 +3071,14 @@ msgid "Unlimited"
 msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Mostrar aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Ocultar aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3144,14 +3152,6 @@ msgstr "Desconectar"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectar"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Mostrar aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Ocultar aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:36+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3027,6 +3027,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3106,14 +3114,6 @@ msgstr "מנותק"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "התחבר"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:37+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3024,6 +3024,14 @@ msgid "Unlimited"
 msgstr "Bezkrajno"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3104,14 +3112,6 @@ msgstr "Prekinuti vezu"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Uspostavi vezu"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3040,6 +3040,14 @@ msgid "Unlimited"
 msgstr "Korlátlan"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "aMule megjelenítése"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "aMule elrejtése"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3113,14 +3121,6 @@ msgstr "Szétkapcsolás"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Kapcsolatfelvétel"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "aMule megjelenítése"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "aMule elrejtése"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:38+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3067,6 +3067,14 @@ msgid "Unlimited"
 msgstr "Illimitato"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Mostra aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Nascondi aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3140,14 +3148,6 @@ msgstr "Disconnetti"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Connetti"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Mostra aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Nascondi aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3052,6 +3052,14 @@ msgid "Unlimited"
 msgstr "無制限"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "aMuleを表示する"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "aMuleを隠す"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3131,14 +3139,6 @@ msgstr "切断する"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "接続する"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "aMuleを表示する"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "aMuleを隠す"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:38+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3073,6 +3073,14 @@ msgid "Unlimited"
 msgstr "무제한"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "어뮬 보이기"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "어뮬 숨기기"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3152,14 +3160,6 @@ msgstr "연결 끊기"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "연결"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "어뮬 보이기"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "어뮬 숨기기"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3087,6 +3087,14 @@ msgid "Unlimited"
 msgstr "Neribojama"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Rodyti aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Slėpti aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3167,14 +3175,6 @@ msgstr "Atsijungti"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Prisijungti"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Rodyti aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Slėpti aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2986,6 +2986,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3059,14 +3067,6 @@ msgstr "Atslēgties"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Pieslēgties"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:39+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3057,6 +3057,14 @@ msgid "Unlimited"
 msgstr "Onbegrensd"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Toon aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Verberg aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3137,14 +3145,6 @@ msgstr "Verbreek"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Verbinden"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Toon aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Verberg aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3071,6 +3071,14 @@ msgid "Unlimited"
 msgstr "Ubegrensa"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Syne aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Gøyme aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3151,14 +3159,6 @@ msgstr "Kople frå"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Kople til"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Syne aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Gøyme aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:40+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3069,6 +3069,14 @@ msgid "Unlimited"
 msgstr "Nielimitowane"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Pokaż aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Ukryj aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3149,14 +3157,6 @@ msgstr "Rozłącz"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Podłącz"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Pokaż aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Ukryj aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3063,6 +3063,14 @@ msgid "Unlimited"
 msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Mostrar aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Ocultar aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3136,14 +3144,6 @@ msgstr "Desconectar"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectar"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Mostrar aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Ocultar aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:41+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3061,6 +3061,14 @@ msgid "Unlimited"
 msgstr "Ilimitado"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Mostrar"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Esconder"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3141,14 +3149,6 @@ msgstr "Desligar"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Ligar"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Mostrar"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Esconder"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3064,6 +3064,14 @@ msgid "Unlimited"
 msgstr "Nelimitat"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Arată aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Ascunde aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3144,14 +3152,6 @@ msgstr "Deconectează"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Conectează"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Arată aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Ascunde aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:43+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3083,6 +3083,14 @@ msgid "Unlimited"
 msgstr "Неограниченно"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Показать aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Свернуть aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3156,14 +3164,6 @@ msgstr "Отключить"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Подключиться"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Показать aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Свернуть aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:43+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3084,6 +3084,14 @@ msgid "Unlimited"
 msgstr "Neomejeno"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Prikaži aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Skrij aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3164,14 +3172,6 @@ msgstr "Prekini povezave"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Poveži se"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Prikaži aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Skrij aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:44+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3065,6 +3065,14 @@ msgid "Unlimited"
 msgstr "E pakufijshme"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Trego aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Fshih aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3144,14 +3152,6 @@ msgstr "Shkeputu"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Lidhu"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Trego aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Fshih aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:44+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3053,6 +3053,14 @@ msgid "Unlimited"
 msgstr "Obegränsad"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Visa aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Dölj aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3133,14 +3141,6 @@ msgstr "Koppla från"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Anslut"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Visa aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Dölj aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2968,6 +2968,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "அகோவேறுகழுதையை மறை"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3041,14 +3049,6 @@ msgstr ""
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "அகோவேறுகழுதையை மறை"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3050,6 +3050,14 @@ msgid "Unlimited"
 msgstr "Sınırsız"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "aMule'yi Göster"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "aMule'yi Gizle"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k: "
 
@@ -3123,14 +3131,6 @@ msgstr "Bağlantıyı Kes"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "Bağlan"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "aMule'yi Göster"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "aMule'yi Gizle"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:45+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3083,6 +3083,14 @@ msgid "Unlimited"
 msgstr "Безмежно"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "Показати aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "Сховати aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3163,14 +3171,6 @@ msgstr "Від'єднатися"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "З'єднатися"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "Показати aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "Сховати aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2967,6 +2967,14 @@ msgid "Unlimited"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr ""
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr ""
 
@@ -3039,14 +3047,6 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr ""
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:46+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3059,6 +3059,14 @@ msgid "Unlimited"
 msgstr "无限制"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "显示 aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "隐藏 aMule"
+
+#: src/MuleTrayIcon.cpp
 msgid "eD2k: "
 msgstr "eD2k： "
 
@@ -3132,14 +3140,6 @@ msgstr "断开连接"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "连接"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "显示 aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "隐藏 aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-05 14:00+0200\n"
+"POT-Creation-Date: 2026-08-06 11:07+0200\n"
 "PO-Revision-Date: 2026-08-06 07:47+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3046,6 +3046,14 @@ msgid "Unlimited"
 msgstr "無限制"
 
 #: src/MuleTrayIcon.cpp
+msgid "Show aMule"
+msgstr "顯示 aMule"
+
+#: src/MuleTrayIcon.cpp
+msgid "Hide aMule"
+msgstr "隱藏 aMule"
+
+#: src/MuleTrayIcon.cpp
 #, fuzzy
 msgid "eD2k: "
 msgstr "eD2k"
@@ -3126,14 +3134,6 @@ msgstr "中斷連線"
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp
 msgid "Connect"
 msgstr "連線"
-
-#: src/MuleTrayIcon.cpp
-msgid "Show aMule"
-msgstr "顯示 aMule"
-
-#: src/MuleTrayIcon.cpp
-msgid "Hide aMule"
-msgstr "隱藏 aMule"
 
 #: src/MuleTrayIcon.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Exit"

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -427,6 +427,35 @@ void CMuleTrayIcon::RebuildMenu()
 
 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
+	// Show / Hide. On a Wayland session we can't reliably detect that
+	// the window has been iconized by the OS minimize button (xdg-shell
+	// doesn't deliver the event), so a single toggle entry would mis-
+	// label itself in that state. Show two deterministic entries
+	// instead — click Show to bring the window back, click Hide to
+	// hide it. On X11 / macOS / Windows the toggle is reliable, so
+	// the single label-aware entry stays.
+	if (CamuleAppCommon::IsWaylandSession()) {
+		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
+			make_action_item((const char *)wxString(_("Show aMule")).utf8_str(),
+				TRAY_ACTION_SHOW,
+				0,
+				this));
+		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
+			make_action_item((const char *)wxString(_("Hide aMule")).utf8_str(),
+				TRAY_ACTION_HIDE,
+				0,
+				this));
+	} else {
+		// Treat iconized as not visible — see DoShowHide for rationale.
+		const bool visible = theApp->amuledlg && theApp->amuledlg->IsShown() &&
+				     !theApp->amuledlg->IsTrayLogicallyIconized();
+		const wxString label = visible ? wxString(_("Hide aMule")) : wxString(_("Show aMule"));
+		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
+			make_action_item((const char *)label.utf8_str(), TRAY_ACTION_SHOW_HIDE, 0, this));
+	}
+
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+
 	// ---- Client information submenu ------------------------------
 	// Snapshot at the moment of the last connection-state change.
 	// Skips truly-live fields (uptime, totals, queued clients) so the
@@ -528,33 +557,6 @@ void CMuleTrayIcon::RebuildMenu()
 		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
 			make_action_item(
 				(const char *)label.utf8_str(), TRAY_ACTION_CONNECT_DISCONNECT, 0, this));
-	}
-
-	// Show / Hide. On a Wayland session we can't reliably detect that
-	// the window has been iconized by the OS minimize button (xdg-shell
-	// doesn't deliver the event), so a single toggle entry would mis-
-	// label itself in that state. Show two deterministic entries
-	// instead — click Show to bring the window back, click Hide to
-	// hide it. On X11 / macOS / Windows the toggle is reliable, so
-	// the single label-aware entry stays.
-	if (CamuleAppCommon::IsWaylandSession()) {
-		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-			make_action_item((const char *)wxString(_("Show aMule")).utf8_str(),
-				TRAY_ACTION_SHOW,
-				0,
-				this));
-		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-			make_action_item((const char *)wxString(_("Hide aMule")).utf8_str(),
-				TRAY_ACTION_HIDE,
-				0,
-				this));
-	} else {
-		// Treat iconized as not visible — see DoShowHide for rationale.
-		const bool visible = theApp->amuledlg && theApp->amuledlg->IsShown() &&
-				     !theApp->amuledlg->IsTrayLogicallyIconized();
-		const wxString label = visible ? wxString(_("Hide aMule")) : wxString(_("Show aMule"));
-		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
-			make_action_item((const char *)label.utf8_str(), TRAY_ACTION_SHOW_HIDE, 0, this));
 	}
 
 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
@@ -821,6 +823,17 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	wxString label = MOD_VERSION_LONG;
 	traymenu->Append(TRAY_MENU_INFO, label);
 	traymenu->AppendSeparator();
+
+	// Treat iconized as not visible — see DoShowHide for rationale.
+	if (theApp->amuledlg->IsShown() && !theApp->amuledlg->IsTrayLogicallyIconized()) {
+		traymenu->Append(TRAY_MENU_HIDE, _("Hide aMule"));
+	} else {
+		traymenu->Append(TRAY_MENU_SHOW, _("Show aMule"));
+	}
+
+	// Separator
+	traymenu->AppendSeparator();
+
 	label = wxString(_("Speed limits:")) + " ";
 
 	// Check for upload limits
@@ -1010,16 +1023,6 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	} else {
 		// Connect item
 		traymenu->Append(TRAY_MENU_CONNECT, _("Connect"));
-	}
-
-	// Separator
-	traymenu->AppendSeparator();
-
-	// Treat iconized as not visible — see DoShowHide for rationale.
-	if (theApp->amuledlg->IsShown() && !theApp->amuledlg->IsTrayLogicallyIconized()) {
-		traymenu->Append(TRAY_MENU_HIDE, _("Hide aMule"));
-	} else {
-		traymenu->Append(TRAY_MENU_SHOW, _("Show aMule"));
 	}
 
 	// Separator


### PR DESCRIPTION
Closes #809.

The Show/Hide entry sat second from last, between Connect and Exit, so restoring the window from the tray meant reading past the version banner, the client-information submenu and both speed submenus. It is the entry people reach for most, and tray menus conventionally lead with it.

## What changed

Moved to the top in **both** backends, so the two don't drift:

| | before | after |
|---|---|---|
| 1 | version banner | version banner |
| 2 | Client Information | **Show / Hide aMule** |
| 3 | Upload / Download limits | Client Information |
| 4 | Connect / Disconnect | Upload / Download limits |
| 5 | **Show / Hide aMule** | Connect / Disconnect |
| 6 | Exit | Exit |

The version banner stays first as the menu's header; Show/Hide sits directly beneath it and above everything else.

On Wayland the entry is a deterministic pair (separate Show and Hide, because xdg-shell doesn't report OS-minimize and a single toggle would mislabel itself) — the pair moves as a unit.

Separators are rebalanced so the entry has one above and one below, leaving Connect and Exit adjacent under a single separator as before.

## Catalogs

Second commit regenerates `po/`. No string is added, removed or changed — but catalogs record each entry's *source position*, so relocating the two `_()` call sites reorders their entries in every catalog and the "App catalogs in sync with source" gate fails on the drift. (It caught this on the fork before the PR existed.)

Mechanical and safe to skim past: the added and removed msgid sets are identical (`"Show aMule"` / `"Hide aMule"` moving), all 40 catalogs still compile under `msgfmt -c`, and translated/fuzzy/untranslated counts are unchanged — spot-checked `it`, `de` and `zh_CN` against the base. Nothing here needs a translator.

## Verification

**The two backends need different machines, and CI covers only one of them.**

`WITH_LIBAYATANA_APPINDICATOR` is auto-enabled by `pkg_check_modules(ayatana-appindicator3-0.1)`. The CI Ubuntu dependency list (`cmake_ubuntu_deps`) does not include `libayatana-appindicator3-dev`, so the probe misses and **CI never compiles the SNI/appindicator backend at all**. macOS and Windows compile only the `wxTaskBarIcon` path. So a change to the GTK menu would otherwise ship having been compiled by nothing.

- **wx path** — built on macOS across monolithic, amulegui, amuled, amulecmd. `ctest` 33/33.
- **appindicator path** — built on Ubuntu 26.04 arm64, where `ayatana-appindicator3-0.1 0.5.94` is present and cmake reports *"tray icon uses SNI backend"*. Confirmed the code was actually compiled in rather than skipped: `nm -C build/src/amule | grep -c app_indicator` → 4. Built from an isolated worktree at this commit, not a shared checkout.
- clang-format 18 clean; Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Not verified: the rendered menu. Both backends are unconditional sequential appends and the order is readable from the diff, but nobody has looked at the actual popup — worth a glance on a KDE session before merge, since that is where #809 was reported.
