### PR TITLE
fix(amulegui): reconnect quietly while the window is minimised or hidden

### DIFF
--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -74,7 +74,7 @@ void CMuleTrayIcon::DoShowHide()
 	// the window vanish entirely (no Dock thumbnail / no taskbar
 	// entry) — destructive UX. Treat iconized as "not visible" so
 	// the menu offers "Show aMule" and clicking restores the frame.
-	const bool visible = theApp->amuledlg->IsShown() && !theApp->amuledlg->IsTrayLogicallyIconized();
+	const bool visible = theApp->amuledlg->IsVisibleToUser();
 	if (visible) {
 #ifdef __WXMAC__
 		// Drop the Dock icon while the window is hidden; the tray

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -732,10 +732,15 @@ void CamuleRemoteGuiApp::OnECConnection(wxEvent &event)
 	if (evt.GetResult() == true) {
 		if (m_reconnecting) {
 			// Reconnected: close the modal reconnect dialog. Execution
-			// resumes right after ShowModal() in BeginReconnect(), which
-			// re-arms the reconcile prune and restarts polling.
+			// resumes right after ShowModal() in ShowReconnectDialog(),
+			// which re-arms the reconcile prune and restarts polling.
 			if (m_reconnectDlg) {
 				m_reconnectDlg->EndModal(wxID_OK);
+			} else {
+				// Reconnected behind a minimised window, so there is no
+				// modal loop to unwind and nothing to close -- finish
+				// here instead (issue #806).
+				FinishReconnect(wxID_OK);
 			}
 		} else {
 			// Connected - go to next init step
@@ -826,22 +831,66 @@ void CamuleRemoteGuiApp::BeginReconnect()
 		m_reconnectTimer = new wxTimer(this, ID_REMOTE_RECONNECT_TIMER);
 	}
 
-	m_reconnectDlg = new CReconnectDialog(amuledlg, CFormat(wxT("%s:%d")) % m_ecHost % m_ecPort);
-
-	// Kick off the first attempt, then run the dialog modally: the retry
-	// timer and OnECConnection pump inside ShowModal(). A success calls
-	// EndModal(wxID_OK); the Abort button ends it with wxID_CANCEL.
+	// Kick off the first attempt before deciding about the dialog, so the
+	// common case -- a blip that reconnects on the first try -- can be over
+	// with before anything is drawn.
 	AttemptReconnect();
-	int result = m_reconnectDlg->ShowModal();
 
+	// The dialog earns its intrusion by explaining a frozen window. With the
+	// window minimised or hidden to tray there is nothing on screen to
+	// explain, and a modal appearing over whatever the user is actually doing
+	// is worse than silence (issue #806). Retry quietly instead; the log still
+	// carries every attempt, and OnMainWindowRestored() puts the dialog up if
+	// the user comes back while this is still going.
+	//
+	// "Visible" has to mean both halves: minimized to Dock/taskbar keeps
+	// IsShown() true with nothing on screen, and hidden to tray leaves the
+	// iconized bit clear while the frame is gone. CamuleDlg tracks the
+	// iconized half from wxIconizeEvent rather than wxFrame::IsIconized(),
+	// which lies on wxGTK mid-transition. Compositors that never report
+	// iconize at all (Wayland xdg-shell has no such notification) keep the
+	// old behaviour for the minimize case.
+	if (amuledlg && !amuledlg->IsVisibleToUser()) {
+		return;
+	}
+
+	ShowReconnectDialog();
+}
+
+void CamuleRemoteGuiApp::ShowReconnectDialog()
+{
+	if (!m_reconnecting || m_reconnectDlg) {
+		return;
+	}
+
+	m_reconnectDlg = new CReconnectDialog(amuledlg, CFormat(wxT("%s:%d")) % m_ecHost % m_ecPort);
+	// The retry loop has been running without us, so open on what it is
+	// actually doing rather than on "attempt 1": mid-countdown after a failed
+	// attempt, or in the middle of one.
+	if (m_reconnectCountdown > 0) {
+		m_reconnectDlg->SetCountdown(m_reconnectCountdown);
+	} else {
+		m_reconnectDlg->SetAttempt(m_reconnectAttempt);
+	}
+
+	// Run it modally: the retry timer and OnECConnection pump inside
+	// ShowModal(). A success calls EndModal(wxID_OK); the Abort button ends it
+	// with wxID_CANCEL.
+	const int result = m_reconnectDlg->ShowModal();
+	m_reconnectDlg->Destroy();
+	m_reconnectDlg = nullptr;
+	FinishReconnect(result);
+}
+
+void CamuleRemoteGuiApp::FinishReconnect(int result)
+{
 	m_reconnecting = false;
+	m_reconnectCountdown = 0;
 	if (m_reconnectTimer) {
 		m_reconnectTimer->Stop();
 	}
 	delete connect_timeout_timer;
 	connect_timeout_timer = nullptr;
-	m_reconnectDlg->Destroy();
-	m_reconnectDlg = nullptr;
 
 	if (result == wxID_OK) {
 		AddLogLineCS(_("Reconnected to the remote core."));
@@ -863,6 +912,18 @@ void CamuleRemoteGuiApp::BeginReconnect()
 		AddLogLineNS(_("Going down"));
 		Quit();
 	}
+}
+
+void CamuleRemoteGuiApp::OnMainWindowRestored()
+{
+	if (!m_reconnecting || m_reconnectDlg) {
+		return;
+	}
+	// Not straight from here: this runs inside the iconize event handler, and
+	// ShowReconnectDialog() ends in either a nested modal loop or Quit(). Let
+	// the handler return first (#738 is what tearing the main window down from
+	// a nested loop costs).
+	CallAfter(&CamuleRemoteGuiApp::ShowReconnectDialog);
 }
 
 void CamuleRemoteGuiApp::AttemptReconnect()

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -926,6 +926,14 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 	void AttemptReconnect();
 	void ScheduleNextReconnect();
 	void OnReconnectTimer(wxTimerEvent &evt);
+	/// Put the modal reconnect dialog up, reflecting whatever the retry loop
+	/// is doing right now, and act on how it ends.
+	void ShowReconnectDialog();
+	/// Tear the reconnect down and act on its outcome: wxID_OK resumes
+	/// polling, anything else is the user aborting. Runs whether or not a
+	/// dialog was ever shown -- reconnecting behind a minimised window
+	/// finishes without one.
+	void FinishReconnect(int result);
 
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
 
@@ -971,6 +979,12 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 
 public:
 	void Startup();
+
+	/// The main window came back from the taskbar/tray. If a reconnect has
+	/// been running quietly behind it, this is the moment to show the dialog
+	/// -- the user can see the frozen window now, so they should be told why
+	/// it is frozen and be given the Abort button. No-op otherwise.
+	void OnMainWindowRestored();
 
 	bool ShowConnectionDialog();
 

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1449,6 +1449,12 @@ void CamuleDlg::OnShow(wxShowEvent &evt)
 	// a previous minimize-to-tray cycle.
 	if (evt.IsShown()) {
 		m_iconized_logical = false;
+#ifdef CLIENT_GUI
+		// Restored from the tray (tray click/menu, or an un-hide after
+		// HideOnClose), which never fires wxIconizeEvent -- see OnMinimize
+		// for the other half of issue #806.
+		theApp->OnMainWindowRestored();
+#endif
 	}
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 	// SNI tray menus are static between rebuilds, so the
@@ -1473,6 +1479,17 @@ void CamuleDlg::OnMinimize(wxIconizeEvent &evt)
 	// iconized (tray menu label, DoShowHide branch decision) read
 	// IsTrayLogicallyIconized() instead.
 	m_iconized_logical = evt.IsIconized();
+
+#ifdef CLIENT_GUI
+	// Coming back from the taskbar/Dock with a reconnect running quietly
+	// behind the window: now that there is a frozen window to explain, put the
+	// dialog up (issue #806). OnShow covers the same for the tray paths, which
+	// hide the frame without ever iconizing it. theApp is the remote-GUI app
+	// here -- this file is compiled per target, not shared via muleappgui.
+	if (IsVisibleToUser()) {
+		theApp->OnMainWindowRestored();
+	}
+#endif
 
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 	// SNI tray menu is built once and held; iconize doesn't fire

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -316,6 +316,14 @@ public:
 	// action stay in sync with reality.
 	bool IsTrayLogicallyIconized() const { return m_iconized_logical; }
 
+	/// Whether the user can actually see the window. Both halves are needed
+	/// and neither is enough: minimized to Dock/taskbar keeps IsShown() true
+	/// while nothing is on screen, and hidden to tray (tray menu, minimize-to-
+	/// tray, HideOnClose) leaves the iconized bit clear while the frame is
+	/// gone. Used by the tray menu to label Show/Hide, and by amulegui to
+	/// decide whether a modal is worth putting up (issue #806).
+	bool IsVisibleToUser() const { return IsShown() && !m_iconized_logical; }
+
 private:
 	bool m_iconized_logical = false;
 	wxFileName m_skinFileName;


### PR DESCRIPTION
Closes #806.

Losing the EC link puts a modal reconnect dialog on screen whether or not the window is there to be seen. Minimised to the taskbar or hidden to the tray, it appears over whatever the user is actually doing and takes focus, to explain a frozen window they cannot see.

## What changed

The dialog earns its intrusion by explaining that frozen window, so it now waits until there is one. With the window out of sight the retry loop runs exactly as before — every attempt logged, the countdown ticking, the same 5 s spacing — and simply draws nothing. Reconnect while minimised and the dialog is never created: the link comes back, polling resumes, nobody is interrupted. Come back to the window mid-reconnect and it appears, opening on whatever the loop is currently doing rather than on "attempt 1", Abort button and all.

## Two states, two restore paths

"Out of sight" means two things and neither alone is enough: **minimised** to Dock/taskbar keeps `IsShown()` true with nothing on screen, while **hidden to tray** leaves the iconized bit clear with no frame at all. `CMuleTrayIcon::DoShowHide` already had that pair spelled out inline to label its Show/Hide entry; it moves to `CamuleDlg::IsVisibleToUser()` and both callers share the one definition.

Restoring is likewise two paths, because tray-hide never fires `wxIconizeEvent` and iconize never fires `EVT_SHOW` — so `OnMinimize` and `OnShow` each carry the hook.

Showing the dialog straight from those handlers would run a nested modal loop whose abort path calls `Quit()`; tearing the main window down from a nested loop is what #738 was about, so it goes through `CallAfter` instead.

The retry machinery needed no changes — `AttemptReconnect`, `ScheduleNextReconnect` and `OnReconnectTimer` already guarded every dialog access. What did need splitting is the tail of `BeginReconnect`, which assumed it was resuming after `ShowModal` returned; that moves to `FinishReconnect()` so it runs whether or not a dialog was ever shown.

## Why this surfaced now

The reporter's build (`3.0.1-419` = `8b3063c0d`) contains #768 from three days earlier, which made a *silent* link trigger a reconnect instead of freezing — so reconnects now happen in situations that previously just hung, including while minimised. #773's move to ~1 s polling makes the watchdog's precondition true far more of the time. The dialog was never gated on window state (`git log -S IsIconized` on that file is empty), so what changed is how often it is reached, not when it may appear.

## Testing

Exercised on macOS against an isolated daemon: visible → dialog as before; minimised → nothing appears and restoring brings it up mid-retry; reconnect while minimised → no dialog ever; hidden to tray → nothing appears and restoring from the tray brings it up.

Builds clean for `amule`, `amulegui` and `amuled`; the monolithic binary carries no reference to the new entry point, so the `CLIENT_GUI` gating holds. clang-format 18 and both clang-tidy tiers clean on the diff.

## Wayland

Iconize is not observable there (xdg-shell has no such notification), so compositors that never report it keep today's behaviour for the minimise case. The tray paths are unaffected.
