### PR TITLE
feat(gui): follow the system light/dark appearance on Windows

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -59,20 +59,24 @@ env:
     pkg-config \
     wxwidgets
 
+  # CLANG64, not MINGW64: wxWidgets 3.3 is not packaged for the latter, and
+  # 3.3 is what the system light/dark appearance support needs. This also
+  # matches the CLANGARM64 leg the release packaging uses, so CI and the
+  # shipped Windows builds share one toolchain.
   cmake_mingw_w64_deps: |
-    mingw-w64-x86_64-boost
-    mingw-w64-x86_64-ccache
-    mingw-w64-x86_64-cmake
-    mingw-w64-x86_64-crypto++
-    mingw-w64-x86_64-gettext
-    mingw-w64-x86_64-libgd
-    mingw-w64-x86_64-libmaxminddb
-    mingw-w64-x86_64-ninja
-    mingw-w64-x86_64-pkgconf
-    mingw-w64-x86_64-readline
-    mingw-w64-x86_64-toolchain
-    mingw-w64-x86_64-wxwidgets3.2-msw
-    mingw-w64-x86_64-zlib
+    mingw-w64-clang-x86_64-boost
+    mingw-w64-clang-x86_64-ccache
+    mingw-w64-clang-x86_64-cmake
+    mingw-w64-clang-x86_64-crypto++
+    mingw-w64-clang-x86_64-gettext
+    mingw-w64-clang-x86_64-libgd
+    mingw-w64-clang-x86_64-libmaxminddb
+    mingw-w64-clang-x86_64-ninja
+    mingw-w64-clang-x86_64-pkgconf
+    mingw-w64-clang-x86_64-readline
+    mingw-w64-clang-x86_64-toolchain
+    mingw-w64-clang-x86_64-wxwidgets3.3-msw
+    mingw-w64-clang-x86_64-zlib
 
   cmake_common_config_flags: |-
     -B build \
@@ -226,7 +230,7 @@ jobs:
       - name: set up MSYS2 mingw-w64
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: CLANG64
           update: true
           install: ${{ env.cmake_mingw_w64_deps }}
       # MSYS2 only packages pupnp 1.14.x; build the pinned 22.x from source so

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -440,7 +440,13 @@ jobs:
           if-no-files-found: error
 
   # ------------------------------------------------------------------
-  # Windows — portable .zip for x64 (MINGW64) and ARM64 (CLANGARM64).
+  # Windows — portable .zip for x64 (CLANG64) and ARM64 (CLANGARM64).
+  #
+  # Both arches are clang + UCRT so there is one Windows toolchain to reason
+  # about, and a Windows-specific bug reproduces the same on either. x64 moved
+  # off MINGW64 because wxWidgets 3.3 is not packaged for that environment --
+  # MSYS2 ships it only for clang-x86_64, clang-aarch64 and ucrt-x86_64 -- and
+  # 3.3 is what makes the app follow the system light/dark appearance.
   # ------------------------------------------------------------------
   windows-zip:
     name: Windows portable .zip (${{ matrix.arch }})
@@ -453,9 +459,9 @@ jobs:
       matrix:
         include:
           - arch: x64
-            msystem: MINGW64
+            msystem: CLANG64
             runs-on: windows-2025
-            pkg_prefix: mingw-w64-x86_64
+            pkg_prefix: mingw-w64-clang-x86_64
           - arch: arm64
             msystem: CLANGARM64
             runs-on: windows-11-arm
@@ -486,7 +492,7 @@ jobs:
             ${{ matrix.pkg_prefix }}-pkgconf
             ${{ matrix.pkg_prefix }}-readline
             ${{ matrix.pkg_prefix }}-toolchain
-            ${{ matrix.pkg_prefix }}-wxwidgets3.2-msw
+            ${{ matrix.pkg_prefix }}-wxwidgets3.3-msw
             ${{ matrix.pkg_prefix }}-zlib
             git
             zip
@@ -566,7 +572,11 @@ jobs:
           if-no-files-found: error
 
   # ------------------------------------------------------------------
-  # Windows — NSIS installer .exe for x64 (MINGW64) and ARM64 (CLANGARM64).
+  # Windows — NSIS installer .exe for x64 and ARM64.
+  #
+  # msystem here is only the shell the job runs in: the step installs bare
+  # git/unzip/python and wraps an already-built payload, so it needs no
+  # compiler and does not have to match the environment windows-zip built in.
   # Consumes the portable tree built by windows-zip rather than building
   # it a second time. Coupling is correct here: with no payload there's
   # nothing to wrap, so a windows-zip failure should skip the installer.

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -389,6 +389,23 @@ bool CamuleGuiApp::OnInit()
 	// of the pointer; wx tears the providers down at app exit.
 	wxArtProvider::Push(new CamuleArtProvider());
 
+#if wxCHECK_VERSION(3, 3, 0)
+	// Follow the desktop's light/dark setting. Every other platform does
+	// this by itself; MSW is the one that has to be asked, which is why
+	// aMule looks native in dark mode on GTK and macOS but not on Windows.
+	//
+	// Must happen before any window exists -- wx answers CannotChange once
+	// one does, and the startup splash is created inside CamuleApp::OnInit()
+	// below, so anywhere later would silently do nothing.
+	//
+	// Not gated on __WXMSW__: Appearance::System is the right request
+	// everywhere and is a no-op where the platform already follows suit.
+	const AppearanceResult appearance = SetAppearance(Appearance::System);
+	if (appearance == AppearanceResult::Failure) {
+		AddDebugLogLineN(logStandard, "Could not follow the system light/dark appearance");
+	}
+#endif
+
 	if (!CamuleApp::OnInit()) {
 		return false;
 	}


### PR DESCRIPTION
Windows has been the one platform where aMule ignores the desktop's dark mode — GTK and macOS pick it up automatically, MSW has to be asked. wx 3.3 added `wxApp::SetAppearance()` for exactly this, so this calls it with `Appearance::System`, and moves the Windows builds onto a wx that has it.

**The call** is guarded with `wxCHECK_VERSION(3, 3, 0)`, matching the existing guard style in `HTTPDownload.cpp`. I checked the boundary against upstream rather than assuming it: `SetAppearance` is present in wx at the `v3.3.0` tag and absent in 3.2.10, so the guard sits exactly on the line — a 3.3.0 build compiles it, a 3.2.x build skips it. The build floor stays `MIN_WX_VERSION 3.2.0`.

It runs before `CamuleApp::OnInit()` because wx answers `CannotChange` once a window exists, and the startup splash is created in there. It is deliberately not gated on `__WXMSW__` — `Appearance::System` is the correct request everywhere and a no-op where the platform already follows the system.

**The toolchain move.** MSYS2 does not package wx 3.3 for `MINGW64`, only for `clang-x86_64`, `clang-aarch64` and `ucrt-x86_64`. So the x64 legs of both workflows move to `CLANG64`. Choosing `CLANG64` over `UCRT64` makes both packaging arches clang + UCRT, giving one Windows toolchain to reason about — the ARM64 leg has been `CLANGARM64` all along, so this converges x64 onto what already ships rather than introducing a new compiler. The installer jobs keep their environment: they install bare git/unzip/python and wrap an already-built payload.

## Verified

- wx 3.3.2 + clang on Windows ARM64: clean build, zero warnings, all targets — and dark mode confirmed working on a real desktop
- wx 3.2.10 + GCC on Windows x86_64: clean build, guard compiles out, so nobody on 3.2 is affected
- wx 3.3.3 + clang on macOS: clean build with the block active
- the `clang-x86_64` dependency list resolves fully (127 packages, `wxwidgets3.3-msw` included)

**Not verified:** an actual x86_64 clang build. Same compiler and wx as the ARM64 leg, different target, and it moves x64 from msvcrt to UCRT — which also changes the DLL set the portable bundles. CI on this PR is the first real test of that, and the x64 zip artifact is the thing to smoke-test after it lands.

**Follow-up worth doing separately:** the hand-drawn surfaces (list-control `CMuleColour` fills, availability bars, the splash) don't follow the appearance automatically. They look right on GTK and macOS dark mode today, so they're likely fine, but MSW takes different paint paths and deserves its own pass.
