### PR TITLE
fix(packaging): accept CLANG64 in the Windows build script

### DIFF
--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Windows portable .zip recipe for aMule.
 #
-# Runs INSIDE MSYS2 on the Windows host (CLANGARM64 or MINGW64 env).
+# Runs INSIDE MSYS2 on the Windows host (CLANGARM64, CLANG64 or MINGW64).
 # Can also be driven remotely over SSH from another machine, e.g.:
 #   ssh <windows-host> 'cd <repo> && packaging/windows/build.sh'
 
@@ -44,6 +44,7 @@ set -a; source "${VERSIONS_ENV}"; set +a
 # across all platforms in dist/.
 case "${WINDOWS_MSYSTEM}" in
     CLANGARM64) ARCH=arm64 ;;
+    CLANG64)    ARCH=x64 ;;
     MINGW64)    ARCH=x64 ;;
     *) echo "fatal: unsupported WINDOWS_MSYSTEM=${WINDOWS_MSYSTEM}" >&2; exit 1 ;;
 esac
@@ -70,7 +71,7 @@ build() {
     require_tool zip   "zip"
 
     # Verify we're in the right MSYS2 env. The MSYSTEM env var should
-    # match versions.env; if a user runs from MINGW64 with versions.env
+    # match versions.env; if a user runs from CLANG64 with versions.env
     # set to CLANGARM64 (or vice versa), the build will silently produce
     # the wrong arch.
     if [[ "${MSYSTEM:-}" != "${WINDOWS_MSYSTEM}" ]]; then

--- a/packaging/windows/versions.env
+++ b/packaging/windows/versions.env
@@ -13,10 +13,14 @@
 # toolchain + dependency packages.
 #
 #   CLANGARM64  arm64 (Snapdragon X Elite, Windows-on-ARM, etc.)
-#   MINGW64     x86_64 (most desktops/laptops). Same arch you run
+#   CLANG64     x86_64 (most desktops/laptops). Same arch you run
 #               "Windows 11" on a typical Intel/AMD PC.
+#   MINGW64     x86_64, still accepted, but capped at wxWidgets 3.2:
+#               MSYS2 does not package wx 3.3 for it, so a MINGW64
+#               build has no system dark mode. CI and the release
+#               packaging both use CLANG64 for x64.
 #
-# Override via env: WINDOWS_MSYSTEM=MINGW64 packaging/windows/build.sh
+# Override via env: WINDOWS_MSYSTEM=CLANG64 packaging/windows/build.sh
 WINDOWS_MSYSTEM=${WINDOWS_MSYSTEM:-CLANGARM64}
 
 # --------------------------------------------------------------------
@@ -24,7 +28,7 @@ WINDOWS_MSYSTEM=${WINDOWS_MSYSTEM:-CLANGARM64}
 # --------------------------------------------------------------------
 
 # Set automatically from WINDOWS_MSYSTEM by build.sh, kept here for
-# transparency: CLANGARM64 -> arm64, MINGW64 -> x64. Neither matches
+# transparency: CLANGARM64 -> arm64, CLANG64/MINGW64 -> x64. Neither matches
 # Windows' own conventions (which would be ARM64 / AMD64) — we use
 # the names AppImage uses for filename consistency across platforms.
 


### PR DESCRIPTION
#818 moved the x64 packaging leg to `CLANG64` but left `build.sh`'s MSYSTEM whitelist at `CLANGARM64`/`MINGW64`, so every x64 packaging run now fails with `fatal: unsupported WINDOWS_MSYSTEM=CLANG64` before configuring anything.

Maps `CLANG64` to the x64 arch suffix alongside `MINGW64`, which stays accepted for local builds — capped at wx 3.2 and therefore without system dark mode, now noted in `versions.env`.

The installer jobs are unaffected: their x64 leg is still `MINGW64`, which maps to the same x64 suffix and so still matches the `windows-x64` artifact.

Missed in #818 because the workflow change was reviewed against `packaging.yml` alone; the value is consumed by a script the diff never touched.

## Testing

`bash -n` clean on both files, and the arch mapping resolves `CLANGARM64` → arm64, `CLANG64` → x64, `MINGW64` → x64, with anything else still rejected. Grepped the rest of `packaging/` and the workflows for other places that enumerate MSYSTEM values — none.

Note that CI on this PR cannot prove the fix: `packaging.yml` only auto-fires on push to master, so the real verification is the packaging run after merge.
