### PR TITLE
ci: build, lint and analyse the SNI tray backend on Ubuntu

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -31,12 +31,20 @@ env:
   CCACHE_MAXSIZE: 500M
 
   # The minus sign removes the trailing new line in the last line
+  #
+  # libayatana-appindicator3-dev is not needed to build aMule, but its
+  # presence is what flips WITH_LIBAYATANA_APPINDICATOR on (CMakeLists.txt
+  # probes for it with pkg_check_modules). Without it the SNI tray backend
+  # in MuleTrayIcon.cpp is #ifdef'd out and never compiled here -- only
+  # packaging.yml built it, and that runs after merge, so a break in that
+  # half landed on master before anything noticed.
   cmake_ubuntu_deps: |-
     binutils-dev \
     build-essential \
     ccache \
     cmake \
     gettext \
+    libayatana-appindicator3-dev \
     libboost-all-dev \
     libcrypto++-dev \
     libgd-dev \

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -52,12 +52,15 @@ env:
 
   # Kept in sync with .github/workflows/ccpp.yml so compile_commands.json
   # matches the real Ubuntu build.
+  # libayatana-appindicator3-dev: without it the SNI tray backend in
+  # MuleTrayIcon.cpp is #ifdef'd out, so neither tidy tier ever sees it.
   cmake_ubuntu_deps: |-
     binutils-dev \
     build-essential \
     ccache \
     cmake \
     gettext \
+    libayatana-appindicator3-dev \
     libboost-all-dev \
     libcrypto++-dev \
     libgd-dev \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,14 @@ on:
 
 env:
   # The minus sign removes the trailing new line in the last line
+  # libayatana-appindicator3-dev: without it the SNI tray backend in
+  # MuleTrayIcon.cpp is #ifdef'd out and is never analysed.
   cmake_ubuntu_deps: |-
     binutils-dev \
     build-essential \
     cmake \
     gettext \
+    libayatana-appindicator3-dev \
     libboost-all-dev \
     libcrypto++-dev \
     libgd-dev \


### PR DESCRIPTION
`WITH_LIBAYATANA_APPINDICATOR` is flipped on by a `pkg_check_modules` probe for `ayatana-appindicator3-0.1`, so whether the SNI tray backend compiles depends on whether that dev package happens to be installed. It isn't in any workflow's `cmake_ubuntu_deps`, so the appindicator half of the tray code — the backend used on Linux desktops — is `#ifdef`'d out on every pre-merge job.

`packaging.yml` *does* build it (the AppImage Dockerfile installs the dev package; the Flatpak manifest builds the stack from source, since GNOME Platform 49 ships none of it) — but that workflow fires on push to master, not on open PRs. So a break in that half passes every check on the PR and is first compiled once it has already landed.

`ccpp.yml`, `clang-tidy.yml` and `codeql.yml` each carry their own dep list, so all three need it: one to compile the code, the others to lint and analyse it.

## Tier-1 risk, checked

Tier-1 clang-tidy is a zero-warnings-anywhere-under-`src/` gate, so making previously invisible code visible could have turned it red on pre-existing findings. It doesn't. All four files referencing the option — `MuleTrayIcon.cpp`, `MuleTrayIcon.h`, `amule.cpp`, `amuleDlg.cpp` — report **zero** Tier-1 findings with the backend enabled, under clang-tidy-21, the version CI pins.

Each zero was control-checked rather than trusted: the same command with `readability-magic-numbers` reports 124, 136 and 162 warnings on the three `.cpp` files, so the translation units really are analysed, and none reports a compiler error that could drop diagnostics silently.

## Verification

Ubuntu 26.04 arm64, against master at `04b1ce8fd`, using CI's exact configure flags:

- cmake reports `AppIndicator3 found: ayatana-appindicator3-0.1 0.5.94 — tray icon uses SNI backend`
- full target set builds clean; `ctest` 33/33
- `app_indicator` symbol references land in **both** `amule` and `amulegui` — `muleappgui` is compiled once and shared, so enabling a backend changes link requirements for both binaries and both needed checking
- `libayatana-appindicator3-dev` 0.5.94 comes from Ubuntu **main**, not a PPA

All three workflow files parse as YAML and their dep lists expand cleanly (16 / 16 / 15 packages, still sorted, no stray tokens — the explanatory comments sit above the block scalars, not inside them, so apt never sees them).

One limit worth stating: this was verified on arm64 / 26.04, while the runners are x86_64 and may be on a different release. If the package name or availability differs there, this PR's own Ubuntu jobs fail outright — which is the right place to find out.
