### PR TITLE
feat(search): filter results as you type (#756)

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3299,10 +3299,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:29+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3341,10 +3341,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:30+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3403,10 +3403,6 @@ msgstr "Disponibilidá"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Fieltru:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Fieltrar Resultaos"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8753,6 +8749,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Fieltrar Resultaos"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Conseñar como ficheru conocíu"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:30+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3334,10 +3334,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3298,10 +3298,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:31+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3393,10 +3393,6 @@ msgstr "Disponibilitat"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtre:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Resultat del filtre"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8696,6 +8692,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Resultat del filtre"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marca com a fitxer conegut"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:32+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3391,10 +3391,6 @@ msgstr "Dostupnost"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtr:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtrování výsledků"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8692,6 +8688,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtrování výsledků"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Označit jako známý soubor"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:32+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3352,10 +3352,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:32+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3391,10 +3391,6 @@ msgstr "Verfügbarkeit"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filterergebnisse"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8710,6 +8706,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Filter Results"
+#~ msgstr "Filterergebnisse"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Als bekannte Datei kennzeichnen"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:33+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3414,10 +3414,6 @@ msgstr "Διαθεσιμότητα"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Φίλτρο:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Αποτελέσματα φιλτραρίσματος"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8772,6 +8768,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Αποτελέσματα φιλτραρίσματος"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Σημείωση αρχείου ως γνωστού"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3299,10 +3299,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:34+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3390,10 +3390,6 @@ msgstr "Disponibilidad"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtrar el resultado"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8691,6 +8687,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtrar el resultado"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marcar como archivo conocido"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3394,10 +3394,6 @@ msgstr "Saadavus"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtreerimise tulemused"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8699,6 +8695,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtreerimise tulemused"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Märgi fail tuntuks"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:35+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3395,10 +3395,6 @@ msgstr "Eskuragarritasuna"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Iragazkia:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Iragazi emaitzak"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8699,6 +8695,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Iragazi emaitzak"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Markatu fitxategia ezaguna bezala"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:35+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3395,10 +3395,6 @@ msgstr "Saatavuus"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Suodatin:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Suodata tulokset"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8699,6 +8695,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Suodata tulokset"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Merkitse tunnetuksi tiedostoksi"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:36+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3388,10 +3388,6 @@ msgstr "Disponibilité"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtre :"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtrer les résultats"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8683,6 +8679,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtrer les résultats"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marquer comme fichier connu"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:36+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3404,10 +3404,6 @@ msgstr "Dispoñibilidade"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtrado:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Resultados do filtro"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8720,6 +8716,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Resultados do filtro"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marcar o ficheiro como coñecido"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:36+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3366,10 +3366,6 @@ msgstr "זמינות"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "מסנן:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "תוצאות מסנן"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8672,6 +8668,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "תוצאות מסנן"
 
 #~ msgid "Mark as known file"
 #~ msgstr "סמן בתור קובץ מוכר"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:37+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3363,10 +3363,6 @@ msgstr "Dostupnost"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtar:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3373,10 +3373,6 @@ msgstr "Elérhetőség"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Szűrő:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Eredmények szűrése"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8666,6 +8662,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Eredmények szűrése"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Ismertként megjelölés"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:38+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3398,10 +3398,6 @@ msgstr "Disponibilità"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtra risultati"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8675,6 +8671,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtra risultati"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Segna come file conosciuto"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3391,10 +3391,6 @@ msgstr "入手可能範囲"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "フィルタ："
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "フィルタの結果"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8700,6 +8696,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "フィルタの結果"
 
 #~ msgid "Mark as known file"
 #~ msgstr "既知ファイルとしてマークする"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:38+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3412,10 +3412,6 @@ msgstr "유효성"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "필터:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "필터링 결과"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8751,6 +8747,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "필터링 결과"
 
 #~ msgid "Bootstrap"
 #~ msgstr "초기적재"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3427,10 +3427,6 @@ msgstr "Skaičius"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtras:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtruoti rezultatus"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8791,6 +8787,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtruoti rezultatus"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Pažymėti failą kaip jau žinomą"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:49+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3316,10 +3316,6 @@ msgstr "Pieejamība"
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:39+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3398,10 +3398,6 @@ msgstr "Beschikbaarheid"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filter resultaat"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8705,6 +8701,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filter resultaat"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Markeer als bekend bestand"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3411,10 +3411,6 @@ msgstr "Tilgjenge"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtrér resultat"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8760,6 +8756,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtrér resultat"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Merk som kjend fil"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:40+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3409,10 +3409,6 @@ msgstr "Dostępność"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtr:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Wyniki filtrowania"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8747,6 +8743,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Wyniki filtrowania"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Oznacz jako znany plik"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3394,10 +3394,6 @@ msgstr "Disponível"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Resultados do Filtro"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8673,6 +8669,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Filter Results"
+#~ msgstr "Resultados do Filtro"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marcar como arquivo conhecido"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:41+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3401,10 +3401,6 @@ msgstr "Disponibilidade"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtro:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtrar Resultados"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8708,6 +8704,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtrar Resultados"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marcar como ficheiro conhecido"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3404,10 +3404,6 @@ msgstr "Disponibilitate"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filtru:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Rezultate filtru"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8725,6 +8721,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Rezultate filtru"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Marchează ca fișier cunoscut"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:43+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3418,10 +3418,6 @@ msgstr "Доступность"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Фильтр:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Фильтровать результаты"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8737,6 +8733,9 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid "Filter Results"
+#~ msgstr "Фильтровать результаты"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Отметить как известный"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:43+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3424,10 +3424,6 @@ msgstr "Razpoložljivost"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtriraj rezultate"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8763,6 +8759,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtriraj rezultate"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Označi kot znano datoteko"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:44+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3404,10 +3404,6 @@ msgstr "Te disponueshem"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filteri:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Rezultatet e filterit"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8731,6 +8727,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Rezultatet e filterit"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Shenoje si fail te njohur"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:44+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3393,10 +3393,6 @@ msgstr "Tillgänglighet"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Filter:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Filtrerresultat"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8696,6 +8692,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Filtrerresultat"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Markera som känd fil"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3298,10 +3298,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3381,10 +3381,6 @@ msgstr "Uygunluk"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Süz:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Süzme Sonuçları"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8676,6 +8672,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Filter Results"
+#~ msgstr "Süzme Sonuçları"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Bilinen dosya olarak işaretle"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:45+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3423,10 +3423,6 @@ msgstr "Доступність"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "Фільтр:"
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "Здобутки фільтру"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8795,6 +8791,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "Здобутки фільтру"
 
 #~ msgid "Mark as known file"
 #~ msgstr "Позначити як відомий файл"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3297,10 +3297,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Filter:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:46+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3390,10 +3390,6 @@ msgstr "可用来源数"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "过滤："
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "过滤结果"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8666,6 +8662,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Filter Results"
+#~ msgstr "过滤结果"
 
 #~ msgid "Mark as known file"
 #~ msgstr "标记为已知文件"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 11:07+0200\n"
+"POT-Creation-Date: 2026-08-06 12:03+0200\n"
 "PO-Revision-Date: 2026-08-06 07:47+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3386,10 +3386,6 @@ msgstr "最小來源數"
 #: src/muuli_wdr.cpp
 msgid "Filter:"
 msgstr "過濾："
-
-#: src/muuli_wdr.cpp
-msgid "Filter Results"
-msgstr "過濾結果"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -8672,6 +8668,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Filter Results"
+#~ msgstr "過濾結果"
 
 #~ msgid "Mark as known file"
 #~ msgstr "標記為已知檔案"

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -58,6 +58,13 @@
 // just to keep compiler happy
 static wxCommandEvent nullEvent;
 
+namespace
+{
+//! How long typing has to pause before the filter is applied, in ms.
+const int kFilterDebounceMs = 250;
+const int ID_FILTER_DEBOUNCE_TIMER = wxID_HIGHEST + 1301;
+} // namespace
+
 wxBEGIN_EVENT_TABLE(CSearchDlg, wxPanel)
 	EVT_BUTTON(IDC_STARTS, CSearchDlg::OnBnClickedStart)
 	EVT_TEXT_ENTER(IDC_SEARCHNAME, CSearchDlg::OnBnClickedStart)
@@ -85,10 +92,11 @@ wxBEGIN_EVENT_TABLE(CSearchDlg, wxPanel)
 	EVT_CUSTOM(wxEVT_CHOICE, wxID_ANY, CSearchDlg::OnFieldChanged)
 
 	// Event handlers for the filter fields getting changed.
+	EVT_TEXT(ID_FILTER_TEXT, CSearchDlg::OnFilterTextChanged)
+	EVT_TIMER(ID_FILTER_DEBOUNCE_TIMER, CSearchDlg::OnFilterDebounceTimer)
 	EVT_TEXT_ENTER(ID_FILTER_TEXT, CSearchDlg::OnFilteringChange)
 	EVT_CHECKBOX(ID_FILTER_INVERT, CSearchDlg::OnFilteringChange)
 	EVT_CHECKBOX(ID_FILTER_KNOWN, CSearchDlg::OnFilteringChange)
-	EVT_BUTTON(ID_FILTER, CSearchDlg::OnFilteringChange)
 	EVT_BUTTON(ID_FILTER_RESET, CSearchDlg::OnFilterReset)
 
 	EVT_IDLE(CSearchDlg::OnIdle)
@@ -101,6 +109,8 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	// windows carrying this style are sent idle events at all -- without it
 	// OnIdle() never runs and the coalesced hit-count flush never happens.
 	SetExtraStyle(GetExtraStyle() | wxWS_EX_PROCESS_IDLE);
+
+	m_filterTimer.SetOwner(this, ID_FILTER_DEBOUNCE_TIMER);
 
 	m_last_search_time = 0;
 	m_expiringSearchID = 0;
@@ -1020,6 +1030,18 @@ void CSearchDlg::OnFilteringChange(wxCommandEvent &WXUNUSED(evt))
 	ApplyFilter();
 }
 
+void CSearchDlg::OnFilterTextChanged(wxCommandEvent &evt)
+{
+	evt.Skip();
+	// Restarted on every keystroke, so only the pause at the end fires it.
+	m_filterTimer.Start(kFilterDebounceMs, wxTIMER_ONE_SHOT);
+}
+
+void CSearchDlg::OnFilterDebounceTimer(wxTimerEvent &WXUNUSED(evt))
+{
+	ApplyFilter();
+}
+
 void CSearchDlg::OnFilterReset(wxCommandEvent &WXUNUSED(evt))
 {
 	// Back to the state a fresh session starts in: empty expression, both
@@ -1038,6 +1060,10 @@ void CSearchDlg::OnFilterReset(wxCommandEvent &WXUNUSED(evt))
 
 void CSearchDlg::ApplyFilter()
 {
+	// Whether we got here from the timer, Enter, the button or a reset, any
+	// pending debounced run is now redundant.
+	m_filterTimer.Stop();
+
 	wxString filter = CastChild(ID_FILTER_TEXT, wxTextCtrl)->GetValue();
 	bool invert = CastChild(ID_FILTER_INVERT, wxCheckBox)->GetValue();
 	bool known = CastChild(ID_FILTER_KNOWN, wxCheckBox)->GetValue();

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -34,7 +34,9 @@ class wxStaticLine;
 
 #include "Types.h" // Needed for uint16 and uint32
 
-#include <map> // Needed for std::map (per-tab progress cache)
+#include <map>        // Needed for std::map (per-tab progress cache)
+#include <wx/timer.h> // Needed for wxTimer (debounced live filtering)
+
 #include <set> // Needed for std::set (pending hit-count recomputes)
 
 class CMuleNotebook;
@@ -386,6 +388,21 @@ private:
 	std::set<CSearchListCtrl *> m_pendingHitCount;
 
 	void OnIdle(wxIdleEvent &evt);
+
+	/**
+	 * Live filtering, debounced.
+	 *
+	 * ApplyFilter() re-filters every open search tab, and each one re-runs
+	 * the regex over its results and resets its model, so applying on every
+	 * keystroke would do that work per character and across all tabs. The
+	 * text box therefore only restarts a short timer; the filter is applied
+	 * once the typing pauses. Enter and the Filter button still apply
+	 * immediately.
+	 */
+	void OnFilterTextChanged(wxCommandEvent &evt);
+	void OnFilterDebounceTimer(wxTimerEvent &evt);
+
+	wxTimer m_filterTimer;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -314,12 +314,8 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item34->Add( 10, 10, wxSizerFlags(1).Center().Border(wxALL, 5) );
     wxStaticText *item35 = new wxStaticText( parent, -1, _("Filter:"), wxDefaultPosition, wxDefaultSize, 0 );
     item34->Add( item35, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxTextCtrl *item36 = new wxTextCtrl( parent, ID_FILTER_TEXT, "", wxDefaultPosition, wxSize(80,-1), wxTE_PROCESS_ENTER );
+    wxTextCtrl *item36 = new wxTextCtrl( parent, ID_FILTER_TEXT, "", wxDefaultPosition, wxSize(220,-1), wxTE_PROCESS_ENTER );
     item34->Add( item36, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxStaticLine *item37 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
-    item34->Add( item37, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxButton *item38 = new wxButton( parent, ID_FILTER, _("Filter Results"), wxDefaultPosition, wxDefaultSize, 0 );
-    item34->Add( item38, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticLine *item39 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item34->Add( item39, wxSizerFlags().Center().Border(wxALL, 5) );
     wxCheckBox *item40 = new wxCheckBox( parent, ID_FILTER_INVERT, _("Invert Result"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -79,7 +79,6 @@ extern wxSizer *s_extended_sizer;
 #define IDC_SPINSEARCHAVAILABILITY 10013
 extern wxSizer *s_filter_sizer;
 #define ID_FILTER_TEXT 10014
-#define ID_FILTER 10015
 #define ID_FILTER_INVERT 10016
 #define ID_FILTER_KNOWN 10017
 // Numbered outside the search block: 10014-10025 is contiguous and full, so a


### PR DESCRIPTION
Closes #756.

The download and shared-files lists filter on every keystroke; search results waited for Enter or the **Filter Results** button. They now behave the same.

Typing restarts a 250 ms timer rather than filtering per character. `CSearchDlg::ApplyFilter()` re-filters *every* open search tab, and each one recompiles the expression, runs it over its results and resets its model — so the cost of a keystroke scales with the number of open tabs, not just the size of one. Enter and the filter reset still apply immediately and cancel anything pending.

A half-typed expression isn't a problem: `ApplyFilter()` already declines to apply a pattern that doesn't compile and leaves the previous filter in place. That guard existed before, but it matters far more now that it sees every intermediate state rather than only finished ones — typing `(` no longer needs to mean anything.

With typing applying the filter, the **Filter Results** button has nothing left to do, so it's removed along with its id and separator, and the text field takes some of the freed width as the only input left in that row. Catalogs regenerated; the string moves to an obsolete entry with its translations kept.

Filtering is entirely GUI-side — no core calls — so this works the same in `amulegui` against a remote daemon, on results already received over EC.

## Testing

macOS, interactively: filtering across multiple open tabs as you type, Enter still applying at once, partial expressions leaving the previous filter alone, and the reset button. `amule` and `amulegui` both build; `clang-format` and both `clang-tidy` tiers clean.

## Worth a look in review

Grouped results collapse when the filter applies, because the model reset drops expand state. That's pre-existing — it happened on every Enter — but at typing cadence it is much more visible. Preserving expansion across the reset is a separate change and I have kept it out of here.
