### PR TITLE
feat(search): keep 100 past queries instead of 30

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -317,9 +317,6 @@ CSearchDlg::~CSearchDlg() {}
 
 namespace
 {
-// eMule's CCustomAutoComplete default (amule-org/amule#643 review).
-const int MAX_SEARCH_HISTORY_ENTRIES = 30;
-
 // Search *query* history -- the strings typed into the Name field, not the
 // results they returned (that's the separate, not-yet-implemented result
 // persistence eMule does via StoredSearches.met; see #641). Deliberately

--- a/src/SearchHistory.h
+++ b/src/SearchHistory.h
@@ -33,6 +33,14 @@
 // strings the user typed, not the results a search returned (that's the
 // separate, not-yet-implemented result persistence tracked in #641).
 
+// How many past queries the Search tab keeps. Started at eMule's
+// CCustomAutoComplete default of 30 (amule-org/amule#643 review) and raised on
+// request (#755): a search history is only useful as far back as it reaches,
+// and clearing it has been a deliberate, confirmed action since #754. It lives
+// here rather than in SearchDlg.cpp so the tests can assert the value the GUI
+// actually passes instead of mirroring a copy of it.
+const size_t MAX_SEARCH_HISTORY_ENTRIES = 100;
+
 // `existing` with `term` moved to the front: any earlier case-insensitive
 // occurrence of `term` is dropped so it doesn't appear twice, and the
 // result is capped to at most `maxEntries` (oldest entries drop off the

--- a/unittests/tests/SearchHistoryTest.cpp
+++ b/unittests/tests/SearchHistoryTest.cpp
@@ -109,19 +109,23 @@ TEST(SearchHistory, ResultIsCappedAtMaxEntries)
 	// term2..term4 fell off the tail -- oldest entries drop first.
 }
 
-TEST(SearchHistory, CapIsExactlyThirtyByProjectConvention)
+TEST(SearchHistory, CapIsTheSharedConstantTheGuiPassesIn)
 {
-	// Locks in eMule's CCustomAutoComplete default (amule-org/amule#643
-	// review) as the constant CSearchDlg actually passes in, not just
-	// that ApplySearchHistoryEntry can cap at an arbitrary N.
+	// Asserts the cap the Search tab actually applies, not just that
+	// ApplySearchHistoryEntry can cap at an arbitrary N -- MAX_SEARCH_HISTORY_
+	// ENTRIES is the same symbol CSearchDlg passes, so this cannot drift from
+	// the GUI the way a hardcoded copy of the number could.
+	const size_t cap = MAX_SEARCH_HISTORY_ENTRIES;
 	wxArrayString existing;
-	for (int i = 0; i < 30; ++i) {
-		existing.Add(wxString::Format("term%d", i));
+	for (size_t i = 0; i < cap; ++i) {
+		existing.Add(wxString::Format("term%d", (int)i));
 	}
 
-	wxArrayString result = ApplySearchHistoryEntry(existing, "newest", 30);
+	wxArrayString result = ApplySearchHistoryEntry(existing, "newest", cap);
 
-	ASSERT_EQUALS((size_t)30, result.GetCount());
+	ASSERT_EQUALS(cap, result.GetCount());
 	ASSERT_EQUALS(wxString("newest"), result[0]);
-	ASSERT_EQUALS(wxString("term28"), result[29]);
+	// The oldest entry falls off the tail: the last survivor is the
+	// second-oldest of what was there before.
+	ASSERT_EQUALS(wxString::Format("term%d", (int)cap - 2), result[cap - 1]);
 }


### PR DESCRIPTION
Addresses the first half of #755.

The Search tab's Name-field history held 30 entries — eMule's `CCustomAutoComplete` default, adopted in the #643 review rather than chosen for aMule. A history is only useful as far back as it reaches, and 30 queries is a short reach for anyone who searches often. Clearing it has been a deliberate, confirmed action since #754, so there is less cost to keeping more of it around.

Eviction is LRU and stays that way: `ApplySearchHistoryEntry` moves a searched term to the front and drops any earlier case-insensitive copy, so the tail that falls off is the least recently *searched*, not the least recently added. Terms you actually reuse stay near the front regardless of the cap, and the extra 70 slots buy depth for the long tail. (Selecting an entry from the dropdown does not refresh it — only running the search does.)

## The constant moves

It goes from an anonymous namespace in `SearchDlg.cpp` to `SearchHistory.h`, beside the function that consumes it. That closes a quiet gap in the tests: `CapIsExactlyThirtyByProjectConvention` claimed to lock "the constant CSearchDlg actually passes in", but hardcoded its own copy of the number — so it would have gone on passing while the GUI used something else entirely. It now reads the same symbol the GUI does and cannot drift from it.

## Dropdown length, checked on all three platforms

The obvious worry is that a longer history makes #755's *other* complaint worse — the dropdown overlapping other UI. Tried with a staged 100-entry history on each platform:

| platform | result |
| --- | --- |
| Windows 11 (ARM64 VM) | best of the three |
| Linux (Ubuntu, GNOME/Wayland) | fine |
| macOS 15 (M2 Max) | large, but stays within the screen |

No platform runs the list off the display, so this does not make that complaint worse. It does not fix it either — capping the visible entries needs a different widget, since wxWidgets exposes no dropdown-height control on plain `wxComboBox` (`SetPopupMaxHeight()` is `wxComboCtrl`/`wxOwnerDrawnComboBox` only). That is left on the issue, which stays open.

33/33 unit tests pass; clang-format 18 and both clang-tidy tiers clean on the diff.
