### PR TITLE
fix(servers): show ping in milliseconds (#823)

### DIFF
--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -280,7 +280,14 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) con
 		if (!server->GetPing()) {
 			return wxEmptyString;
 		}
-		return CastSecondsToHM(server->GetPing() / 1000, server->GetPing() % 1000);
+		// GetPing() is already milliseconds (a GetTickCount64() delta), and
+		// milliseconds is how latency is written everywhere else -- including
+		// our own REST API, which publishes it as "ping_ms". It used to go
+		// through CastSecondsToHM(), a general duration helper whose
+		// sub-minute branch prints "0.203 secs" (issue #823).
+		// "ms" is an SI unit symbol, identical in every language, so unlike
+		// the secs/mins/hours abbreviations elsewhere it is not translated.
+		return CFormat("%u ms") % server->GetPing();
 
 	case COLUMN_SERVER_USERS:
 		if (!server->GetUsers()) {


### PR DESCRIPTION
Closes #823.

`CServer::GetPing()` is already milliseconds — it is a `GetTickCount64()` delta — but the column ran it through `CastSecondsToHM()`, a general duration helper whose sub-minute branch prints `%.3f secs`. Server pings are almost always under a second, so the useful digits ended up behind a decimal point in a unit nobody measures latency in.

Printed as `203 ms` instead, which is also shorter than the `0.203 secs` it replaces, so the column keeps its current width. That matches what we already publish over the REST API, where the field is named `ping_ms`.

Both builds are covered by the one change: `ServerListCtrl.cpp` is compiled into `amule` and `amulegui` alike, and the remote GUI stores the raw millisecond value the core sends in `EC_TAG_SERVER_PING`, so there is no second formatting path to keep in step.

The unit is deliberately not translated. Unlike the `secs`/`mins`/`hours` abbreviations elsewhere, which are shortened unit names, `ms` is an SI symbol and is written the same way in every language — so no catalog changes here.

Sorting is unaffected: `CompareItemData()` orders on the raw value, not the rendered string.

## Testing

Builds clean on macOS for `amule` and `amulegui`; `clang-format` and both `clang-tidy` tiers clean.
