### PR TITLE
fix(servers): translate the ping unit

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6359,6 +6359,10 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "ms"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6454,6 +6454,11 @@ msgstr ""
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "دقيقة"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6569,6 +6569,11 @@ msgstr "(Nome desconocíu)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "De xuru quies desaniciar el sirvidor fixu %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "mins"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6429,6 +6429,11 @@ msgstr "(Неизвестно име)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "мин."
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6358,6 +6358,10 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "ms"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6539,6 +6539,11 @@ msgstr "(Nom desconegut)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Esteu segur que voleu esborrar el servidor estàtic %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "mins"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:01+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6548,6 +6548,11 @@ msgstr "(neznámý název)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Opravdu si přejete smazat stálý server %s?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min."
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:02+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6470,6 +6470,11 @@ msgstr ""
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6535,6 +6535,11 @@ msgstr "(Unbekannter Name)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Wirklich den statischen Server '%s' löschen?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "Minuten"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:03+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6582,6 +6582,11 @@ msgstr "(Άγνωστο όνομα)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Είστε σίγουρος/η ότι θέλετε να διαγράψετε τον στατικό διακομιστή %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "λεπτά"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6359,6 +6359,10 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "ms"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6518,6 +6518,11 @@ msgstr "(Nombre desconocido)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "¿Seguro que quiere eliminar el servidor fijo %s?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minutos"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6545,6 +6545,11 @@ msgstr "(Tundmatu nimi)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Oled kindel et tahad kustutada staatilise serveri %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6543,6 +6543,11 @@ msgstr "(Izen ezezaguna)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ziur al zaude %s zerbitzari tinkoa ezabatu nahi duzula"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6543,6 +6543,11 @@ msgstr "(Tuntematon nimi)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Oletko varma että haluat poistaa pysyvän palvelimen %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "m"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:05+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6510,6 +6510,11 @@ msgstr "(Nom inconnu)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Êtes-vous sûr de vouloir supprimer le serveur statique %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6549,6 +6549,11 @@ msgstr "(Nome descoñecido)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Seguro de que quere borrar o servidor estático %s?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minutos"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6506,6 +6506,11 @@ msgstr "(שם לא ידוע)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "האם אתה בטוח שאתה רוצה למחוק את השרת הקבוע %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "דקות"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6499,6 +6499,11 @@ msgstr ""
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minuta"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:07+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6512,6 +6512,11 @@ msgstr "(Ismeretlen név)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Biztos, hogy törlöd az állandó %s kiszolgálót"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "perc"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6505,6 +6505,11 @@ msgstr "(nome sconosciuto)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Sei sicuro di voler eliminare il server statico %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6535,6 +6535,11 @@ msgstr "（不明な名前）"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "スタティックサーバ %s を本当に削除しますか？"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "分"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6572,6 +6572,11 @@ msgstr "(알수없는 이름)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "정적 서버 %s를 삭제하시겠습니까?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "분"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:09+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6601,6 +6601,11 @@ msgstr "(pavadinimas nežinomas)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ar tikrai norite pašalinti šį statišką serverį %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min."
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6399,6 +6399,11 @@ msgstr ""
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr ""
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minūtes"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:09+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6544,6 +6544,11 @@ msgstr "(Onbekende naam)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Weet u zeker dat u de statische server %s wilt verwijderen"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minuten"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:10+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6573,6 +6573,11 @@ msgstr "(Ukjent namn)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Er du sikker på at du vil slette den statiske tenaren %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minutt"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:10+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6580,6 +6580,11 @@ msgstr "(Nieznana nazwa)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Na pewno chcesz usunąć serwer statyczny %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:11+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6502,6 +6502,11 @@ msgstr "(Nome Desconhecido)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Deseja remover o servidor estático %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:11+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6551,6 +6551,11 @@ msgstr "(Nome desconhecido)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Tem a certeza que deseja eliminar o servidor estático %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minutos"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:12+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6562,6 +6562,11 @@ msgstr "(Nume necunoscut)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Sigur doriți să ștergeți serverul static %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minute"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6552,6 +6552,11 @@ msgstr "(Неизвестное имя)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Уверены, что хотите удалить постоянный сервер %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "м"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6599,6 +6599,11 @@ msgstr "(neznano ime)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ali res želite izbrisati statičen strežnik %s?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "min."
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6563,6 +6563,11 @@ msgstr "(Emer i panjohur)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Jeni te sigurte qe doni te fshini kete server te qendrueshem %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minuta"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6539,6 +6539,11 @@ msgstr "(Okänt namn)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Är du säker på att du vill ta bort den statiska servern %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "minuter"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6358,6 +6358,10 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "ms"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6503,6 +6503,11 @@ msgstr "(Bilinmeyen ad)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Statik sunucu %s'i silmek istediğinizden emin misiniz"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "dk"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6604,6 +6604,11 @@ msgstr "(невідома назва)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "Ви впевнені, що хочете видалити постійний сервер %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "хв"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6357,6 +6357,10 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
+msgstr ""
+
+#: src/ServerListCtrl.cpp
+msgid "ms"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:16+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6498,6 +6498,11 @@ msgstr "(未知名称)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "您确定要删除静态服务器 %s ?"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "分钟"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-06 12:03+0200\n"
+"POT-Creation-Date: 2026-08-06 13:42+0200\n"
 "PO-Revision-Date: 2026-08-06 11:16+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6522,6 +6522,11 @@ msgstr "(不明名稱)"
 #, c-format
 msgid "Are you sure you want to delete the static server %s"
 msgstr "您確定要刪除靜態伺服器 %s"
+
+#: src/ServerListCtrl.cpp
+#, fuzzy
+msgid "ms"
+msgstr "分"
 
 #: src/ServerListCtrl.cpp
 #, c-format

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -285,9 +285,11 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) con
 		// our own REST API, which publishes it as "ping_ms". It used to go
 		// through CastSecondsToHM(), a general duration helper whose
 		// sub-minute branch prints "0.203 secs" (issue #823).
-		// "ms" is an SI unit symbol, identical in every language, so unlike
-		// the secs/mins/hours abbreviations elsewhere it is not translated.
-		return CFormat("%u ms") % server->GetPing();
+		// The unit is translated: it is not written "ms" everywhere -- ru and
+		// uk use "мс", and it is localised in zh and ja too -- and the number
+		// is kept out of the catalog entry the way CastSecondsToHM() keeps it
+		// out of _("secs") and _("mins").
+		return CFormat("%u %s") % server->GetPing() % _("ms");
 
 	case COLUMN_SERVER_USERS:
 		if (!server->GetUsers()) {


### PR DESCRIPTION
Follow-up to #824, correcting a claim I made in it.

I hardcoded `ms` there on the grounds that an SI symbol reads the same in every language. @adem4ik [pointed out](https://github.com/amule-org/amule/pull/824#issuecomment-5204155374) that it doesn't: ru and uk write `мс`, and it is localised in zh and ja too. So the one hardcoded unit in the interface was also the one users of those locales could not read in their own script — the opposite of the intended effect.

Now translated like every other unit the UI shows. The number stays outside the catalog entry, matching how `CastSecondsToHM()` keeps it out of `_("secs")` and `_("mins")`, so a translator sees `ms` on its own rather than a format string with a `%u` in it.

Catalogs regenerated from current master; `ms` is the only new `msgid`, with no unrelated churn.

## Testing

`amule` and `amulegui` build on macOS; `clang-format` and both `clang-tidy` tiers clean.
