### PR TITLE
fix(search): restore search results in amulegui, and share the result index

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -324,16 +324,13 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 	m_browseBar.erase(searchID);
 	m_browseStatus.erase(searchID);
 
-	ResultMap::iterator it = m_results.find(searchID);
-	if (it != m_results.end()) {
-		CSearchResultList &list = it->second;
-
-		for (size_t i = 0; i < list.size(); ++i) {
-			delete list.at(i);
-		}
-
-		m_results.erase(it);
+	// This list owns its results, so free them before dropping the index
+	// (which, being shared with the remote search list, never deletes).
+	const CSearchResultList &list = GetSearchResults(searchID);
+	for (CSearchFile *file : list) {
+		delete file;
 	}
+	DropResultIndex(searchID);
 }
 
 wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchParams &params)
@@ -804,8 +801,10 @@ bool CSearchList::AddToList(CSearchFile *toadd, bool clientResponse)
 		}
 	}
 
-	// Get, or implicitly create, the map of results for this search
-	CSearchResultList &results = m_results[toadd->GetSearchID()];
+	// Scan the results already indexed for this search (empty if it is the
+	// first one) for a duplicate; the new result is indexed further down,
+	// through IndexResult().
+	const CSearchResultList &results = GetSearchResults(toadd->GetSearchID());
 
 	for (size_t i = 0; i < results.size(); ++i) {
 		CSearchFile *item = results.at(i);
@@ -845,22 +844,10 @@ bool CSearchList::AddToList(CSearchFile *toadd, bool clientResponse)
 		CFormat("Added new result '%s' : %s") % toadd->GetFileName() % toadd->GetFileHash().Encode());
 
 	// New unique result, simply add and display.
-	results.push_back(toadd);
+	IndexResult(toadd);
 	Notify_Search_Add_Result(toadd);
 
 	return true;
-}
-
-const CSearchResultList &CSearchList::GetSearchResults(wxUIntPtr searchID) const
-{
-	ResultMap::const_iterator it = m_results.find(searchID);
-	if (it != m_results.end()) {
-		return it->second;
-	}
-
-	// TODO: Should we assert in this case?
-	static CSearchResultList list;
-	return list;
 }
 
 void CSearchList::AddFileToDownloadByHash(const CMD4Hash &hash, uint8 cat)

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -26,13 +26,14 @@
 #ifndef SEARCHLIST_H
 #define SEARCHLIST_H
 
-#include "Timer.h"           // Needed for CTimer
-#include "ObservableQueue.h" // Needed for CQueueObserver
-#include "SearchFile.h"      // Needed for CSearchFile
-#include <common/SmartPtr.h> // Needed for CSmartPtr
-#include <set>               // Needed for std::set (per-search Kad completion)
-#include <map>               // Needed for std::map (per-search start times)
-#include <vector>            // Needed for std::vector (same-hash result fan-out)
+#include "Timer.h"             // Needed for CTimer
+#include "ObservableQueue.h"   // Needed for CQueueObserver
+#include "SearchFile.h"        // Needed for CSearchFile
+#include "SearchResultIndex.h" // Needed for CSearchResultIndex
+#include <common/SmartPtr.h>   // Needed for CSmartPtr
+#include <set>                 // Needed for std::set (per-search Kad completion)
+#include <map>                 // Needed for std::map (per-search start times)
+#include <vector>              // Needed for std::vector (same-hash result fan-out)
 
 class CMemFile;
 class CMD4Hash;
@@ -54,7 +55,7 @@ enum SearchType
 
 typedef std::vector<CSearchFile *> CSearchResultList;
 
-class CSearchList : public wxEvtHandler
+class CSearchList : public wxEvtHandler, public CSearchResultIndex
 {
 public:
 	//! Structure used to pass search-parameters.
@@ -256,12 +257,8 @@ public:
 	/** This function is called once the local (ed2k) search has ended. */
 	void LocalSearchEnd();
 
-	/**
-	 * Returns the list of results for the specified search.
-	 *
-	 * If the search is not valid, an empty list is returned.
-	 */
-	const CSearchResultList &GetSearchResults(wxUIntPtr searchID) const;
+	// GetSearchResults() is inherited from CSearchResultIndex, which holds the
+	// per-search result index this class fills through IndexResult().
 
 	/** Removes all results for the specified search. */
 	void RemoveResults(wxUIntPtr searchID);
@@ -478,11 +475,8 @@ private:
 	//! TODO: Replace with 'cookie' system.
 	CQueueObserver<CServer *> m_serverQueue;
 
-	//! Shorthand for the map of results (key is a SearchID).
-	typedef std::map<wxUIntPtr, CSearchResultList> ResultMap;
-
-	//! Map of all search-results added.
-	ResultMap m_results;
+	// The map of search-results (ResultMap / m_results) lives in
+	// CSearchResultIndex, shared with the remote search list.
 
 	//! Contains the results type desired in the current search.
 	//! If not empty, results of different types are filtered.

--- a/src/SearchResultIndex.h
+++ b/src/SearchResultIndex.h
@@ -1,0 +1,121 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef SEARCHRESULTINDEX_H
+#define SEARCHRESULTINDEX_H
+
+#include <algorithm> // Needed for std::find
+#include <map>       // Needed for std::map
+
+#include "SearchFile.h" // Needed for CSearchFile, CSearchResultList
+
+/**
+ * The per-search result index shared by the two search-list implementations.
+ *
+ * The search list has one implementation per build: CSearchList (monolithic,
+ * fed by the network stack) and CSearchListRem (amulegui, fed over EC). Both
+ * are reached through the same theApp->searchlist seam, and the GUI reads its
+ * rows from GetSearchResults() -- the wxDataViewCtrl search model builds every
+ * row from it, so a result that is not indexed here is invisible, no matter
+ * how correctly it arrived.
+ *
+ * That contract used to be satisfied by each implementation keeping its own
+ * copy of this map, which is how the remote one came to never populate it at
+ * all (the pre-wxDataViewCtrl list control held its own rows, so nothing broke
+ * visibly until the port made this map the row source). Keeping the map here,
+ * with IndexResult() as the only way to add to it, means a new implementation
+ * cannot answer GetSearchResults() correctly and still forget to fill it.
+ *
+ * Ownership deliberately stays with the derived class: the monolithic list
+ * owns its CSearchFile objects, while the remote one only borrows pointers
+ * owned by its CRemoteContainer. This index therefore never deletes anything
+ * -- DropResultIndex() drops the bookkeeping and leaves freeing to the owner.
+ */
+class CSearchResultIndex
+{
+public:
+	/**
+	 * Returns the list of results for the specified search.
+	 *
+	 * If the search is not known, an empty list is returned.
+	 */
+	const CSearchResultList &GetSearchResults(wxUIntPtr searchID) const
+	{
+		ResultMap::const_iterator it = m_results.find(searchID);
+		if (it != m_results.end()) {
+			return it->second;
+		}
+
+		static const CSearchResultList emptyList;
+		return emptyList;
+	}
+
+protected:
+	//! Not polymorphic: derived classes are never deleted through this type.
+	~CSearchResultIndex() = default;
+
+	//! Shorthand for the map of results (key is a SearchID).
+	typedef std::map<wxUIntPtr, CSearchResultList> ResultMap;
+
+	/**
+	 * Makes a result visible to the GUI, under its own search id.
+	 *
+	 * This is the single point where a result enters the index, and every
+	 * search-list implementation has to route new results through it.
+	 */
+	void IndexResult(CSearchFile *file) { m_results[file->GetSearchID()].push_back(file); }
+
+	/**
+	 * Drops a single result from the index, without freeing it.
+	 *
+	 * Call this before the owner frees a result, so no freed pointer is left
+	 * behind for GetSearchResults() to hand out.
+	 */
+	void UnindexResult(CSearchFile *file)
+	{
+		ResultMap::iterator it = m_results.find(file->GetSearchID());
+		if (it == m_results.end()) {
+			return;
+		}
+
+		CSearchResultList &list = it->second;
+		CSearchResultList::iterator pos = std::find(list.begin(), list.end(), file);
+		if (pos != list.end()) {
+			list.erase(pos);
+		}
+	}
+
+	/**
+	 * Drops a whole search from the index, without freeing its results.
+	 *
+	 * The results belong to the derived class, which frees them itself where
+	 * it owns them.
+	 */
+	void DropResultIndex(wxUIntPtr searchID) { m_results.erase(searchID); }
+
+	//! Map of all indexed search-results, keyed by search id.
+	ResultMap m_results;
+};
+
+#endif // SEARCHRESULTINDEX_H

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -55,7 +55,6 @@
 #include "Friend.h"
 #include "GetTickCount.h" // Needed for GetTickCount64
 #include "GuiEvents.h"
-#include "OtherFunctions.h" // Needed for EraseValue
 #ifdef GEOIP_GUI
 #include "IP2Country.h" // Needed for IP2Country
 #endif
@@ -3593,12 +3592,10 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 		m_needSearchListRequery = true;
 	}
 
-	// Index this result under its search id. The DataView search model reads
-	// its rows from GetSearchResults() (this m_results map), mirroring the core
-	// CSearchList::AddToList -- without this the remote map stays empty and
-	// amulegui shows no results at all. m_items (the CRemoteContainer) still
-	// owns the objects; this is a non-owning per-search index.
-	m_results[file->GetSearchID()].push_back(file);
+	// Make the result visible to the GUI: the search model builds its rows
+	// from GetSearchResults(), so a result that is not indexed here shows up
+	// nowhere, however correctly it arrived over EC.
+	IndexResult(file);
 
 	theApp->amuledlg->m_searchwnd->AddResult(file);
 
@@ -3607,12 +3604,9 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 
 void CSearchListRem::DeleteItem(CSearchFile *file)
 {
-	// De-index from the per-search results map before freeing, so a later
-	// GetSearchResults()/GetChildren never dereferences this freed pointer.
-	ResultMap::iterator it = m_results.find(file->GetSearchID());
-	if (it != m_results.end()) {
-		EraseValue(it->second, file);
-	}
+	// De-index before freeing, so a later GetSearchResults() never hands out
+	// this freed pointer.
+	UnindexResult(file);
 	delete file;
 }
 
@@ -3696,23 +3690,11 @@ bool CSearchListRem::Phase1Done(const CECPacket *WXUNUSED(reply))
 
 void CSearchListRem::RemoveResults(wxUIntPtr nSearchID)
 {
-	// m_results is a non-owning index into the CRemoteContainer: m_items owns
-	// the CSearchFile objects and frees them via DeleteItem(). Only drop the
-	// index here -- deleting would double-free the container-owned results.
-	m_results.erase(nSearchID);
+	// The index only borrows: the CRemoteContainer owns these results and
+	// frees them through DeleteItem(), so dropping the index is all that is
+	// needed here -- deleting would double-free.
+	DropResultIndex(nSearchID);
 	m_kadActive.erase((uint32)nSearchID);
-}
-
-const CSearchResultList &CSearchListRem::GetSearchResults(wxUIntPtr nSearchID)
-{
-	ResultMap::const_iterator it = m_results.find(nSearchID);
-	if (it != m_results.end()) {
-		return it->second;
-	}
-
-	// TODO: Should we assert in this case?
-	static CSearchResultList list;
-	return list;
 }
 
 void CStatsUpdaterRem::HandlePacket(const CECPacket *packet)

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -55,6 +55,7 @@
 #include "Friend.h"
 #include "GetTickCount.h" // Needed for GetTickCount64
 #include "GuiEvents.h"
+#include "OtherFunctions.h" // Needed for EraseValue
 #ifdef GEOIP_GUI
 #include "IP2Country.h" // Needed for IP2Country
 #endif
@@ -3592,6 +3593,13 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 		m_needSearchListRequery = true;
 	}
 
+	// Index this result under its search id. The DataView search model reads
+	// its rows from GetSearchResults() (this m_results map), mirroring the core
+	// CSearchList::AddToList -- without this the remote map stays empty and
+	// amulegui shows no results at all. m_items (the CRemoteContainer) still
+	// owns the objects; this is a non-owning per-search index.
+	m_results[file->GetSearchID()].push_back(file);
+
 	theApp->amuledlg->m_searchwnd->AddResult(file);
 
 	return file;
@@ -3599,6 +3607,12 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 
 void CSearchListRem::DeleteItem(CSearchFile *file)
 {
+	// De-index from the per-search results map before freeing, so a later
+	// GetSearchResults()/GetChildren never dereferences this freed pointer.
+	ResultMap::iterator it = m_results.find(file->GetSearchID());
+	if (it != m_results.end()) {
+		EraseValue(it->second, file);
+	}
 	delete file;
 }
 
@@ -3682,14 +3696,10 @@ bool CSearchListRem::Phase1Done(const CECPacket *WXUNUSED(reply))
 
 void CSearchListRem::RemoveResults(wxUIntPtr nSearchID)
 {
-	ResultMap::iterator it = m_results.find(nSearchID);
-	if (it != m_results.end()) {
-		CSearchResultList &list = it->second;
-		for (unsigned int i = 0; i < list.size(); ++i) {
-			delete list[i];
-		}
-		m_results.erase(it);
-	}
+	// m_results is a non-owning index into the CRemoteContainer: m_items owns
+	// the CSearchFile objects and frees them via DeleteItem(). Only drop the
+	// index here -- deleting would double-free the container-owned results.
+	m_results.erase(nSearchID);
 	m_kadActive.erase((uint32)nSearchID);
 }
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -629,7 +629,8 @@ public:
 	bool IsReady() const { return true; }
 };
 
-class CSearchListRem : public CRemoteContainer<CSearchFile, uint32, CEC_SearchFile_Tag>
+class CSearchListRem : public CRemoteContainer<CSearchFile, uint32, CEC_SearchFile_Tag>,
+		       public CSearchResultIndex
 {
 	virtual void HandlePacket(const CECPacket *);
 
@@ -697,12 +698,12 @@ public:
 	// the search runs and greys out once it completes — the progress lifecycle
 	// is the gate, no extra status needed. Pruned on tab close / removal.
 	std::map<uint32, bool> m_kadActive;
-	typedef std::map<wxUIntPtr, CSearchResultList> ResultMap;
-	ResultMap m_results;
 
-	const CSearchResultList &GetSearchResults(wxUIntPtr nSearchID);
+	// The result index (ResultMap / m_results) and GetSearchResults() live in
+	// CSearchResultIndex, shared with the monolithic search list. Results here
+	// are owned by the CRemoteContainer, so the index only borrows pointers.
+
 	void RemoveResults(wxUIntPtr nSearchID);
-	const CSearchResultList &GetSearchResults(wxUIntPtr nSearchID) const;
 	//
 	// Actions
 	//


### PR DESCRIPTION
Addresses the empty-results half of #827. (The Enter-key-to-start-search regression noted there is separate and not included here - it does not reproduce on macOS, so it needs a Linux/Windows look first.)

**Problem**
In amulegui, a search creates the tab and the progress bar moves, but the result list stays empty. The search itself works - `amulecmd results N` lists the results and the monolithic GUI displays them - so it is purely a remote-GUI display bug.

**Cause**
The wxDataViewCtrl port (#796) made `CSearchListModel` build its rows from `theApp->searchlist->GetSearchResults()`, i.e. the search list's per-search result map. The monolithic `CSearchList` fills that map in `AddToList()`; the remote `CSearchListRem` never did - its results live only in the `CRemoteContainer` - so the model read an empty map. The old list control held its own rows, so the unpopulated remote map stayed invisible until the port made it the row source.

**Fix**
The remote list now indexes each result as it arrives, de-indexes before the container frees one, and drops the index when a search is removed.

**Refactor**
Rather than leave two copies of a map that both implementations have to remember to fill, the map now lives in one place: a new header-only `CSearchResultIndex` that `CSearchList` and `CSearchListRem` both inherit. It provides the single `GetSearchResults()` the GUI reads (previously duplicated verbatim in both classes) and `IndexResult()` as the only way in, so an implementation can no longer answer the query while forgetting to populate what it answers from.

Ownership deliberately stays with the derived class and the index never deletes: `CSearchList` owns its results and frees them before dropping the index, while `CSearchListRem` only borrows pointers owned by its `CRemoteContainer`. No CMake changes - the header compiles into whichever build includes it.

The other migrated lists are unaffected: they use the `CMuleVirtualDataViewCtrl` base, which owns its row store and is filled through the same base methods in both builds, so there is no second implementation to drift.

**Testing**
amulegui and monolithic both build clean (macOS); clang-format and diff-scoped clang-tidy (Tier-2) clean. Verified live in both: search results display, and closing a search tab (the free-then-drop-index path) is clean.
