### PR TITLE
fix(search): index top-level results only, and enforce that in the index

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -286,8 +286,8 @@ CSearchList::~CSearchList()
 	// Search_Removed broadcast below -- there is no tab left worth closing
 	// and the notify would reach a half-destroyed CamuleDlg.
 	m_shuttingDown = true;
-	while (!m_results.empty()) {
-		RemoveResults(m_results.begin()->first);
+	while (!AllResults().empty()) {
+		RemoveResults(AllResults().begin()->first);
 	}
 }
 
@@ -554,8 +554,7 @@ std::size_t CSearchList::GetCurrentSearchResultCount() const
 	if (m_currentSearch == wxUIntPtr(-1)) {
 		return 0;
 	}
-	ResultMap::const_iterator it = m_results.find(m_currentSearch);
-	return (it == m_results.end()) ? 0 : it->second.size();
+	return GetSearchResults(m_currentSearch).size();
 }
 
 uint8 CSearchList::GetSearchLifecyclePercent() const
@@ -852,13 +851,10 @@ bool CSearchList::AddToList(CSearchFile *toadd, bool clientResponse)
 
 void CSearchList::AddFileToDownloadByHash(const CMD4Hash &hash, uint8 cat)
 {
-	ResultMap::iterator it = m_results.begin();
-	for (; it != m_results.end(); ++it) {
-		CSearchResultList &list = it->second;
-
-		for (unsigned int i = 0; i < list.size(); ++i) {
-			if (list[i]->GetFileHash() == hash) {
-				CoreNotify_Search_Add_Download(list[i], cat);
+	for (const auto &entry : AllResults()) {
+		for (CSearchFile *sf : entry.second) {
+			if (sf->GetFileHash() == hash) {
+				CoreNotify_Search_Add_Download(sf, cat);
 
 				return;
 			}
@@ -868,7 +864,7 @@ void CSearchList::AddFileToDownloadByHash(const CMD4Hash &hash, uint8 cat)
 
 CSearchFile *CSearchList::GetSearchFileByID(const CMD4Hash &hash) const
 {
-	for (const auto &entry : m_results) {
+	for (const auto &entry : AllResults()) {
 		for (CSearchFile *sf : entry.second) {
 			if (sf->GetFileHash() == hash) {
 				return sf;
@@ -891,7 +887,7 @@ void CSearchList::GetAllSearchFilesByID(const CMD4Hash &hash, std::vector<CSearc
 	// search keeps its own CSearchFile with its own note list. On-demand Kad
 	// notes and the running flag must reach all of them, or only the first tab
 	// would show the comments.
-	for (const auto &entry : m_results) {
+	for (const auto &entry : AllResults()) {
 		for (CSearchFile *sf : entry.second) {
 			if (sf->GetFileHash() == hash) {
 				out.push_back(sf);
@@ -910,7 +906,7 @@ void CSearchList::AddFileToDownloadByEcid(uint32 ecid, uint8 cat)
 	// Match against parents and their same-hash/different-name children
 	// (issue #431 grouping); downloading the specific CSearchFile lands
 	// the partfile under that result's own filename.
-	for (auto &entry : m_results) {
+	for (const auto &entry : AllResults()) {
 		for (CSearchFile *sf : entry.second) {
 			if (sf->ECID() == ecid) {
 				CoreNotify_Search_Add_Download(sf, cat);
@@ -1034,8 +1030,7 @@ CSearchList::SearchLifecycleState CSearchList::GetSearchLifecycleStateById(wxUIn
 		return GetSearchLifecycleState();
 	}
 	// Otherwise: results retained => finished; nothing => idle/unknown.
-	return (m_results.find(searchID) != m_results.end()) ? SEARCH_LIFECYCLE_FINISHED
-							     : SEARCH_LIFECYCLE_IDLE;
+	return HasSearchResults(searchID) ? SEARCH_LIFECYCLE_FINISHED : SEARCH_LIFECYCLE_IDLE;
 }
 
 uint8 CSearchList::GetSearchLifecyclePercentById(wxUIntPtr searchID) const
@@ -1508,8 +1503,8 @@ void CSearchList::KademliaSearchKeyword(uint32_t searchID,
 
 void CSearchList::UpdateSearchFileByHash(const CMD4Hash &hash)
 {
-	for (ResultMap::iterator it = m_results.begin(); it != m_results.end(); ++it) {
-		CSearchResultList &results = it->second;
+	for (const auto &entry : AllResults()) {
+		const CSearchResultList &results = entry.second;
 		for (size_t i = 0; i < results.size(); ++i) {
 			CSearchFile *item = results.at(i);
 

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -315,15 +315,12 @@ size_t CSearchListCtrl::GetHiddenItemCount() const
 	}
 	size_t hidden = 0;
 	const CSearchResultList &results = theApp->searchlist->GetSearchResults(m_nResultsID);
+	// Only top-level results are indexed (see CSearchResultIndex), so this
+	// counts exactly the results the list would show but for the filter. A
+	// grouped child is never "hidden" in its own right: it is reached through
+	// its parent, which surfaces as a container for it.
 	for (CSearchFile *file : results) {
-		if (!file->GetParent() && !ShouldShow(file)) {
-			++hidden;
-		}
-		// Children are only ever "hidden" for filtering purposes via their
-		// own IsFiltered() test -- a filtered-in child under a filtered-out
-		// parent still counts as visible (the parent surfaces as a
-		// container for it), so it is not counted as hidden here either.
-		if (file->GetParent() && !IsFiltered(file)) {
+		if (!ShouldShow(file)) {
 			++hidden;
 		}
 	}

--- a/src/SearchResultIndex.h
+++ b/src/SearchResultIndex.h
@@ -51,12 +51,25 @@
  * owns its CSearchFile objects, while the remote one only borrows pointers
  * owned by its CRemoteContainer. This index therefore never deletes anything
  * -- DropResultIndex() drops the bookkeeping and leaves freeing to the owner.
+ *
+ * What the index holds -- part of the contract, not an implementation detail:
+ * TOP-LEVEL RESULTS ONLY. A result grouped under another one (same hash, a
+ * different filename) is reachable through its parent's GetChildren() and must
+ * not be indexed here, or GetSearchResults(id).size() stops meaning "hits for
+ * this search" and consumers see each grouped result twice.
+ *
+ * Performance note for whenever result counts grow: UnindexResult() is a linear
+ * scan of one search's list, so tearing down a whole search one result at a
+ * time (CRemoteContainer::FullReload, which calls DeleteItem per item) costs
+ * O(N^2) in results per search. That is irrelevant at the few hundred results a
+ * search returns today; if the caps ever rise, drop the whole index for the
+ * search up front with DropResultIndex() rather than unindexing item by item.
  */
 class CSearchResultIndex
 {
 public:
 	/**
-	 * Returns the list of results for the specified search.
+	 * Returns the list of top-level results for the specified search.
 	 *
 	 * If the search is not known, an empty list is returned.
 	 */
@@ -79,12 +92,46 @@ protected:
 	typedef std::map<wxUIntPtr, CSearchResultList> ResultMap;
 
 	/**
-	 * Makes a result visible to the GUI, under its own search id.
+	 * True if this search is present in the index at all.
+	 *
+	 * Distinct from GetSearchResults(id).empty(): a search that is known but
+	 * currently holds no results answers true here and empty there.
+	 */
+	bool HasSearchResults(wxUIntPtr searchID) const
+	{
+		return m_results.find(searchID) != m_results.end();
+	}
+
+	/**
+	 * Every indexed search, for the few operations that have to walk them all
+	 * (find a result by hash across open searches, drain the index).
+	 *
+	 * Read-only on purpose: the map is private so that IndexResult() is the
+	 * only way a result can enter it. Walking the lists to call non-const
+	 * methods on the results themselves is still fine -- the constness applies
+	 * to the index, not to what it points at.
+	 */
+	const ResultMap &AllResults() const { return m_results; }
+
+	/**
+	 * Makes a top-level result visible to the GUI, under its own search id.
 	 *
 	 * This is the single point where a result enters the index, and every
 	 * search-list implementation has to route new results through it.
+	 *
+	 * Passing a grouped result is a no-op rather than a caller error: the
+	 * top-level rule is the index's to keep, so an implementation that hands
+	 * over everything it receives still ends up with a correct index instead
+	 * of one that is wrong in a way only a consumer notices.
 	 */
-	void IndexResult(CSearchFile *file) { m_results[file->GetSearchID()].push_back(file); }
+	void IndexResult(CSearchFile *file)
+	{
+		if (file->GetParent() != nullptr) {
+			return;
+		}
+
+		m_results[file->GetSearchID()].push_back(file);
+	}
 
 	/**
 	 * Drops a single result from the index, without freeing it.
@@ -94,6 +141,15 @@ protected:
 	 */
 	void UnindexResult(CSearchFile *file)
 	{
+		// Symmetric with IndexResult(): a grouped result was never indexed, so
+		// searching for it would scan the whole list to find nothing. A result
+		// is parented when it is constructed or loaded, before it could have
+		// been indexed, and nothing re-parents an indexed one -- so this can
+		// never skip a result that is actually in the index.
+		if (file->GetParent() != nullptr) {
+			return;
+		}
+
 		ResultMap::iterator it = m_results.find(file->GetSearchID());
 		if (it == m_results.end()) {
 			return;
@@ -114,7 +170,11 @@ protected:
 	 */
 	void DropResultIndex(wxUIntPtr searchID) { m_results.erase(searchID); }
 
-	//! Map of all indexed search-results, keyed by search id.
+private:
+	//! Map of all indexed top-level search-results, keyed by search id.
+	//! Private so the only way in is IndexResult(): an implementation that
+	//! answers GetSearchResults() cannot quietly stop filling what it answers
+	//! from, which is exactly the drift this class exists to prevent.
 	ResultMap m_results;
 };
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3592,9 +3592,24 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 		m_needSearchListRequery = true;
 	}
 
+	// A result whose tag names a parent this client has not built yet cannot be
+	// grouped: the constructor's lookup came back empty, so it stays parentless
+	// and is indexed as a top-level row that nothing ever re-parents. The
+	// daemon emits a parent before its children, so this should not happen --
+	// log it rather than assert, since the trigger would be the wire order
+	// rather than a bug on this side, and losing the result would be worse than
+	// showing it ungrouped.
+	if (tag->ParentID() != 0 && file->GetParent() == nullptr) {
+		AddDebugLogLineN(logSearch,
+			CFormat("Search result %u names parent %u, which has not arrived; "
+				"showing it as a top-level result") %
+				file->ECID() % tag->ParentID());
+	}
+
 	// Make the result visible to the GUI: the search model builds its rows
 	// from GetSearchResults(), so a result that is not indexed here shows up
-	// nowhere, however correctly it arrived over EC.
+	// nowhere, however correctly it arrived over EC. Grouped children are
+	// dropped by IndexResult() itself, which is where that rule lives.
 	IndexResult(file);
 
 	theApp->amuledlg->m_searchwnd->AddResult(file);


### PR DESCRIPTION
Review follow-up to #828, which moved the per-search result index into a shared `CSearchResultIndex` so the monolithic and remote search lists could not drift apart. Three ways they still could.

**The two builds filled the index differently**
In the remote build a grouped result (same hash, different filename) is attached to its parent by the `CSearchFile` constructor, and `CreateItem` then indexed it anyway; the monolithic `AddToList` returns on the grouping path before it reaches the index. So `GetSearchResults()` meant "top-level results" in one build and "top-level plus children" in the other - exactly the divergence the shared class was introduced to prevent, and one it did not catch.

This was not purely latent: `CSearchListCtrl::GetHiddenItemCount()` counts filtered-out children, a branch that can only fire when children are indexed, so amulegui and the monolithic GUI already reported different "hidden" counts for the same search.

Rather than add a caller-side check that a future implementation can forget - especially now that the consumer-side guard in `GetHiddenItemCount()` is gone - the rule lives in `IndexResult()`, which ignores a grouped result. The index keeps its own invariant, so an implementation that simply hands over every result it receives still ends up with a correct index. The child branch in `GetHiddenItemCount()`, now unreachable in both builds and contradicted by its own comment, is removed.

**`IndexResult()` was not really the only way in**
`m_results` was protected, and `CSearchList` still reached for it directly in half a dozen places, so the encapsulation the class exists for was convention rather than something the compiler enforces. The map is now private, behind a read-only `AllResults()` for the operations that legitimately walk every search, plus a protected `HasSearchResults()` for the "is this search known" test a raw `find()` was doing. No caller retains direct access, so an implementation can no longer answer `GetSearchResults()` without filling what it answers from.

**An ordering case the invariant depends on**
A result whose tag names a parent this client has not built yet cannot be grouped: the constructor's lookup comes back empty, so it stays parentless and is indexed as a top-level row that nothing re-parents afterwards. The daemon emits a parent before its children, so this is not expected. It is logged rather than asserted: the trigger would be the wire order rather than a bug on this side, and dropping the result would be worse than showing it ungrouped. Note that a `GetParent() == nullptr` assertion in `IndexResult()` would *not* catch this case - the orphan genuinely has no parent at that point; the tag's unresolved `ParentID()` is the only evidence, which is why the check sits at the call site.

**Teardown cost, noted for later**
`UnindexResult()` is a linear scan, so tearing a search down one result at a time (`CRemoteContainer::FullReload`, which calls `DeleteItem` per item) is quadratic in results per search. Irrelevant at the few hundred results a search returns today; the header now says so, and says to drop the whole index up front if the caps ever rise.

**Testing**
Monolithic, amulegui and amuled build clean on macOS; clang-format and diff-scoped clang-tidy (Tier-2) clean. Verified live in both GUIs: grouped results show once with their children under them, hit and hidden counts now agree between the two builds, downloading a grouped child still starts the right file, and closing a search tab is clean.
