### PR TITLE
fix(gui): keep descending sort across restarts on the wxDataViewCtrl lists

### DIFF
--- a/src/ListColumnStore.cpp
+++ b/src/ListColumnStore.cpp
@@ -31,11 +31,17 @@
 
 #include "Types.h" // Needed for EmptyString
 
-// SORT_DES/SORT_ALT/SORTING_MASK are CMuleListCtrl::MLOrder flags, not a
-// concept this store defines itself -- it just needs the same bit values
-// CMuleListCtrl encodes/decodes with, so referencing them here (rather than
-// duplicating the magic numbers) keeps there being exactly one definition.
-#include "MuleListCtrl.h"
+namespace
+{
+// The config format that predates this store wrote CMuleListCtrl::MLOrder
+// values verbatim, so reading one back means translating those bits rather
+// than assuming they match what this store writes today. Spelled out here
+// instead of including MuleListCtrl.h: the store serves both list bases and
+// must not adopt either one's vocabulary (see CListColumnStore::SortFlag).
+const unsigned long kLegacySortDescending = 0x1000;
+const unsigned long kLegacySortAlternate = 0x2000;
+const unsigned long kLegacySortMask = kLegacySortDescending | kLegacySortAlternate;
+} // namespace
 
 void CListColumnStore::RegisterColumn(int index, int defaultWidth, const wxString &name)
 {
@@ -134,9 +140,9 @@ void CListColumnStore::SaveSettings(const IColumnWidthProvider &widget, const CS
 		if (!columnName.IsEmpty()) {
 			sortOrder += columnName;
 			sortOrder += ":";
-			sortOrder += it->second & CMuleListCtrl::SORT_DES ? "1" : "0";
+			sortOrder += it->second & SORT_DESCENDING ? "1" : "0";
 			sortOrder += ":";
-			sortOrder += it->second & CMuleListCtrl::SORT_ALT ? "1" : "0";
+			sortOrder += it->second & SORT_ALTERNATE ? "1" : "0";
 			if (++it != sortOrders.end()) {
 				sortOrder += ",";
 			}
@@ -184,8 +190,12 @@ void CListColumnStore::ParseOldConfigEntries(const wxString &sortOrders,
 				// Sanity checking, to avoid asserting if column count changes.
 				if (column >= 0 && column < widget.GetColumnCount()) {
 					// Sanity checking, to avoid asserting if data-format changes.
-					if ((order & ~CMuleListCtrl::SORTING_MASK) == 0) {
-						outSortOrders.emplace_back(column, order);
+					if ((order & ~kLegacySortMask) == 0) {
+						outSortOrders.emplace_back(column,
+							(order & kLegacySortDescending ? SORT_DESCENDING
+										       : 0) |
+								(order & kLegacySortAlternate ? SORT_ALTERNATE
+											      : 0));
 					}
 				}
 			}
@@ -236,8 +246,8 @@ void CListColumnStore::LoadSettings(
 		long alt = StrToLong(token.AfterLast(':'));
 		int col = GetColumnIndex(name);
 		if (col >= 0) {
-			outSortOrders.emplace_back(col,
-				(order ? CMuleListCtrl::SORT_DES : 0) | (alt ? CMuleListCtrl::SORT_ALT : 0));
+			outSortOrders.emplace_back(
+				col, (order ? SORT_DESCENDING : 0) | (alt ? SORT_ALTERNATE : 0));
 		}
 	}
 

--- a/src/ListColumnStore.h
+++ b/src/ListColumnStore.h
@@ -84,7 +84,31 @@ public:
 class CListColumnStore
 {
 public:
-	//! A column index paired with its CMuleListCtrl::MLOrder flags.
+	/**
+	 * The sort flags this store reads and writes.
+	 *
+	 * Deliberately its own, not borrowed from either list base: the two use
+	 * different bit values for the same idea (CMuleListCtrl 0x1000/0x2000,
+	 * CMuleDataViewCtrl 0x1/0x2), so a store that spoke one of them silently
+	 * dropped descending and alternate sorting for every list built on the
+	 * other -- saving them as "not set" and restoring them as ascending. The
+	 * store owns the serialised format; each base converts to and from it at
+	 * the call, which is the only place the two vocabularies meet.
+	 *
+	 * These values are not interchangeable with either base's flags even
+	 * where the numbers happen to line up. Convert; never pass through.
+	 */
+	enum SortFlag
+	{
+		//! Sort this column in descending order.
+		SORT_DESCENDING = 0x1,
+		//! Sort this column by its alternate criterion.
+		SORT_ALTERNATE = 0x2,
+		//! Every bit this store defines; anything else is malformed.
+		SORT_FLAG_MASK = SORT_DESCENDING | SORT_ALTERNATE
+	};
+
+	//! A column index paired with this store's SortFlag bits.
 	typedef std::pair<unsigned, unsigned> CColPair;
 	typedef std::list<CColPair> CSortingList;
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -194,6 +194,25 @@ void CMuleDataViewCtrl::ApplySorting(unsigned column, unsigned order)
 	OnSortingChanged();
 }
 
+namespace
+{
+// This control's sort bits and CListColumnStore's are different values for the
+// same two ideas, so every crossing converts -- see the note in MuleListCtrl.cpp
+// for what passing them through unconverted costs. The numbers currently
+// coincide; that is incidental and must not be relied on.
+unsigned ToStoreFlags(unsigned order)
+{
+	return (order & CMuleDataViewCtrl::SORT_DES ? CListColumnStore::SORT_DESCENDING : 0) |
+	       (order & CMuleDataViewCtrl::SORT_ALT ? CListColumnStore::SORT_ALTERNATE : 0);
+}
+
+unsigned FromStoreFlags(unsigned storeFlags)
+{
+	return (storeFlags & CListColumnStore::SORT_DESCENDING ? CMuleDataViewCtrl::SORT_DES : 0) |
+	       (storeFlags & CListColumnStore::SORT_ALTERNATE ? CMuleDataViewCtrl::SORT_ALT : 0);
+}
+} // namespace
+
 void CMuleDataViewCtrl::LoadColumnSettings()
 {
 	if (!m_columnStore.HasTableName()) {
@@ -218,7 +237,7 @@ void CMuleDataViewCtrl::LoadColumnSettings()
 	if (!decoded.empty()) {
 		m_sort_orders.clear();
 		for (const CListColumnStore::CColPair &pair : decoded) {
-			ApplySorting(pair.first, pair.second);
+			ApplySorting(pair.first, FromStoreFlags(pair.second));
 		}
 	}
 
@@ -236,7 +255,12 @@ void CMuleDataViewCtrl::SaveColumnSettings()
 	if (!m_columnStore.HasTableName()) {
 		return;
 	}
-	m_columnStore.SaveSettings(m_widthAdapter, m_sort_orders);
+	CListColumnStore::CSortingList stored;
+	for (const CColPair &pair : m_sort_orders) {
+		stored.emplace_back(pair.first, ToStoreFlags(pair.second));
+	}
+
+	m_columnStore.SaveSettings(m_widthAdapter, stored);
 }
 
 void CMuleDataViewCtrl::OnColumnHeaderClick(wxDataViewEvent &event)

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -105,11 +105,36 @@ long CMuleListCtrl::InsertColumn(
 	return MuleExtern::wxGenericListCtrl::InsertColumn(col, heading, format, width);
 }
 
+namespace
+{
+// CMuleListCtrl's MLOrder bits and CListColumnStore's SortFlag bits mean the
+// same two things with different values, so every crossing converts. Passing
+// one where the other is expected compiles cleanly and silently loses both
+// flags, which is exactly how descending sort stopped persisting once a second
+// list base started sharing the store.
+unsigned ToStoreFlags(unsigned mlOrder)
+{
+	return (mlOrder & CMuleListCtrl::SORT_DES ? CListColumnStore::SORT_DESCENDING : 0) |
+	       (mlOrder & CMuleListCtrl::SORT_ALT ? CListColumnStore::SORT_ALTERNATE : 0);
+}
+
+unsigned FromStoreFlags(unsigned storeFlags)
+{
+	return (storeFlags & CListColumnStore::SORT_DESCENDING ? CMuleListCtrl::SORT_DES : 0) |
+	       (storeFlags & CListColumnStore::SORT_ALTERNATE ? CMuleListCtrl::SORT_ALT : 0);
+}
+} // namespace
+
 void CMuleListCtrl::SaveSettings()
 {
 	wxCHECK_RET(m_columnStore.HasTableName(), "Cannot save settings for unnamed list");
 
-	m_columnStore.SaveSettings(*this, m_sort_orders);
+	CListColumnStore::CSortingList stored;
+	for (const CColPair &pair : m_sort_orders) {
+		stored.emplace_back(pair.first, ToStoreFlags(pair.second));
+	}
+
+	m_columnStore.SaveSettings(*this, stored);
 }
 
 void CMuleListCtrl::LoadSettings()
@@ -127,7 +152,7 @@ void CMuleListCtrl::LoadSettings()
 	for (CListColumnStore::CSortingList::const_iterator it = decodedSortOrders.begin();
 		it != decodedSortOrders.end();
 		++it) {
-		SetSorting(it->first, it->second);
+		SetSorting(it->first, FromStoreFlags(it->second));
 	}
 
 	// Must have at least one sort-order specified


### PR DESCRIPTION
Sorting a list descending and restarting brought it back ascending: the Servers list remembered which column, never which direction, and the Search list did not come back sorted at all.

## Cause

`CListColumnStore` serialises the sort chain for both list bases, but spoke only one base's vocabulary:

| | descending | alternate |
| --- | --- | --- |
| `CMuleListCtrl::MLOrder` | `0x1000` | `0x2000` |
| `CMuleDataViewCtrl` | `0x1` | `0x2` |

The store tested and produced the `CMuleListCtrl` values throughout. So for anything on the DataView base, `0x1 & 0x1000` is zero on the way out — descending written as "not set" — and `0x1000 & 0x1` is zero on the way back in, so even a stored `1` restored as ascending. Broken in both directions, and silent: both are plain `unsigned`, so nothing fails to compile.

That is why the symptom looked list-specific. The lists still on the old base kept their descending sorts; the two migrated to `wxDataViewCtrl` lost them:

| list | base | descending persisted |
| --- | --- | --- |
| Downloads, Shared | `CMuleVirtualListCtrl` | yes |
| Sources | `CGenericClientListCtrl` | yes |
| **Servers** | `CMuleVirtualDataViewCtrl` | **no** |
| **Search** | `CMuleDataViewCtrl` | **no** |

## Fix

The store now defines the flags it serialises, and each base converts at the call — the only place the two vocabularies meet. That is the layering `CListColumnStore` was extracted for: a serialiser shared by two clients cannot borrow one client's enum.

The legacy config format is translated too. It stored raw `MLOrder` values, so reading one back now means converting those bits rather than assuming they still mean what the store writes — without that, every pre-existing profile would lose its sort direction on upgrade.

## Testing

No unit test, deliberately: a store-level one would have passed both before and after, since the store was self-consistent — the mismatch existed only between it and one of its two callers, which needs a GUI to exercise. Adding a test that cannot fail on the bug it is named for would be worse than none.

Verified two ways instead. Round-tripping the store directly:

| case | result |
| --- | --- |
| save `DESC`, `DESC+ALT`, ascending | writes `N:1:0,S:1:1,P:0:0` |
| load it back | `DESC`, `DESC+ALT`, ascending |
| legacy `0 4096,1 8192` (raw `MLOrder`) | decodes to `DESC`, `ALT` |

And end to end in the GUI, on both affected lists:

| list | written after sorting descending | restores descending |
| --- | --- | --- |
| Servers, by Users | `TableOrderingServer=U:1:0,N:0:0` (was `U:0:0`) | yes |
| Search, by Sources | `TableOrderingSearch=u:1:0,N:0:0` | yes |

Monolithic and amulegui build clean on macOS; 33/33 unit tests; clang-format 18 and both clang-tidy tiers clean on the diff.

## Note

Existing profiles keep their all-ascending entry until the list is re-sorted once under a fixed build. There is nothing to migrate — the direction was never recorded.

The Search list persists on a different schedule from the others -- only the first tab loads settings and only the last one saves them -- so it was worth confirming separately rather than assuming the flag fix reached it. It does: the table above is a full quit-and-reopen cycle on that list too.

