### PR TITLE
fix(gui): share the systray/window layer with amulegui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,7 +372,12 @@ unset (_amule_wxgtk_idx)
 # headers are present we build a SNI backend into MuleTrayIcon; on
 # platforms where the library is missing (Windows, macOS, builds
 # without the dep) we fall back to wxTaskBarIcon.
-if (BUILD_MONOLITHIC AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+#
+# Both GUI binaries compile MuleTrayIcon (it is in GUI_SOURCES), so the
+# probe covers either of them being built — gating it on the monolithic
+# build alone left a remote-GUI-only build with the invisible legacy
+# backend and no way to know.
+if ((BUILD_MONOLITHIC OR BUILD_REMOTEGUI) AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	find_package (PkgConfig QUIET)
 	if (PkgConfig_FOUND)
 		# `0.1` is the API version (never bumped, every release uses it),
@@ -594,7 +599,7 @@ if (NEED_ZLIB)
 	message ("			zlib				${ZLIB_VERSION_STRING}")
 endif()
 
-if (BUILD_MONOLITHIC AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if ((BUILD_MONOLITHIC OR BUILD_REMOTEGUI) AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	if (WITH_LIBAYATANA_APPINDICATOR)
 		message ("			tray-icon backend		StatusNotifierItem (libayatana-appindicator ${AYATANA_APPINDICATOR_VERSION})")
 	else()

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -49,10 +49,6 @@
 #include "Friend.h"
 #include "Logger.h"
 
-#ifdef __WXMAC__
-#include "MacAppHelper.h" // mac_set_accessory_mode
-#endif
-
 #ifndef AMULE_DAEMON
 #include "ChatWnd.h"
 #include "amuleDlg.h"
@@ -214,23 +210,13 @@ void ServersURLChanged(wxString NOT_ON_DAEMON(url))
 void ShowGUI()
 {
 #ifndef AMULE_DAEMON
-	// Triggered from a duplicate-launch RAISE_DIALOG signal (the
-	// running instance picks it up via ED2KLinks polling) and
-	// from MacReopenApp when the user clicks the Dock icon. Cover
-	// every hidden state the main window can be in:
-	//   * Show(false) via the close-button HideOnClose path
-	//   * Iconize(true) via the minimize-to-tray path
-	//   * just behind another app's window
-#ifdef __WXMAC__
-	// If we're still in accessory mode (window was hidden via the
-	// tray), restore the regular Dock icon before the window
-	// comes back, otherwise activate-ignoring-other-apps lands on
-	// a Dock-less app and the focus shift is invisible.
-	mac_set_accessory_mode(false);
-#endif
-	theApp->amuledlg->Show(true);
-	theApp->amuledlg->Iconize(false);
-	theApp->amuledlg->Raise();
+	// Triggered by a duplicate-launch RAISE_DIALOG signal, which the
+	// running instance picks up via ED2KLinks polling. The signal can
+	// arrive before the main window exists -- the second launch only has
+	// to beat the first one to the point where it builds its GUI.
+	if (theApp->amuledlg) {
+		theApp->amuledlg->RestoreMainWindow();
+	}
 #endif
 }
 

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -42,10 +42,6 @@
 #include <common/Format.h>    // Needed for CFormat
 #include <common/MenuIDs.h>   // Needed to access menu item constants
 
-#ifdef __WXMAC__
-#include "MacAppHelper.h" // mac_set_accessory_mode
-#endif
-
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 // gtk_window_present is the xdg-activation-aware way to request
 // focus on Wayland — wxFrame::Raise() alone doesn't reach the
@@ -76,30 +72,9 @@ void CMuleTrayIcon::DoShowHide()
 	// the menu offers "Show aMule" and clicking restores the frame.
 	const bool visible = theApp->amuledlg->IsVisibleToUser();
 	if (visible) {
-#ifdef __WXMAC__
-		// Drop the Dock icon while the window is hidden; the tray
-		// icon (NSStatusItem) is the only recovery surface in this
-		// state. Restored when the user un-hides via the tray click
-		// or menu.
-		mac_set_accessory_mode(true);
-#endif
-		theApp->amuledlg->Show(false);
+		theApp->amuledlg->HideToTray();
 	} else {
-#ifdef __WXMAC__
-		mac_set_accessory_mode(false);
-#endif
-		// Clear the iconized bit on every platform — the window
-		// might be hidden (Show(false) via HideOnClose / minimize-to-
-		// tray) or just iconized to the OS dock/taskbar; in either
-		// case the user wants a normal restored frame. Without this
-		// Show(true) on a still-iconized window would leave it as a
-		// taskbar entry / Dock thumbnail without un-minimizing.
-		// Iconize(false) is idempotent on a non-iconized window —
-		// don't gate on IsIconized() because wxGTK can report a
-		// stale value during the tray-restore transition.
-		theApp->amuledlg->Iconize(false);
-		theApp->amuledlg->Show(true);
-		theApp->amuledlg->Raise();
+		theApp->amuledlg->RestoreMainWindow();
 	}
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 	// Refresh so the menu label flips to "Hide aMule" / "Show aMule"
@@ -111,12 +86,7 @@ void CMuleTrayIcon::DoShowHide()
 
 void CMuleTrayIcon::DoShow()
 {
-#ifdef __WXMAC__
-	mac_set_accessory_mode(false);
-#endif
-	theApp->amuledlg->Iconize(false);
-	theApp->amuledlg->Show(true);
-	theApp->amuledlg->Raise();
+	theApp->amuledlg->RestoreMainWindow();
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 	// Ask the compositor to bring our window forward. The timestamp
 	// matters on Wayland: GNOME Shell's focus-stealing-prevention
@@ -137,10 +107,7 @@ void CMuleTrayIcon::DoShow()
 
 void CMuleTrayIcon::DoHide()
 {
-#ifdef __WXMAC__
-	mac_set_accessory_mode(true);
-#endif
-	theApp->amuledlg->Show(false);
+	theApp->amuledlg->HideToTray();
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 	RebuildMenu();
 #endif

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -345,19 +345,17 @@ void CamuleGuiApp::OnEndSession(wxCloseEvent &evt)
 void CamuleGuiApp::MacReopenApp()
 {
 	// Fired when the user clicks the Dock icon and aMule has no
-	// visible top-level windows. Without this override, wxApp's
-	// default Reopen handler is a no-op when the frame is hidden,
-	// so a window hidden via the close button (HideOnClose pref =
-	// macOS-style "close hides instead of quits") stays permanently
-	// hidden — the only way to bring aMule back was to Cmd+Tab.
+	// visible top-level windows, and on a re-launch from Finder /
+	// Launchpad. Without this override, wxApp's default Reopen handler
+	// is a no-op when the frame is hidden, so a window hidden via the
+	// close button (HideOnClose pref = macOS-style "close hides instead
+	// of quits") stays permanently hidden — the only way to bring aMule
+	// back was to Cmd+Tab.
 	//
-	// Show + Iconize(false) + Raise covers all three hidden states:
-	// hidden via Show(false), iconized to the dock, or just behind
-	// other apps.
+	// The restore itself lives on the window, shared with the tray icon
+	// and with CamuleRemoteGuiApp's identical override.
 	if (amuledlg) {
-		amuledlg->Show(true);
-		amuledlg->Iconize(false);
-		amuledlg->Raise();
+		amuledlg->RestoreMainWindow();
 	}
 }
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -264,6 +264,18 @@ void CamuleRemoteGuiApp::OnEndSession(wxCloseEvent &evt)
 }
 
 #ifdef __WXMAC__
+void CamuleRemoteGuiApp::MacReopenApp()
+{
+	// Dock-icon click (and re-launch from Finder / Launchpad) while no
+	// window is visible. wxApp's default handler only de-iconizes; a frame
+	// hidden with Show(false) -- the close-button HideOnClose path and the
+	// minimize-to-tray path both end there -- is not a candidate, so
+	// without this amulegui simply never came back. Mirrors CamuleGuiApp.
+	if (amuledlg) {
+		amuledlg->RestoreMainWindow();
+	}
+}
+
 void CamuleRemoteGuiApp::MacOpenFiles(const wxArrayString &fileNames)
 {
 	// Also fires for Dock drops of arbitrary files; anything that is not
@@ -1055,6 +1067,15 @@ void CamuleRemoteGuiApp::Startup()
 	ipfilter = new CIPFilterRem(m_connect);
 
 	m_allUploadingKnownFile = new CKnownFile;
+
+	// Must run before InitGui() below: the CamuleDlg constructor reads
+	// UseTrayIcon() to decide whether to create the tray icon at all, so a
+	// guard applied after it would leave the icon built for a backend that
+	// cannot show it. Nothing here waits on the EC connection -- these are
+	// amulegui's own local preferences, not packed by CEC_Prefs_Packet and
+	// with no category in the EC_PREFS_* mask -- so OnInit() would have
+	// worked equally well; this sits next to the call it has to precede.
+	SanitiseTrayPreferences();
 
 	// Create main dialog
 	InitGui(m_geometryEnabled, m_geometryString);

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -956,6 +956,11 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 #endif
 
 #ifdef __WXMAC__
+	// Restore the main window when the user clicks the Dock icon while no
+	// window is visible. Mirrors CamuleGuiApp; both hand off to
+	// CamuleDlg::RestoreMainWindow().
+	virtual void MacReopenApp();
+
 	// Finder "Open With" / double-click on a .emulecollection, and
 	// ed2k:// / magnet: clicks. Both queue into the ED2KLinks file rather
 	// than touching downloadqueue, which here does not exist until the EC

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -707,34 +707,9 @@ bool CamuleApp::OnInit()
 	// Initialize wx sockets (needed for http download in background with Asio sockets)
 	wxSocketBase::Initialize();
 
-#if defined(__WXGTK__) && !defined(WITH_LIBAYATANA_APPINDICATOR)
-	// On Linux without libayatana-appindicator3 the tray icon falls
-	// back to the legacy GtkStatusIcon backend, which GNOME Shell
-	// dropped in 3.26 and wlroots-based compositors never picked up
-	// — the icon is silently invisible. Force the pref off so users
-	// don't end up with the window hidden via HideOnClose and no
-	// surface to bring it back. The existing sanity check below
-	// will then cascade MinToTray off as well.
-	thePrefs::SetUseTrayIcon(false);
-#endif
-
-#ifdef __WXGTK__
-	// xdg-shell intentionally doesn't deliver iconified-state
-	// notifications to clients, so on Wayland the system minimize
-	// button cannot trigger our Show(false) hide-to-tray path.
-	// The same gap is documented in qBittorrent #17265, Telegram
-	// #2123, KeePassXC #6502 and others. Force MinToTray off when
-	// running under a Wayland session so the option doesn't appear
-	// to "do nothing" — the prefs panel also greys the checkbox.
-	if (CamuleAppCommon::IsWaylandSession()) {
-		thePrefs::SetMinToTray(false);
-	}
-#endif
-
-	// Some sanity check
-	if (!thePrefs::UseTrayIcon()) {
-		thePrefs::SetMinToTray(false);
-	}
+	// Before InitGui() below builds the window that these settings decide
+	// how to hide. amulegui does the same from Startup().
+	SanitiseTrayPreferences();
 
 	// Build the filenames for the two OS files
 	SetOSFiles(thePrefs::GetOSDir().GetRaw());

--- a/src/amule.h
+++ b/src/amule.h
@@ -299,6 +299,20 @@ public:
 	static bool IsWaylandSession();
 #endif
 
+	/**
+	 * Forces the tray-dependent preferences off where the tray can't
+	 * deliver what they promise.
+	 *
+	 * Both settings hide the main window and leave the tray icon as the
+	 * only way back, so each one has to be switched off wherever that
+	 * icon won't be there: no SNI backend on Linux (the legacy
+	 * GtkStatusIcon is invisible on modern desktops), a Wayland session
+	 * (no iconify notification to hide on), or simply the tray icon
+	 * turned off. Called by every GUI app before it builds its window --
+	 * amuled inherits it harmlessly, having no window to hide.
+	 */
+	static void SanitiseTrayPreferences();
+
 	// Set when a quit was requested out-of-band of the main-window
 	// close button (Cmd+Q, Dock right-click → Quit, tray-icon Exit).
 	// CamuleDlg::OnClose checks this so HideOnClose only hides the

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -124,6 +124,39 @@ bool CamuleAppCommon::IsWaylandSession()
 }
 #endif
 
+void CamuleAppCommon::SanitiseTrayPreferences()
+{
+#if defined(__WXGTK__) && !defined(WITH_LIBAYATANA_APPINDICATOR)
+	// On Linux without libayatana-appindicator3 the tray icon falls
+	// back to the legacy GtkStatusIcon backend, which GNOME Shell
+	// dropped in 3.26 and wlroots-based compositors never picked up
+	// — the icon is silently invisible. Force the pref off so users
+	// don't end up with the window hidden via HideOnClose and no
+	// surface to bring it back. The sanity check below will then
+	// cascade MinToTray off as well.
+	thePrefs::SetUseTrayIcon(false);
+#endif
+
+#ifdef __WXGTK__
+	// xdg-shell intentionally doesn't deliver iconified-state
+	// notifications to clients, so on Wayland the system minimize
+	// button cannot trigger our Show(false) hide-to-tray path.
+	// The same gap is documented in qBittorrent #17265, Telegram
+	// #2123, KeePassXC #6502 and others. Force MinToTray off when
+	// running under a Wayland session so the option doesn't appear
+	// to "do nothing" — the prefs panel also greys the checkbox.
+	if (IsWaylandSession()) {
+		thePrefs::SetMinToTray(false);
+	}
+#endif
+
+	// Minimize-to-tray without a tray icon hides the window with nothing
+	// left to bring it back.
+	if (!thePrefs::UseTrayIcon()) {
+		thePrefs::SetMinToTray(false);
+	}
+}
+
 void CamuleAppCommon::RefreshSingleInstanceChecker()
 {
 	// Reacquire after daemonization fork(). POSIX advisory locks are

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -588,6 +588,41 @@ void CamuleDlg::RemoveSystray()
 	m_wndTaskbarNotifier = NULL;
 }
 
+void CamuleDlg::RestoreMainWindow()
+{
+#ifdef __WXMAC__
+	// Restore the regular Dock icon before the window comes back. It has
+	// to happen first: activating a Dock-less (accessory) application
+	// gives no visible focus change, so the window would return behind
+	// whatever the user is looking at.
+	mac_set_accessory_mode(false);
+#endif
+	// Clear the iconized bit on every platform — the window might be
+	// hidden (Show(false) via HideOnClose / minimize-to-tray) or just
+	// iconized to the OS Dock/taskbar; in either case the user wants a
+	// normal restored frame. Without this, Show(true) on a still-iconized
+	// window would leave it as a taskbar entry / Dock thumbnail without
+	// un-minimizing. Iconize(false) is idempotent on a non-iconized
+	// window — don't gate on IsIconized(), because wxGTK can report a
+	// stale value during the tray-restore transition.
+	Iconize(false);
+	Show(true);
+	Raise();
+}
+
+void CamuleDlg::HideToTray()
+{
+#ifdef __WXMAC__
+	// Drop NSApp's activation policy to Accessory before hiding — that
+	// removes the Dock icon (and any in-flight miniaturize-to-Dock
+	// target), so hiding doesn't leave a Dock thumbnail behind. The tray
+	// icon stays as the only recovery surface; RestoreMainWindow() restores
+	// both the Dock icon and the window.
+	mac_set_accessory_mode(true);
+#endif
+	Show(false);
+}
+
 void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 {
 	static int lastbutton = ID_BUTTONDOWNLOADS;
@@ -1246,11 +1281,12 @@ void CamuleDlg::DlgShutDown()
 
 void CamuleDlg::OnClose(wxCloseEvent &evt)
 {
-	// The tray icon is the only recovery surface for a window hidden
-	// via the close button on every platform: Linux/Windows use the
-	// NSStatusItem-equivalent to bring the window back, and on macOS
-	// the matching path drops the Dock icon (accessory mode) while
-	// hidden, so the Dock is no longer a fallback either.
+	// Gated on the tray icon because on Linux and Windows it is the only
+	// way back once the frame is hidden. Deliberately a plain Show(false)
+	// rather than HideToTray(): on macOS the Dock icon stays, which is
+	// what the close button is supposed to leave behind there, and the
+	// Dock-reopen handler (CamuleGuiApp / CamuleRemoteGuiApp
+	// ::MacReopenApp) brings the window back from it.
 	bool hideOnClose = thePrefs::HideOnClose() && thePrefs::UseTrayIcon();
 	// Quit menus (Cmd+Q, Dock right-click → Quit, tray-icon Exit) all
 	// either pass force=true to Close() (CanVeto()==false) or set the
@@ -1514,20 +1550,9 @@ void CamuleDlg::OnMinimize(wxIconizeEvent &evt)
 		} else {
 			if (m_wndTaskbarNotifier && thePrefs::DoMinToTray()) {
 				if (evt.IsIconized()) {
-#ifdef __WXMAC__
-					// Drop NSApp's activation policy to Accessory
-					// before hiding — that removes the Dock icon
-					// (and any in-flight miniaturize-to-Dock target),
-					// so the yellow button doesn't leave a Dock
-					// thumbnail. Tray icon stays as the only
-					// recovery surface; Show(true) from the tray's
-					// DoShowHide restores both the Dock icon and the
-					// window.
-					mac_set_accessory_mode(true);
-#endif
-					Show(false);
+					HideToTray();
 				} else {
-					Show(true);
+					RestoreMainWindow();
 				}
 			} else {
 				evt.Skip();

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -207,6 +207,35 @@ public:
 	void CreateSystray();
 	void RemoveSystray();
 
+	/**
+	 * Brings the main window back from every state that hides it.
+	 *
+	 * The one restore path, shared by the tray icon (click, menu), the
+	 * duplicate-launch RAISE_DIALOG signal and the macOS Dock-reopen
+	 * handler of both applications. Written once because the hidden
+	 * states compose: the window can be hidden (Show(false) via
+	 * HideOnClose or minimize-to-tray), iconized to the Dock/taskbar,
+	 * merely behind another application's window, or -- on macOS -- any
+	 * of those with the Dock icon dropped as well.
+	 */
+	void RestoreMainWindow();
+
+	/**
+	 * Hides the main window, leaving the tray icon as the way back.
+	 *
+	 * The counterpart of RestoreMainWindow(), and the reason both are
+	 * here: on macOS the hide has a second half (dropping NSApp to
+	 * accessory so no Dock icon is left behind) that every hide path has
+	 * to perform and every show path has to undo.
+	 *
+	 * Named for the tray where its counterpart is not, because every
+	 * caller of this one really is a tray path -- the tray menu, and
+	 * minimize-to-tray, which only runs when the icon exists. The
+	 * close-button HideOnClose path deliberately does not come here; see
+	 * OnClose().
+	 */
+	void HideToTray();
+
 	void StartGuiTimer() { gui_timer->Start(100); }
 	void StopGuiTimer() { gui_timer->Stop(); }
 


### PR DESCRIPTION
## The bug

With the main window hidden to the systray, clicking the Dock icon brings the monolithic aMule back. amulegui does nothing — the window stays gone, and Cmd+Tab is the only way to reach it.

`MacReopenApp()` is a `wxApp` virtual, so it needs an override per application class, and only `CamuleGuiApp` had one. `CamuleRemoteGuiApp` picked up `MacOpenFiles` and `MacOpenURL` from the same batch of macOS hooks and missed this one. Without the override wx's default handler runs, and it only de-iconizes a top-level window — a frame hidden with `Show(false)`, which is where both the close-button HideOnClose path and the minimize-to-tray path leave it, is not a candidate. That is exactly why the monolithic build needed the override in the first place.

## What changed

Rather than add a second copy of the restore, the restore moves onto the window it acts on, as `CamuleDlg::RestoreMainWindow()` / `HideToTray()`, and every path now goes through them: the tray icon (click, menu, `DoShow`, `DoHide`), minimize-to-tray, the duplicate-launch RAISE_DIALOG signal, and both Dock-reopen handlers.

There were four near-copies of "restore the window" and three of "hide it", and they disagreed in ways that mattered:

- `CamuleGuiApp::MacReopenApp()` was the only restore that skipped `mac_set_accessory_mode(false)`, so re-launching from Finder while hidden to the tray brought the window back with no Dock icon.
- `MuleNotify::ShowGUI()` ordered `Show(true)` before `Iconize(false)`; the tray ordered them the other way round and carried the comment explaining why that order is the correct one.
- `ShowGUI()` dereferenced `theApp->amuledlg` unguarded, while `MacReopenApp()` null-checked it — the RAISE_DIALOG signal can arrive before the main window exists.
- `OnMinimize`'s restore branch (de-iconize while minimize-to-tray is on) was a bare `Show(true)`. It now runs the full sequence, which is a deliberate behaviour change on that path: `Iconize(false)` and the macOS Dock-icon restore are fixes, and `Raise()` is a focus grab that path did not previously make.

Two more monolithic-only pieces of the same feature move to shared code:

**Tray preference guards.** No SNI backend on Linux, a Wayland session, or the tray icon simply switched off — each one means "the tray isn't there", and both `HideOnClose` and `MinToTray` hide the window with the tray as the only way back. Those three guards lived in `CamuleApp::OnInit`, so amulegui had none of them and could run with MinToTray active under Wayland or against an invisible GtkStatusIcon. They are now `CamuleAppCommon::SanitiseTrayPreferences()`, called by `CamuleApp::OnInit` as before and by `CamuleRemoteGuiApp::Startup()`, which has to run ahead of `InitGui()` because the `CamuleDlg` constructor reads `UseTrayIcon()` to decide whether to create the tray icon at all.

**SNI detection.** The libayatana-appindicator probe was gated on `BUILD_MONOLITHIC`, so a remote-GUI-only build silently fell back to the legacy GtkStatusIcon — invisible on modern GNOME and wlroots — with nothing in the configure summary to say so. `src/CMakeLists.txt` already linked SNI into amulegui whenever the flag happened to be set, so this was only the probe never running.

`CamuleDlg::OnClose` deliberately keeps its plain `Show(false)` rather than calling `HideToTray()`: on macOS the Dock icon is meant to survive the close button, and `MacReopenApp` is what brings the window back from it. The comment there claimed the opposite; corrected.

## Verification

Builds clean on macOS (amule + amulegui + amuled), Ubuntu ARM64 and Windows ARM64 — zero warnings from project sources on all three. `clang-format` and both clang-tidy tiers clean over the diff.

Tested interactively on macOS with both binaries: close-button hide, tray-menu hide, yellow-button minimize, then Dock click and re-launch from Finder. Linux and Windows testing is in progress; the Linux tester's session is Wayland, where MinToTray is correctly forced off in both binaries now, so the minimize path there needs an X11 session to exercise.
