### PR TITLE
fix(gui): say when the configured video player is missing, and fall back

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2202,8 +2202,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2213,10 +2222,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2228,8 +2228,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2239,10 +2248,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2276,9 +2276,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Previsualizar"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR:¡Fallu al executar un reproductor de medios esternu! Comandu: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2288,10 +2297,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Previsualizar"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2225,8 +2225,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2236,10 +2245,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2201,8 +2201,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2212,10 +2221,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2270,9 +2270,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Previsualització"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR: No s'ha pogut executar un reproductor multimèdia extern! Ordre: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2282,10 +2291,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Previsualització"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:01+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2262,9 +2262,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Náhled souboru"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "CHYBA: Nezdařilo se spustit externí přehrávač! Příkaz: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2274,10 +2283,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Náhled souboru"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:02+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2233,8 +2233,17 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2244,10 +2253,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2276,9 +2276,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Dateivorschau"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEHLER: Konnte externen Mediaplayer nicht starten!Befehl: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2288,10 +2297,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Dateivorschau"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:03+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2285,9 +2285,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Προεπισκόπηση αρχείου"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία εκτέλεσης του εξωτερικού προγράμματος εμφάνισης πολυμέσων! Εντολή: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2297,10 +2306,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Προεπισκόπηση αρχείου"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2202,8 +2202,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2213,10 +2222,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2279,9 +2279,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Previsualizar el archivo"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROR: ¡no se ha podido ejecutar el reproductor de medios externo! Comando: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2291,10 +2300,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Previsualizar el archivo"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2271,9 +2271,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Faili eelvaade"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "VIGA: Ei suutnud käivitada välist meediamängijat! Käsk: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2283,10 +2292,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Faili eelvaade"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2272,9 +2272,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Fitxategi aurreikuspena"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERROREA: Huts kanpo bideo erreproduzigailua abiaraztean! Komandoa: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2284,10 +2293,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Fitxategi aurreikuspena"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2272,9 +2272,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f KB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Tiedoston esikatselu"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "VIRHE: Ulkoista mediatoistinta ei voitu käynnistää! Komento: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2284,10 +2293,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Tiedoston esikatselu"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:05+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2277,9 +2277,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f Ko/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Aperçu"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERREUR : Échec de l'exécution du lecteur multimédia externe ! Commande : '%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2289,10 +2298,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Aperçu"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2289,9 +2289,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Previsualizar ficheiro"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Non se puido executar o reprodutor multimedia externo! Orde: «%s»"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2301,10 +2310,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Previsualizar ficheiro"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2240,9 +2240,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f ק\"ב/ש"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "תקדימון לקובץ"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "שגיאה: הרצת נגן הסרטים נכשלה! הפקודה: '%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2252,10 +2261,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "תקדימון לקובץ"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2242,8 +2242,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2253,10 +2262,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:07+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2263,9 +2263,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Fájl előnézet"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "HIBA: Külső média-lejátszó indítása sikertelen! Parancs: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2275,10 +2284,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Fájl előnézet"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2279,9 +2279,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Anteprima"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRORE: Impossibile eseguire il lettore multimediale esterno! Comando: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2291,10 +2300,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Anteprima"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2274,9 +2274,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "ファイル・プレビュー"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "エラー：外部メディア・プレイヤーを実行できませんでした！コマンド: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2286,10 +2295,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "ファイル・プレビュー"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2284,9 +2284,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "미리보기"
+
+#: src/FileLaunch.cpp
 #, fuzzy, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "오류: 외부 재생기를 실행하지 못했습니다."
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2296,10 +2305,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "미리보기"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:09+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2293,9 +2293,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Failo peržiūra"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "KLAIDA: nepavyko paleisti išorinio vaizdo grotuvo! Komanda: „%s“"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2305,10 +2314,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Failo peržiūra"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2216,8 +2216,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Datnes priekšskatījums"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2228,10 +2237,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Datnes priekšskatījums"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:09+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2274,9 +2274,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Voorbeeld"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FOUT: Opstarten externe mediaspeler mislukt! Commando: '%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2286,10 +2295,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Voorbeeld"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:10+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2284,9 +2284,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f·kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Førehandssyning"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEIL: Greidde ikkje å starte ekstern mediespelar! Kommando: '%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2296,10 +2305,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Førehandssyning"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:10+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2281,9 +2281,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Podgląd pliku"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "BŁĄD: Nie udało się uruchomić zewnętrznego odtwarzacza! Komenda: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2293,10 +2302,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Podgląd pliku"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:11+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2275,9 +2275,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Pré-visualização"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Falha ao executar o player de mídia externo! Comando: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2287,10 +2296,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Pré-visualização"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:11+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2278,9 +2278,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Pré-visualização do ficheiro"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ERRO: Erro na execução do leitor multimédia externo! Comando: '%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2290,10 +2299,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Pré-visualização do ficheiro"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:12+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2276,9 +2276,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Previzualizare fișier"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "EROARE: A eșuat execuția playerului media extern! Comanda: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2288,10 +2297,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Previzualizare fișier"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2289,9 +2289,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f КБ/с"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Предпросмотр файла"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ОШИБКА: невозможно запустить проигрыватель видео. Команда: «%s»"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2301,10 +2310,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Предпросмотр файла"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2291,9 +2291,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Ogled datoteke"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "NAPAKA: Ni bilo mogoče zagnati zunanjega predvajalnika. Ukaz: »%s«"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2303,10 +2312,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Ogled datoteke"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2278,9 +2278,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Parashikimi i failit"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "GABIM: Deshtoi te luaj media-player te jashtem! Komanda: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2290,10 +2299,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Parashikimi i failit"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2270,9 +2270,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Förhandsvisning av fil"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "FEL: Kunde inte starta externa mediaspelaren! Kommado: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2282,10 +2291,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Förhandsvisning av fil"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2201,8 +2201,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2212,10 +2221,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2270,9 +2270,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Dosya ön izlemesi"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "Hata: Ortam oynatıcısını çalıştırma başarısız! Komut : `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2282,10 +2291,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Dosya ön izlemesi"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2288,9 +2288,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f кбайт/с"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "Попередній перегляд файлу"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "ПОМИЛКА: не вдалося виконати зовнішній медіа-програвач! Команда: '%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2300,10 +2309,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "Попередній перегляд файлу"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2200,8 +2200,17 @@ msgid "%.2f kB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr ""
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
+msgstr ""
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2211,10 +2220,6 @@ msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
-msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
 msgstr ""
 
 #: src/FileLaunch.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:16+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2271,9 +2271,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f kB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "文件预览"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "错误: 无法运行外部媒体播放器！ 命令: `%s'"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2283,10 +2292,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "文件预览"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 01:22+0200\n"
+"POT-Creation-Date: 2026-08-07 11:05+0200\n"
 "PO-Revision-Date: 2026-08-06 11:16+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2268,9 +2268,18 @@ msgid "%.2f kB/s"
 msgstr "%.2f KB/s"
 
 #: src/FileLaunch.cpp
+msgid "File preview"
+msgstr "檔案預覽"
+
+#: src/FileLaunch.cpp
 #, c-format
 msgid "ERROR: Failed to execute external media-player! Command: `%s'"
 msgstr "錯誤：無法執行媒體播放器！指令：「 %s 」"
+
+#: src/FileLaunch.cpp
+#, c-format
+msgid "The configured video player was not found: %s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 #, c-format
@@ -2280,10 +2289,6 @@ msgstr ""
 #: src/FileLaunch.cpp
 msgid "Previewing an unfinished download needs a video player: the partly-downloaded file has no type the system can open on its own. One can be set in Preferences -> General."
 msgstr ""
-
-#: src/FileLaunch.cpp
-msgid "File preview"
-msgstr "檔案預覽"
 
 #: src/FileLaunch.cpp
 #, c-format

--- a/src/FileLaunch.cpp
+++ b/src/FileLaunch.cpp
@@ -26,9 +26,10 @@
 
 #include <vector> // Needed for std::vector
 
-#include <wx/cmdline.h> // Needed for wxCmdLineParser::ConvertStringToArgs
-#include <wx/msgdlg.h>  // Needed for wxMessageBox
-#include <wx/utils.h>   // Needed for wxExecute, wxLaunchDefaultApplication
+#include <wx/cmdline.h>  // Needed for wxCmdLineParser::ConvertStringToArgs
+#include <wx/filename.h> // Needed for wxFileName::IsFileExecutable
+#include <wx/msgdlg.h>   // Needed for wxMessageBox
+#include <wx/utils.h>    // Needed for wxExecute, wxLaunchDefaultApplication
 
 #include <common/Format.h> // Needed for CFormat
 
@@ -98,6 +99,16 @@ bool RunDetached(const wxString &description, const std::vector<wxString> &args)
 	return true;
 }
 
+// Log a launch failure, and put it in front of the user when the caller has no
+// second option to fall through to.
+void Fail(const wxString &message, wxWindow *parent, bool reportModally)
+{
+	AddLogLineC(message);
+	if (reportModally && parent != nullptr) {
+		wxMessageBox(message, _("File preview"), wxOK | wxICON_EXCLAMATION, parent);
+	}
+}
+
 // Hand the path to the user's configured player.
 //
 // The template is split into arguments ONCE, with wxCmdLineParser, and the
@@ -109,7 +120,10 @@ bool RunDetached(const wxString &description, const std::vector<wxString> &args)
 // players like mpv and vlc execute scripts given that way. Escaping the quotes
 // was the previous defence and was itself bypassable with a backslash; not
 // building a string in the first place removes the class.
-void LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *WXUNUSED(parent))
+// `reportModally` is for the caller that has nothing to fall back to: a failure
+// it only logs is, from the user's side, the same silent nothing this is meant
+// to remove. The caller that can fall back leaves it false and stays quiet.
+bool LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *parent, bool reportModally)
 {
 	const wxString target = path.GetRaw();
 	const wxString name = path.GetFullName().GetRaw();
@@ -125,9 +139,34 @@ void LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *WXUNU
 	wxArrayString parts = wxCmdLineParser::ConvertStringToArgs(player, wxCMD_LINE_SPLIT_UNIX);
 #endif
 	if (parts.IsEmpty()) {
-		AddLogLineC(
-			CFormat(_("ERROR: Failed to execute external media-player! Command: `%s'")) % player);
-		return;
+		Fail(CFormat(_("ERROR: Failed to execute external media-player! Command: `%s'")) % player,
+			parent,
+			reportModally);
+		return false;
+	}
+
+	// An absolute program path that is not a runnable file is worth catching
+	// here. IsFileExecutable covers both halves: a path that is absent, and one
+	// that exists without the exec bit -- a data file, or a wrapper script that
+	// was never chmod +x -- which would otherwise fail the same way.
+	// wxExecute cannot report it: the async form returns the pid as soon as the
+	// fork succeeds and execvp then fails in the child, so the caller sees
+	// success while the user sees only wx's "execvp ... failed with error 2".
+	// That is the normal state of affairs inside a Flatpak, where a host player
+	// such as /usr/bin/vlc is simply not on the sandbox's filesystem.
+	//
+	// A bare command name is left alone: resolving it would mean reimplementing
+	// the PATH search that the exec does anyway.
+	//
+	// Windows paths never match this test, and do not need to: there wxExecute
+	// goes through CreateProcess, which fails synchronously, so the launch
+	// returns 0 and the error path below already reports it. Only the POSIX
+	// fork/exec pair can succeed at the fork and fail out of sight in the child.
+	if (parts[0].StartsWith("/") && !wxFileName::IsFileExecutable(parts[0])) {
+		Fail(CFormat(_("The configured video player was not found: %s")) % parts[0],
+			parent,
+			reportModally);
+		return false;
 	}
 
 	std::vector<wxString> argv;
@@ -165,9 +204,12 @@ void LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *WXUNU
 	}
 
 	if (!RunDetached(player, argv)) {
-		AddLogLineC(
-			CFormat(_("ERROR: Failed to execute external media-player! Command: `%s'")) % player);
+		Fail(CFormat(_("ERROR: Failed to execute external media-player! Command: `%s'")) % player,
+			parent,
+			reportModally);
+		return false;
 	}
+	return true;
 }
 
 // The platform's "open this with whatever handles it" action.
@@ -281,15 +323,18 @@ void Open(CKnownFile *file, wxWindow *parent)
 			}
 			return;
 		}
-		LaunchWithPlayer(player, path, parent);
+		// Nothing to fall back to for a .part, so this one has to be seen.
+		LaunchWithPlayer(player, path, parent, true);
 		return;
 	}
 
 	// Completed: the configured player is for watching media, so it is used for
 	// media and deliberately not for anything else -- which is what used to send
 	// an archive to the video player.
-	if (media && !player.IsEmpty()) {
-		LaunchWithPlayer(player, path, parent);
+	// A player that could not be launched should not cost the user the action:
+	// for a finished file the desktop handler is a reasonable second choice, and
+	// inside a Flatpak that is the portal, which reaches the host's application.
+	if (media && !player.IsEmpty() && LaunchWithPlayer(player, path, parent, false)) {
 		return;
 	}
 


### PR DESCRIPTION
Follow-up to #831, from testing the Flatpak bundle.

Inside a Flatpak a host player such as `/usr/bin/vlc` is not on the sandbox's filesystem, so launching it fails — and nothing could report that. The async `wxExecute` returns the pid as soon as the **fork** succeeds; `execvp` then fails in the **child**, so the caller sees success and the only trace is wx's own line in the log:

```
execvp(/usr/bin/vlc, /home/dev/.aMule/Temp/001.part) failed with error 2!
```

## What changes

An absolute program path is checked before spawning — with `wxFileName::IsFileExecutable`, not a bare existence test, so a path that exists without the exec bit (a data file, or a wrapper script never `chmod +x`) is caught too rather than failing the same invisible way. When it does not resolve:

- the log says which player is missing, rather than leaving the user with an `execvp` errno
- a **completed** media file falls back to the desktop handler, so the action still happens — in a Flatpak that is the portal, which reaches the host's application

A bare command name (`vlc`, relying on `PATH`) is deliberately left alone: resolving it would mean reimplementing the search the exec does anyway, and getting that subtly wrong would break players that work today.

Windows paths never reach the test and do not need to: there `wxExecute` goes through `CreateProcess`, which fails synchronously, so the launch returns 0 and the existing error path already reports it. Only the POSIX fork/exec pair can succeed at the fork and fail out of sight in the child.

An **unfinished** download has nothing to fall back to — its `.part` has no handler — so it reports in front of the user, the same way the no-player-configured case already did. Logging alone there would have left the silent failure this PR sets out to remove, one branch over: from the user's side "no player configured" and "player configured but missing" are the same event, and only one of them was visible.

This is not Flatpak-specific: a player uninstalled or renamed since it was configured behaves the same way anywhere.

## Testing

Built on macOS; `ctest` 33/33, clang-format 18 clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors. One new string, extracted correctly.

**The case this fixes cannot be reproduced on macOS**, where a configured player is simply present. It is verified from the Flatpak bundle after merge, using the packaging artifact — the same route that surfaced the bug.
