### PR TITLE
fix(i18n): translate the "Clients" context-menu title

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2499,6 +2499,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6982,10 +6986,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
-msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2531,6 +2531,10 @@ msgstr ""
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "عميل"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7097,10 +7101,6 @@ msgstr ""
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "عميل"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2585,6 +2585,10 @@ msgstr "Unviar mensax al usuariu"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensax a unviar:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Veceros"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7206,10 +7210,6 @@ msgstr "Media de conexones (estimáu): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Picu de conexones (estimáu): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Veceros"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:00+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2528,6 +2528,10 @@ msgstr ""
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Клиенти"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7071,10 +7075,6 @@ msgstr ""
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Клиенти"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2498,6 +2498,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6981,10 +6985,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
-msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2579,6 +2579,10 @@ msgstr "Envia un missatge a l'usuari"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Missatge a enviar:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clients"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7165,10 +7169,6 @@ msgstr "Mitjana de connexions (aprox.): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pic de connexions (aprox.): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clients"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:01+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2571,6 +2571,10 @@ msgstr "Poslat zprávu uživateli"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Zpráva k odeslání:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klienti"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7190,10 +7194,6 @@ msgstr "Průměrný počet připojení (odhad): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klienti"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:02+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2537,6 +2537,10 @@ msgstr ""
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klienter"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7115,10 +7119,6 @@ msgstr ""
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klienter"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2584,6 +2584,10 @@ msgstr "Sende Nachricht an Benutzer"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Zu sendende Nachricht:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clients"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7160,10 +7164,6 @@ msgstr "Durchschnittliche Verbindungen (geschätzt): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Höchste Verbindungsanzahl (geschätzt): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clients"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:03+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2594,6 +2594,10 @@ msgstr "Αποστολή μηνύματος στον χρήστη"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Μήνυμα προς αποστολή:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Πελάτες"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7223,10 +7227,6 @@ msgstr "Μέσες συνδέσεις (εκτίμηση): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Κορυφαίες συνδέσεις (εκτίμηση): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Πελάτες"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2499,6 +2499,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6982,10 +6986,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
-msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2587,6 +2587,10 @@ msgstr "Enviar un mensaje al usuario"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensaje a enviar:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clientes"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7142,10 +7146,6 @@ msgstr "Media de conexiones (estimada): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de conexiones (estimado): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clientes"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2580,6 +2580,10 @@ msgstr "Saada kasutajale teade"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Saadetav teade:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Kliendid"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7175,10 +7179,6 @@ msgstr "Keskmiselt ühendusi (hinnang): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Suurim ühenduste arv (hinnang): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Kliendid"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2581,6 +2581,10 @@ msgstr "Bidali mezua erabiltzaileari"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Bidali behar de mezua:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Bezeroak"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7171,10 +7175,6 @@ msgstr "Batez besteko konexioak (ebaluazioa): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Puntako konexioak (estimazioa): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Bezeroak"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2581,6 +2581,10 @@ msgstr "Lähetä viesti käyttäjälle"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Lähetettävä viesti:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Asiakkaat"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7171,10 +7175,6 @@ msgstr "Yhteyksiä keskimäärin (arvio): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Yhteyksiä enimmillään (arvio): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Asiakkaat"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:05+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2585,6 +2585,10 @@ msgstr "Envoyer un message à l'utilisateur"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Message à envoyer :"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clients"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7134,10 +7138,6 @@ msgstr "Moyenne de connexions (estimation) : %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pics de connexions (estimation) : %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clients"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2597,6 +2597,10 @@ msgstr "Enviar mensaxe ao usuario"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensaxes a enviar:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clientes"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7175,10 +7179,6 @@ msgstr "Media de conexións (estimado): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de conexións (estimado): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clientes"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2549,6 +2549,10 @@ msgstr "שלח הודעה למשתמש"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "הודה שתשלח:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "לקוחות"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7150,10 +7154,6 @@ msgstr "חיבורים בממוצע (משוער): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "שיא החיבורים (משוער): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "לקוחות"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:06+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2546,6 +2546,10 @@ msgstr ""
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klienti"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7147,10 +7151,6 @@ msgstr ""
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klienti"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:07+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2571,6 +2571,10 @@ msgstr "Üzenet küldése ennek a személynek"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Küldendő üzenet:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Kliensek"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7133,10 +7137,6 @@ msgstr "Kapcsolatok átlagos száma (becsült): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Legtöbb kapcsolat (becsült): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Kliensek"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2596,6 +2596,10 @@ msgstr "Invia messaggio all'utente"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Messaggio da inviare:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Client"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7127,10 +7131,6 @@ msgstr "Connessioni medie (stima): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Picco connessioni (stima): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Client"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2579,6 +2579,10 @@ msgstr "ユーザへメッセージを送る"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "メッセージ："
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "クライアント数"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7173,10 +7177,6 @@ msgstr "平均接続数（推測）： %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "ピーク接続数（推測）： %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "クライアント数"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:08+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2595,6 +2595,10 @@ msgstr "사용자에게 메시지를 보내기"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "보낼 메시지:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "클라이언트"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7222,10 +7226,6 @@ msgstr "평균 연결 (평가): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "최대 연결 (평가): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "클라이언트"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:09+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2602,6 +2602,10 @@ msgstr "Siųsti žinutę naudotojui"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Siųsti žinutę:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Naudotojai"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7247,10 +7251,6 @@ msgstr "Vidutinis ryšių skaičius (apytikriai): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Daugiausia ryšių (apytikriai): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Naudotojai"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2516,6 +2516,10 @@ msgstr ""
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klienti"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7026,10 +7030,6 @@ msgstr ""
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klienti"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:09+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2583,6 +2583,10 @@ msgstr "Verstuur bericht naar gebruiker"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Bericht om te versturen:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clients"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7170,10 +7174,6 @@ msgstr "Gemiddelde verbindingen (schatting): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Aantal piekverbindingen (schatting): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clients"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:10+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2593,6 +2593,10 @@ msgstr "Send melding til brukar"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Melding å sende:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klientar"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7216,10 +7220,6 @@ msgstr "Gjennomsnittleg tal på koplingar (berekna): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Topp koplingar (berekna): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klientar"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:10+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2590,6 +2590,10 @@ msgstr "Wyślij wiadomość do użytkownika"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Wiadomość do wysłania:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klienci"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7217,10 +7221,6 @@ msgstr "Średnio połączeń (szacunkowo): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Szczytowe połączenia (szacunkowo): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klienci"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:11+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2592,6 +2592,10 @@ msgstr "Enviar mensagem ao usuário"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensagem a Enviar:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clientes"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7124,10 +7128,6 @@ msgstr "Média de conexões (estimativa): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de conexões (estimada): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clientes"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:11+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2587,6 +2587,10 @@ msgstr "Enviar uma mensagem ao utilizador"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mensagem a enviar:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clientes"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7179,10 +7183,6 @@ msgstr "Média de Ligações (estimativa): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Pico de Ligações (estimativa): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clientes"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:12+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2585,6 +2585,10 @@ msgstr "Trimite mesaj utilizatorului"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mesaj de trimis:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Clienți"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7194,10 +7198,6 @@ msgstr "Medie conexiuni (estimativ): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Vârf conexiuni (estimare): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Clienți"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2606,6 +2606,10 @@ msgstr "Послать сообщение пользователю"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Сообщение:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Клиенты"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7185,10 +7189,6 @@ msgstr "Соединений в среднем (примерно): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Максимальное число соединений (примерно): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Клиенты"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2600,6 +2600,10 @@ msgstr "Pošlji uporabniku sporočilo"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Sporočilo:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Odjemalci"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7236,10 +7240,6 @@ msgstr "Povprečno povezav (ocena): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Največ povezav (ocena): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Odjemalci"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:13+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2587,6 +2587,10 @@ msgstr "Dergo nje mesash perdoruesit"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Mesazhi qe do te dergohet:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Kliente"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7206,10 +7210,6 @@ msgstr "Mesatarja e lidhjeve (vleresim): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Kulmi i lidhjeve (vleresim): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Kliente"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2579,6 +2579,10 @@ msgstr "Skicka meddelande till användare"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Meddelande att skicka:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Klienter"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7165,10 +7169,6 @@ msgstr "Genomsnittliga anslutningar (uppskattning): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Toppar anslutningar (uppskattning): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Klienter"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2498,6 +2498,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6981,10 +6985,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
-msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2578,6 +2578,10 @@ msgstr "Kullanıcıya ileti gönder"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Gönderilecek ileti:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Kullanıcılar"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7127,10 +7131,6 @@ msgstr "Ortalama Bağlantılar (yaklaşık): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Doruk Bağlantılar (yaklaşık): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Kullanıcılar"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2597,6 +2597,10 @@ msgstr "Надіслати повідомлення користувачу"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "Повідомлення:"
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "Клієнти"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7246,10 +7250,6 @@ msgstr "Середня кількість з'єднань (приблизно): 
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "Найбільше з'єднань (приблизно): %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "Клієнти"
 
 #: src/Statistics.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2497,6 +2497,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6979,10 +6983,6 @@ msgstr ""
 #: src/Statistics.cpp
 #, c-format
 msgid "Peak Connections (estimate): %i"
-msgstr ""
-
-#: src/Statistics.cpp
-msgid "Clients"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:16+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2588,6 +2588,10 @@ msgstr "发送消息给用户"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "发送消息："
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "用户"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7120,10 +7124,6 @@ msgstr "平均连接数 (估计): %g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "最高连接（估计值）： %i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "用户"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 11:05+0200\n"
+"POT-Creation-Date: 2026-08-07 11:26+0200\n"
 "PO-Revision-Date: 2026-08-06 11:16+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2577,6 +2577,10 @@ msgstr "傳送訊息給使用者"
 #: src/GenericClientListCtrl.cpp
 msgid "Message to send:"
 msgstr "傳送訊息："
+
+#: src/GenericClientListCtrl.cpp src/Statistics.cpp
+msgid "Clients"
+msgstr "客戶端"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Remove from friends"
@@ -7145,10 +7149,6 @@ msgstr "平均連線數 (估計值)：%g"
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr "最高連線數 (估計值)：%i"
-
-#: src/Statistics.cpp
-msgid "Clients"
-msgstr "客戶端"
 
 #: src/Statistics.cpp
 #, c-format

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -650,7 +650,7 @@ void CGenericClientListCtrl::OnMouseRightClick(wxListEvent &evt)
 	ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(ItemAt(index));
 	CClientRef &client = item->GetSource();
 
-	m_menu = new wxMenu("Clients");
+	m_menu = new wxMenu(_("Clients"));
 	m_menu->Append(MP_DETAIL, _("Show &Details"));
 	m_menu->Append(MP_ADDFRIEND, client.IsFriend() ? _("Remove from friends") : _("Add to Friends"));
 


### PR DESCRIPTION
Fixes #834.

**Problem**
Right-clicking a peer in the Downloads tab's lower list shows a menu whose header reads "Clients" in English regardless of the interface language.

**Cause**
The menu was constructed with a literal string rather than a translatable one. It is the only menu title in the tree that was not wrapped - `Downloads`, `Shared Files`, `Friends`, `Server`, `Chat` and `Category` all already are.

**Fix**
Wrap it. No new message: `Clients` is an existing msgid the catalogs already carry from `src/Statistics.cpp`, so the header starts showing translated in every language that has that entry filled in, with no Weblate round needed. Sampled after regeneration: `it: Client`, `es: Clientes`, `ru: Клиенты`, `ar: عميل`, `zh_CN: 用户`.

The catalog churn is that msgid gaining a second source location and its entry moving with it. No message text changes, and the translated-entry count per catalog is unchanged.

Note this is only visible where the desktop draws a popup menu's title - GTK/KDE does, macOS does not - which is why it was reported from KDE.
