### PR TITLE
feat(gui): port CFileDetailListCtrl to CMuleVirtualDataViewCtrl (#180, #801)

### DIFF
--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -35,8 +35,7 @@
 #include "amule.h"              // Needed for theApp
 #include "SharedFileList.h"     // Needed for CSharedFileList
 #include "OtherFunctions.h"
-#include "DataToText.h" // Needed for PriorityToStr
-#include "MuleColour.h"
+#include "DataToText.h"    // Needed for PriorityToStr
 #include <tags/FileTags.h> // Needed for FT_MEDIA_* metadata tag names
 
 #include <set>
@@ -48,7 +47,7 @@ wxBEGIN_EVENT_TABLE(CFileDetailDialog, wxDialog)
 	EVT_BUTTON(ID_CLOSEWNDFD, CFileDetailDialog::OnClosewnd)
 	EVT_BUTTON(IDC_BUTTONSTRIP, CFileDetailDialog::OnBnClickedButtonStrip)
 	EVT_BUTTON(IDC_TAKEOVER, CFileDetailDialog::OnBnClickedTakeOver)
-	EVT_LIST_ITEM_ACTIVATED(IDC_LISTCTRLFILENAMES, CFileDetailDialog::OnListClickedTakeOver)
+	EVT_DATAVIEW_ITEM_ACTIVATED(IDC_LISTCTRLFILENAMES, CFileDetailDialog::OnListClickedTakeOver)
 	EVT_BUTTON(IDC_CMTBT, CFileDetailDialog::OnBnClickedShowComment)
 	EVT_TEXT(IDC_FILENAME, CFileDetailDialog::OnTextFileNameChange)
 	EVT_BUTTON(IDC_APPLY_AND_CLOSE, CFileDetailDialog::OnBnClickedOk)
@@ -97,6 +96,9 @@ CFileDetailDialog::~CFileDetailDialog()
 {
 	OpenInstances().erase(this);
 	m_timer.Stop();
+	for (const auto &entry : m_sourcenames) {
+		delete entry.second;
+	}
 }
 
 void CFileDetailDialog::DropReferencesTo(const CKnownFile *file)
@@ -300,10 +302,7 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 
 void CFileDetailDialog::FillSourcenameList()
 {
-	CFileDetailListCtrl *pmyListCtrl;
-	int itempos;
-	int inserted = 0;
-	pmyListCtrl = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl);
+	CFileDetailListCtrl *pmyListCtrl = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl);
 
 	// The source-name list is a download-only view (how sources name the file).
 	// A plain shared file has none, so clear any rows a prior file left behind
@@ -311,17 +310,17 @@ void CFileDetailDialog::FillSourcenameList()
 	// source accessors below.
 	CPartFile *part = m_file->IsPartFile() ? static_cast<CPartFile *>(m_file) : nullptr;
 	if (!part) {
-		for (int i = 0; i < pmyListCtrl->GetItemCount(); ++i) {
-			delete reinterpret_cast<SourcenameItem *>(pmyListCtrl->GetItemData(i));
+		for (const auto &entry : m_sourcenames) {
+			delete entry.second;
 		}
-		pmyListCtrl->DeleteAllItems();
+		m_sourcenames.clear();
+		pmyListCtrl->ClearSources();
 		return;
 	}
 
 	// reset
-	for (int i = 0; i < pmyListCtrl->GetItemCount(); i++) {
-		SourcenameItem *item = reinterpret_cast<SourcenameItem *>(pmyListCtrl->GetItemData(i));
-		item->count = 0;
+	for (const auto &entry : m_sourcenames) {
+		entry.second->count = 0;
 	}
 
 	// update
@@ -329,21 +328,13 @@ void CFileDetailDialog::FillSourcenameList()
 	const SourcenameItemMap &sources = part->GetSourcenameItemMap();
 	for (SourcenameItemMap::const_iterator it = sources.begin(); it != sources.end(); ++it) {
 		const SourcenameItem &cur_src = it->second;
-		itempos = pmyListCtrl->FindItem(-1, cur_src.name);
-		if (itempos == -1) {
-			int itemid = pmyListCtrl->InsertItem(0, cur_src.name);
+		auto found = m_sourcenames.find(cur_src.name);
+		if (found == m_sourcenames.end()) {
 			SourcenameItem *item = new SourcenameItem(cur_src.name, cur_src.count);
-			pmyListCtrl->SetItemPtrData(0, reinterpret_cast<wxUIntPtr>(item));
-			// background.. argh -- PA: was in old version - do we still need this?
-			wxListItem tmpitem;
-			tmpitem.m_itemId = itemid;
-			tmpitem.SetBackgroundColour(CMuleColour(wxSYS_COLOUR_LISTBOX));
-			pmyListCtrl->SetItem(tmpitem);
-			inserted++;
+			m_sourcenames[cur_src.name] = item;
+			pmyListCtrl->AddSource(item);
 		} else {
-			SourcenameItem *item =
-				reinterpret_cast<SourcenameItem *>(pmyListCtrl->GetItemData(itempos));
-			item->count = cur_src.count;
+			found->second->count = cur_src.count;
 		}
 	}
 #else  // CLIENT_GUI
@@ -355,39 +346,27 @@ void CFileDetailDialog::FillSourcenameList()
 			continue;
 		}
 
-		itempos = pmyListCtrl->FindItem(-1, cur_src.GetClientFilename());
-		if (itempos == -1) {
-			int itemid = pmyListCtrl->InsertItem(0, cur_src.GetClientFilename());
+		auto found = m_sourcenames.find(cur_src.GetClientFilename());
+		if (found == m_sourcenames.end()) {
 			SourcenameItem *item = new SourcenameItem(cur_src.GetClientFilename(), 1);
-			pmyListCtrl->SetItemPtrData(0, reinterpret_cast<wxUIntPtr>(item));
-			// background.. argh -- PA: was in old version - do we still need this?
-			wxListItem tmpitem;
-			tmpitem.m_itemId = itemid;
-			tmpitem.SetBackgroundColour(CMuleColour(wxSYS_COLOUR_LISTBOX));
-			pmyListCtrl->SetItem(tmpitem);
-			inserted++;
+			m_sourcenames[cur_src.GetClientFilename()] = item;
+			pmyListCtrl->AddSource(item);
 		} else {
-			SourcenameItem *item =
-				reinterpret_cast<SourcenameItem *>(pmyListCtrl->GetItemData(itempos));
-			item->count++;
+			found->second->count++;
 		}
 	}
 #endif // CLIENT_GUI
 
-	// remove 0'er and update counts
-	for (int i = 0; i < pmyListCtrl->GetItemCount(); ++i) {
-		SourcenameItem *item = reinterpret_cast<SourcenameItem *>(pmyListCtrl->GetItemData(i));
-		if (item->count == 0) {
-			delete item;
-			pmyListCtrl->DeleteItem(i);
-			i--; // PA: one step back is enough, no need to go back to 0
+	// Drop entries no longer reported by any source, refresh the rest.
+	for (auto it2 = m_sourcenames.begin(); it2 != m_sourcenames.end();) {
+		if (it2->second->count == 0) {
+			pmyListCtrl->RemoveSource(it2->second);
+			delete it2->second;
+			it2 = m_sourcenames.erase(it2);
 		} else {
-			pmyListCtrl->SetItem(i, 1, CFormat("%i") % item->count);
+			pmyListCtrl->RefreshSource(it2->second);
+			++it2;
 		}
-	}
-
-	if (inserted) {
-		pmyListCtrl->SortList();
 	}
 	// no need to call Layout() here, it's called in UpdateData()
 }
@@ -624,18 +603,15 @@ void CFileDetailDialog::OnBnClickedButtonStrip(wxCommandEvent &WXUNUSED(evt))
 
 void CFileDetailDialog::OnBnClickedTakeOver(wxCommandEvent &WXUNUSED(evt))
 {
-	CFileDetailListCtrl *pmyListCtrl;
-	pmyListCtrl = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl);
-	if (pmyListCtrl->GetSelectedItemCount() > 0) {
-		// get first selected item (there is only one)
-		long pos = pmyListCtrl->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-		if (pos != -1) { // shouldn't happen, we checked if something is selected
-			setValueForFilenameTextEdit(pmyListCtrl->GetItemText(pos));
-		}
+	CFileDetailListCtrl *pmyListCtrl = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl);
+	// The list only ever allows one selected row (CFileDetailListCtrl::OnSelectionChanged).
+	const std::vector<wxUIntPtr> selected = pmyListCtrl->GetSelectedItemData();
+	if (!selected.empty()) {
+		setValueForFilenameTextEdit(reinterpret_cast<SourcenameItem *>(selected.front())->name);
 	}
 }
 
-void CFileDetailDialog::OnListClickedTakeOver(wxListEvent &WXUNUSED(evt))
+void CFileDetailDialog::OnListClickedTakeOver(wxDataViewEvent &WXUNUSED(evt))
 {
 	wxCommandEvent ev;
 	OnBnClickedTakeOver(ev);

--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -8,10 +8,6 @@
 // or contributed by third-party developers are copyrighted by their
 // respective authors.
 //
-// Any parts of this program derived from the xMule, lMule or eMule project,
-// or contributed by third-party developers are copyrighted by their
-// respective authors.
-//
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or

--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -96,6 +96,15 @@ CFileDetailDialog::~CFileDetailDialog()
 {
 	OpenInstances().erase(this);
 	m_timer.Stop();
+	// Drop the rows before freeing what they point at. The list control is a
+	// child window and so outlives this body, and the base states the rule
+	// plainly: it has to be told before the caller frees the item data.
+	// Nothing can currently paint or sort in between -- both call sites are
+	// stack temporaries, so destruction is synchronous -- but that is a
+	// property of wx's teardown rather than something this code should rest on.
+	if (CFileDetailListCtrl *list = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl)) {
+		list->ClearSources();
+	}
 	for (const auto &entry : m_sourcenames) {
 		delete entry.second;
 	}
@@ -310,11 +319,13 @@ void CFileDetailDialog::FillSourcenameList()
 	// source accessors below.
 	CPartFile *part = m_file->IsPartFile() ? static_cast<CPartFile *>(m_file) : nullptr;
 	if (!part) {
+		// Rows first, then the objects they point at -- same rule as the
+		// destructor and as the prune loop below.
+		pmyListCtrl->ClearSources();
 		for (const auto &entry : m_sourcenames) {
 			delete entry.second;
 		}
 		m_sourcenames.clear();
-		pmyListCtrl->ClearSources();
 		return;
 	}
 
@@ -322,6 +333,7 @@ void CFileDetailDialog::FillSourcenameList()
 	for (const auto &entry : m_sourcenames) {
 		entry.second->count = 0;
 	}
+	bool inserted = false;
 
 	// update
 #ifdef CLIENT_GUI
@@ -333,6 +345,7 @@ void CFileDetailDialog::FillSourcenameList()
 			SourcenameItem *item = new SourcenameItem(cur_src.name, cur_src.count);
 			m_sourcenames[cur_src.name] = item;
 			pmyListCtrl->AddSource(item);
+			inserted = true;
 		} else {
 			found->second->count = cur_src.count;
 		}
@@ -351,6 +364,7 @@ void CFileDetailDialog::FillSourcenameList()
 			SourcenameItem *item = new SourcenameItem(cur_src.GetClientFilename(), 1);
 			m_sourcenames[cur_src.GetClientFilename()] = item;
 			pmyListCtrl->AddSource(item);
+			inserted = true;
 		} else {
 			found->second->count++;
 		}
@@ -367,6 +381,21 @@ void CFileDetailDialog::FillSourcenameList()
 			pmyListCtrl->RefreshSource(it2->second);
 			++it2;
 		}
+	}
+
+	// Counts are zeroed above and then rewritten in place, so while this runs
+	// the list is not ordered by the column it is sorted on -- and AddSource()
+	// places a new row with a binary search, which needs that ordering to
+	// hold. So an insertion leaves rows in arbitrary positions and has to be
+	// repaired here, exactly as the pre-port code did.
+	//
+	// Only on insertion, though. A count that merely changed is what the
+	// live-sort preference governs: RefreshSource() re-sorts when it is on,
+	// and when it is off the row is meant to stay where it is rather than move
+	// under the user. Sorting unconditionally would quietly override that
+	// setting for this list.
+	if (inserted) {
+		pmyListCtrl->SortList();
 	}
 	// no need to call Layout() here, it's called in UpdateData()
 }

--- a/src/FileDetailDialog.h
+++ b/src/FileDetailDialog.h
@@ -28,13 +28,15 @@
 
 #include <wx/dialog.h>
 #include <wx/event.h>
-#include <wx/listctrl.h>
 #include <wx/timer.h>
 
+#include <map>
 #include <vector>
 
 class CPartFile;
 class CKnownFile;
+class SourcenameItem;
+class wxDataViewEvent;
 
 // CFileDetailDialog dialog
 
@@ -70,6 +72,12 @@ private:
 	wxTimer m_timer;
 	bool m_filenameChanged;
 
+	//! Source-name rows for the currently displayed partfile, keyed by name
+	//! so FillSourcenameList() can find-or-create by identity across ticks
+	//! instead of searching the list widget. Owns the SourcenameItem objects
+	//! handed to CFileDetailListCtrl as item data.
+	std::map<wxString, SourcenameItem *> m_sourcenames;
+
 	void OnClosewnd(wxCommandEvent &evt);
 	void FillSourcenameList();
 	void setEnableForApplyButton();
@@ -79,7 +87,7 @@ private:
 	void OnBnClickedButtonStrip(wxCommandEvent &evt);
 	void OnBnClickedShowComment(wxCommandEvent &evt);
 	void OnBnClickedTakeOver(wxCommandEvent &evt);
-	void OnListClickedTakeOver(wxListEvent &evt);
+	void OnListClickedTakeOver(wxDataViewEvent &evt);
 	void OnTextFileNameChange(wxCommandEvent &evt);
 	void OnBnClickedOk(wxCommandEvent &evt);
 	void OnBnClickedApply(wxCommandEvent &evt);

--- a/src/FileDetailListCtrl.cpp
+++ b/src/FileDetailListCtrl.cpp
@@ -106,7 +106,14 @@ int CFileDetailListCtrl::CompareItemData(
 
 bool CFileDetailListCtrl::IsLiveSortColumn() const
 {
-	return true;
+	// Only the source count moves on its own; a row's name is the key it was
+	// created under and never changes. Answering "yes" for the name column
+	// would schedule a re-sort on every refresh tick that could not reorder
+	// anything. Same shape as CServerListCtrl.
+	if (m_sort_orders.empty()) {
+		return false;
+	}
+	return static_cast<int>(m_sort_orders.front().first) == COLUMN_FILEDETAIL_SOURCES;
 }
 
 void CFileDetailListCtrl::OnSelectionChanged(wxDataViewEvent &event)

--- a/src/FileDetailListCtrl.cpp
+++ b/src/FileDetailListCtrl.cpp
@@ -23,63 +23,97 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "muuli_wdr.h"          // Needed for ID_CLOSEWNDFD
 #include "FileDetailListCtrl.h" // Interface declarations
 
-#define wxLIST_STATE_DESELECTED 0x0000
+#include <common/Format.h> // Needed for CFormat
 
-wxBEGIN_EVENT_TABLE(CFileDetailListCtrl, CMuleListCtrl)
-	EVT_LIST_ITEM_SELECTED(
-		IDC_LISTCTRLFILENAMES, CFileDetailListCtrl::OnSelect) // Care for single selection
+#include "OtherFunctions.h" // Needed for CmpAny
+#include "PartFile.h"       // Needed for SourcenameItem
+
+wxBEGIN_EVENT_TABLE(CFileDetailListCtrl, CMuleVirtualDataViewCtrl)
+	EVT_DATAVIEW_SELECTION_CHANGED(wxID_ANY, CFileDetailListCtrl::OnSelectionChanged)
 wxEND_EVENT_TABLE()
 
 CFileDetailListCtrl::CFileDetailListCtrl(wxWindow *&parent, int id, const wxPoint &pos, wxSize siz, int flags)
-: CMuleListCtrl(parent, id, pos, siz, flags)
+: CMuleVirtualDataViewCtrl(parent, id, pos, siz, flags)
 {
-	// Set sorter function
-	SetSortFunc(SortProc);
+	const int columnFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+	AppendTextColumn(_("File Name"),
+		COLUMN_FILEDETAIL_NAME,
+		wxDATAVIEW_CELL_INERT,
+		370,
+		wxALIGN_LEFT,
+		columnFlags);
+	AppendTextColumn(_("Sources"),
+		COLUMN_FILEDETAIL_SOURCES,
+		wxDATAVIEW_CELL_INERT,
+		70,
+		wxALIGN_LEFT,
+		columnFlags);
 
-	// Initial sorting: Sources descending
-	InsertColumn(0, _("File Name"), wxLIST_FORMAT_LEFT, 370);
-	InsertColumn(1, _("Sources"), wxLIST_FORMAT_LEFT, 70);
+	AppendSpacerColumn(COLUMN_FILEDETAIL_SPACER);
+	AssociateVirtualModel();
 
-	SetSorting(1, CMuleListCtrl::SORT_DES);
+	// Initial sorting: Sources descending, matching the pre-port default.
+	ApplySorting(COLUMN_FILEDETAIL_SOURCES, SORT_DES);
 
-	SortList();
+	InitColumnState();
 }
 
-int CFileDetailListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
+void CFileDetailListCtrl::AddSource(SourcenameItem *item)
 {
-	// Comparison for different sortings
-	SourcenameItem *item1 = reinterpret_cast<SourcenameItem *>(param1);
-	SourcenameItem *item2 = reinterpret_cast<SourcenameItem *>(param2);
+	AddItemData(reinterpret_cast<wxUIntPtr>(item));
+}
 
-	int mod = (sortData & CMuleListCtrl::SORT_DES) ? -1 : 1;
+void CFileDetailListCtrl::RefreshSource(SourcenameItem *item)
+{
+	RefreshItemData(reinterpret_cast<wxUIntPtr>(item));
+}
 
-	switch (sortData & CMuleListCtrl::COLUMN_MASK) {
-	case 1:
-		return mod * (item1->count - item2->count); // Sources descending
-	case 0:
-		return mod * item1->name.CmpNoCase(item2->name); // Name descending
+void CFileDetailListCtrl::RemoveSource(SourcenameItem *item)
+{
+	RemoveItemData(reinterpret_cast<wxUIntPtr>(item));
+}
+
+wxString CFileDetailListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) const
+{
+	const SourcenameItem *source = reinterpret_cast<const SourcenameItem *>(item);
+	switch (column) {
+	case COLUMN_FILEDETAIL_NAME:
+		return source->name;
+	case COLUMN_FILEDETAIL_SOURCES:
+		return CFormat("%i") % source->count;
+	default:
+		return wxEmptyString;
+	}
+}
+
+int CFileDetailListCtrl::CompareItemData(
+	wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool WXUNUSED(alt), int modifier) const
+{
+	const SourcenameItem *s1 = reinterpret_cast<const SourcenameItem *>(data1);
+	const SourcenameItem *s2 = reinterpret_cast<const SourcenameItem *>(data2);
+
+	switch (column) {
+	case COLUMN_FILEDETAIL_NAME:
+		return modifier * s1->name.CmpNoCase(s2->name);
+	case COLUMN_FILEDETAIL_SOURCES:
+		return modifier * CmpAny(s1->count, s2->count);
 	default:
 		return 0;
 	}
 }
 
-void CFileDetailListCtrl::OnSelect(wxListEvent &event)
+bool CFileDetailListCtrl::IsLiveSortColumn() const
 {
-	// Damn wxLC_SINGLE_SEL does not work! So we have to care for single selection ourselves:
-	long realpos = event.m_itemIndex;
-	long pos = -1;
-	do {
-		// Loop through all selected items
-		pos = GetNextItem(pos, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-		if (pos != realpos && pos != -1) {
-			// Deselect all items except the one we have just clicked
-			SetItemState(pos, wxLIST_STATE_DESELECTED, wxLIST_STATE_SELECTED);
-		}
-	} while (pos != -1);
+	return true;
+}
 
-	event.Skip();
+void CFileDetailListCtrl::OnSelectionChanged(wxDataViewEvent &event)
+{
+	if (GetSelectedItemsCount() > 1 && event.GetItem().IsOk()) {
+		UnselectAll();
+		Select(event.GetItem());
+	}
 }
 // File_checked_for_headers

--- a/src/FileDetailListCtrl.h
+++ b/src/FileDetailListCtrl.h
@@ -26,23 +26,51 @@
 #ifndef FILEDETAILLISTCTRL_H
 #define FILEDETAILLISTCTRL_H
 
-#include "MuleListCtrl.h" // Needed for CMuleListCtrl
+#include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
 
-class CFileDetailListCtrl : public CMuleListCtrl
+#define COLUMN_FILEDETAIL_NAME 0
+#define COLUMN_FILEDETAIL_SOURCES 1
+//! Always empty. Absorbs the macOS trailing-column sizing; see
+//! CMuleDataViewCtrl::AppendSpacerColumn().
+#define COLUMN_FILEDETAIL_SPACER 2
+
+class SourcenameItem;
+
+class CFileDetailListCtrl : public CMuleVirtualDataViewCtrl
 {
-
 public:
 	CFileDetailListCtrl(wxWindow *&parent, int id, const wxPoint &pos, wxSize siz, int flags);
 
-private:
-	struct SourcenameItem
-	{
-		wxString name;
-		long count;
-	};
+	void AddSource(SourcenameItem *item);
+	void RefreshSource(SourcenameItem *item);
+	void RemoveSource(SourcenameItem *item);
+	void ClearSources() { ClearItemData(); }
 
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
-	void OnSelect(wxListEvent &event);
+protected:
+	/// Text of a cell, pulled on demand for the rows being drawn.
+	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
+
+	/// Name compare on column 0, source-count compare on column 1.
+	int CompareItemData(
+		wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const override;
+
+	/**
+	 * The Sources column's value (a live source count) changes on every
+	 * 5-second refresh timer tick while the dialog is open, so a
+	 * sources-sorted list needs the coalesced live re-sort.
+	 */
+	bool IsLiveSortColumn() const override;
+
+private:
+	/**
+	 * The base always constructs with wxDV_MULTIPLE (CMuleDataViewCtrl has
+	 * no single-selection mode), but this list is meant to only ever have
+	 * one row selected -- the "take over filename" actions assume it.
+	 * Collapses the selection down to the just-clicked row whenever more
+	 * than one ends up selected, the wxDataViewCtrl equivalent of the old
+	 * list's own OnSelect() enforcement.
+	 */
+	void OnSelectionChanged(wxDataViewEvent &event);
 
 	wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
## Context

Continues #180/#801's `wxListCtrl` -> `wxDataViewCtrl` migration on the shared base from #811. Search (#796), Servers (#807/#811) and Friends (#830) are done; this ports `CFileDetailListCtrl` (the small source-name list inside the File Details dialog).

Picked next because it has no `CBarShader` rendering — unlike Downloads/SharedFiles/Sources-Peers, which additionally need a `wxDataViewCustomRenderer` that doesn't exist anywhere in the tree yet, so those stay a separate, dedicated piece of work.

## What changed

Its caller, `CFileDetailDialog::FillSourcenameList()`, drove the old list with raw position-indexed CRUD (`FindItem` by name, `SetItemPtrData`, `SetItem` by column index, `DeleteItem`) rather than the pointer-identity style `CServerListCtrl`/`CFriendListCtrl` already use, so porting the control cleanly meant refactoring the caller too:

- `CFileDetailDialog` gained a `std::map<wxString, SourcenameItem *> m_sourcenames` member, replacing "search the list widget by name" with a map lookup. `FillSourcenameList()`'s reset/update/prune shape is otherwise unchanged, just re-keyed to the map and driven through the control's new `AddSource`/`RefreshSource`/`RemoveSource` API.
- `OnBnClickedTakeOver()`/`OnListClickedTakeOver()` resolve the selected row through `GetSelectedItemData()` (inherited from `CMuleVirtualDataViewCtrl`) instead of `GetNextItem`+`GetItemText`.
- The dialog's `EVT_LIST_ITEM_ACTIVATED` binding on `IDC_LISTCTRLFILENAMES` becomes `EVT_DATAVIEW_ITEM_ACTIVATED`; `wxDataViewEvent` is a `wxNotifyEvent`/`wxCommandEvent` descendant so it still propagates from the child control to the dialog-level handler the same way.
- Fixed a latent leak: nothing in `~CFileDetailDialog()` freed the `SourcenameItem` objects still referenced by open rows — only the "not a partfile" and "pruned to zero" paths in `FillSourcenameList()` ever deleted them. Now freed in the destructor via `m_sourcenames`.

`CMuleDataViewCtrl` always ORs in `wxDV_MULTIPLE` (no single-selection mode exists on the shared base), but this list's "take over filename" actions assume exactly one selection — same as before the port, since the old list never actually requested `wxLC_SINGLE_SEL` either (checked `muuli_wdr.cpp`); it enforced single-selection itself via `OnSelect()` deselecting every other row. `CFileDetailListCtrl::OnSelectionChanged()` does the equivalent: collapses to the just-clicked row whenever more than one ends up selected.

Also deleted a vestigial nested `SourcenameItem` struct in `FileDetailListCtrl.h` that duplicated (by accident of matching memory layout) the real one in `PartFile.h`, and dropped a per-row background-colour set that reproduced the default and carried its own "*do we still need this?*" comment.

## Verification

- Builds clean.
- `clang-format` v18 (pinned Docker image) applied.
- clang-tidy Tier-1 (whole-tree) and Tier-2 (changed-lines, `.clang-tidy-new-code`) both clean via a local CI replica.
- Grepped for other `CFileDetailListCtrl`/`IDC_LISTCTRLFILENAMES` references to confirm `muuli_wdr.cpp`'s construction call needed no changes.
- **Not yet verified interactively**: source-name list populate/re-tally over the 5s refresh timer, "Take over filename" via button and via double-click, single-selection enforcement, sort by clicking either header, and a VoiceOver spot-check — happy to have this checked before or after merge.