### PR TITLE
feat(gui): add CBarShader renderer bridge, port CSharedFilesCtrl to wxDataViewCtrl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -951,6 +951,7 @@ if (NEED_LIB_MULEAPPGUI)
 		EditServerListDlg.cpp
 		FileDetailListCtrl.cpp
 		ListColumnStore.cpp
+		MuleBarRenderer.cpp
 		MuleColour.cpp
 		MuleGifCtrl.cpp
 		MuleDataViewCtrl.cpp

--- a/src/MuleBarRenderer.cpp
+++ b/src/MuleBarRenderer.cpp
@@ -1,0 +1,95 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include "MuleBarRenderer.h" // Interface declarations
+
+#include "Preferences.h" // Needed for thePrefs::UseFlatBar(), CPreferences::Get3DDepth()
+
+wxIMPLEMENT_DYNAMIC_CLASS(CBarFillSpec, wxObject);
+wxIMPLEMENT_VARIANT_OBJECT(CBarFillSpec);
+
+CMuleBarRenderer::CMuleBarRenderer()
+: wxDataViewCustomRenderer("CBarFillSpec", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT)
+{
+}
+
+bool CMuleBarRenderer::SetValue(const wxVariant &value)
+{
+	m_spec << value;
+	return true;
+}
+
+bool CMuleBarRenderer::GetValue(wxVariant &value) const
+{
+	value << m_spec;
+	return true;
+}
+
+wxSize CMuleBarRenderer::GetSize() const
+{
+	// A minimum only: the column's actual on-screen width comes from
+	// AppendBarColumn()'s caller and, after that, CListColumnStore.
+	return wxSize(40, GetTextExtent("Xg").GetHeight());
+}
+
+bool CMuleBarRenderer::Render(wxRect cell, wxDC *dc, int WXUNUSED(state))
+{
+	if (cell.GetWidth() <= 0 || cell.GetHeight() <= 0) {
+		return true;
+	}
+
+	const bool bFlat = thePrefs::UseFlatBar();
+
+	wxRect barRect = cell;
+	if (!bFlat) {
+		// Round bar has a black border; the bar itself is inset by one pixel
+		// on each side -- matches every pre-port CBarShader caller.
+		barRect.x++;
+		barRect.y++;
+		barRect.width -= 2;
+		barRect.height -= 2;
+	}
+	if (barRect.GetWidth() <= 0 || barRect.GetHeight() <= 0) {
+		return true;
+	}
+
+	m_bar.SetWidth(barRect.GetWidth());
+	m_bar.SetHeight(barRect.GetHeight());
+	m_bar.Set3dDepth(CPreferences::Get3DDepth());
+	m_bar.SetFileSize(m_spec.GetFileSize());
+
+	if (!m_spec.GetSpans().empty()) {
+		for (const CBarFillSpan &span : m_spec.GetSpans()) {
+			m_bar.FillRange(span.start, span.end, span.colour);
+		}
+		m_bar.Draw(dc, barRect.x, barRect.y, bFlat);
+	}
+
+	if (!bFlat) {
+		wxDCPenChanger pen(*dc, *wxBLACK_PEN);
+		wxDCBrushChanger brush(*dc, *wxTRANSPARENT_BRUSH);
+		dc->DrawRectangle(cell);
+	}
+	return true;
+}

--- a/src/MuleBarRenderer.cpp
+++ b/src/MuleBarRenderer.cpp
@@ -50,9 +50,17 @@ bool CMuleBarRenderer::GetValue(wxVariant &value) const
 
 wxSize CMuleBarRenderer::GetSize() const
 {
-	// A minimum only: the column's actual on-screen width comes from
-	// AppendBarColumn()'s caller and, after that, CListColumnStore.
-	return wxSize(40, GetTextExtent("Xg").GetHeight());
+	// The generic backend passes the real cell rect to Render() and treats this
+	// only as a best-width hint, but the native macOS backend takes GetSize()
+	// as the cell size itself (wxCustomRendererObject::cellSize), so a constant
+	// here paints a fixed-width bar inside an arbitrarily wide column. Report
+	// the owning column's current width to keep both backends in step; the
+	// literal is the fallback for before the renderer is attached.
+	int width = 40;
+	if (const wxDataViewColumn *column = GetOwner()) {
+		width = std::max(width, column->GetWidth());
+	}
+	return wxSize(width, GetTextExtent("Xg").GetHeight());
 }
 
 bool CMuleBarRenderer::Render(wxRect cell, wxDC *dc, int WXUNUSED(state))

--- a/src/MuleBarRenderer.cpp
+++ b/src/MuleBarRenderer.cpp
@@ -27,7 +27,9 @@
 #include "Preferences.h" // Needed for thePrefs::UseFlatBar(), CPreferences::Get3DDepth()
 
 wxIMPLEMENT_DYNAMIC_CLASS(CBarFillSpec, wxObject);
-wxIMPLEMENT_VARIANT_OBJECT(CBarFillSpec);
+// Non-"wx"-prefixed spelling -- see the comment on the DECLARE_VARIANT_OBJECT
+// use in MuleBarRenderer.h.
+IMPLEMENT_VARIANT_OBJECT(CBarFillSpec)
 
 CMuleBarRenderer::CMuleBarRenderer()
 : wxDataViewCustomRenderer("CBarFillSpec", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT)

--- a/src/MuleBarRenderer.h
+++ b/src/MuleBarRenderer.h
@@ -27,7 +27,7 @@
 
 #include <wx/dataview.h>
 #include <wx/variant.h> // Needed for wxDECLARE_VARIANT_OBJECT -- not reliably pulled in
-                         // transitively by <wx/dataview.h> across wx versions/ports
+			// transitively by <wx/dataview.h> across wx versions/ports
 
 #include "BarShader.h"  // Needed for CBarShader
 #include "MuleColour.h" // Needed for CMuleColour
@@ -79,14 +79,24 @@ public:
 		return m_fileSize == other.m_fileSize && m_spans == other.m_spans;
 	}
 
-	wxDECLARE_VARIANT_OBJECT(CBarFillSpec);
-
 private:
 	uint64 m_fileSize = 0;
 	std::vector<CBarFillSpan> m_spans;
 
 	wxDECLARE_DYNAMIC_CLASS(CBarFillSpec);
 };
+
+// Declared at namespace scope with the non-"wx"-prefixed macro, not the
+// in-class wxDECLARE_VARIANT_OBJECT() used for e.g. wxDataViewIconText:
+// wxWidgets 3.2 (the CI's Linux package) only has
+// DECLARE_VARIANT_OBJECT/IMPLEMENT_VARIANT_OBJECT, whose expansion is a pair
+// of free-function declarations, not friend declarations -- placing them
+// inside the class body compiles as ill-formed member operators on 3.2.
+// Neither operator touches CBarFillSpec's private members, so free
+// functions need no special access and this works on every wx version.
+// Confirmed by a build failure against 3.2 that a green build against
+// Homebrew's wx 3.3.3 locally didn't catch.
+DECLARE_VARIANT_OBJECT(CBarFillSpec)
 
 /**
  * Renders a CBarShader chunk bar in a wxDataViewCtrl cell.

--- a/src/MuleBarRenderer.h
+++ b/src/MuleBarRenderer.h
@@ -26,6 +26,8 @@
 #define MULEBARRENDERER_H
 
 #include <wx/dataview.h>
+#include <wx/variant.h> // Needed for wxDECLARE_VARIANT_OBJECT -- not reliably pulled in
+                         // transitively by <wx/dataview.h> across wx versions/ports
 
 #include "BarShader.h"  // Needed for CBarShader
 #include "MuleColour.h" // Needed for CMuleColour

--- a/src/MuleBarRenderer.h
+++ b/src/MuleBarRenderer.h
@@ -1,0 +1,122 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#ifndef MULEBARRENDERER_H
+#define MULEBARRENDERER_H
+
+#include <wx/dataview.h>
+
+#include "BarShader.h"  // Needed for CBarShader
+#include "MuleColour.h" // Needed for CMuleColour
+#include "Types.h"      // Needed for uint64
+
+#include <vector>
+
+/**
+ * One coloured span of a CBarShader-style bar, in byte-offset (virtual
+ * filesize) space -- exactly what CBarShader::FillRange() takes.
+ */
+struct CBarFillSpan
+{
+	uint64 start = 0;
+	uint64 end = 0;
+	CMuleColour colour;
+
+	bool operator==(const CBarFillSpan &other) const
+	{
+		return start == other.start && end == other.end && colour.IsSameAs(other.colour);
+	}
+};
+
+/**
+ * The payload a bar-drawing column cell carries through a wxVariant, from a
+ * CMuleVirtualDataViewCtrl::GetItemBarFill() implementation to
+ * CMuleBarRenderer::Render().
+ *
+ * Deliberately just data: turning a file's source/availability information
+ * into spans is per-list business logic and stays in the list, the same
+ * split GetItemColumnText() already has. A CBarFillSpec knows nothing about
+ * where its spans came from.
+ */
+class CBarFillSpec : public wxObject
+{
+public:
+	CBarFillSpec() = default;
+	CBarFillSpec(uint64 fileSize, std::vector<CBarFillSpan> spans)
+	: m_fileSize(fileSize)
+	, m_spans(std::move(spans))
+	{
+	}
+
+	uint64 GetFileSize() const { return m_fileSize; }
+	const std::vector<CBarFillSpan> &GetSpans() const { return m_spans; }
+
+	bool operator==(const CBarFillSpec &other) const
+	{
+		return m_fileSize == other.m_fileSize && m_spans == other.m_spans;
+	}
+
+	wxDECLARE_VARIANT_OBJECT(CBarFillSpec);
+
+private:
+	uint64 m_fileSize = 0;
+	std::vector<CBarFillSpan> m_spans;
+
+	wxDECLARE_DYNAMIC_CLASS(CBarFillSpec);
+};
+
+/**
+ * Renders a CBarShader chunk bar in a wxDataViewCtrl cell.
+ *
+ * List-agnostic: every list feeds it the same CBarFillSpec shape through
+ * GetItemBarFill(), so one renderer instance (registered via
+ * CMuleDataViewCtrl::AppendBarColumn()) serves any list that wants a bar
+ * column. Matches the flat/3D and border-drawing behaviour every existing
+ * CBarShader caller already has, since those come from a global preference
+ * (thePrefs::UseFlatBar()) rather than anything list-specific.
+ *
+ * The CBarShader is a renderer member, not a per-Render() local: SetWidth()/
+ * SetHeight() reset its content buffer, so it must not be resized more than
+ * once per paint, and rebuilding one from scratch per cell per repaint would
+ * be wasteful -- the same reason the pre-port code kept it as a function-
+ * local static.
+ */
+class CMuleBarRenderer : public wxDataViewCustomRenderer
+{
+public:
+	CMuleBarRenderer();
+
+	bool SetValue(const wxVariant &value) override;
+	bool GetValue(wxVariant &value) const override;
+
+	bool Render(wxRect cell, wxDC *dc, int state) override;
+	wxSize GetSize() const override;
+
+private:
+	CBarFillSpec m_spec;
+	CBarShader m_bar;
+};
+
+#endif // MULEBARRENDERER_H
+// File_checked_for_headers

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -31,7 +31,8 @@
 
 #include <common/MenuIDs.h> // Needed for MP_LISTCOL_1 .. MP_LISTCOL_15
 
-#include "GetTickCount.h" // Needed for GetTickCount64()
+#include "GetTickCount.h"    // Needed for GetTickCount64()
+#include "MuleBarRenderer.h" // Needed for CMuleBarRenderer
 
 namespace
 {
@@ -96,6 +97,13 @@ void CMuleDataViewCtrl::AppendSpacerColumn(unsigned modelColumn)
 #else
 	(void)modelColumn;
 #endif
+}
+
+void CMuleDataViewCtrl::AppendBarColumn(const wxString &title, unsigned modelColumn, int width, int flags)
+{
+	wxDataViewColumn *column =
+		new wxDataViewColumn(title, new CMuleBarRenderer(), modelColumn, width, wxALIGN_LEFT, flags);
+	AppendColumn(column);
 }
 
 unsigned CMuleDataViewCtrl::RealColumnCount() const

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -194,6 +194,17 @@ protected:
 	void AppendSpacerColumn(unsigned modelColumn);
 
 	/**
+	 * Appends a column rendered by a CMuleBarRenderer (a CBarShader chunk
+	 * bar), for lists that used to paint one with direct wxDC calls in an
+	 * owner-drawn OnDrawItem(). The subclass supplies the per-row fill data
+	 * through CMuleVirtualDataViewCtrl::GetItemBarFill().
+	 */
+	void AppendBarColumn(const wxString &title,
+		unsigned modelColumn,
+		int width,
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+
+	/**
 	 * Sizes the per-column state and snapshots the current widths. Call
 	 * after the columns exist and after LoadColumnSettings(): it preserves
 	 * any hidden flags already restored through the width adapter.

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -70,12 +70,16 @@ public:
 
 	void GetValueByRow(wxVariant &variant, unsigned row, unsigned col) const override
 	{
-		const bool iconText = (GetColumnType(col) == "wxDataViewIconText");
+		const wxString type = GetColumnType(col);
+		const bool iconText = (type == "wxDataViewIconText");
+		const bool barFill = (type == "CBarFillSpec");
 		if (row >= m_owner->m_items.size() || col >= m_owner->RealColumnCount()) {
 			// Out of range, or the trailing spacer column, which is always
 			// empty by construction.
 			if (iconText) {
 				variant << wxDataViewIconText(wxEmptyString, wxIcon());
+			} else if (barFill) {
+				variant << CBarFillSpec();
 			} else {
 				variant = wxString();
 			}
@@ -83,6 +87,13 @@ public:
 		}
 
 		const wxUIntPtr data = m_owner->m_items[row];
+		if (barFill) {
+			CBarFillSpec spec;
+			m_owner->GetItemBarFill(data, col, spec);
+			variant << spec;
+			return;
+		}
+
 		const wxString text = m_owner->GetItemColumnText(data, col);
 		if (!iconText) {
 			variant = text;

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -25,6 +25,7 @@
 #ifndef MULEVIRTUALDATAVIEWCTRL_H
 #define MULEVIRTUALDATAVIEWCTRL_H
 
+#include "MuleBarRenderer.h"  // Needed for CBarFillSpec
 #include "MuleDataViewCtrl.h" // Needed for CMuleDataViewCtrl
 
 #include <wx/timer.h> // Needed for wxTimer (deferred live re-sort)
@@ -147,6 +148,17 @@ protected:
 		wxUIntPtr WXUNUSED(data), unsigned WXUNUSED(column), wxDataViewItemAttr &WXUNUSED(attr)) const
 	{
 		return false;
+	}
+
+	/**
+	 * Fill data for a cell in a column appended with
+	 * CMuleDataViewCtrl::AppendBarColumn(). Default leaves `out` empty,
+	 * which CMuleBarRenderer draws as an empty bar -- fine for any column
+	 * that never asks for one.
+	 */
+	virtual void GetItemBarFill(
+		wxUIntPtr WXUNUSED(data), unsigned WXUNUSED(column), CBarFillSpec &WXUNUSED(out)) const
+	{
 	}
 
 	//! Single-column comparison of two items; the caller applies `modifier`.

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -90,7 +90,7 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 , m_batchUpdate(false)
 , m_shownSize(0)
 {
-	m_menu = NULL;
+	m_menu = nullptr;
 
 	// The name column carries the rating/comment smiley, so it is icon+text;
 	// Obtained Parts is the availability bar; the rest are plain text.
@@ -186,7 +186,7 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	// watcher can mutate the list while the menu is open.
 	m_menuItem = selected.front();
 
-	if (m_menu == NULL) {
+	if (m_menu == nullptr) {
 		m_menu = new wxMenu(_("Shared Files"));
 		wxMenu *prioMenu = new wxMenu();
 		prioMenu->AppendCheckItem(MP_PRIOVERYLOW, _("Very low"));
@@ -276,7 +276,7 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 
 		delete m_menu;
 
-		m_menu = NULL;
+		m_menu = nullptr;
 	}
 }
 
@@ -391,8 +391,8 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 		       CastItoXBytes(file->statistic.GetAllTimeTransferred()) + ")";
 
 	case COLUMN_SHARED_RTIO:
-		return CFormat("%.2f") %
-		       ((double)file->statistic.GetAllTimeTransferred() / file->GetFileSize());
+		return CFormat("%.2f") % (static_cast<double>(file->statistic.GetAllTimeTransferred()) /
+						 static_cast<double>(file->GetFileSize()));
 
 	case COLUMN_SHARED_CMPL:
 		if (file->m_nCompleteSourcesCountLo == 0) {
@@ -911,8 +911,10 @@ int CSharedFilesCtrl::CompareItemData(
 
 	// Sort by Share Ratio. Ascending.
 	case COLUMN_SHARED_RTIO:
-		return mod * CmpAny((double)file1->statistic.GetAllTimeTransferred() / file1->GetFileSize(),
-				     (double)file2->statistic.GetAllTimeTransferred() / file2->GetFileSize());
+		return mod * CmpAny(static_cast<double>(file1->statistic.GetAllTimeTransferred()) /
+					     static_cast<double>(file1->GetFileSize()),
+				     static_cast<double>(file2->statistic.GetAllTimeTransferred()) /
+					     static_cast<double>(file2->GetFileSize()));
 
 	// Complete sources asc
 	case COLUMN_SHARED_CMPL:

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -46,6 +46,7 @@
 #include "Preferences.h"      // Needed for thePrefs
 #include "MuleBarRenderer.h"  // Needed for CBarFillSpec, CBarFillSpan
 #include "DataToText.h"       // Needed for PriorityToStr
+#include "OtherFunctions.h"   // Needed for GetRateString
 #include "GuiEvents.h"        // Needed for CoreNotify_*
 #include "MuleCollection.h"   // Needed for CMuleCollection
 #include "DownloadQueue.h"    // Needed for CDownloadQueue
@@ -92,27 +93,31 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 {
 	m_menu = nullptr;
 
-	// The name column carries the rating/comment smiley, so it is icon+text;
-	// Obtained Parts is the availability bar; the rest are plain text.
+	// Rating is the smiley plus its label and sorts by rating value; Obtained
+	// Parts is the availability bar; the rest are plain text. File Name is
+	// deliberately plain text, not icon+text: an icon renderer in the first
+	// column reserves the icon slot on every row, indenting names that have no
+	// icon of their own.
 	const int colFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+	AppendTextColumn(
+		_("File Name"), COLUMN_SHARED_NAME, wxDATAVIEW_CELL_INERT, 400, wxALIGN_LEFT, colFlags);
 	AppendIconTextColumn(
-		_("File Name"), COLUMN_SHARED_NAME, wxDATAVIEW_CELL_INERT, 250, wxALIGN_LEFT, colFlags);
+		_("Rating"), COLUMN_SHARED_RATING, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, colFlags);
 	AppendTextColumn(_("Size"), COLUMN_SHARED_SIZE, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(_("Type"), COLUMN_SHARED_TYPE, wxDATAVIEW_CELL_INERT, 50, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(_("Type"), COLUMN_SHARED_TYPE, wxDATAVIEW_CELL_INERT, 90, wxALIGN_LEFT, colFlags);
 	AppendTextColumn(
 		_("Priority"), COLUMN_SHARED_PRIO, wxDATAVIEW_CELL_INERT, 70, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(
-		_("Requests"), COLUMN_SHARED_REQ, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(_("Requests"), COLUMN_SHARED_REQ, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, colFlags);
 	AppendTextColumn(_("Accepted Requests"),
 		COLUMN_SHARED_AREQ,
 		wxDATAVIEW_CELL_INERT,
-		100,
+		80,
 		wxALIGN_LEFT,
 		colFlags);
 	AppendTextColumn(
 		_("Transferred Data"), COLUMN_SHARED_TRA, wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT, colFlags);
 	AppendTextColumn(
-		_("Share Ratio"), COLUMN_SHARED_RTIO, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
+		_("Share Ratio"), COLUMN_SHARED_RTIO, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, colFlags);
 	AppendBarColumn(_("Obtained Parts"), COLUMN_SHARED_PART, 120, colFlags);
 	AppendTextColumn(_("Complete Sources"),
 		COLUMN_SHARED_CMPL,
@@ -129,25 +134,27 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	AppendTextColumn(
 		_("Last upload"), COLUMN_SHARED_LASTUP, wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT, colFlags);
 	AppendTextColumn(
-		_("Directory Path"), COLUMN_SHARED_PATH, wxDATAVIEW_CELL_INERT, 220, wxALIGN_LEFT, colFlags);
+		_("Directory Path"), COLUMN_SHARED_PATH, wxDATAVIEW_CELL_INERT, 430, wxALIGN_LEFT, colFlags);
 
 	AppendSpacerColumn(COLUMN_SHARED_SPACER);
+
 	AssociateVirtualModel();
 
-	m_columnStore.RegisterColumn(COLUMN_SHARED_NAME, 250, "N");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_NAME, 400, "N");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_RATING, 80, "G");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_SIZE, 100, "Z");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_TYPE, 50, "Y");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_TYPE, 90, "Y");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_PRIO, 70, "p");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_REQ, 100, "Q");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_AREQ, 100, "A");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_REQ, 80, "Q");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_AREQ, 80, "A");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_TRA, 120, "T");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_RTIO, 100, "R");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_RTIO, 80, "R");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_PART, 120, "P");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_CMPL, 120, "C");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_SPEED, 90, "U");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_SINCE, 130, "H");
 	m_columnStore.RegisterColumn(COLUMN_SHARED_LASTUP, 130, "L");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_PATH, 220, "D");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_PATH, 430, "D");
 
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it
 	// when the config has something saved.
@@ -365,9 +372,13 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 
 	switch (column) {
 	case COLUMN_SHARED_NAME:
-		// The rating/comment smiley is the icon on this column, not part of
-		// the text -- see GetItemIcon().
 		return file->GetFileName().GetPrintable();
+
+	case COLUMN_SHARED_RATING:
+		// The smiley comes from GetItemIcon(); the label names it. Unrated
+		// files stay blank rather than repeating "Not rated" down the column --
+		// a comment with no rating still shows its icon.
+		return file->GetFileRating() ? GetRateString(file->GetFileRating()) : wxString();
 
 	case COLUMN_SHARED_SIZE:
 		return CastItoXBytes(file->GetFileSize());
@@ -446,7 +457,7 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 
 bool CSharedFilesCtrl::GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const
 {
-	if (column != COLUMN_SHARED_NAME) {
+	if (column != COLUMN_SHARED_RATING) {
 		return false;
 	}
 	CKnownFile *file = reinterpret_cast<CKnownFile *>(item);
@@ -862,6 +873,20 @@ int CSharedFilesCtrl::CompareItemData(
 	// Sort by filename.
 	case COLUMN_SHARED_NAME:
 		return mod * CmpAny(file1->GetFileName(), file2->GetFileName());
+
+	// Sort by rating. The cell text is blank for unrated files, so sorting on
+	// it would lump them together; rank explicitly instead -- rated files order
+	// by rating, a comment with no rating ranks just below the lowest rating,
+	// and files with neither come last.
+	case COLUMN_SHARED_RATING: {
+		const int rank1 = file1->GetFileRating()             ? file1->GetFileRating()
+				  : file1->GetFileComment().Length() ? 0
+								     : -1;
+		const int rank2 = file2->GetFileRating()             ? file2->GetFileRating()
+				  : file2->GetFileComment().Length() ? 0
+								     : -1;
+		return mod * CmpAny(rank1, rank2);
+	}
 
 	// Sort by filesize.
 	case COLUMN_SHARED_SIZE:

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -25,6 +25,8 @@
 
 #include "SharedFilesCtrl.h" // Interface declarations
 
+#include <algorithm> // Needed for std::find
+
 #include <wx/file.h>    // Needed for wxFile
 #include <wx/filedlg.h> // Needed for wxFileDialog
 
@@ -42,7 +44,7 @@
 #include "amule.h"            // Needed for theApp
 #include "ServerConnect.h"    // Needed for CServerConnect
 #include "Preferences.h"      // Needed for thePrefs
-#include "BarShader.h"        // Needed for CBarShader
+#include "MuleBarRenderer.h"  // Needed for CBarFillSpec, CBarFillSpan
 #include "DataToText.h"       // Needed for PriorityToStr
 #include "GuiEvents.h"        // Needed for CoreNotify_*
 #include "MuleCollection.h"   // Needed for CMuleCollection
@@ -50,11 +52,11 @@
 #include "TransferWnd.h"      // Needed for CTransferWnd
 #include "Logger.h"           // Needed for AddLogLine
 
-wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualListCtrl)
-	EVT_LIST_ITEM_RIGHT_CLICK(-1, CSharedFilesCtrl::OnRightClick)
+wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualDataViewCtrl)
+	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CSharedFilesCtrl::OnItemRightClicked)
 	EVT_MENU(MP_VIEW, CSharedFilesCtrl::OnOpenFile)
 	EVT_MENU(MP_SHOWINFOLDER, CSharedFilesCtrl::OnShowInFolder)
-	EVT_LIST_ITEM_ACTIVATED(-1, CSharedFilesCtrl::OnItemActivated)
+	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CSharedFilesCtrl::OnItemActivated)
 
 	EVT_MENU(MP_METINFO, CSharedFilesCtrl::OnViewFileDetails)
 
@@ -80,60 +82,80 @@ wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualListCtrl)
 	EVT_MENU(MP_RENAME, CSharedFilesCtrl::OnRename)
 	EVT_MENU(MP_WS, CSharedFilesCtrl::OnGetFeedback)
 	EVT_MENU(MP_VERIFY, CSharedFilesCtrl::OnVerifyLocalData)
-	EVT_CHAR(CSharedFilesCtrl::OnKeyPressed)
 wxEND_EVENT_TABLE()
 
-enum SharedFilesListColumns
-{
-	ID_SHARED_COL_NAME = 0,
-	ID_SHARED_COL_SIZE,
-	ID_SHARED_COL_TYPE,
-	ID_SHARED_COL_PRIO,
-	ID_SHARED_COL_REQ,
-	ID_SHARED_COL_AREQ,
-	ID_SHARED_COL_TRA,
-	ID_SHARED_COL_RTIO,
-	ID_SHARED_COL_PART,
-	ID_SHARED_COL_CMPL,
-	ID_SHARED_COL_SPEED,
-	ID_SHARED_COL_SINCE,
-	ID_SHARED_COL_LASTUP,
-	ID_SHARED_COL_PATH
-};
-
 CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos, wxSize size, int flags)
-: CMuleVirtualListCtrl(parent, id, pos, size, flags | wxLC_OWNERDRAW)
+: CMuleVirtualDataViewCtrl(parent, id, pos, size, flags)
 , m_inBulkUpdate(false)
 , m_batchUpdate(false)
 , m_shownSize(0)
 {
-	// Setting the sorter function.
-	SetSortFunc(SortProc);
-
-	// Set the table-name (for loading and saving preferences).
-	SetTableName("Shared");
-
 	m_menu = NULL;
 
-	InsertColumn(ID_SHARED_COL_NAME, _("File Name"), wxLIST_FORMAT_LEFT, 250, "N");
-	InsertColumn(ID_SHARED_COL_SIZE, _("Size"), wxLIST_FORMAT_LEFT, 100, "Z");
-	InsertColumn(ID_SHARED_COL_TYPE, _("Type"), wxLIST_FORMAT_LEFT, 50, "Y");
-	InsertColumn(ID_SHARED_COL_PRIO, _("Priority"), wxLIST_FORMAT_LEFT, 70, "p");
-	InsertColumn(ID_SHARED_COL_REQ, _("Requests"), wxLIST_FORMAT_LEFT, 100, "Q");
-	InsertColumn(ID_SHARED_COL_AREQ, _("Accepted Requests"), wxLIST_FORMAT_LEFT, 100, "A");
-	InsertColumn(ID_SHARED_COL_TRA, _("Transferred Data"), wxLIST_FORMAT_LEFT, 120, "T");
-	InsertColumn(ID_SHARED_COL_RTIO, _("Share Ratio"), wxLIST_FORMAT_LEFT, 100, "R");
-	InsertColumn(ID_SHARED_COL_PART, _("Obtained Parts"), wxLIST_FORMAT_LEFT, 120, "P");
-	InsertColumn(ID_SHARED_COL_CMPL, _("Complete Sources"), wxLIST_FORMAT_LEFT, 120, "C");
+	// The name column carries the rating/comment smiley, so it is icon+text;
+	// Obtained Parts is the availability bar; the rest are plain text.
+	const int colFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+	AppendIconTextColumn(
+		_("File Name"), COLUMN_SHARED_NAME, wxDATAVIEW_CELL_INERT, 250, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(_("Size"), COLUMN_SHARED_SIZE, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(_("Type"), COLUMN_SHARED_TYPE, wxDATAVIEW_CELL_INERT, 50, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(
+		_("Priority"), COLUMN_SHARED_PRIO, wxDATAVIEW_CELL_INERT, 70, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(
+		_("Requests"), COLUMN_SHARED_REQ, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(_("Accepted Requests"),
+		COLUMN_SHARED_AREQ,
+		wxDATAVIEW_CELL_INERT,
+		100,
+		wxALIGN_LEFT,
+		colFlags);
+	AppendTextColumn(
+		_("Transferred Data"), COLUMN_SHARED_TRA, wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(
+		_("Share Ratio"), COLUMN_SHARED_RTIO, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
+	AppendBarColumn(_("Obtained Parts"), COLUMN_SHARED_PART, 120, colFlags);
+	AppendTextColumn(_("Complete Sources"),
+		COLUMN_SHARED_CMPL,
+		wxDATAVIEW_CELL_INERT,
+		120,
+		wxALIGN_LEFT,
+		colFlags);
 	// FileID (== file hash) was dropped — the hash is on the details modal. The
 	// three new columns reuse existing translations ("Speed", "Shared since",
 	// "Last upload"); Directory Path stays but moves to the end.
-	InsertColumn(ID_SHARED_COL_SPEED, _("Speed"), wxLIST_FORMAT_LEFT, 90, "U");
-	InsertColumn(ID_SHARED_COL_SINCE, _("Shared since"), wxLIST_FORMAT_LEFT, 130, "H");
-	InsertColumn(ID_SHARED_COL_LASTUP, _("Last upload"), wxLIST_FORMAT_LEFT, 130, "L");
-	InsertColumn(ID_SHARED_COL_PATH, _("Directory Path"), wxLIST_FORMAT_LEFT, 220, "D");
+	AppendTextColumn(_("Speed"), COLUMN_SHARED_SPEED, wxDATAVIEW_CELL_INERT, 90, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(
+		_("Shared since"), COLUMN_SHARED_SINCE, wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(
+		_("Last upload"), COLUMN_SHARED_LASTUP, wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT, colFlags);
+	AppendTextColumn(
+		_("Directory Path"), COLUMN_SHARED_PATH, wxDATAVIEW_CELL_INERT, 220, wxALIGN_LEFT, colFlags);
 
-	LoadSettings();
+	AppendSpacerColumn(COLUMN_SHARED_SPACER);
+	AssociateVirtualModel();
+
+	m_columnStore.RegisterColumn(COLUMN_SHARED_NAME, 250, "N");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_SIZE, 100, "Z");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_TYPE, 50, "Y");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_PRIO, 70, "p");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_REQ, 100, "Q");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_AREQ, 100, "A");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_TRA, 120, "T");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_RTIO, 100, "R");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_PART, 120, "P");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_CMPL, 120, "C");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_SPEED, 90, "U");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_SINCE, 130, "H");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_LASTUP, 130, "L");
+	m_columnStore.RegisterColumn(COLUMN_SHARED_PATH, 220, "D");
+
+	// Default sort is by name, ascending; LoadColumnSettings() replaces it
+	// when the config has something saved.
+	ApplySorting(COLUMN_SHARED_NAME, 0);
+
+	m_columnStore.SetTableName("Shared");
+	LoadColumnSettings();
+	InitColumnState();
 }
 
 wxString CSharedFilesCtrl::GetOldColumnOrder() const
@@ -143,12 +165,28 @@ wxString CSharedFilesCtrl::GetOldColumnOrder() const
 
 CSharedFilesCtrl::~CSharedFilesCtrl() {}
 
-void CSharedFilesCtrl::OnRightClick(wxListEvent &event)
+void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 {
-	long item_hit = CheckSelection(event);
-	m_menuItem = (item_hit != -1) ? ItemAt(item_hit) : 0;
+	// Right-clicking a row outside the selection acts on that row alone.
+	if (event.GetItem().IsOk()) {
+		wxDataViewItemArray selection;
+		GetSelections(selection);
+		if (selection.Index(event.GetItem()) == wxNOT_FOUND) {
+			UnselectAll();
+			Select(event.GetItem());
+		}
+	}
 
-	if ((m_menu == NULL) && (item_hit != -1)) {
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.empty()) {
+		return;
+	}
+	// Bound re-checked by the handlers that use it (OnOpenFile,
+	// OnShowInFolder): PopupMenu runs a nested event loop, so the shared-dir
+	// watcher can mutate the list while the menu is open.
+	m_menuItem = selected.front();
+
+	if (m_menu == NULL) {
 		m_menu = new wxMenu(_("Shared Files"));
 		wxMenu *prioMenu = new wxMenu();
 		prioMenu->AppendCheckItem(MP_PRIOVERYLOW, _("Very low"));
@@ -168,7 +206,7 @@ void CSharedFilesCtrl::OnRightClick(wxListEvent &event)
 		m_menu->Append(MP_METINFO, _("Show file &details"));
 		m_menu->AppendSeparator();
 
-		CKnownFile *file = FileAtRow(item_hit);
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(m_menuItem);
 		if (file->GetFileComment().IsEmpty() && !file->GetFileRating()) {
 			m_menu->Append(MP_CMT, _("Add Comment/Rating"));
 		} else {
@@ -234,7 +272,7 @@ void CSharedFilesCtrl::OnRightClick(wxListEvent &event)
 		prioMenu->Check(MP_POWERSHARE, priority == PR_POWERSHARE);
 		prioMenu->Check(MP_PRIOAUTO, priority == PR_AUTO);
 
-		PopupMenu(m_menu, event.GetPoint());
+		PopupMenu(m_menu);
 
 		delete m_menu;
 
@@ -244,17 +282,17 @@ void CSharedFilesCtrl::OnRightClick(wxListEvent &event)
 
 void CSharedFilesCtrl::ShowFileDetailDialog(long focused)
 {
-	if (focused == -1) {
+	if (focused < 0) {
 		return;
 	}
 	// Pass every listed file so the dialog's Next/Prev can walk the shared
 	// list, anchored on the clicked row. Reuses the same CFileDetailDialog as
 	// the downloads list; per-file state decides which sections it shows.
 	std::vector<CKnownFile *> files;
-	int nrItems = GetItemCount();
+	const long nrItems = ItemDataCount();
 	files.reserve(nrItems);
 	int index = 0;
-	for (int i = 0; i < nrItems; i++) {
+	for (long i = 0; i < nrItems; i++) {
 		if (i == focused) {
 			index = static_cast<int>(files.size());
 		}
@@ -265,43 +303,55 @@ void CSharedFilesCtrl::ShowFileDetailDialog(long focused)
 
 void CSharedFilesCtrl::OnViewFileDetails(wxCommandEvent &WXUNUSED(event))
 {
-	ShowFileDetailDialog(GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED));
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (!selected.empty()) {
+		ShowFileDetailDialog(RowOfData(selected.front()));
+	}
 }
 
-void CSharedFilesCtrl::OnItemActivated(wxListEvent &event)
+void CSharedFilesCtrl::OnItemActivated(wxDataViewEvent &event)
 {
-	ShowFileDetailDialog(event.GetIndex());
+	// Open details on the activated row alone, whatever else was selected.
+	// event.GetItem()'s ID is the row-addressed model's row index, not the
+	// item data -- see the "item identity is not row identity" note in
+	// MuleVirtualDataViewCtrl.h -- so the row is resolved through the
+	// selection rather than cast directly from the item.
+	if (!event.GetItem().IsOk()) {
+		return;
+	}
+	UnselectAll();
+	Select(event.GetItem());
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (!selected.empty()) {
+		ShowFileDetailDialog(RowOfData(selected.front()));
+	}
 }
 
 void CSharedFilesCtrl::OnVerifyLocalData(wxCommandEvent &WXUNUSED(event))
 {
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	while (index != -1) {
-		CKnownFile *file = FileAtRow(index);
-		if (file->IsPartFile())
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
+		if (file->IsPartFile()) {
 			AddLogLineN(
 				CFormat(_("Verify Local Data on PartFile is currently not supported: %s")) %
 				file->GetFileName());
-		else
+		} else {
 			theApp->sharedfiles->VerifyLocalData(file);
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+		}
 	}
 }
 
 void CSharedFilesCtrl::OnGetFeedback(wxCommandEvent &WXUNUSED(event))
 {
 	wxString feed;
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	while (index != -1) {
+	for (wxUIntPtr data : GetSelectedItemData()) {
 		if (feed.IsEmpty()) {
 			feed = CFormat(_("Feedback from: %s (%s)\n\n")) % thePrefs::GetUserNick() %
 			       theApp->GetFullMuleVersion();
 		} else {
 			feed += "\n";
 		}
-		feed += FileAtRow(index)->GetFeedback();
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+		feed += reinterpret_cast<CKnownFile *>(data)->GetFeedback();
 	}
 
 	if (!feed.IsEmpty()) {
@@ -309,25 +359,193 @@ void CSharedFilesCtrl::OnGetFeedback(wxCommandEvent &WXUNUSED(event))
 	}
 }
 
-wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, long WXUNUSED(column)) const
+wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) const
 {
-	// Owner-drawn: only used for keyboard type-ahead, so the file name is enough.
 	CKnownFile *file = reinterpret_cast<CKnownFile *>(item);
-	return file ? file->GetFileName().GetPrintable() : wxString();
+
+	switch (column) {
+	case COLUMN_SHARED_NAME:
+		// The rating/comment smiley is the icon on this column, not part of
+		// the text -- see GetItemIcon().
+		return file->GetFileName().GetPrintable();
+
+	case COLUMN_SHARED_SIZE:
+		return CastItoXBytes(file->GetFileSize());
+
+	case COLUMN_SHARED_TYPE:
+		return GetFiletypeByName(file->GetFileName());
+
+	case COLUMN_SHARED_PRIO:
+		return PriorityToStr(file->GetUpPriority(), file->IsAutoUpPriority());
+
+	case COLUMN_SHARED_REQ:
+		return CFormat("%u (%u)") % file->statistic.GetRequests() %
+		       file->statistic.GetAllTimeRequests();
+
+	case COLUMN_SHARED_AREQ:
+		return CFormat("%u (%u)") % file->statistic.GetAccepts() %
+		       file->statistic.GetAllTimeAccepts();
+
+	case COLUMN_SHARED_TRA:
+		return CastItoXBytes(file->statistic.GetTransferred()) + " (" +
+		       CastItoXBytes(file->statistic.GetAllTimeTransferred()) + ")";
+
+	case COLUMN_SHARED_RTIO:
+		return CFormat("%.2f") %
+		       ((double)file->statistic.GetAllTimeTransferred() / file->GetFileSize());
+
+	case COLUMN_SHARED_CMPL:
+		if (file->m_nCompleteSourcesCountLo == 0) {
+			if (file->m_nCompleteSourcesCountHi) {
+				return CFormat("< %u") % file->m_nCompleteSourcesCountHi;
+			}
+			return "0";
+		} else if (file->m_nCompleteSourcesCountLo == file->m_nCompleteSourcesCountHi) {
+			return CFormat("%u") % file->m_nCompleteSourcesCountLo;
+		} else {
+			return CFormat("%u - %u") % file->m_nCompleteSourcesCountLo %
+			       file->m_nCompleteSourcesCountHi;
+		}
+
+	case COLUMN_SHARED_SPEED:
+		// Live upload speed, adaptive kB/s / MB/s and blank below
+		// 1 kB/s — same formatting as the peers (client) list. Sorting
+		// uses the raw byte/s value (see CompareItemData), not this string.
+		if (file->GetUploadDatarate() >= 1024) {
+			if (file->GetUploadDatarate() >= 1048576) {
+				return CFormat(_("%.1f MB/s")) % (file->GetUploadDatarate() / 1048576.0);
+			}
+			return CFormat(_("%.1f kB/s")) % (file->GetUploadDatarate() / 1024.0);
+		}
+		return wxEmptyString;
+
+	case COLUMN_SHARED_SINCE:
+		if (file->GetDateShared()) {
+			wxDateTime ds(file->GetDateShared());
+			return ds.FormatISODate() + " " + ds.FormatISOTime();
+		}
+		return wxEmptyString;
+
+	case COLUMN_SHARED_LASTUP:
+		if (file->GetLastUpload()) {
+			wxDateTime lu(file->GetLastUpload());
+			return lu.FormatISODate() + " " + lu.FormatISOTime();
+		}
+		return wxEmptyString;
+
+	case COLUMN_SHARED_PATH:
+		// Status-agnostic: the Temp dir for a partfile, the
+		// destination once completed (EC_TAG_KNOWNFILE_PATH in
+		// the remote GUI).
+		return file->GetFilePath().GetPrintable();
+
+	default:
+		return wxEmptyString;
+	}
+}
+
+bool CSharedFilesCtrl::GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const
+{
+	if (column != COLUMN_SHARED_NAME) {
+		return false;
+	}
+	CKnownFile *file = reinterpret_cast<CKnownFile *>(item);
+	if (!file->GetFileRating() && file->GetFileComment().Length() == 0) {
+		return false;
+	}
+
+	int image = Client_CommentOnly_Smiley;
+	if (file->GetFileRating()) {
+		image = Client_InvalidRating_Smiley + file->GetFileRating() - 1;
+	}
+	wxASSERT(image >= Client_InvalidRating_Smiley);
+	wxASSERT(image <= Client_CommentOnly_Smiley);
+
+	icon = theApp->amuledlg->m_imagelist.GetIcon(image);
+	return true;
+}
+
+void CSharedFilesCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const
+{
+	if (column != COLUMN_SHARED_PART) {
+		return;
+	}
+	CKnownFile *file = reinterpret_cast<CKnownFile *>(item);
+	if (!file->GetPartCount()) {
+		return;
+	}
+
+	std::vector<CBarFillSpan> spans;
+	const bool bFlat = thePrefs::UseFlatBar();
+
+	if (file->GetHashingProgress() > 0) {
+		const CMuleColour crPending(255, 208, 0);
+		const CMuleColour crFlatPending(255, 255, 100);
+		const CMuleColour crProgress(0, 224, 0);
+		const CMuleColour crFlatProgress(0, 150, 0);
+
+		uint64 left = file->GetHashingProgress() * PARTSIZE;
+		if (left < file->GetFileSize() - 1) {
+			spans.push_back(
+				{ left + 1, file->GetFileSize() - 1, bFlat ? crFlatPending : crPending });
+		} else {
+			left = file->GetFileSize() - 1;
+		}
+		// The amount already hashed, in green.
+		spans.push_back({ 0, left, bFlat ? crFlatProgress : crProgress });
+	} else {
+		// Reference to the availability list
+		const ArrayOfUInts16 &list = file->IsPartFile()
+						     ? static_cast<CPartFile *>(file)->m_SrcpartFrequency
+						     : file->m_AvailPartFrequency;
+
+		uint64 end = 0;
+		for (unsigned int i = 0; i < list.size(); ++i) {
+			const uint64 start = PARTSIZE * static_cast<uint64>(i);
+			end = PARTSIZE * static_cast<uint64>(i + 1);
+			spans.push_back({ start,
+				end,
+				CMuleColour(list[i] ? 0 : 255,
+					list[i] ? ((210 - (22 * (list[i] - 1)) < 0)
+								  ? 0
+								  : (210 - (22 * (list[i] - 1))))
+						: 0,
+					list[i] ? 255 : 0) });
+		}
+		spans.push_back({ end + 1, file->GetFileSize() - 1, CMuleColour(255, 0, 0) });
+	}
+
+	out = CBarFillSpec(file->GetFileSize(), std::move(spans));
+}
+
+bool CSharedFilesCtrl::AltSortAllowed(unsigned column) const
+{
+	switch (column) {
+	case COLUMN_SHARED_REQ:
+	case COLUMN_SHARED_AREQ:
+	case COLUMN_SHARED_TRA:
+		return true;
+
+	default:
+		return false;
+	}
 }
 
 bool CSharedFilesCtrl::IsLiveSortColumn() const
 {
 	// Columns whose values change while sharing/uploading. Static columns
 	// (name, size, type, priority, shared-since, path) never auto-resort.
-	switch (GetSortColumn()) {
-	case ID_SHARED_COL_REQ:
-	case ID_SHARED_COL_AREQ:
-	case ID_SHARED_COL_TRA:
-	case ID_SHARED_COL_RTIO:
-	case ID_SHARED_COL_CMPL:
-	case ID_SHARED_COL_SPEED:
-	case ID_SHARED_COL_LASTUP:
+	if (m_sort_orders.empty()) {
+		return false;
+	}
+	switch (static_cast<int>(m_sort_orders.front().first)) {
+	case COLUMN_SHARED_REQ:
+	case COLUMN_SHARED_AREQ:
+	case COLUMN_SHARED_TRA:
+	case COLUMN_SHARED_RTIO:
+	case COLUMN_SHARED_CMPL:
+	case COLUMN_SHARED_SPEED:
+	case COLUMN_SHARED_LASTUP:
 		return true;
 	default:
 		return false;
@@ -341,8 +559,7 @@ void CSharedFilesCtrl::ShowFileList()
 	// The rebuild renumbers every row, so keep selection + focus by item
 	// identity -- otherwise editing the filter (which comes through here)
 	// drops whatever the user had selected.
-	wxUIntPtr focused = 0;
-	const std::vector<wxUIntPtr> selected = SaveSelection(focused);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
 	ClearItemData();
 
@@ -357,7 +574,7 @@ void CSharedFilesCtrl::ShowFileList()
 	}
 	m_shownSize = totalSize;
 	FinishBulkLoad();
-	RestoreSelection(selected, focused);
+	SetSelectedItemData(selected);
 	ShowFilesCount();
 
 	Thaw();
@@ -365,8 +582,8 @@ void CSharedFilesCtrl::ShowFileList()
 
 void CSharedFilesCtrl::RebuildFilteredView()
 {
-	// Filter hook from CMuleVirtualListCtrl: the master share is the model, so
-	// the visible set is rebuilt from it in one pass.
+	// Filter hook from CMuleVirtualDataViewCtrl: the master share is the
+	// model, so the visible set is rebuilt from it in one pass.
 	ShowFileList();
 }
 
@@ -475,29 +692,19 @@ void CSharedFilesCtrl::OnSetPriority(wxCommandEvent &event)
 		break;
 	}
 
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	while (index != -1) {
-		CKnownFile *file = FileAtRow(index);
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
 		CoreNotify_KnownFile_Up_Prio_Set(file, priority);
-
-		RefreshItem(index);
-
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+		RefreshItemData(data);
 	}
 }
 
 void CSharedFilesCtrl::OnSetPriorityAuto(wxCommandEvent &WXUNUSED(event))
 {
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	while (index != -1) {
-		CKnownFile *file = FileAtRow(index);
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
 		CoreNotify_KnownFile_Up_Prio_Auto(file);
-
-		RefreshItem(index);
-
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+		RefreshItemData(data);
 	}
 }
 
@@ -528,13 +735,11 @@ wxString CSharedFilesCtrl::SelectedLinks(int menuId) const
 {
 	wxString links;
 
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	while (index != -1) {
-		const CKnownFile *file = FileAtRow(index);
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		const CKnownFile *file = reinterpret_cast<const CKnownFile *>(data);
 		if (file != nullptr) {
 			links += LinkForFile(file, menuId) + "\n";
 		}
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	}
 
 	return links;
@@ -638,41 +843,37 @@ void CSharedFilesCtrl::OnExportCollection(wxCommandEvent &WXUNUSED(evt))
 
 void CSharedFilesCtrl::OnEditComment(wxCommandEvent &WXUNUSED(event))
 {
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	if (index != -1) {
-		CKnownFile *file = FileAtRow(index);
-
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (!selected.empty()) {
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(selected.front());
 		CCommentDialog dialog(this, file);
-
 		dialog.ShowModal();
 	}
 }
 
-int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
+int CSharedFilesCtrl::CompareItemData(
+	wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const
 {
-	CKnownFile *file1 = reinterpret_cast<CKnownFile *>(item1);
-	CKnownFile *file2 = reinterpret_cast<CKnownFile *>(item2);
+	const CKnownFile *file1 = reinterpret_cast<const CKnownFile *>(data1);
+	const CKnownFile *file2 = reinterpret_cast<const CKnownFile *>(data2);
+	const int mod = modifier;
 
-	int mod = (sortData & CMuleListCtrl::SORT_DES) ? -1 : 1;
-	bool altSorting = (sortData & CMuleListCtrl::SORT_ALT) > 0;
-
-	switch (sortData & CMuleListCtrl::COLUMN_MASK) {
+	switch (column) {
 	// Sort by filename.
-	case ID_SHARED_COL_NAME:
+	case COLUMN_SHARED_NAME:
 		return mod * CmpAny(file1->GetFileName(), file2->GetFileName());
 
 	// Sort by filesize.
-	case ID_SHARED_COL_SIZE:
+	case COLUMN_SHARED_SIZE:
 		return mod * CmpAny(file1->GetFileSize(), file2->GetFileSize());
 
 	// Sort by filetype.
-	case ID_SHARED_COL_TYPE:
+	case COLUMN_SHARED_TYPE:
 		return mod * GetFiletypeByName(file1->GetFileName())
 				     .CmpNoCase(GetFiletypeByName(file2->GetFileName()));
 
 	// Sort by priority.
-	case ID_SHARED_COL_PRIO: {
+	case COLUMN_SHARED_PRIO: {
 		int8 prioA = file1->GetUpPriority();
 		int8 prioB = file2->GetUpPriority();
 
@@ -681,8 +882,8 @@ int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortDa
 	}
 
 	// Sort by Requests this session.
-	case ID_SHARED_COL_REQ:
-		if (altSorting) {
+	case COLUMN_SHARED_REQ:
+		if (alt) {
 			return mod * CmpAny(file1->statistic.GetAllTimeRequests(),
 					     file2->statistic.GetAllTimeRequests());
 		} else {
@@ -690,8 +891,8 @@ int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortDa
 		}
 
 	// Sort by accepted requests. Ascending.
-	case ID_SHARED_COL_AREQ:
-		if (altSorting) {
+	case COLUMN_SHARED_AREQ:
+		if (alt) {
 			return mod * CmpAny(file1->statistic.GetAllTimeAccepts(),
 					     file2->statistic.GetAllTimeAccepts());
 		} else {
@@ -699,8 +900,8 @@ int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortDa
 		}
 
 	// Sort by transferred. Ascending.
-	case ID_SHARED_COL_TRA:
-		if (altSorting) {
+	case COLUMN_SHARED_TRA:
+		if (alt) {
 			return mod * CmpAny(file1->statistic.GetAllTimeTransferred(),
 					     file2->statistic.GetAllTimeTransferred());
 		} else {
@@ -709,28 +910,28 @@ int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortDa
 		}
 
 	// Sort by Share Ratio. Ascending.
-	case ID_SHARED_COL_RTIO:
+	case COLUMN_SHARED_RTIO:
 		return mod * CmpAny((double)file1->statistic.GetAllTimeTransferred() / file1->GetFileSize(),
 				     (double)file2->statistic.GetAllTimeTransferred() / file2->GetFileSize());
 
 	// Complete sources asc
-	case ID_SHARED_COL_CMPL:
+	case COLUMN_SHARED_CMPL:
 		return mod * CmpAny(file1->m_nCompleteSourcesCount, file2->m_nCompleteSourcesCount);
 
 	// Live upload speed asc
-	case ID_SHARED_COL_SPEED:
+	case COLUMN_SHARED_SPEED:
 		return mod * CmpAny(file1->GetUploadDatarate(), file2->GetUploadDatarate());
 
 	// Shared-since date asc
-	case ID_SHARED_COL_SINCE:
+	case COLUMN_SHARED_SINCE:
 		return mod * CmpAny(file1->GetDateShared(), file2->GetDateShared());
 
 	// Last-upload date asc
-	case ID_SHARED_COL_LASTUP:
+	case COLUMN_SHARED_LASTUP:
 		return mod * CmpAny(file1->GetLastUpload(), file2->GetLastUpload());
 
 	// Directory path asc (status-agnostic: the Temp dir for a partfile)
-	case ID_SHARED_COL_PATH:
+	case COLUMN_SHARED_PATH:
 		return mod * CmpAny(file1->GetFilePath(), file2->GetFilePath());
 
 	default:
@@ -743,20 +944,22 @@ void CSharedFilesCtrl::UpdateItem(CKnownFile *toupdate)
 	if (m_inBulkUpdate) {
 		// Caller (e.g. CSharedFileList::ClearED2KPublishInfo) will
 		// issue a single Refresh() in EndBulkUpdate(). Skipping the
-		// per-row FindItem here is what turns ClearED2KPublishInfo
+		// per-row refresh here is what turns ClearED2KPublishInfo
 		// from O(N²) into O(N) for users with thousands of shared
 		// files. See #302.
 		return;
 	}
-	const long row = RowOfData(reinterpret_cast<wxUIntPtr>(toupdate));
-	if (row != -1) {
-		// Base repaints the row and, if sorted by a live column, schedules the
-		// throttled+idle-gated re-sort.
-		RefreshItemData(reinterpret_cast<wxUIntPtr>(toupdate));
+	const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(toupdate);
+	if (!HasItemData(data)) {
+		return;
+	}
+	// Repaints the row and, if sorted by a live column, schedules the
+	// throttled+idle-gated re-sort.
+	RefreshItemData(data);
 
-		if (GetItemState(row, wxLIST_STATE_SELECTED)) {
-			theApp->amuledlg->m_sharedfileswnd->SelectionUpdated();
-		}
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (std::find(selected.begin(), selected.end(), data) != selected.end()) {
+		theApp->amuledlg->m_sharedfileswnd->SelectionUpdated();
 	}
 }
 
@@ -781,7 +984,7 @@ void CSharedFilesCtrl::ShowFilesCount()
 {
 	wxStaticText *label = CastByName("sharedFilesLabel", GetParent(), wxStaticText);
 
-	label->SetLabel(CFormat(_("Shared Files (%i)")) % GetItemCount());
+	label->SetLabel(CFormat(_("Shared Files (%i)")) % ItemDataCount());
 
 	// Combined size of the shown files. The label lives in the statistics box
 	// (the bottom pane of the shared splitter), a different window from this
@@ -802,319 +1005,55 @@ void CSharedFilesCtrl::ShowFilesCount()
 	theApp->amuledlg->m_sharedfileswnd->SelectionUpdated();
 }
 
-void CSharedFilesCtrl::OnDrawItem(
-	int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted)
-{
-	CKnownFile *file = FileAtRow(item);
-	wxASSERT(file);
-
-	if (highlighted) {
-		CMuleColour newcol = GetFocus() ? CMuleColour(wxSYS_COLOUR_HIGHLIGHT)
-						: CMuleColour(CMuleColour::GetUnfocusedHighlight());
-		dc->SetBackground(newcol /*.Blend(125)*/.GetBrush());
-		dc->SetTextForeground(CMuleColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
-		// The second blending goes over the first one.
-		dc->SetPen(newcol.Blend(65).GetPen());
-	} else {
-		dc->SetBackground(CMuleColour(wxSYS_COLOUR_LISTBOX).GetBrush());
-		dc->SetTextForeground(CMuleColour(wxSYS_COLOUR_WINDOWTEXT));
-		dc->SetPen(*wxTRANSPARENT_PEN);
-	}
-
-	dc->SetBrush(dc->GetBackground());
-	dc->DrawRectangle(rectHL);
-	dc->SetPen(*wxTRANSPARENT_PEN);
-
-	// Offset based on the height of the fonts
-	const int textVOffset = (rect.GetHeight() - dc->GetCharHeight()) / 2;
-	// Empty space to each side of a column
-	const int SPARE_PIXELS_HORZ = 4;
-
-	// The leftmost position of the current column
-	int columnLeft = 0;
-
-	for (int i = 0; i < GetColumnCount(); ++i) {
-		const int columnWidth = GetColumnWidth(i);
-
-		if (columnWidth > 2 * SPARE_PIXELS_HORZ) {
-			wxRect columnRect(columnLeft + SPARE_PIXELS_HORZ,
-				rect.y,
-				columnWidth - 2 * SPARE_PIXELS_HORZ,
-				rect.height);
-
-			wxDCClipper clipper(*dc, columnRect);
-
-			wxString textBuffer;
-			switch (i) {
-			case ID_SHARED_COL_NAME:
-				textBuffer = file->GetFileName().GetPrintable();
-
-				if (file->GetFileRating() || file->GetFileComment().Length()) {
-					int image = Client_CommentOnly_Smiley;
-					if (file->GetFileRating()) {
-						image = Client_InvalidRating_Smiley + file->GetFileRating() -
-							1;
-					}
-
-					wxASSERT(image >= Client_InvalidRating_Smiley);
-					wxASSERT(image <= Client_CommentOnly_Smiley);
-
-					int imgWidth = 16;
-
-					theApp->amuledlg->m_imagelist.Draw(image,
-						*dc,
-						columnRect.x,
-						columnRect.y + 1,
-						wxIMAGELIST_DRAW_TRANSPARENT);
-
-					// Move the text to the right
-					columnRect.x += (imgWidth + 4);
-				}
-
-				break;
-
-			case ID_SHARED_COL_SIZE:
-				textBuffer = CastItoXBytes(file->GetFileSize());
-				break;
-
-			case ID_SHARED_COL_TYPE:
-				textBuffer = GetFiletypeByName(file->GetFileName());
-				break;
-
-			case ID_SHARED_COL_PRIO:
-				textBuffer = PriorityToStr(file->GetUpPriority(), file->IsAutoUpPriority());
-				break;
-
-			case ID_SHARED_COL_REQ:
-				textBuffer = CFormat("%u (%u)") % file->statistic.GetRequests() %
-					     file->statistic.GetAllTimeRequests();
-				break;
-
-			case ID_SHARED_COL_AREQ:
-				textBuffer = CFormat("%u (%u)") % file->statistic.GetAccepts() %
-					     file->statistic.GetAllTimeAccepts();
-				break;
-
-			case ID_SHARED_COL_TRA:
-				textBuffer = CastItoXBytes(file->statistic.GetTransferred()) + " (" +
-					     CastItoXBytes(file->statistic.GetAllTimeTransferred()) + ")";
-				break;
-
-			case ID_SHARED_COL_RTIO:
-				textBuffer =
-					CFormat("%.2f") % ((double)file->statistic.GetAllTimeTransferred() /
-								  file->GetFileSize());
-				break;
-
-			case ID_SHARED_COL_PART:
-				if (file->GetPartCount()) {
-					wxRect barRect(columnRect.x,
-						columnRect.y + 1,
-						columnRect.width,
-						columnRect.height - 2);
-
-					DrawAvailabilityBar(file, dc, barRect);
-				}
-				break;
-
-			case ID_SHARED_COL_CMPL:
-				if (file->m_nCompleteSourcesCountLo == 0) {
-					if (file->m_nCompleteSourcesCountHi) {
-						textBuffer =
-							CFormat("< %u") % file->m_nCompleteSourcesCountHi;
-					} else {
-						textBuffer = "0";
-					}
-				} else if (file->m_nCompleteSourcesCountLo ==
-					   file->m_nCompleteSourcesCountHi) {
-					textBuffer = CFormat("%u") % file->m_nCompleteSourcesCountLo;
-				} else {
-					textBuffer = CFormat("%u - %u") % file->m_nCompleteSourcesCountLo %
-						     file->m_nCompleteSourcesCountHi;
-				}
-
-				break;
-
-			case ID_SHARED_COL_SPEED:
-				// Live upload speed, adaptive kB/s / MB/s and blank below
-				// 1 kB/s — same formatting as the peers (client) list. Sorting
-				// uses the raw byte/s value (see SortProc), not this string.
-				if (file->GetUploadDatarate() >= 1024) {
-					if (file->GetUploadDatarate() >= 1048576) {
-						textBuffer = CFormat(_("%.1f MB/s")) %
-							     (file->GetUploadDatarate() / 1048576.0);
-					} else {
-						textBuffer = CFormat(_("%.1f kB/s")) %
-							     (file->GetUploadDatarate() / 1024.0);
-					}
-				}
-				break;
-
-			case ID_SHARED_COL_SINCE:
-				if (file->GetDateShared()) {
-					wxDateTime ds(file->GetDateShared());
-					textBuffer = ds.FormatISODate() + " " + ds.FormatISOTime();
-				}
-				break;
-
-			case ID_SHARED_COL_LASTUP:
-				if (file->GetLastUpload()) {
-					wxDateTime lu(file->GetLastUpload());
-					textBuffer = lu.FormatISODate() + " " + lu.FormatISOTime();
-				}
-				break;
-
-			case ID_SHARED_COL_PATH:
-				// Status-agnostic: the Temp dir for a partfile, the
-				// destination once completed (EC_TAG_KNOWNFILE_PATH in
-				// the remote GUI).
-				textBuffer = file->GetFilePath().GetPrintable();
-			}
-
-			if (!textBuffer.IsEmpty()) {
-				dc->DrawText(textBuffer, columnRect.x, columnRect.y + textVOffset);
-			}
-		}
-
-		// Move to the next column
-		columnLeft += columnWidth;
-	}
-}
-
-wxString CSharedFilesCtrl::GetTTSText(unsigned item) const
-{
-	return FileAtRow(item)->GetFileName().GetPrintable();
-}
-
-bool CSharedFilesCtrl::AltSortAllowed(unsigned column) const
-{
-	switch (column) {
-	case ID_SHARED_COL_REQ:
-	case ID_SHARED_COL_AREQ:
-	case ID_SHARED_COL_TRA:
-		return true;
-
-	default:
-		return false;
-	}
-}
-
-void CSharedFilesCtrl::DrawAvailabilityBar(CKnownFile *file, wxDC *dc, const wxRect &rect) const
-{
-	// Reference to the availability list
-	const ArrayOfUInts16 &list = file->IsPartFile() ? static_cast<CPartFile *>(file)->m_SrcpartFrequency
-							: file->m_AvailPartFrequency;
-	wxPen old_pen = dc->GetPen();
-	wxBrush old_brush = dc->GetBrush();
-	bool bFlat = thePrefs::UseFlatBar();
-
-	wxRect barRect = rect;
-	if (!bFlat) { // round bar has a black border, the bar itself is 1 pixel less on each border
-		barRect.x++;
-		barRect.y++;
-		barRect.height -= 2;
-		barRect.width -= 2;
-	}
-	static CBarShader s_ChunkBar;
-	s_ChunkBar.SetFileSize(file->GetFileSize());
-	s_ChunkBar.SetHeight(barRect.GetHeight());
-	s_ChunkBar.SetWidth(barRect.GetWidth());
-	s_ChunkBar.Set3dDepth(CPreferences::Get3DDepth());
-
-	if (file->GetHashingProgress() > 0) {
-		const CMuleColour crPending(255, 208, 0);
-		const CMuleColour crFlatPending(255, 255, 100);
-		const CMuleColour crProgress(0, 224, 0);
-		const CMuleColour crFlatProgress(0, 150, 0);
-
-		uint64 left = file->GetHashingProgress() * PARTSIZE;
-		if (left < file->GetFileSize() - 1) {
-			s_ChunkBar.FillRange(
-				left + 1, file->GetFileSize() - 1, bFlat ? crFlatPending : crPending);
-		} else {
-			left = file->GetFileSize() - 1;
-		}
-		// Fill the amount already hashed with green.
-		s_ChunkBar.FillRange(0, left, bFlat ? crFlatProgress : crProgress);
-		s_ChunkBar.Draw(dc, barRect.x, barRect.y, bFlat);
-	} else {
-		uint64 end = 0;
-		for (unsigned int i = 0; i < list.size(); ++i) {
-			uint64 start = PARTSIZE * static_cast<uint64>(i);
-			end = PARTSIZE * static_cast<uint64>(i + 1);
-			s_ChunkBar.FillRange(start,
-				end,
-				CMuleColour(list[i] ? 0 : 255,
-					list[i] ? ((210 - (22 * (list[i] - 1)) < 0)
-								  ? 0
-								  : (210 - (22 * (list[i] - 1))))
-						: 0,
-					list[i] ? 255 : 0));
-		}
-		s_ChunkBar.FillRange(end + 1, file->GetFileSize() - 1, CMuleColour(255, 0, 0));
-		s_ChunkBar.Draw(dc, barRect.x, barRect.y, bFlat);
-	}
-
-	if (!bFlat) {
-		// Draw black border
-		dc->SetPen(*wxBLACK_PEN);
-		dc->SetBrush(*wxTRANSPARENT_BRUSH);
-		dc->DrawRectangle(rect);
-	}
-
-	dc->SetPen(old_pen);
-	dc->SetBrush(old_brush);
-}
-
 void CSharedFilesCtrl::OnRename(wxCommandEvent &WXUNUSED(event))
 {
-	int item = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	if (item != -1) {
-		CKnownFile *file = FileAtRow(item);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.empty()) {
+		return;
+	}
+	CKnownFile *file = reinterpret_cast<CKnownFile *>(selected.front());
 
-		wxString strNewName = ::wxGetTextFromUser(_("Enter new name for this file:"),
-			_("File rename"),
-			file->GetFileName().GetPrintable());
+	wxString strNewName = ::wxGetTextFromUser(
+		_("Enter new name for this file:"), _("File rename"), file->GetFileName().GetPrintable());
 
-		CPath newName = CPath(strNewName);
-		if (newName.IsOk() && (newName != file->GetFileName())) {
-			theApp->sharedfiles->RenameFile(file, newName);
-		}
+	CPath newName = CPath(strNewName);
+	if (newName.IsOk() && (newName != file->GetFileName())) {
+		theApp->sharedfiles->RenameFile(file, newName);
 	}
 }
 
-void CSharedFilesCtrl::OnKeyPressed(wxKeyEvent &event)
+bool CSharedFilesCtrl::OnListKey(wxKeyEvent &event)
 {
 	if (event.GetKeyCode() == WXK_F2) {
 		wxCommandEvent evt;
 		OnRename(evt);
-
-		return;
+		return true;
 	}
-	event.Skip();
+	return false;
 }
 
 void CSharedFilesCtrl::OnAddCollection(wxCommandEvent &WXUNUSED(evt))
 {
-	int item = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	if (item != -1) {
-		CKnownFile *file = FileAtRow(item);
-		wxString CollectionFile = file->GetFilePath().JoinPaths(file->GetFileName()).GetRaw();
-		CMuleCollection my_collection;
-		if (my_collection.Open(CollectionFile)) {
-			wxArrayString links;
-			for (size_t e = 0; e < my_collection.size(); ++e) {
-				// eMule stores collection strings as UTF-8. Fall back to
-				// raw bytes rather than dropping the entry, since
-				// FromUTF8 yields an empty string on invalid input.
-				wxString link = wxString::FromUTF8(my_collection[e].c_str());
-				if (link.IsEmpty()) {
-					link = wxString::From8BitData(my_collection[e].c_str());
-				}
-				links.Add(link);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.empty()) {
+		return;
+	}
+	CKnownFile *file = reinterpret_cast<CKnownFile *>(selected.front());
+	wxString CollectionFile = file->GetFilePath().JoinPaths(file->GetFileName()).GetRaw();
+	CMuleCollection my_collection;
+	if (my_collection.Open(CollectionFile)) {
+		wxArrayString links;
+		for (size_t e = 0; e < my_collection.size(); ++e) {
+			// eMule stores collection strings as UTF-8. Fall back to
+			// raw bytes rather than dropping the entry, since
+			// FromUTF8 yields an empty string on invalid input.
+			wxString link = wxString::FromUTF8(my_collection[e].c_str());
+			if (link.IsEmpty()) {
+				link = wxString::From8BitData(my_collection[e].c_str());
 			}
-			theApp->downloadqueue->AddLinks(links);
+			links.Add(link);
 		}
+		theApp->downloadqueue->AddLinks(links);
 	}
 }
 

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -29,22 +29,23 @@
 #include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
 
 #define COLUMN_SHARED_NAME 0
-#define COLUMN_SHARED_SIZE 1
-#define COLUMN_SHARED_TYPE 2
-#define COLUMN_SHARED_PRIO 3
-#define COLUMN_SHARED_REQ 4
-#define COLUMN_SHARED_AREQ 5
-#define COLUMN_SHARED_TRA 6
-#define COLUMN_SHARED_RTIO 7
-#define COLUMN_SHARED_PART 8
-#define COLUMN_SHARED_CMPL 9
-#define COLUMN_SHARED_SPEED 10
-#define COLUMN_SHARED_SINCE 11
-#define COLUMN_SHARED_LASTUP 12
-#define COLUMN_SHARED_PATH 13
+#define COLUMN_SHARED_RATING 1
+#define COLUMN_SHARED_SIZE 2
+#define COLUMN_SHARED_TYPE 3
+#define COLUMN_SHARED_PRIO 4
+#define COLUMN_SHARED_REQ 5
+#define COLUMN_SHARED_AREQ 6
+#define COLUMN_SHARED_TRA 7
+#define COLUMN_SHARED_RTIO 8
+#define COLUMN_SHARED_PART 9
+#define COLUMN_SHARED_CMPL 10
+#define COLUMN_SHARED_SPEED 11
+#define COLUMN_SHARED_SINCE 12
+#define COLUMN_SHARED_LASTUP 13
+#define COLUMN_SHARED_PATH 14
 //! Always empty. Absorbs the macOS trailing-column sizing; see
 //! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_SHARED_SPACER 14
+#define COLUMN_SHARED_SPACER 15
 
 class CSharedFileList;
 class CKnownFile;
@@ -136,7 +137,7 @@ protected:
 	/// Text of one cell, pulled on demand for the cells being drawn.
 	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
 
-	/// Rating/comment smiley on the Name column, nothing elsewhere.
+	/// Rating/comment smiley on the Rating column, nothing elsewhere.
 	bool GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const override;
 
 	/// Availability-bar spans for the Obtained Parts column.

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -26,7 +26,25 @@
 #ifndef SHAREDFILESCTRL_H
 #define SHAREDFILESCTRL_H
 
-#include "MuleVirtualListCtrl.h" // Needed for CMuleVirtualListCtrl
+#include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
+
+#define COLUMN_SHARED_NAME 0
+#define COLUMN_SHARED_SIZE 1
+#define COLUMN_SHARED_TYPE 2
+#define COLUMN_SHARED_PRIO 3
+#define COLUMN_SHARED_REQ 4
+#define COLUMN_SHARED_AREQ 5
+#define COLUMN_SHARED_TRA 6
+#define COLUMN_SHARED_RTIO 7
+#define COLUMN_SHARED_PART 8
+#define COLUMN_SHARED_CMPL 9
+#define COLUMN_SHARED_SPEED 10
+#define COLUMN_SHARED_SINCE 11
+#define COLUMN_SHARED_LASTUP 12
+#define COLUMN_SHARED_PATH 13
+//! Always empty. Absorbs the macOS trailing-column sizing; see
+//! CMuleDataViewCtrl::AppendSpacerColumn().
+#define COLUMN_SHARED_SPACER 14
 
 class CSharedFileList;
 class CKnownFile;
@@ -35,7 +53,7 @@ class wxMenu;
 /**
  * This class represents the widget used to list shared files.
  */
-class CSharedFilesCtrl : public CMuleVirtualListCtrl
+class CSharedFilesCtrl : public CMuleVirtualDataViewCtrl
 {
 public:
 	/**
@@ -58,8 +76,8 @@ public:
 	 * (case-insensitive) are shown; an empty string clears the filter. Purely
 	 * GUI-side, so it works the same in the monolithic app and amulegui.
 	 */
-	// SetFilterText() is inherited from CMuleVirtualListCtrl; the rebuild it
-	// triggers is RebuildFilteredView() below.
+	// SetFilterText() is inherited from CMuleVirtualDataViewCtrl; the rebuild
+	// it triggers is RebuildFilteredView() below.
 
 	/** Empties the list (virtual-mode: clears the model + row index). */
 	void ClearList();
@@ -113,7 +131,40 @@ public:
 
 protected:
 	/// Return old column order.
-	wxString GetOldColumnOrder() const;
+	wxString GetOldColumnOrder() const override;
+
+	/// Text of one cell, pulled on demand for the cells being drawn.
+	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
+
+	/// Rating/comment smiley on the Name column, nothing elsewhere.
+	bool GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const override;
+
+	/// Availability-bar spans for the Obtained Parts column.
+	void GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const override;
+
+	/** Whether the current primary sort column changes value during
+	 *  operation (drives the base's live auto-sort). */
+	bool IsLiveSortColumn() const override;
+
+	/** Pause live auto-sort while the context menu is open. */
+	bool IsMenuOpen() const override { return m_menu != nullptr; }
+
+	/// Single-column comparison for the base's sort chain.
+	int CompareItemData(
+		wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const override;
+
+	/**
+	 * Function that specifies which columns have alternate sorting.
+	 *
+	 * @see CMuleListCtrl::AltSortAllowed
+	 */
+	bool AltSortAllowed(unsigned column) const override;
+
+	//! True if @a file passes the current text filter (name substring match).
+	/**
+	 * @see CMuleVirtualDataViewCtrl::RebuildFilteredView
+	 */
+	void RebuildFilteredView() override;
 
 private:
 	/**
@@ -126,65 +177,10 @@ private:
 	void DoShowFile(CKnownFile *file, bool batch);
 
 	/**
-	 * Draws the graph of file-part availability.
-	 *
-	 * @param file The file to make a graph over.
-	 * @param dc The wcDC to draw on.
-	 * @param rect The drawing area.
-	 *
-	 * This function draws a barspan showing the availability of the parts of
-	 * a file, for both Part-files and Known-files. Availability for Part-files
-	 * is determined using the currently known sources, while availability for
-	 * Known-files is determined using the sources requesting that file.
-	 */
-	void DrawAvailabilityBar(CKnownFile *file, wxDC *dc, const wxRect &rect) const;
-
-	/**
-	 * Overloaded function needed to do custom drawing of the items.
-	 */
-	virtual void OnDrawItem(
-		int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted);
-
-	/**
-	 * @see CMuleListCtrl::GetTTSText
-	 */
-	virtual wxString GetTTSText(unsigned item) const;
-
-	/**
-	 * The list is owner-drawn (OnDrawItem paints every cell from the file), so
-	 * this only feeds the generic control's keyboard type-ahead: the file name.
-	 */
-	virtual wxString GetItemColumnText(wxUIntPtr item, long column) const;
-
-	/** Whether the current primary sort column changes value during operation
-	 *  (drives the base's live auto-sort). */
-	virtual bool IsLiveSortColumn() const;
-
-	/** Pause live auto-sort while the context menu is open. */
-	virtual bool IsMenuOpen() const { return m_menu != nullptr; }
-
-	/**
-	 * Sorter-function.
-	 *
-	 * @see wxListCtrl::SortItems
-	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
-
-	/**
-	 * Function that specifies which columns have alternate sorting.
-	 *
-	 * @see CMuleListCtrl::AltSortAllowed
-	 */
-	virtual bool AltSortAllowed(unsigned column) const;
-
-	/**
 	 * Event-handler for right-clicks on the list-items.
 	 */
-	void OnRightClick(wxListEvent &event);
+	void OnItemRightClicked(wxDataViewEvent &event);
 
-	/**
-	 * Event-handler for right-clicks on the list-items.
-	 */
 	void OnGetFeedback(wxCommandEvent &event);
 	void OnOpenFile(wxCommandEvent &event);
 	void OnShowInFolder(wxCommandEvent &event);
@@ -250,7 +246,7 @@ private:
 	/**
 	 * Checks for renaming via F2.
 	 */
-	void OnKeyPressed(wxKeyEvent &event);
+	bool OnListKey(wxKeyEvent &event) override;
 
 	/**
 	 * Adds links in a collection to transfers
@@ -270,19 +266,13 @@ private:
 	 * Double-click / Enter on a row also opens the file-details dialog, for
 	 * parity with the downloads list.
 	 */
-	void OnItemActivated(wxListEvent &event);
+	void OnItemActivated(wxDataViewEvent &event);
 
 	/** Shared helper: open CFileDetailDialog anchored on the clicked row. */
 	void ShowFileDetailDialog(long focused);
 
 	//! Pointer used to ensure that the menu isn't displayed twice.
 	wxMenu *m_menu;
-
-	//! True if @a file passes the current text filter (name substring match).
-	/**
-	 * @see CMuleVirtualListCtrl::RebuildFilteredView
-	 */
-	virtual void RebuildFilteredView();
 
 	//! When true, UpdateItem() short-circuits and the bulk caller is
 	//! responsible for issuing a single Refresh() at end-of-bulk.
@@ -296,7 +286,7 @@ private:
 	uint64 m_shownSize;
 
 	// The virtual-list model, sorting, live auto-sort and selection
-	// preservation all live in CMuleVirtualListCtrl now.
+	// preservation all live in CMuleVirtualDataViewCtrl now.
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/SharedFilesWnd.cpp
+++ b/src/SharedFilesWnd.cpp
@@ -149,10 +149,6 @@ CSharedFilesWnd::~CSharedFilesWnd()
 // part and only depends on the selection in ClientShowSelected mode.
 void CSharedFilesWnd::UpdateSelectionStats()
 {
-	if (sharedfilesctrl->IsSorting()) {
-		return;
-	}
-
 	// Bars fill with this session's share of the file's all-time activity
 	// (session / all-time -- the same two numbers as each label). Both come
 	// from the per-file EC counters, so it is reliable in the remote GUI --
@@ -171,10 +167,8 @@ void CSharedFilesWnd::UpdateSelectionStats()
 	uint64 all_transferred = 0;
 	int selectedCount = 0;
 
-	long index = -1;
-	while ((index = sharedfilesctrl->GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED)) != -1) {
-		// Virtual-list control: rows map to files via the model, not per-item data.
-		CKnownFile *file = sharedfilesctrl->FileAtRow(index);
+	for (wxUIntPtr data : sharedfilesctrl->GetSelectedItemData()) {
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
 		wxASSERT(file);
 		session_requests += file->statistic.GetRequests();
 		session_accepted += file->statistic.GetAccepts();
@@ -232,20 +226,20 @@ void CSharedFilesWnd::UpdateSelectionStats()
 
 void CSharedFilesWnd::SelectionUpdated()
 {
-	if (sharedfilesctrl->IsSorting()) {
-		return;
-	}
-
 	UpdateSelectionStats();
 
 	// The client list follows the client-show mode.
 	CKnownFileVector fileVector;
 	if (m_clientShow != ClientShowUploading) {
-		long index = -1;
-		int filter =
-			(m_clientShow == ClientShowSelected) ? wxLIST_STATE_SELECTED : wxLIST_STATE_DONTCARE;
-		while ((index = sharedfilesctrl->GetNextItem(index, wxLIST_NEXT_ALL, filter)) != -1) {
-			fileVector.push_back(sharedfilesctrl->FileAtRow(index));
+		if (m_clientShow == ClientShowSelected) {
+			for (wxUIntPtr data : sharedfilesctrl->GetSelectedItemData()) {
+				fileVector.push_back(reinterpret_cast<CKnownFile *>(data));
+			}
+		} else {
+			const long count = sharedfilesctrl->ItemDataCount();
+			for (long index = 0; index < count; ++index) {
+				fileVector.push_back(sharedfilesctrl->FileAtRow(index));
+			}
 		}
 		// ShowSources() requires the file vector sorted (see CGenericClientListCtrl).
 		std::sort(fileVector.begin(), fileVector.end());

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -715,7 +715,7 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticBox *item66 = new wxStaticBox( parent, -1, _("File Names") );
     wxStaticBoxSizer *item65 = new wxStaticBoxSizer( item66, wxVERTICAL );
 
-    CFileDetailListCtrl *item67 = new CFileDetailListCtrl( parent, IDC_LISTCTRLFILENAMES, wxDefaultPosition, wxSize(-1,130), wxLC_REPORT|wxSUNKEN_BORDER );
+    CFileDetailListCtrl *item67 = new CFileDetailListCtrl( parent, IDC_LISTCTRLFILENAMES, wxDefaultPosition, wxSize(-1,130), 0 );
     wxASSERT( item67 );
     item65->Add( item67, wxSizerFlags(1).Expand().FixedMinSize() );
     wxBoxSizer *item68 = new wxBoxSizer( wxHORIZONTAL );
@@ -2512,7 +2512,7 @@ wxSizer *serverListDlgUp( wxWindow *parent, bool call_fit, bool set_sizer )
     // Top border: without it this row sits flush against the tab strip
     // (issue #402 review: "too close to the borders of the tab container").
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
-    CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxSize(200, 100), wxLC_REPORT|wxSUNKEN_BORDER );
+    CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxSize(200, 100), 0 );
     item0->Add( item15, wxSizerFlags(1).Expand().CenterVertical() );
     wxBoxSizer *item5 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -3403,7 +3403,7 @@ wxSizer *sharedfilesTopDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item1->Add( itemShRight, wxSizerFlags(1).CenterVertical() );
 
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
-    CSharedFilesCtrl *item6 = new CSharedFilesCtrl( parent, ID_SHFILELIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
+    CSharedFilesCtrl *item6 = new CSharedFilesCtrl( parent, ID_SHFILELIST, wxDefaultPosition, wxDefaultSize, 0 );
     item6->SetName( "sharedFilesCt" );
     item0->Add( item6, wxSizerFlags(1).Expand().CenterVertical() );
     if (set_sizer)
@@ -3428,7 +3428,7 @@ wxSizer *messagePageFriends( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticText *item3 = new wxStaticText( parent, -1, _("Friends"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item3, wxSizerFlags().Center().Border(wxLEFT|wxTOP|wxBOTTOM, 5) );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
-    CFriendListCtrl *item4 = new CFriendListCtrl( parent, ID_FRIENDLIST, wxDefaultPosition, wxSize(160,150), wxLC_REPORT|wxSUNKEN_BORDER );
+    CFriendListCtrl *item4 = new CFriendListCtrl( parent, ID_FRIENDLIST, wxDefaultPosition, wxSize(160,150), 0 );
     item0->Add( item4, wxSizerFlags(1).Expand().FixedMinSize().CenterVertical().Border(wxRIGHT|wxBOTTOM, 5) );
     if (set_sizer)
     {


### PR DESCRIPTION
## Summary

Continues #180/#801's `wxListCtrl` → `wxDataViewCtrl` migration. Adds the shared `CBarShader`-to-`wxDataViewCustomRenderer` bridge the three remaining lists (Downloads, Shared Files, Sources/Peers) all need, and ports the first of them, `CSharedFilesCtrl`, onto it. Design sketched on #801 first since this touches got3nks's shared base from #811, not just a leaf list: https://github.com/amule-org/amule/issues/801#issuecomment-5216203158

- **`CMuleBarRenderer`/`CBarFillSpec`** (`src/MuleBarRenderer.h/.cpp`, new): a list-agnostic `wxDataViewCustomRenderer` wrapping a `CBarShader`, fed per-row fill data through a `wxVariant`-carried `CBarFillSpec` (spans + file size), the same mechanism `wxDataViewIconText` already uses. Turning a file's data into spans stays in the list's own code, matching how `GetItemColumnText()` already keeps per-list logic out of the base.
- **`CMuleDataViewCtrl::AppendBarColumn()`** and **`CMuleVirtualDataViewCtrl::GetItemBarFill()`**: wire a bar column into the existing column/model machinery, alongside `AppendTextColumn`/`AppendIconTextColumn` and `GetItemColumnText`/`GetItemIcon`.
- **`CSharedFilesCtrl`** rewritten onto `CMuleVirtualDataViewCtrl`, following the `CServerListCtrl`/`CFriendListCtrl` pattern. `DrawAvailabilityBar`'s span math moves into `GetItemBarFill()` unchanged; `OnDrawItem`'s per-column switch becomes `GetItemColumnText()`; `SortProc` becomes `CompareItemData()`; the Name column's rating/comment smiley becomes `GetItemIcon()` (same pattern `SearchListModel.cpp` already uses). `OnItemActivated` resolves the activated row through the selection rather than casting the `wxDataViewItem`'s ID directly — that ID is a row index on this model, not the item pointer, the exact bug got3nks caught in the Friends port (#830).
- `SharedFilesWnd.cpp`'s two direct callers are updated: `IsSorting()` was a `wxListCtrl`-specific reentrancy guard for its callback-driven `SortItems()`, with no equivalent hazard under the new model-driven `SortList()`, so both guards are dropped; `GetNextItem()` loops become `GetSelectedItemData()`/`ItemDataCount()`+`FileAtRow()` loops.

Scoped to `CSharedFilesCtrl` only, not Downloads or the generic client list (Sources/Peers): `DrawFileStatusBar` (Downloads) and `DrawSourceStatusBar` (Sources/Peers) both cache the painted bitmap for a few seconds, and a naive renderer port would delete that cache — that redesign deserves its own PR. `SharedFilesCtrl::DrawAvailabilityBar` has no such cache today, and `Render()` only fires for visible cells, so it's the safe list to prove the renderer on first.

## Portability note

Built clean locally against Homebrew's wx 3.3.3 on the first pass, but the variant-object macros (`wxDataViewIconText`'s own pattern) turned out to need the legacy non-`wx`-prefixed spelling (`DECLARE_VARIANT_OBJECT`, declared at namespace scope) for wx 3.2 compatibility — wx 3.3's in-class friend-based `wxDECLARE_VARIANT_OBJECT` doesn't exist on 3.2, and even once the header was included, placing it inside the class body compiles as ill-formed member operators on 3.2 specifically. Found and fixed against the `amule-ci-local` Docker replica (Ubuntu 24.04, distro wx 3.2.4) — see the second and third commits.

## Test plan

- [x] Built `amule` (monolithic) and `amulegui` (`-DBUILD_REMOTEGUI=ON`) clean from a fresh CMake configure, both locally (wx 3.3.3) and in the `amule-ci-local` replica (wx 3.2.4)
- [x] Formatted with the pinned `clang-format:18` Docker image
- [x] `clang-tidy` Tier-1 (whole-tree) and Tier-2 (changed-lines) clean via the local CI replica — Tier-1's only findings are pre-existing `unittests/` warnings unrelated to this branch
- [x] Grepped for orphaned call sites (`DrawAvailabilityBar`, `OnDrawItem`, `IsSorting`, `GetNextItem` on `CSharedFilesCtrl`) — none remain
- [x] Manual: shared files list renders correctly (compare against current release build), bar column shows correct availability colours and border, sort/resize/hide columns still work, rating/comment smiley still shows, context menu and rename/priority/comment actions still work, VoiceOver spot-check on the new bar column
