### PR TITLE
refactor(gui): declare each column width once; persist the file-details list

### DIFF
--- a/src/FileDetailListCtrl.cpp
+++ b/src/FileDetailListCtrl.cpp
@@ -38,24 +38,23 @@ CFileDetailListCtrl::CFileDetailListCtrl(wxWindow *&parent, int id, const wxPoin
 : CMuleVirtualDataViewCtrl(parent, id, pos, siz, flags)
 {
 	const int columnFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
-	AppendTextColumn(_("File Name"),
-		COLUMN_FILEDETAIL_NAME,
-		wxDATAVIEW_CELL_INERT,
-		370,
-		wxALIGN_LEFT,
-		columnFlags);
-	AppendTextColumn(_("Sources"),
-		COLUMN_FILEDETAIL_SOURCES,
-		wxDATAVIEW_CELL_INERT,
-		70,
-		wxALIGN_LEFT,
-		columnFlags);
+	AddTextColumn(_("File Name"), COLUMN_FILEDETAIL_NAME, "N", 370, wxALIGN_LEFT, columnFlags);
+	AddTextColumn(_("Sources"), COLUMN_FILEDETAIL_SOURCES, "S", 70, wxALIGN_LEFT, columnFlags);
 
 	AppendSpacerColumn(COLUMN_FILEDETAIL_SPACER);
 	AssociateVirtualModel();
 
 	// Initial sorting: Sources descending, matching the pre-port default.
+	// LoadColumnSettings() replaces it once the config has something saved.
 	ApplySorting(COLUMN_FILEDETAIL_SOURCES, SORT_DES);
+
+	// This list gains persistence here: it is the one dataview list that never
+	// had it, so a user who widened "File Name" lost it the moment the dialog
+	// closed, and the sort reset to Sources-descending on every open. There is
+	// no GetOldColumnOrder() override because there is no pre-dataview config
+	// to migrate -- nothing was ever written under this name.
+	m_columnStore.SetTableName("FileDetail");
+	LoadColumnSettings();
 
 	InitColumnState();
 }

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -56,9 +56,9 @@ wxEND_EVENT_TABLE()
 CFriendListCtrl::CFriendListCtrl(wxWindow *parent, int id, const wxPoint &pos, wxSize siz, int flags)
 : CMuleVirtualDataViewCtrl(parent, id, pos, siz, flags)
 {
-	AppendTextColumn(_("Username"),
+	AddTextColumn(_("Username"),
 		COLUMN_FRIEND_NAME,
-		wxDATAVIEW_CELL_INERT,
+		"N",
 		siz.GetWidth() - 4,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
@@ -70,7 +70,6 @@ CFriendListCtrl::CFriendListCtrl(wxWindow *parent, int id, const wxPoint &pos, w
 
 	// One-letter name so CListColumnStore has something to write under
 	// /eMule/TableWidthsFriend.
-	m_columnStore.RegisterColumn(COLUMN_FRIEND_NAME, siz.GetWidth() - 4, "N");
 
 	ApplySorting(COLUMN_FRIEND_NAME, 0);
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -111,9 +111,10 @@ void CMuleDataViewCtrl::AddTextColumn(const wxString &label,
 	const wxString &key,
 	int width,
 	wxAlignment align,
-	int flags)
+	int flags,
+	wxDataViewCellMode mode)
 {
-	AppendTextColumn(label, modelColumn, wxDATAVIEW_CELL_INERT, width, align, flags);
+	AppendTextColumn(label, modelColumn, mode, width, align, flags);
 	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
 }
 
@@ -122,9 +123,10 @@ void CMuleDataViewCtrl::AddIconTextColumn(const wxString &label,
 	const wxString &key,
 	int width,
 	wxAlignment align,
-	int flags)
+	int flags,
+	wxDataViewCellMode mode)
 {
-	AppendIconTextColumn(label, modelColumn, wxDATAVIEW_CELL_INERT, width, align, flags);
+	AppendIconTextColumn(label, modelColumn, mode, width, align, flags);
 	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
 }
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -106,6 +106,35 @@ void CMuleDataViewCtrl::AppendBarColumn(const wxString &title, unsigned modelCol
 	AppendColumn(column);
 }
 
+void CMuleDataViewCtrl::AddTextColumn(const wxString &label,
+	unsigned modelColumn,
+	const wxString &key,
+	int width,
+	wxAlignment align,
+	int flags)
+{
+	AppendTextColumn(label, modelColumn, wxDATAVIEW_CELL_INERT, width, align, flags);
+	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
+}
+
+void CMuleDataViewCtrl::AddIconTextColumn(const wxString &label,
+	unsigned modelColumn,
+	const wxString &key,
+	int width,
+	wxAlignment align,
+	int flags)
+{
+	AppendIconTextColumn(label, modelColumn, wxDATAVIEW_CELL_INERT, width, align, flags);
+	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
+}
+
+void CMuleDataViewCtrl::AddBarColumn(
+	const wxString &label, unsigned modelColumn, const wxString &key, int width, int flags)
+{
+	AppendBarColumn(label, modelColumn, width, flags);
+	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
+}
+
 unsigned CMuleDataViewCtrl::RealColumnCount() const
 {
 	const unsigned columns = GetColumnCount();

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -220,6 +220,13 @@ protected:
 	 * format, so changing one resets that column's saved width and forgets its
 	 * sort.
 	 *
+	 * @a mode is last, rather than in wx's position ahead of the width, because
+	 * width has no default and a parameter before it could not have one either
+	 * -- every caller would have to spell out INERT. Every column is inert
+	 * today; the parameter exists so that an editable one later does not have
+	 * to drop back to Append* plus a hand-written RegisterColumn(), which is
+	 * the duplication this exists to remove.
+	 *
 	 * Named Add* rather than overloading wx's Append*: an overload with a
 	 * different signature would still bind to the wx method wherever a call
 	 * was missed, compiling cleanly and persisting nothing. A distinct name
@@ -231,7 +238,8 @@ protected:
 		const wxString &key,
 		int width,
 		wxAlignment align = wxALIGN_LEFT,
-		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE,
+		wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT);
 
 	/// AddTextColumn() for a column whose cells carry an icon beside the text.
 	void AddIconTextColumn(const wxString &label,
@@ -239,7 +247,8 @@ protected:
 		const wxString &key,
 		int width,
 		wxAlignment align = wxALIGN_LEFT,
-		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE,
+		wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT);
 
 	/// AddTextColumn() for a CMuleBarRenderer column; see AppendBarColumn().
 	void AddBarColumn(const wxString &label,

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -205,6 +205,50 @@ protected:
 		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 
 	/**
+	 * Append a column and register it for persistence, in one call.
+	 *
+	 * A column's width has to reach two places that never meet: wx, which
+	 * uses it as the initial on-screen width, and CListColumnStore, which
+	 * keeps it as the default to restore a column to when it is un-hidden
+	 * with no width cached for it. Passing it separately to AppendTextColumn()
+	 * and RegisterColumn() meant writing the same number twice with nothing
+	 * keeping the two honest -- the legacy CMuleListCtrl::InsertColumn() took
+	 * both in one call and could not drift.
+	 *
+	 * @a key is the persistence key: a single letter, written to
+	 * TableWidths<list> / TableOrdering<list> in the config. It is the on-disk
+	 * format, so changing one resets that column's saved width and forgets its
+	 * sort.
+	 *
+	 * Named Add* rather than overloading wx's Append*: an overload with a
+	 * different signature would still bind to the wx method wherever a call
+	 * was missed, compiling cleanly and persisting nothing. A distinct name
+	 * makes "still calls Append*" a signal that grep can check, which is what
+	 * the migration is validated with.
+	 */
+	void AddTextColumn(const wxString &label,
+		unsigned modelColumn,
+		const wxString &key,
+		int width,
+		wxAlignment align = wxALIGN_LEFT,
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+
+	/// AddTextColumn() for a column whose cells carry an icon beside the text.
+	void AddIconTextColumn(const wxString &label,
+		unsigned modelColumn,
+		const wxString &key,
+		int width,
+		wxAlignment align = wxALIGN_LEFT,
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+
+	/// AddTextColumn() for a CMuleBarRenderer column; see AppendBarColumn().
+	void AddBarColumn(const wxString &label,
+		unsigned modelColumn,
+		const wxString &key,
+		int width,
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+
+	/**
 	 * Sizes the per-column state and snapshots the current widths. Call
 	 * after the columns exist and after LoadColumnSettings(): it preserves
 	 * any hidden flags already restored through the width adapter.

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -97,77 +97,76 @@ CSearchListCtrl::CSearchListCtrl(
 	AssociateModel(m_model);
 	m_model->DecRef(); // the control now holds the only reference
 
-	AppendTextColumn(_("File Name"),
+	AddTextColumn(_("File Name"),
 		CSearchListModel::COL_NAME,
-		wxDATAVIEW_CELL_INERT,
+		"N",
 		500,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("Size"),
+	AddTextColumn(_("Size"),
 		CSearchListModel::COL_SIZE,
-		wxDATAVIEW_CELL_INERT,
+		"Z",
 		100,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("Sources"),
+	AddTextColumn(_("Sources"),
 		CSearchListModel::COL_SOURCES,
-		wxDATAVIEW_CELL_INERT,
+		"u",
 		50,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("Type"),
+	AddTextColumn(_("Type"),
 		CSearchListModel::COL_TYPE,
-		wxDATAVIEW_CELL_INERT,
+		"Y",
 		65,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 	// Rating: smiley icon + text label in one cell.
-	AppendIconTextColumn(_("Rating"),
+	AddIconTextColumn(_("Rating"),
 		CSearchListModel::COL_RATING,
-		wxDATAVIEW_CELL_INERT,
+		"R",
 		120,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("FileID"),
+	AddTextColumn(_("FileID"),
 		CSearchListModel::COL_FILEID,
-		wxDATAVIEW_CELL_INERT,
+		"I",
 		280,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("Status"),
+	AddTextColumn(_("Status"),
 		CSearchListModel::COL_STATUS,
-		wxDATAVIEW_CELL_INERT,
+		"S",
 		100,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 	// Media tag columns: ed2k/Kad publishers (eMule, eMule AI, aMule) can
 	// advertise per-file media metadata in FT_MEDIA_LENGTH / _BITRATE /
 	// _CODEC. Cells stay empty for non-media results.
-	AppendTextColumn(_("Length"),
+	AddTextColumn(_("Length"),
 		CSearchListModel::COL_LENGTH,
-		wxDATAVIEW_CELL_INERT,
+		"L",
 		80,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("Bitrate"),
+	AddTextColumn(_("Bitrate"),
 		CSearchListModel::COL_BITRATE,
-		wxDATAVIEW_CELL_INERT,
+		"B",
 		80,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
-	AppendTextColumn(_("Codec"),
+	AddTextColumn(_("Codec"),
 		CSearchListModel::COL_CODEC,
-		wxDATAVIEW_CELL_INERT,
+		"C",
 		80,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 	// Directories is almost always empty (only populated when the result
 	// came from a "view shared files" request, rare in practice), so put
 	// it at the end with the other usually-empty columns.
-	AppendTextColumn(
-		_("Directories"), // I would have preferred "Directory" but this is already translated
+	AddTextColumn(_("Directories"), // I would have preferred "Directory" but this is already translated
 		CSearchListModel::COL_DIRECTORY,
-		wxDATAVIEW_CELL_INERT,
+		"D",
 		280,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
@@ -175,18 +174,6 @@ CSearchListCtrl::CSearchListCtrl(
 	// Absorbs the macOS trailing-column sizing; the model answers COL_SPACER
 	// with an empty string.
 	AppendSpacerColumn(CSearchListModel::COL_SPACER);
-
-	m_columnStore.RegisterColumn(CSearchListModel::COL_NAME, 500, "N");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_SIZE, 100, "Z");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_SOURCES, 50, "u");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_TYPE, 65, "Y");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_RATING, 120, "R");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_FILEID, 280, "I");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_STATUS, 100, "S");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_LENGTH, 80, "L");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_BITRATE, 80, "B");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_CODEC, 80, "C");
-	m_columnStore.RegisterColumn(CSearchListModel::COL_DIRECTORY, 280, "D");
 
 	// Default sort is by name, ascending.
 	m_sort_orders.emplace_back(CSearchListModel::COL_NAME, 0);

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -86,36 +86,29 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 	// The name column carries the country flag, so it is icon+text; the rest
 	// are plain text. Sortable throughout, or wx draws no header caret.
 	const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
-	AppendIconTextColumn(
-		_("Server Name"), COLUMN_SERVER_NAME, wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Address"), COLUMN_SERVER_ADDR, wxDATAVIEW_CELL_INERT, 140, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Port"), COLUMN_SERVER_PORT, wxDATAVIEW_CELL_INERT, 25, wxALIGN_LEFT, flags);
-	AppendTextColumn(
-		_("Description"), COLUMN_SERVER_DESC, wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Ping"), COLUMN_SERVER_PING, wxDATAVIEW_CELL_INERT, 25, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Users"), COLUMN_SERVER_USERS, wxDATAVIEW_CELL_INERT, 40, wxALIGN_LEFT, flags);
+	AddIconTextColumn(_("Server Name"), COLUMN_SERVER_NAME, "N", 150, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Address"), COLUMN_SERVER_ADDR, "A", 140, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Port"), COLUMN_SERVER_PORT, "P", 25, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Description"), COLUMN_SERVER_DESC, "D", 150, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Ping"), COLUMN_SERVER_PING, "p", 25, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Users"), COLUMN_SERVER_USERS, "U", 40, wxALIGN_LEFT, flags);
 	// Beside Users, since the pair is read together: how many are on now, and
 	// how many the server will take.
-	AppendTextColumn(
-		_("Max Users"), COLUMN_SERVER_MAXUSERS, wxDATAVIEW_CELL_INERT, 85, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Files"), COLUMN_SERVER_FILES, wxDATAVIEW_CELL_INERT, 45, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Priority"), COLUMN_SERVER_PRIO, wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Failed"), COLUMN_SERVER_FAILS, wxDATAVIEW_CELL_INERT, 40, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Static"), COLUMN_SERVER_STATIC, wxDATAVIEW_CELL_INERT, 40, wxALIGN_LEFT, flags);
-	AppendTextColumn(_("Version"), COLUMN_SERVER_VERSION, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Max Users"), COLUMN_SERVER_MAXUSERS, "m", 85, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Files"), COLUMN_SERVER_FILES, "F", 45, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Priority"), COLUMN_SERVER_PRIO, "r", 60, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Failed"), COLUMN_SERVER_FAILS, "f", 40, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Static"), COLUMN_SERVER_STATIC, "S", 40, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Version"), COLUMN_SERVER_VERSION, "V", 80, wxALIGN_LEFT, flags);
 
-	AppendTextColumn(
-		_("Soft Files"), COLUMN_SERVER_SOFTFILES, wxDATAVIEW_CELL_INERT, 85, wxALIGN_LEFT, flags);
-	AppendTextColumn(
-		_("Hard Files"), COLUMN_SERVER_HARDFILES, wxDATAVIEW_CELL_INERT, 85, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Soft Files"), COLUMN_SERVER_SOFTFILES, "s", 85, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Hard Files"), COLUMN_SERVER_HARDFILES, "h", 85, wxALIGN_LEFT, flags);
 
 	// Same columns in both binaries: diagnostics, hidden by default in release
 	// builds (below), and the flags are streamed over EC so the remote GUI has
 	// the data behind them.
-	AppendTextColumn(
-		_("TCP Flags"), COLUMN_SERVER_TCPFLAGS, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, flags);
-	AppendTextColumn(
-		_("UDP Flags"), COLUMN_SERVER_UDPFLAGS, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, flags);
+	AddTextColumn(_("TCP Flags"), COLUMN_SERVER_TCPFLAGS, "t", 80, wxALIGN_LEFT, flags);
+	AddTextColumn(_("UDP Flags"), COLUMN_SERVER_UDPFLAGS, "u", 80, wxALIGN_LEFT, flags);
 	// Per-user publishing limits the server advertises: how many of a user's
 	// shared files it will index. Both arrive with the periodic UDP status
 	// reply, the same one that fills Users and Files.
@@ -124,23 +117,6 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 	// past the real ones with an empty value.
 	AppendSpacerColumn(COLUMN_SERVER_SPACER);
 	AssociateVirtualModel();
-
-	m_columnStore.RegisterColumn(COLUMN_SERVER_NAME, 150, "N");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_ADDR, 140, "A");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_PORT, 25, "P");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_DESC, 150, "D");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_PING, 25, "p");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_USERS, 40, "U");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_FILES, 45, "F");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_PRIO, 60, "r");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_FAILS, 40, "f");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_STATIC, 40, "S");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_VERSION, 80, "V");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_TCPFLAGS, 80, "t");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_UDPFLAGS, 80, "u");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_SOFTFILES, 85, "s");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_HARDFILES, 85, "h");
-	m_columnStore.RegisterColumn(COLUMN_SERVER_MAXUSERS, 85, "m");
 
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it
 	// when the config has something saved.

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -99,62 +99,28 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	// column reserves the icon slot on every row, indenting names that have no
 	// icon of their own.
 	const int colFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
-	AppendTextColumn(
-		_("File Name"), COLUMN_SHARED_NAME, wxDATAVIEW_CELL_INERT, 400, wxALIGN_LEFT, colFlags);
-	AppendIconTextColumn(
-		_("Rating"), COLUMN_SHARED_RATING, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(_("Size"), COLUMN_SHARED_SIZE, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(_("Type"), COLUMN_SHARED_TYPE, wxDATAVIEW_CELL_INERT, 90, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(
-		_("Priority"), COLUMN_SHARED_PRIO, wxDATAVIEW_CELL_INERT, 70, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(_("Requests"), COLUMN_SHARED_REQ, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(_("Accepted Requests"),
-		COLUMN_SHARED_AREQ,
-		wxDATAVIEW_CELL_INERT,
-		80,
-		wxALIGN_LEFT,
-		colFlags);
-	AppendTextColumn(
-		_("Transferred Data"), COLUMN_SHARED_TRA, wxDATAVIEW_CELL_INERT, 120, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(
-		_("Share Ratio"), COLUMN_SHARED_RTIO, wxDATAVIEW_CELL_INERT, 80, wxALIGN_LEFT, colFlags);
-	AppendBarColumn(_("Obtained Parts"), COLUMN_SHARED_PART, 120, colFlags);
-	AppendTextColumn(_("Complete Sources"),
-		COLUMN_SHARED_CMPL,
-		wxDATAVIEW_CELL_INERT,
-		120,
-		wxALIGN_LEFT,
-		colFlags);
+	AddTextColumn(_("File Name"), COLUMN_SHARED_NAME, "N", 400, wxALIGN_LEFT, colFlags);
+	AddIconTextColumn(_("Rating"), COLUMN_SHARED_RATING, "G", 80, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Size"), COLUMN_SHARED_SIZE, "Z", 100, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Type"), COLUMN_SHARED_TYPE, "Y", 90, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Priority"), COLUMN_SHARED_PRIO, "p", 70, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Requests"), COLUMN_SHARED_REQ, "Q", 80, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Accepted Requests"), COLUMN_SHARED_AREQ, "A", 80, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Transferred Data"), COLUMN_SHARED_TRA, "T", 120, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Share Ratio"), COLUMN_SHARED_RTIO, "R", 80, wxALIGN_LEFT, colFlags);
+	AddBarColumn(_("Obtained Parts"), COLUMN_SHARED_PART, "P", 120, colFlags);
+	AddTextColumn(_("Complete Sources"), COLUMN_SHARED_CMPL, "C", 120, wxALIGN_LEFT, colFlags);
 	// FileID (== file hash) was dropped — the hash is on the details modal. The
 	// three new columns reuse existing translations ("Speed", "Shared since",
 	// "Last upload"); Directory Path stays but moves to the end.
-	AppendTextColumn(_("Speed"), COLUMN_SHARED_SPEED, wxDATAVIEW_CELL_INERT, 90, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(
-		_("Shared since"), COLUMN_SHARED_SINCE, wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(
-		_("Last upload"), COLUMN_SHARED_LASTUP, wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT, colFlags);
-	AppendTextColumn(
-		_("Directory Path"), COLUMN_SHARED_PATH, wxDATAVIEW_CELL_INERT, 430, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Speed"), COLUMN_SHARED_SPEED, "U", 90, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Shared since"), COLUMN_SHARED_SINCE, "H", 130, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Last upload"), COLUMN_SHARED_LASTUP, "L", 130, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Directory Path"), COLUMN_SHARED_PATH, "D", 430, wxALIGN_LEFT, colFlags);
 
 	AppendSpacerColumn(COLUMN_SHARED_SPACER);
 
 	AssociateVirtualModel();
-
-	m_columnStore.RegisterColumn(COLUMN_SHARED_NAME, 400, "N");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_RATING, 80, "G");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_SIZE, 100, "Z");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_TYPE, 90, "Y");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_PRIO, 70, "p");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_REQ, 80, "Q");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_AREQ, 80, "A");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_TRA, 120, "T");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_RTIO, 80, "R");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_PART, 120, "P");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_CMPL, 120, "C");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_SPEED, 90, "U");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_SINCE, 130, "H");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_LASTUP, 130, "L");
-	m_columnStore.RegisterColumn(COLUMN_SHARED_PATH, 430, "D");
 
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it
 	// when the config has something saved.


### PR DESCRIPTION
**Two changes:** a mechanical de-duplication across the wxDataViewCtrl lists, and one behaviour change that comes with it — **the file-details dialog's list now remembers its column widths and sort order**, which it never did. Details in its own section below; everything else is behaviour-preserving.

---

Every column in the wxDataViewCtrl lists declares its width twice, in two calls that nothing keeps in sync:

```cpp
AppendTextColumn(_("File Name"), COLUMN_SHARED_NAME, wxDATAVIEW_CELL_INERT, 400, wxALIGN_LEFT, colFlags);
m_columnStore.RegisterColumn(COLUMN_SHARED_NAME, 400, "N");
```

The two are consumed by different paths, which is why the duplication went unnoticed: wx uses its copy as the initial on-screen width, while `CListColumnStore` keeps its own as the width to restore a column to when it is un-hidden with nothing cached for it. Let them drift and a column returns from the header menu at a different width than it launched with.

The legacy `CMuleListCtrl::InsertColumn()` took the width and the persistence key in one call and could not drift. The dataview port split that apart, because `wxDataViewCtrl::AppendTextColumn()` has nowhere to put a key.

## What changes

Three wrappers on `CMuleDataViewCtrl` — `AddTextColumn`, `AddIconTextColumn`, `AddBarColumn` — take the label, model column, key and width together and forward the one width to both destinations. The 43 columns across the server, search, friend and shared-files lists go through them, and every standalone `RegisterColumn()` is gone from the list subclasses.

`CListColumnStore::RegisterColumn()` itself is untouched: the legacy wxListCtrl lists still reach it through `CMuleListCtrl::InsertColumn()`.

## Why `Add*` and not an `Append*` overload

An overload with a different signature still binds to the wx method wherever a call is missed — compiling cleanly and persisting nothing.

That is not hypothetical. The sweep did miss one: `COL_DIRECTORY` in the search list, whose trailing comment sits after a comma and confused the rewrite, while the cleanup still removed its registration. With a distinct name it stayed visible as `AppendTextColumn`, and both `grep` and the width/key check caught it. As an overload it would have compiled and silently stopped persisting that column.

## New behaviour: CFileDetailListCtrl gains persistence

It was the one dataview list without any: a user who widened "File Name" lost it the moment the dialog closed, and the sort reset to Sources-descending on every open.

It needs no teardown handling, because saving is event-driven in the base — header click, show/hide, and drag-resize through `OnIdle` → `OnColumnWidthsChanged()`. The dialog the user acted on is the one that writes, so the per-open lifetime is not a problem. New keys `N` and `S` under `TableWidthsFileDetail` / `TableOrderingFileDetail`; no `GetOldColumnOrder()` override, since nothing was ever written under that name to migrate.

## Behaviour elsewhere

No column's width, order, visibility or key changes. All 43 were checked identical to master — and re-checked after clang-format rewrapped the calls, since that rewrote the very lines carrying them.

Worth setting expectations for review: **no column had drifted on master**, so hide/show already returns the launch width today. This removes the possibility of drift rather than fixing a live symptom — there is nothing to reproduce before/after.

## Testing

`amule` and `amulegui` build clean; 33/33 unit tests; clang-format 18 and both clang-tidy tiers clean on the diff with 0 compiler errors. Validation greps: `RegisterColumn(` matches only `ListColumnStore.cpp`, `MuleListCtrl.cpp` and `MuleDataViewCtrl.cpp`; no list subclass still calls wx's `Append*`.

Manual GUI passes still to do: hide/show every column in each of the five lists, and a fresh-profile layout comparison.
