### PR TITLE
fix(search): keep a queued result visible under "Hide Known Files"

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -243,7 +243,12 @@ bool CSearchListCtrl::IsFiltered(const CSearchFile *file) const
 		result = m_filter.Matches(file->GetFileName().GetPrintable());
 		result = ((result && !m_invert) || (!result && m_invert));
 		if (result && m_filterKnown) {
-			result = file->GetDownloadStatus() == CSearchFile::NEW;
+			// Still a live status test, so results that were already known
+			// stay hidden -- but never for the ones the user just queued
+			// from this list, which would otherwise disappear under the
+			// click that queued them (see m_userQueued).
+			const bool queuedHere = m_userQueued.count(file->GetFileHash()) != 0;
+			result = queuedHere || file->GetDownloadStatus() == CSearchFile::NEW;
 		}
 	}
 
@@ -285,6 +290,8 @@ void CSearchListCtrl::UpdateResult(CSearchFile *toupdate)
 void CSearchListCtrl::ShowResults(wxUIntPtr ResultsID)
 {
 	m_nResultsID = ResultsID;
+	// Different result set entirely; nothing kept for the old one applies.
+	m_userQueued.clear();
 	m_model->NotifyFilterChanged(); // full reset: new search-id, entirely different result set
 }
 
@@ -294,6 +301,10 @@ void CSearchListCtrl::SetFilter(const wxString &regExp, bool invert, bool filter
 	m_filter.Compile(m_filterText, wxRE_DEFAULT | wxRE_ICASE);
 	m_filterKnown = filterKnown;
 	m_invert = invert;
+	// Re-applying the filter is the point at which the user asked to see the
+	// list filtered afresh, so the rows held over from earlier downloads
+	// collapse away here rather than lingering for the rest of the session.
+	m_userQueued.clear();
 
 	if (m_filterEnabled) {
 		m_model->NotifyFilterChanged();
@@ -832,6 +843,11 @@ void CSearchListCtrl::DownloadSelected(int category)
 	GetSelections(selections);
 	for (const wxDataViewItem &item : selections) {
 		CSearchFile *file = CSearchListModel::ToFile(item);
+		// Exempt from "Hide Known Files" before queueing, so the row
+		// survives the status change this is about to cause. Results are
+		// only grouped when their hashes match (CSearchList::AddResult), so
+		// the one insert covers a group's variants along with its parent.
+		m_userQueued.insert(file->GetFileHash());
 		CoreNotify_Search_Add_Download(file, category);
 	}
 

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -31,9 +31,11 @@
 #include <wx/regex.h>         // Needed for wxRegExp
 
 #include "ListColumnStore.h" // Needed for CListColumnStore, IColumnWidthProvider
+#include "MD4Hash.h"         // Needed for CMD4Hash (known-files filter set)
 #include "Types.h"           // Needed for uint32
 
 #include <list>
+#include <set> // Needed for std::set (known-files filter set)
 #include <utility>
 #include <vector>
 
@@ -274,6 +276,26 @@ protected:
 	bool m_invert;
 	//! Specifies if filtering should be used.
 	bool m_filterEnabled;
+
+	/**
+	 * Results the user queued from this list, exempted from "Hide Known
+	 * Files" until the filter is applied again.
+	 *
+	 * Queueing a result makes it known, and every result update resets the
+	 * whole model (see CSearchListModel::MarkDirty), so a plain status test
+	 * re-runs immediately and the row vanishes from under the click that
+	 * queued it -- before the colour confirming the download was added is
+	 * ever visible, and leaving nothing on screen to say which results were
+	 * taken (#756). Keeping them listed here holds those rows in place, in
+	 * their queued colour, until SetFilter() or ShowResults() clears the set.
+	 *
+	 * Deliberately keyed on the user's action rather than on when a result
+	 * became known: in amulegui every result is constructed NEW and learns
+	 * its real status from a later poll (CSearchListRem::ProcessItemUpdate),
+	 * so "was it known when it arrived" is not a question the remote GUI can
+	 * answer, and hiding already-known results has to stay a live test there.
+	 */
+	std::set<CMD4Hash> m_userQueued;
 
 	//! Last-seen column widths, used to detect a user drag-resize (there is
 	//! no portable wxDataViewCtrl "column resized" event to hook directly)


### PR DESCRIPTION
## The bug

Reported by @ghysler on #756: with "Hide Known Files" active, starting a download from search results makes the row disappear immediately. Queueing makes the result known, so it stops passing the filter. The item never turns its queued colour where the user can see it, and nothing is left on screen to say which results were just taken — for anyone who keeps the option on permanently, adding a file loses all its feedback.

This came from the wxDataViewCtrl port, not from the live filtering in #821. Filtering as you type only debounced the text field; the Hide Known Files checkbox applied instantly before that too. What changed is on the other side: since the port, every result update marks the model dirty and the idle flush issues a full `Cleared()`, so the filter predicate re-runs on any update. Before it, `UpdateResult()` patched the row's cells in place and had no path that could remove one, so a result that became known simply recoloured and stayed.

## Why not just make updates incremental again

That would be the direct fix, and it is not available. `ItemChanged()` and delete+re-add were both tried during the port and neither made GTK/MSW re-derive container-ness when a group forms — the reason every change became a coalesced reset in the first place (see the note on `CSearchListModel::MarkDirty`). Going back would trade this regression for that one.

## What changed

The results the user queued from the list are exempted from the known test instead. `DownloadSelected()` records each selected result by hash before queueing it, and `IsFiltered()` skips the known check for those. `SetFilter()` and `ShowResults()` clear the set, so re-applying the filter or starting a new search collapses the kept rows away — the rows persist for the moment of feedback, not for the rest of the session.

Recording by hash is enough to cover a group: results are only ever grouped when their hashes match, so one insert covers a parent and its variants.

Results that were *already* known keep being hidden, by the same live status test as before. The only behaviour that changes is for results the user queued from that list.

## Why it keys on the action rather than on when a result became known

The obvious alternative — record which results were already known when they arrived, hide only those — is correct in the monolithic build and silently wrong in amulegui. `CSearchFile`'s remote constructor hardcodes `NEW` and never reads the status tag; `CSearchListRem::ProcessUpdate` calls `ProcessItemUpdate`, which does read it, only for results the client already holds. Every remote result therefore arrives NEW and learns its real status from a later poll, so "was it known on arrival" is not a question the remote GUI can answer, and that approach would have stopped Hide Known Files hiding anything at all there.

Hooking the GUI action sits above where the two builds diverge, so one code path stays correct for both.

## Verification

Built clean with zero warnings on macOS for all three binaries (`amule`, `amulegui`, `amuled`); `clang-format` and both clang-tidy tiers clean over the diff.

Tested interactively in the monolithic GUI: the queued row stays and takes its colour, results already downloading stay hidden, and touching the filter collapses the kept rows. The changed code is in `SearchListCtrl.cpp`, which both GUIs compile, so amulegui takes the same path — with the caveat that there the row has to survive the poll that delivers the new status, a beat after the click rather than immediately.
