### PR TITLE
fix(gui): stop CListColumnStore renumbering registered column ids

### DIFF
--- a/src/ListColumnStore.cpp
+++ b/src/ListColumnStore.cpp
@@ -53,21 +53,35 @@ void CListColumnStore::RegisterColumn(int index, int defaultWidth, const wxStrin
 		name.Find(',') == wxNOT_FOUND, "Column name \"" + name + "\" contains invalid characters!");
 
 	// Check for uniqueness of names.
-	for (ColNameList::const_iterator uit = m_column_names.begin(); uit != m_column_names.end(); ++uit) {
-		if (name == uit->name) {
+	for (const ColNameEntry &entry : m_column_names) {
+		if (name == entry.name) {
 			wxFAIL_MSG("Column name \"" + name + "\" is not unique!");
 		}
 	}
+
+	// ... and of indices. Every lookup here (GetColumnName, GetColumnDefaultWidth,
+	// GetColumnIndex) matches on index and returns the first entry that does, so a
+	// second registration of the same index is not an alternative -- it is dead
+	// weight that shadows nothing and reports nothing.
+	for (const ColNameEntry &entry : m_column_names) {
+		if (index == entry.index) {
+			wxFAIL_MSG(wxString::Format(
+				"Column index %d is already registered as \"%s\"!", index, entry.name));
+		}
+	}
 #endif
+	// Kept sorted by index. Entries are NOT renumbered around an insert: index is
+	// the caller's own column id -- a stable #define for the wxDataViewCtrl lists,
+	// the wxListCtrl column position for the legacy ones -- and every lookup above
+	// matches the value the caller passes back in. Shifting stored indices would
+	// break that correspondence, and since a key maps to a column through it, the
+	// on-disk TableWidths*/TableOrdering* entries would start addressing the wrong
+	// columns.
 	ColNameList::iterator it = m_column_names.begin();
 	while (it != m_column_names.end() && it->index < index) {
 		++it;
 	}
 	m_column_names.insert(it, ColNameEntry(index, defaultWidth, name));
-	while (it != m_column_names.end()) {
-		++it;
-		++(it->index);
-	}
 }
 
 const wxString &CListColumnStore::GetColumnName(int index) const

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -669,3 +669,28 @@ target_link_libraries (RefresherTest
 	webcommon
 	wxWidgets::NET
 )
+
+# CListColumnStore maps a column id to its persistence key and default width.
+# The key is the on-disk config format, so the id a caller registers has to be
+# the id it looks the column up by -- a registry that renumbered stored ids
+# would hand a saved width back to the wrong column, with nothing to see. Needs
+# no GUI: the registry half of the class is plain wxString bookkeeping.
+add_executable (ListColumnStoreTest
+	ListColumnStoreTest.cpp
+	${CMAKE_SOURCE_DIR}/src/ListColumnStore.cpp
+)
+
+add_test (NAME ListColumnStoreTest
+	COMMAND ListColumnStoreTest
+)
+
+target_include_directories (ListColumnStoreTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (ListColumnStoreTest
+	muleunit
+	mulecommon
+)

--- a/unittests/tests/ListColumnStoreTest.cpp
+++ b/unittests/tests/ListColumnStoreTest.cpp
@@ -1,0 +1,127 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// CListColumnStore maps a column's id to its persistence key and default width.
+// The key is the on-disk config format (TableWidths*/TableOrdering*), so the id
+// a caller registers has to be the id it can look the column back up by -- if
+// the store were to renumber stored ids, a saved width would come back attached
+// to a different column, silently.
+//
+// These tests pin that the registry is a plain sorted insert. Registering out of
+// order is the case that matters: it never happens in the app today, because
+// every list registers its columns in ascending order, which is exactly why a
+// renumbering bug in this path could sit here unnoticed.
+
+#include <muleunit/test.h>
+
+#include <ListColumnStore.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(CListColumnStore)
+
+TEST(CListColumnStore, RegistrationOutOfOrderKeepsEveryColumnAddressable)
+{
+	// The middle insert: 1 lands between columns already registered, which is
+	// the shape a renumbering insert would corrupt -- moving 2 and 3 out from
+	// under the callers that still ask for them by those ids.
+	//
+	// Two entries have to follow the insertion point for that to be visible.
+	// With only one, an off-by-one in such a loop skips the single displaced
+	// entry and the damage lands somewhere unobservable instead.
+	CListColumnStore store;
+	store.RegisterColumn(0, 250, "N");
+	store.RegisterColumn(2, 100, "Z");
+	store.RegisterColumn(3, 90, "Y");
+	store.RegisterColumn(1, 70, "P");
+
+	ASSERT_EQUALS(wxString("N"), store.GetColumnName(0));
+	ASSERT_EQUALS(wxString("P"), store.GetColumnName(1));
+	ASSERT_EQUALS(wxString("Z"), store.GetColumnName(2));
+	ASSERT_EQUALS(wxString("Y"), store.GetColumnName(3));
+
+	ASSERT_EQUALS(250, store.GetColumnDefaultWidth(0));
+	ASSERT_EQUALS(70, store.GetColumnDefaultWidth(1));
+	ASSERT_EQUALS(100, store.GetColumnDefaultWidth(2));
+	ASSERT_EQUALS(90, store.GetColumnDefaultWidth(3));
+}
+
+TEST(CListColumnStore, KeyLookupSurvivesOutOfOrderRegistration)
+{
+	// The reverse direction, which is how a saved config finds its column:
+	// LoadSettings() reads a key and calls GetColumnIndex() to place it.
+	CListColumnStore store;
+	store.RegisterColumn(0, 250, "N");
+	store.RegisterColumn(2, 100, "Z");
+	store.RegisterColumn(1, 70, "P");
+
+	ASSERT_EQUALS(0, store.GetColumnIndex("N"));
+	ASSERT_EQUALS(1, store.GetColumnIndex("P"));
+	ASSERT_EQUALS(2, store.GetColumnIndex("Z"));
+}
+
+TEST(CListColumnStore, AscendingRegistrationIsUnchanged)
+{
+	// What every list in the app actually does; guards the common path against
+	// a regression in the insert itself.
+	CListColumnStore store;
+	store.RegisterColumn(0, 400, "N");
+	store.RegisterColumn(1, 100, "Z");
+	store.RegisterColumn(2, 90, "Y");
+
+	ASSERT_EQUALS(wxString("N"), store.GetColumnName(0));
+	ASSERT_EQUALS(wxString("Z"), store.GetColumnName(1));
+	ASSERT_EQUALS(wxString("Y"), store.GetColumnName(2));
+
+	ASSERT_EQUALS(400, store.GetColumnDefaultWidth(0));
+	ASSERT_EQUALS(100, store.GetColumnDefaultWidth(1));
+	ASSERT_EQUALS(90, store.GetColumnDefaultWidth(2));
+
+	ASSERT_EQUALS(0, store.GetColumnIndex("N"));
+	ASSERT_EQUALS(1, store.GetColumnIndex("Z"));
+	ASSERT_EQUALS(2, store.GetColumnIndex("Y"));
+}
+
+TEST(CListColumnStore, NonContiguousIdsAreKeptAsGiven)
+{
+	// Ids need not be dense: the store must not compact them into positions.
+	CListColumnStore store;
+	store.RegisterColumn(5, 120, "T");
+	store.RegisterColumn(9, 130, "H");
+
+	ASSERT_EQUALS(wxString("T"), store.GetColumnName(5));
+	ASSERT_EQUALS(wxString("H"), store.GetColumnName(9));
+	ASSERT_EQUALS(5, store.GetColumnIndex("T"));
+	ASSERT_EQUALS(9, store.GetColumnIndex("H"));
+}
+
+TEST(CListColumnStore, UnknownColumnsReportTheirMissValues)
+{
+	CListColumnStore store;
+	store.RegisterColumn(0, 250, "N");
+
+	ASSERT_TRUE(store.GetColumnName(7).IsEmpty());
+	ASSERT_EQUALS(-1, store.GetColumnDefaultWidth(7)); // wxLIST_AUTOSIZE
+	ASSERT_EQUALS(-1, store.GetColumnIndex("nope"));
+}


### PR DESCRIPTION
`RegisterColumn()` keeps its registry sorted by index, and then renumbered every entry after an insert:

```cpp
m_column_names.insert(it, ColNameEntry(index, defaultWidth, name));
while (it != m_column_names.end()) {
    ++it;
    ++(it->index);
}
```

Two things are wrong with that loop. It increments the iterator before dereferencing, so the displaced entry — the first one that would need renumbering — is skipped. And on its final pass it steps to `end()` and writes through the sentinel.

## Why it has never fired

Every caller registers in ascending order, so the preceding search always walks to `end()`, leaving `it == end()` and the loop a no-op. #844 made that ordering structural by tying registration to append order, but nothing enforces or records it — a later mid-list column would have tripped it.

## Why it's removed rather than repaired

The two list families need opposite semantics.

The wxDataViewCtrl lists key on **stable column ids** — `#define`s the caller passes straight back into `GetColumnName()` and `GetColumnDefaultWidth()`. Shifting a stored id detaches a column from its persistence key, and since that key is the on-disk config format, a saved width would come back attached to the wrong column, silently.

The legacy wxListCtrl lists key on the **column position**: `CMuleListCtrl::InsertColumn()` passes `col` straight to `wxGenericListCtrl::InsertColumn()`, and a mid-list insert there really does shift everything after it. Renumbering is what those lists would want.

So no single behaviour is correct for both. Neither family inserts mid-list — every call site was checked, including the one loop-driven site at `GenericClientListCtrl.cpp:233` — so the loop is unreachable as well as ambiguous. It goes, and the plain sorted insert stays.

## Debug assert on duplicate indices

The shift used to mask a double registration by pushing the existing entry up. Without it, two entries share an index and every lookup silently resolves to the first. That now asserts in Debug, beside the existing name-uniqueness check.

## Test

Adds `ListColumnStoreTest` (34 tests total, was 33). It needs no GUI — the registry half of the class is plain `wxString` bookkeeping.

The out-of-order case needs **two** entries after the insertion point to be observable. With only one, the off-by-one skips the single displaced entry and the damage lands on the sentinel instead, where no assertion can see it. Verified by restoring the old loop: the test fails with `Expected 'Y' but got ''` and exits 1, and passes with the fix. A three-column version of the same test passed against the bug.

## Testing

Full build clean; 34/34 tests; clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Based on current master rather than on #844 — no textual overlap, so they merge in either order. No app behaviour changes: the removed code was unreachable, so there is no before/after to demonstrate, only the test.
