### PR TITLE
feat(gui): port CDownloadListCtrl to wxDataViewCtrl

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1260,7 +1260,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
@@ -1540,29 +1540,14 @@ msgstr ""
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
@@ -1635,6 +1620,21 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1283,7 +1283,7 @@ msgstr "اسم مستخدم"
 msgid "File Name"
 msgstr "اسم الملف"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "تقيم"
 
@@ -1564,32 +1564,15 @@ msgstr "اخر اكتمال"
 msgid "Last Reception"
 msgstr "اخر إستقبال"
 
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
-
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "ذاتي"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "إلغاء"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "ذاتي"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1662,6 +1645,23 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&فتح الملف"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟\n"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1300,7 +1300,7 @@ msgstr "Nome d'usuariu"
 msgid "File Name"
 msgstr "Nome de ficheru"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoración"
 
@@ -1582,32 +1582,15 @@ msgstr "Cabera comprobación completa"
 msgid "Last Reception"
 msgstr "Cabera receición"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "¿De xuru quies desaniciar esti ficheru?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "¿De xuru quies desaniciar estos ficheros?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Encaboxar"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Reaición dende: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1680,6 +1663,23 @@ msgstr "Asignar a categoría"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Abrir el ficheru"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "¿De xuru quies desaniciar esti ficheru?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "¿De xuru quies desaniciar estos ficheros?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Reaición dende: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1278,7 +1278,7 @@ msgstr "Потребителско име"
 msgid "File Name"
 msgstr "Име на файл"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Оценка"
 
@@ -1559,32 +1559,15 @@ msgstr ""
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
-
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Автоматично"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отказ"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Автоматично"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1656,6 +1639,23 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Сигурни ли сте,че желаете да откажете свалянето и изтриете тези файлове ?\n"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
@@ -1539,29 +1539,14 @@ msgstr ""
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
@@ -1634,6 +1619,21 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1297,7 +1297,7 @@ msgstr "Usuari"
 msgid "File Name"
 msgstr "Fitxer"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoració"
 
@@ -1579,32 +1579,15 @@ msgstr "Últim cop vist complet"
 msgid "Last Reception"
 msgstr "Última recepció"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Esteu segur que voleu esborrar el fitxer seleccionat?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Esteu segur que voleu esborrar els fitxers seleccionats?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancel·la"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Retroacció des de: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1677,6 +1660,23 @@ msgstr "Assigna a una categoria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Obre el fitxer"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Esteu segur que voleu esborrar el fitxer seleccionat?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Esteu segur que voleu esborrar els fitxers seleccionats?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Retroacció des de: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1301,7 +1301,7 @@ msgstr "Jméno"
 msgid "File Name"
 msgstr "Název souboru"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Hodnocení"
 
@@ -1584,32 +1584,15 @@ msgstr "Naposledy spatřen kompletní"
 msgid "Last Reception"
 msgstr "Poslední příjem"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Opravdu si přejete smazat vybraný soubor?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Opravdu si přejete smazat vybrané soubory?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Zrušit"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Odezva od: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1682,6 +1665,23 @@ msgstr "Zařadit do kategorie"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Otevřít tento soubor"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Opravdu si přejete smazat vybraný soubor?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Opravdu si přejete smazat vybrané soubory?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Odezva od: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1286,7 +1286,7 @@ msgstr "Brugernavn"
 msgid "File Name"
 msgstr "Fil Navn"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
@@ -1567,32 +1567,15 @@ msgstr "Sidst Færdig"
 msgid "Last Reception"
 msgstr "Sidste Kontakt"
 
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
-
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Afbryd"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1665,6 +1648,23 @@ msgstr "Flyt til kategori"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Åben filen"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1306,7 +1306,7 @@ msgstr "Benutzername"
 msgid "File Name"
 msgstr "Dateiname"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Bewertung"
 
@@ -1587,32 +1587,15 @@ msgstr "Zuletzt vollständig gesehen"
 msgid "Last Reception"
 msgstr "Letzter Empfang"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Wirklich die ausgewählte Datei löschen?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Wirklich die ausgewählten Dateien löschen?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatisch"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Abbruch"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Rückmeldung von: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatisch"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1685,6 +1668,23 @@ msgstr "Einer Kategorie hinzufügen"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Oeffne diese Datei"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Wirklich die ausgewählte Datei löschen?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Wirklich die ausgewählten Dateien löschen?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Rückmeldung von: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1309,7 +1309,7 @@ msgstr "Όνομα Χρήστη"
 msgid "File Name"
 msgstr "Όνομα αρχείου"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Αξιολόγηση"
 
@@ -1590,32 +1590,15 @@ msgstr "Τελευταία φορά που εμφανίστηκε ολοκληρ
 msgid "Last Reception"
 msgstr "Τελευταία λήψη"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το συγκεκριμένο αρχείο;"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε τα συγκεκριμένα αρχεία;"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Αυτόματη"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Ακύρωση"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Αντίδραση από %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Αυτόματη"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1688,6 +1671,23 @@ msgstr "Ανάθεση σε κατηγορία"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Άνοιγμα αρχείου"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το συγκεκριμένο αρχείο;"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε τα συγκεκριμένα αρχεία;"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Αντίδραση από %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1260,7 +1260,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
@@ -1540,29 +1540,14 @@ msgstr ""
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
@@ -1635,6 +1620,21 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1310,7 +1310,7 @@ msgstr "Nombre de usuario"
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoración"
 
@@ -1590,32 +1590,15 @@ msgstr "Visto completo por última vez"
 msgid "Last Reception"
 msgstr "Última recepción"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "¿Seguro que desea borrar el archivo seleccionado?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "¿Seguro que desea borrar los archivos seleccionados?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automática"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Reacción desde: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automática"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1688,6 +1671,23 @@ msgstr "Asignar a la categoría"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Abrir el archivo"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "¿Seguro que desea borrar el archivo seleccionado?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "¿Seguro que desea borrar los archivos seleccionados?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Reacción desde: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1298,7 +1298,7 @@ msgstr "Kasutajanimi"
 msgid "File Name"
 msgstr "Faili nimi"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Hinnang"
 
@@ -1580,32 +1580,15 @@ msgstr "Viimati nähtud terviklikuna"
 msgid "Last Reception"
 msgstr "Viimane vastuvõtt"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Oled kindel et tahad valitud faili kustutada?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Oled kindel et tahad valitud failid kustutada?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Loobu"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Tagasiside : %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1678,6 +1661,23 @@ msgstr "Määra kategooria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Ava Fail"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Oled kindel et tahad valitud faili kustutada?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Oled kindel et tahad valitud failid kustutada?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Tagasiside : %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1299,7 +1299,7 @@ msgstr "Erabiltzaile izena"
 msgid "File Name"
 msgstr "Fitxategi izena"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Kalifikazioa"
 
@@ -1581,32 +1581,15 @@ msgstr "Azkenez osoa ikusirik"
 msgid "Last Reception"
 msgstr "Azkenez jasoa"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Ziur zaude aukeratutako fitxategia ezabatu nahi duzula?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Ziur zaude aukeratutako fitxategia ezabatu nahi duzula?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Utzi"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Erantzuna hemendik: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1679,6 +1662,23 @@ msgstr "Ezarri kategoria bat"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Ireki fitxategia"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Ziur zaude aukeratutako fitxategia ezabatu nahi duzula?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Ziur zaude aukeratutako fitxategia ezabatu nahi duzula?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Erantzuna hemendik: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1299,7 +1299,7 @@ msgstr "Käyttäjänimi"
 msgid "File Name"
 msgstr "Tiedoston nimi"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Luokitus"
 
@@ -1581,32 +1581,15 @@ msgstr "Viimeksi nähty kokonaisena"
 msgid "Last Reception"
 msgstr "Viimeisin vastaanotto"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Oletko varma että haluat poistaa valitun tiedoston?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Oletko varma että haluat poistaa valitut tiedostot?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automaattinen"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Peruuta"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Palaute tullut: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automaattinen"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1679,6 +1662,23 @@ msgstr "Luokittele"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Avaa tied&osto"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Oletko varma että haluat poistaa valitun tiedoston?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Oletko varma että haluat poistaa valitut tiedostot?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Palaute tullut: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1308,7 +1308,7 @@ msgstr "Nom d'utilisateur"
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Évaluation"
 
@@ -1588,32 +1588,15 @@ msgstr "Vu complet pour la dernière fois"
 msgid "Last Reception"
 msgstr "Dernière réception"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Êtes-vous sûr de vouloir supprimer le fichier sélectionné ?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Êtes-vous sûr de vouloir supprimer les fichiers sélectionnés ?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuler"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Retour de : %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1686,6 +1669,23 @@ msgstr "Associer à une catégorie"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Ouvrir le fichier"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Êtes-vous sûr de vouloir supprimer le fichier sélectionné ?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Êtes-vous sûr de vouloir supprimer les fichiers sélectionnés ?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Retour de : %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1319,7 +1319,7 @@ msgstr "Nome de usuario"
 msgid "File Name"
 msgstr "Nome do ficheiro"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Valoración"
 
@@ -1600,32 +1600,15 @@ msgstr "Última vez que se vira completo"
 msgid "Last Reception"
 msgstr "Última recepción"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Seguro que quere borrar o ficheiro seleccionado?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Seguro que quere borrar os ficheiros seleccionados?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automático"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Comentarios de : %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automático"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1698,6 +1681,23 @@ msgstr "Asignar á categoría"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Abrir o ficheir&o"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Seguro que quere borrar o ficheiro seleccionado?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Seguro que quere borrar os ficheiros seleccionados?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Comentarios de : %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1290,7 +1290,7 @@ msgstr "שם משתמש"
 msgid "File Name"
 msgstr "שם קובץ"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "דרוג"
 
@@ -1571,30 +1571,15 @@ msgstr "פעם אחרונה שנראה שלם"
 msgid "Last Reception"
 msgstr "פעם אחרונה שנתקבל"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "האם אתה בטוח שברצונך למחוק את הקובץ שנבחר?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "האם אתה בטוח שברצונל ךמחוק את הקבצים שנבחרו?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "אוטמטי"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "ביטול"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "אוטמטי"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1667,6 +1652,21 @@ msgstr "ייחס לקטיגוריה"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&תפתח את הקובץ"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "האם אתה בטוח שברצונך למחוק את הקובץ שנבחר?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "האם אתה בטוח שברצונל ךמחוק את הקבצים שנבחרו?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1292,7 +1292,7 @@ msgstr "Ime korisnika"
 msgid "File Name"
 msgstr "Ime fajla"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Ocjena"
 
@@ -1574,32 +1574,15 @@ msgstr "Posljednji put vidjen kompletno"
 msgid "Last Reception"
 msgstr "Posljedni prijem"
 
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
-
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatski"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Otkaz"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatski"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1672,6 +1655,23 @@ msgstr "Odredi u kategoriju"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Otvori fajl"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1296,7 +1296,7 @@ msgstr "Felhasználói név"
 msgid "File Name"
 msgstr "Fájlnév"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Értékelés"
 
@@ -1576,32 +1576,15 @@ msgstr "Utoljára teljesnek látott"
 msgid "Last Reception"
 msgstr "Utoljára fogadott"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Biztos, hogy törlöd a kiválasztott fájlt?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Biztos, hogy törlöd a kiválasztott fájlokat?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatikus"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Mégsem"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Visszajelzés %s-től (%s):\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatikus"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1674,6 +1657,23 @@ msgstr "Hozzárendelés kategórához"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Fájl &megnyitása"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Biztos, hogy törlöd a kiválasztott fájlt?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Biztos, hogy törlöd a kiválasztott fájlokat?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Visszajelzés %s-től (%s):\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1310,7 +1310,7 @@ msgstr "Nome utente"
 msgid "File Name"
 msgstr "Nome file"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Giudizio"
 
@@ -1590,32 +1590,15 @@ msgstr "Ultima fonte completa vista"
 msgid "Last Reception"
 msgstr "Ultima ricezione"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Sei certo di voler eliminare il file selezionato?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Sei certo di volere eliminare i file selezionati?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annulla"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Feedback da: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1688,6 +1671,23 @@ msgstr "Assegna a categoria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Apri file"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Sei certo di voler eliminare il file selezionato?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Sei certo di volere eliminare i file selezionati?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Feedback da: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1300,7 +1300,7 @@ msgstr "ユーザ名"
 msgid "File Name"
 msgstr "ファイル名"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "評価"
 
@@ -1580,32 +1580,15 @@ msgstr "最後に全部分を確認した時刻"
 msgid "Last Reception"
 msgstr "最後に受信した時刻"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "本当に選択されたファイルを削除しますか？"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "本当に選択されたファイルを削除しますか？"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "自動"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "キャンセル"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"フィードバック:%s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "自動"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1678,6 +1661,23 @@ msgstr "カテゴリに割り当てる"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "ファイルを開く(&O)"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "本当に選択されたファイルを削除しますか？"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "本当に選択されたファイルを削除しますか？"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"フィードバック:%s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1308,7 +1308,7 @@ msgstr "사용자이름"
 msgid "File Name"
 msgstr "파일 이름"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "등급"
 
@@ -1588,32 +1588,15 @@ msgstr "최종 완료"
 msgid "Last Reception"
 msgstr "최종 받음"
 
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "선택된파일을 지우시겠습니까?"
-
-#: src/DownloadListCtrl.cpp
-#, fuzzy
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "선택된파일을 지우시겠습니까?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "자동"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "취소"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "자동"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1686,6 +1669,23 @@ msgstr "분류로 할당"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "파일 열기(&O)"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "선택된파일을 지우시겠습니까?"
+
+#: src/DownloadListCtrl.cpp
+#, fuzzy
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "선택된파일을 지우시겠습니까?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1313,7 +1313,7 @@ msgstr "Vardas"
 msgid "File Name"
 msgstr "Failo pavadinimas"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Reitingas"
 
@@ -1595,32 +1595,15 @@ msgstr "Paskutinį kartą matyta pilna"
 msgid "Last Reception"
 msgstr "Paskutinį kartą siųsta"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Ar tikrai norite pašalinti pažymėtą failą?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Ar tikrai norite pašalinti pažymėtus failus?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatiškas"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Atšaukti"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Atsakymas iš: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatiškas"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1693,6 +1676,23 @@ msgstr "Priskirti į kategoriją"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Atverti failą"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Ar tikrai norite pašalinti pažymėtą failą?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Ar tikrai norite pašalinti pažymėtus failus?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Atsakymas iš: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1273,7 +1273,7 @@ msgstr "Lietotājvārds"
 msgid "File Name"
 msgstr "Datnes nosaukums"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Vērtējums"
 
@@ -1554,12 +1554,8 @@ msgstr "Pēdējo reizi datne bija pilnībā pieejama"
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
@@ -1567,17 +1563,6 @@ msgstr ""
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Atcelt"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr ""
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1649,6 +1634,21 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1299,7 +1299,7 @@ msgstr "Gebruikersnaam"
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Waardering"
 
@@ -1581,32 +1581,15 @@ msgstr "Laatst compleet gezien"
 msgid "Last Reception"
 msgstr "Laatste overdracht"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Weet u zeker dat u het geselecteerde bestand wilt verwijderen?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Weet u zeker dat u de geselecteerde bestanden wilt verwijderen?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuleren"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Feedback van: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1679,6 +1662,23 @@ msgstr "Toewijzen aan catgorie"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Open het bestand"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Weet u zeker dat u het geselecteerde bestand wilt verwijderen?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Weet u zeker dat u de geselecteerde bestanden wilt verwijderen?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Feedback van: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1307,7 +1307,7 @@ msgstr "Brukarnamn"
 msgid "File Name"
 msgstr "Filnamn"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Verdi"
 
@@ -1588,32 +1588,15 @@ msgstr "Sist sett komplett"
 msgid "Last Reception"
 msgstr "Sist motteke"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Er du viss på at du vil slette den valde fila?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Er du viss på at du vil slette dei valte filene?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatisk"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Tilbakemelding frå: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatisk"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1686,6 +1669,23 @@ msgstr "Vel kategori"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Opne fila"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Er du viss på at du vil slette den valde fila?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Er du viss på at du vil slette dei valte filene?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Tilbakemelding frå: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1305,7 +1305,7 @@ msgstr "Nazwa użytkownika"
 msgid "File Name"
 msgstr "Nazwa pliku"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Ocena"
 
@@ -1588,32 +1588,15 @@ msgstr "Ostatnio widziano cały"
 msgid "Last Reception"
 msgstr "Ostatnio widziany"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Jesteś pewien, że chcesz usunąć wybrany plik?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Jesteś pewien, że chcesz usunąć wybrane pliki?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatyczny"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anuluj"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Informacja zwrotna od:  %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatyczny"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1686,6 +1669,23 @@ msgstr "Przydziel do kategorii"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Otwórz plik"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Jesteś pewien, że chcesz usunąć wybrany plik?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Jesteś pewien, że chcesz usunąć wybrane pliki?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Informacja zwrotna od:  %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1306,7 +1306,7 @@ msgstr "Nome do usuário"
 msgid "File Name"
 msgstr "Nome do arquivo"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Avaliação"
 
@@ -1586,32 +1586,15 @@ msgstr "Última vez concluído"
 msgid "Last Reception"
 msgstr "Último recebimento"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Deseja remover os arquivo selecionado?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Deseja remover os arquivos selecionados?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Resposta de: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1684,6 +1667,23 @@ msgstr "Adicionar na Categoria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Abrir &o arquivo"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Deseja remover os arquivo selecionado?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Deseja remover os arquivos selecionados?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Resposta de: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1305,7 +1305,7 @@ msgstr "Nome de Utilizador"
 msgid "File Name"
 msgstr "Nome do Ficheiro"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Classificação"
 
@@ -1587,32 +1587,15 @@ msgstr "Última Vez Visto Completo"
 msgid "Last Reception"
 msgstr "Última recepção"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Tem a certeza que deseja eliminar o ficheiro seleccionado?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Tem a certeza que deseja eliminar os ficheiros seleccionados?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automática"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Comentário de: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automática"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1685,6 +1668,23 @@ msgstr "Atribuir à categoria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Abrir o ficheiro"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Tem a certeza que deseja eliminar o ficheiro seleccionado?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Tem a certeza que deseja eliminar os ficheiros seleccionados?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Comentário de: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1302,7 +1302,7 @@ msgstr "Utilizator"
 msgid "File Name"
 msgstr "Denumire fișier"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Evaluare"
 
@@ -1585,32 +1585,15 @@ msgstr "Văzut complet ultima dată"
 msgid "Last Reception"
 msgstr "Ultima recepție"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Sigur doriți să ștergeți fișierul selectat?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Sigur doriți să ștergeți fișierele selectate?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automat"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anulare"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Feedback de la: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automat"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1683,6 +1666,23 @@ msgstr "Atribuit la categoria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Deshide fișierul"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Sigur doriți să ștergeți fișierul selectat?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Sigur doriți să ștergeți fișierele selectate?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Feedback de la: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1314,7 +1314,7 @@ msgstr "Имя пользователя"
 msgid "File Name"
 msgstr "Имя файла"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Оценка"
 
@@ -1597,32 +1597,15 @@ msgstr "Замечен целиком"
 msgid "Last Reception"
 msgstr "Последний приём"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Удалить выбранный файл?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Уверены, что хотите удалить выбранные файлы?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Авто"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отмена"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Ответ от: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Авто"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1695,6 +1678,23 @@ msgstr "Назначить категорию"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Открыть файл"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Удалить выбранный файл?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Уверены, что хотите удалить выбранные файлы?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Ответ от: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1311,7 +1311,7 @@ msgstr "Uporabniško ime"
 msgid "File Name"
 msgstr "Ime datoteke"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Ocena"
 
@@ -1595,32 +1595,15 @@ msgstr "Nazadnje videno celotno"
 msgid "Last Reception"
 msgstr "Zadnji sprejem"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Ali res želite izbrisati izbrano datoteko?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Ali res želite izbrisati izbrane datoteke?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Samod."
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Prekliči"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Odziv od: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Samod."
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1693,6 +1676,23 @@ msgstr "Dodeli kategoriji"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Odpri datoteko"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Ali res želite izbrisati izbrano datoteko?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Ali res želite izbrisati izbrane datoteke?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Odziv od: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1304,7 +1304,7 @@ msgstr "Emri i perdorimit"
 msgid "File Name"
 msgstr "Emri i failit"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Vleresimi"
 
@@ -1585,30 +1585,15 @@ msgstr "Hera e fundit qe u pa e kompletuar"
 msgid "Last Reception"
 msgstr "Marrja e fundit"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Jeni te sigurte qe deshironi te fshini failin e zgjedhur?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Jeni te sigurte qe deshironi te fshini failet e zgjedhura?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Automatike"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Fshij"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Automatike"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1681,6 +1666,21 @@ msgstr "Vendos tek kategoria"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Hap failin"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Jeni te sigurte qe deshironi te fshini failin e zgjedhur?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Jeni te sigurte qe deshironi te fshini failet e zgjedhura?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1297,7 +1297,7 @@ msgstr "Användarnamn"
 msgid "File Name"
 msgstr "Filnamn"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Rankning"
 
@@ -1579,32 +1579,15 @@ msgstr "Senast sedd komplett"
 msgid "Last Reception"
 msgstr "Senast mottagen"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Är du säker på att du vill ta bort vald fil?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Är du säker på att du vill ta bort alla valda filer?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Återkoppling från: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Auto"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1677,6 +1660,23 @@ msgstr "Koppla till kategori"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "&Öppna filen"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Är du säker på att du vill ta bort vald fil?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Är du säker på att du vill ta bort alla valda filer?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Återkoppling från: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
@@ -1539,29 +1539,14 @@ msgstr ""
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
@@ -1634,6 +1619,21 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1301,7 +1301,7 @@ msgstr "Kullanıcı Adı"
 msgid "File Name"
 msgstr "Dosya Adı"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Puanlama"
 
@@ -1581,32 +1581,15 @@ msgstr "Son Tamamlanmış Görülme"
 msgid "Last Reception"
 msgstr "Son Alım"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Seçili dosyayı silmek istediğinizden emin misiniz?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Seçili dosyaları silmek istediğinizden emin misiniz?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Otomatik"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "İptal"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Geri besleme: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Otomatik"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1679,6 +1662,23 @@ msgstr "Sınıfa Ekle"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Dosyayı &Aç"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Seçili dosyayı silmek istediğinizden emin misiniz?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Seçili dosyaları silmek istediğinizden emin misiniz?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Geri besleme: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1304,7 +1304,7 @@ msgstr "Ім'я користувача"
 msgid "File Name"
 msgstr "Назва файлу"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "Рейтинг"
 
@@ -1591,32 +1591,15 @@ msgstr "Востаннє повний"
 msgid "Last Reception"
 msgstr "Останнє отримання"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "Ви впевнені, що хочете видалити вибраний файл?"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "Ви впевнені, що хочете видалити вибрані файли?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "Автоматично"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Скасувати"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"Відгук від: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "Автоматично"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1689,6 +1672,23 @@ msgstr "Призначити категорію"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "Відкрити файл"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "Ви впевнені, що хочете видалити вибраний файл?"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "Ви впевнені, що хочете видалити вибрані файли?"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"Відгук від: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1258,7 +1258,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr ""
 
@@ -1538,29 +1538,14 @@ msgstr ""
 msgid "Last Reception"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
@@ -1633,6 +1618,21 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1302,7 +1302,7 @@ msgstr "用户名"
 msgid "File Name"
 msgstr "文件名"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "评价"
 
@@ -1582,32 +1582,15 @@ msgstr "最后一次发现完整文件"
 msgid "Last Reception"
 msgstr "最后一次下载"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "您确定要删除选择的文件吗？"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "您确定要删除选择的文件吗？"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "自动"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"报告来自: %s (%s)\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "自动"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1680,6 +1663,23 @@ msgstr "指定到分类"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "打开文件 (&O)"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "您确定要删除选择的文件吗？"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "您确定要删除选择的文件吗？"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"报告来自: %s (%s)\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 17:11+0200\n"
+"POT-Creation-Date: 2026-08-07 21:37+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1298,7 +1298,7 @@ msgstr "使用者名稱"
 msgid "File Name"
 msgstr "檔案名稱"
 
-#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/SearchListCtrl.cpp
 msgid "Rating"
 msgstr "評價"
 
@@ -1579,32 +1579,15 @@ msgstr "最後看到完整檔案"
 msgid "Last Reception"
 msgstr "最後一次下載"
 
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected file?"
-msgstr "您確定要刪除這個檔案嗎？"
-
-#: src/DownloadListCtrl.cpp
-msgid "Are you sure that you wish to delete the selected files?"
-msgstr "您確定要刪除這些檔案嗎？"
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+msgid "Auto"
+msgstr "自動"
 
 #: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 #: src/ServerListCtrl.cpp src/TransferWnd.cpp
 #: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
-
-#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
-#, c-format
-msgid ""
-"Feedback from: %s (%s)\n"
-"\n"
-msgstr ""
-"%s (%s) 回覆訊息\n"
-"\n"
-
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-msgid "Auto"
-msgstr "自動"
 
 #: src/DownloadListCtrl.cpp src/TransferWnd.cpp
 msgid "&Stop"
@@ -1677,6 +1660,23 @@ msgstr "分類"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "&Open the file"
 msgstr "開啟檔案(&O)"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected file?"
+msgstr "您確定要刪除這個檔案嗎？"
+
+#: src/DownloadListCtrl.cpp
+msgid "Are you sure that you wish to delete the selected files?"
+msgstr "您確定要刪除這些檔案嗎？"
+
+#: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid ""
+"Feedback from: %s (%s)\n"
+"\n"
+msgstr ""
+"%s (%s) 回覆訊息\n"
+"\n"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Enter new name for this file:"

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -103,7 +103,7 @@ private:
 		if (showStrip && barRect.GetWidth() > 0) {
 			const int width = static_cast<int>((static_cast<double>(barRect.GetWidth()) /
 								   static_cast<double>(file->GetFileSize())) *
-							   file->GetCompletedSize());
+							   static_cast<double>(file->GetCompletedSize()));
 			if (bFlat) {
 				dc->SetPen(*wxTRANSPARENT_PEN);
 				dc->SetBrush(crFlatProgress.GetBrush());
@@ -121,9 +121,9 @@ private:
 			return;
 		}
 		const uint16 hashingProgress = file->GetHashingProgress();
-		double percent = hashingProgress == 0
-					 ? file->GetPercentCompleted()
-					 : 100.0 * hashingProgress * PARTSIZE / file->GetFileSize();
+		double percent = hashingProgress == 0 ? file->GetPercentCompleted()
+						      : 100.0 * hashingProgress * PARTSIZE /
+								static_cast<double>(file->GetFileSize());
 		if (file->IsCompleted()) {
 			percent = 100.0;
 		} else if (percent > 99.9) {
@@ -234,7 +234,7 @@ wxString CDownloadListCtrl::GetRowLabel(const wxDataViewItem &item) const
 	return GetItemColumnText(data, COLUMN_DL_NAME);
 }
 
-CDownloadListCtrl::~CDownloadListCtrl() {}
+CDownloadListCtrl::~CDownloadListCtrl() = default;
 
 void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 {
@@ -478,7 +478,8 @@ void CDownloadListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 			if (i == 0) {
 				cats->Append(MP_ASSIGNCAT, _("unassign"));
 			} else {
-				cats->Append(MP_ASSIGNCAT + i, theApp->glob_prefs->GetCategory(i)->title);
+				cats->Append(MP_ASSIGNCAT + static_cast<int>(i),
+					theApp->glob_prefs->GetCategory(i)->title);
 			}
 		}
 	}

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -25,80 +25,130 @@
 
 #include "DownloadListCtrl.h" // Interface declarations
 
-#include <protocol/ed2k/ClientSoftware.h>
+#include <common/Format.h> // Needed for CFormat
 #include <common/MenuIDs.h>
 
-#include <common/Format.h>    // Needed for CFormat
 #include "amule.h"            // Needed for theApp
 #include "amuleDlg.h"         // Needed for CamuleDlg
-#include "FileLaunch.h"       // Needed for FileLaunch::Open / Reveal
-#include "BarShader.h"        // Needed for CBarShader
 #include "CommentDialogLst.h" // Needed for CCommentDialogLst
 #include "DataToText.h"       // Needed for PriorityToStr
 #include "DownloadQueue.h"
 #include "FileDetailDialog.h" // Needed for CFileDetailDialog
-#include "GuiEvents.h"        // Needed for CoreNotify_*
+#include "FileLaunch.h"       // Needed for FileLaunch::Open / Reveal
+#include "GuiEvents.h"        // Needed for CoreNotify_*, Notify_DownloadCtrlDoItemSelectionChanged
 #include "Logger.h"
-#include "muuli_wdr.h" // Needed for ID_DLOADLIST
-#include "PartFile.h"  // Needed for CPartFile
+#include "MuleBarRenderer.h" // Needed for CBarFillSpec, CBarFillSpan, CMuleBarRenderer
+#include "PartFile.h"        // Needed for CPartFile
 #include "Preferences.h"
 #include "SharedFileList.h" // Needed for CSharedFileList
-#include "Statistics.h"     // Needed for theStats (free space), FREE_SPACE_UNKNOWN
-#include "TransferWnd.h"
 #include "SourceListCtrl.h"
+#include "Statistics.h" // Needed for theStats (free space), FREE_SPACE_UNKNOWN
+#include "TransferWnd.h"
+#include "muuli_wdr.h" // Needed for ID_DLOADLIST
 
-class CPartFile;
-
-struct FileCtrlItem_Struct
+namespace
 {
-	FileCtrlItem_Struct()
-	: dwUpdated(0)
-	, status(NULL)
-	, m_fileValue(NULL)
+// Colours for the chunk/gap bar; matches every value DrawFileStatusBar used.
+const CMuleColour crHave(104, 104, 104);
+const CMuleColour crFlatHave(0, 0, 0);
+
+const CMuleColour crPending(255, 208, 0);
+const CMuleColour crFlatPending(255, 255, 100);
+
+const CMuleColour crProgress(0, 224, 0);
+const CMuleColour crFlatProgress(0, 150, 0);
+
+const CMuleColour crMissing(255, 0, 0);
+
+/**
+ * Draws the Progress column: the chunk/gap bar (via the base class) plus two
+ * things Shared Files' bar never needed -- a completed-progress overlay
+ * strip and a live percentage label. Checked both CGenericClientListCtrl
+ * bars while designing this: neither draws text or a strip, so this stays a
+ * Downloads-only subclass rather than growing CBarFillSpec for everyone.
+ */
+class CDownloadBarRenderer : public CMuleBarRenderer
+{
+public:
+	bool Render(wxRect cell, wxDC *dc, int state) override
 	{
+		// Gates the whole cell -- bar, strip and percent text alike -- exactly
+		// as the pre-port ColumnProgress case did.
+		if (!thePrefs::ShowProgBar()) {
+			return true;
+		}
+		CMuleBarRenderer::Render(cell, dc, state);
+		DrawOverlay(cell, dc);
+		return true;
 	}
 
-	~FileCtrlItem_Struct() { delete status; }
-
-	CPartFile *GetFile() const { return m_fileValue; }
-
-	void SetContents(CPartFile *file) { m_fileValue = file; }
-
-	uint64 dwUpdated;
-	wxBitmap *status;
-
 private:
-	CPartFile *m_fileValue;
+	void DrawOverlay(wxRect cell, wxDC *dc) const
+	{
+		CPartFile *file = reinterpret_cast<CPartFile *>(GetSpec().GetIdentity());
+		if (!file || file->GetFileSize() == 0) {
+			return;
+		}
+
+		const bool bFlat = thePrefs::UseFlatBar();
+		const wxRect barRect = InsetForBar(cell, bFlat);
+
+		// The completed-progress strip only makes sense for a file still
+		// assembling from gaps/pending blocks: DrawFileStatusBar's completed
+		// and hashing branches already fill the whole bar solid, so the strip
+		// would be redundant there (and, while hashing, actively wrong -- that
+		// fill tracks hashed bytes, not completed bytes).
+		const bool showStrip = !file->IsCompleted() && file->GetStatus() != PS_COMPLETING &&
+				       file->GetHashingProgress() == 0;
+		if (showStrip && barRect.GetWidth() > 0) {
+			const int width = static_cast<int>((static_cast<double>(barRect.GetWidth()) /
+								   static_cast<double>(file->GetFileSize())) *
+							   file->GetCompletedSize());
+			if (bFlat) {
+				dc->SetPen(*wxTRANSPARENT_PEN);
+				dc->SetBrush(crFlatProgress.GetBrush());
+				dc->DrawRectangle(barRect.x, barRect.y, width, 3);
+			} else {
+				dc->SetPen(*wxBLACK_PEN);
+				dc->DrawLine(barRect.x, barRect.y + 0, barRect.x + width, barRect.y + 0);
+				dc->DrawLine(barRect.x, barRect.y + 2, barRect.x + width, barRect.y + 2);
+				dc->SetPen(*(wxThePenList->FindOrCreatePen(crProgress, 1, wxPENSTYLE_SOLID)));
+				dc->DrawLine(barRect.x, barRect.y + 1, barRect.x + width, barRect.y + 1);
+			}
+		}
+
+		if (!thePrefs::ShowPercent()) {
+			return;
+		}
+		const uint16 hashingProgress = file->GetHashingProgress();
+		double percent = hashingProgress == 0
+					 ? file->GetPercentCompleted()
+					 : 100.0 * hashingProgress * PARTSIZE / file->GetFileSize();
+		if (file->IsCompleted()) {
+			percent = 100.0;
+		} else if (percent > 99.9) {
+			percent = 99.9;
+		}
+		const wxString buffer = CFormat("%.1f%%") % percent;
+		const int middlex = (2 * cell.GetX() + cell.GetWidth()) >> 1;
+		const int middley = (2 * cell.GetY() + cell.GetHeight()) >> 1;
+		wxCoord textwidth;
+		wxCoord textheight;
+		dc->GetTextExtent(buffer, &textwidth, &textheight);
+		const wxColour oldColour = dc->GetTextForeground();
+		// Ordinary progress bar: white percentage. Hashing (green/yellow
+		// bar): black percentage.
+		dc->SetTextForeground(hashingProgress == 0 ? *wxWHITE : *wxBLACK);
+		dc->DrawText(buffer, middlex - (textwidth >> 1), middley - (textheight >> 1));
+		dc->SetTextForeground(oldColour);
+	}
 };
+} // namespace
 
-#define m_ImageList theApp->amuledlg->m_imagelist
-
-enum ColumnEnum
-{
-	ColumnPart = 0,
-	ColumnFileName,
-	ColumnSize,
-	ColumnTransferred,
-	ColumnCompleted,
-	ColumnSpeed,
-	ColumnProgress,
-	ColumnSources,
-	ColumnPriority,
-	ColumnStatus,
-	ColumnTimeRemaining,
-	ColumnLastSeenComplete,
-	ColumnLastReception,
-	ColumnNumberOfColumns
-};
-
-wxBEGIN_EVENT_TABLE(CDownloadListCtrl, CMuleVirtualListCtrl)
-	EVT_LIST_ITEM_ACTIVATED(ID_DLOADLIST, CDownloadListCtrl::OnItemActivated)
-	EVT_LIST_ITEM_RIGHT_CLICK(ID_DLOADLIST, CDownloadListCtrl::OnMouseRightClick)
-	EVT_LIST_ITEM_MIDDLE_CLICK(ID_DLOADLIST, CDownloadListCtrl::OnMouseMiddleClick)
-	EVT_LIST_ITEM_SELECTED(ID_DLOADLIST, CDownloadListCtrl::OnItemSelectionChanged)
-	EVT_LIST_ITEM_DESELECTED(ID_DLOADLIST, CDownloadListCtrl::OnItemSelectionChanged)
-
-	EVT_CHAR(CDownloadListCtrl::OnKeyPressed)
+wxBEGIN_EVENT_TABLE(CDownloadListCtrl, CMuleVirtualDataViewCtrl)
+	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CDownloadListCtrl::OnItemActivated)
+	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CDownloadListCtrl::OnItemRightClicked)
+	EVT_DATAVIEW_SELECTION_CHANGED(wxID_ANY, CDownloadListCtrl::OnSelectionChanged)
 
 	EVT_MENU(MP_CANCEL, CDownloadListCtrl::OnCancelFile)
 
@@ -128,117 +178,85 @@ wxBEGIN_EVENT_TABLE(CDownloadListCtrl, CMuleVirtualListCtrl)
 	EVT_MENU(MP_VIEWFILECOMMENTS, CDownloadListCtrl::OnViewFileComments)
 
 	EVT_MENU(MP_WS, CDownloadListCtrl::OnGetFeedback)
-
 wxEND_EVENT_TABLE()
-
-//! This listtype is used when gathering the selected items.
-typedef std::list<FileCtrlItem_Struct *> ItemList;
 
 CDownloadListCtrl::CDownloadListCtrl(wxWindow *parent,
 	wxWindowID winid,
 	const wxPoint &pos,
 	const wxSize &size,
 	long style,
-	const wxValidator &validator,
 	const wxString &name)
-: CMuleVirtualListCtrl(parent, winid, pos, size, style | wxLC_OWNERDRAW, validator, name)
+: CMuleVirtualDataViewCtrl(parent, winid, pos, size, style, name)
 {
-	// Setting the sorter function.
-	SetSortFunc(SortProc);
+	const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+	AddTextColumn(_("Part"), COLUMN_DL_PART, "a", 30, wxALIGN_LEFT, flags);
+	AddIconTextColumn(_("File Name"), COLUMN_DL_NAME, "N", 260, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Size"), COLUMN_DL_SIZE, "Z", 60, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Transferred"), COLUMN_DL_TRANSFERRED, "T", 65, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Completed"), COLUMN_DL_COMPLETED, "C", 65, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Speed"), COLUMN_DL_SPEED, "S", 65, wxALIGN_LEFT, flags);
+	AddBarColumn(_("Progress"), COLUMN_DL_PROGRESS, "P", 170, flags, new CDownloadBarRenderer());
+	AddTextColumn(_("Sources"), COLUMN_DL_SOURCES, "u", 50, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Priority"), COLUMN_DL_PRIORITY, "p", 55, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Status"), COLUMN_DL_STATUS, "s", 70, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Time Remaining"), COLUMN_DL_TIMEREMAINING, "r", 110, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Last Seen Complete"), COLUMN_DL_LASTSEENCOMPLETE, "c", 220, wxALIGN_LEFT, flags);
+	AddTextColumn(_("Last Reception"), COLUMN_DL_LASTRECEPTION, "R", 220, wxALIGN_LEFT, flags);
 
-	// Set the table-name (for loading and saving preferences).
-	SetTableName("Download");
+	AppendSpacerColumn(COLUMN_DL_SPACER);
+	AssociateVirtualModel();
 
-	m_menu = NULL;
+	// Default sort is by name, ascending; LoadColumnSettings() replaces it
+	// when the config has something saved.
+	ApplySorting(COLUMN_DL_NAME, 0);
 
-	m_hilightBrush = CMuleColour(wxSYS_COLOUR_HIGHLIGHT) /*.Blend(125)*/.GetBrush();
-
-	m_hilightUnfocusBrush = CMuleColour(CMuleColour::GetUnfocusedHighlight()).GetBrush();
-
-	InsertColumn(ColumnPart, _("Part"), wxLIST_FORMAT_LEFT, 30, "a");
-	InsertColumn(ColumnFileName, _("File Name"), wxLIST_FORMAT_LEFT, 260, "N");
-	InsertColumn(ColumnSize, _("Size"), wxLIST_FORMAT_LEFT, 60, "Z");
-	InsertColumn(ColumnTransferred, _("Transferred"), wxLIST_FORMAT_LEFT, 65, "T");
-	InsertColumn(ColumnCompleted, _("Completed"), wxLIST_FORMAT_LEFT, 65, "C");
-	InsertColumn(ColumnSpeed, _("Speed"), wxLIST_FORMAT_LEFT, 65, "S");
-	InsertColumn(ColumnProgress, _("Progress"), wxLIST_FORMAT_LEFT, 170, "P");
-	InsertColumn(ColumnSources, _("Sources"), wxLIST_FORMAT_LEFT, 50, "u");
-	InsertColumn(ColumnPriority, _("Priority"), wxLIST_FORMAT_LEFT, 55, "p");
-	InsertColumn(ColumnStatus, _("Status"), wxLIST_FORMAT_LEFT, 70, "s");
-	InsertColumn(ColumnTimeRemaining, _("Time Remaining"), wxLIST_FORMAT_LEFT, 110, "r");
-	InsertColumn(ColumnLastSeenComplete, _("Last Seen Complete"), wxLIST_FORMAT_LEFT, 220, "c");
-	InsertColumn(ColumnLastReception, _("Last Reception"), wxLIST_FORMAT_LEFT, 220, "R");
-
-	m_category = 0;
-	m_filecount = 0;
-	m_shownSize = 0;
-	m_ItemSelectionChangePending = false;
-	LoadSettings();
-
-	// m_ready = true;
+	m_columnStore.SetTableName("Download");
+	LoadColumnSettings();
+	InitColumnState();
 }
 
-// This is the order the columns had before extendable list-control settings save/load code was introduced.
-// Don't touch when inserting new columns!
 wxString CDownloadListCtrl::GetOldColumnOrder() const
 {
 	return "N,Z,T,C,S,P,u,p,s,r,c,R";
 }
 
-bool CDownloadListCtrl::IsLiveSortColumn() const
+wxString CDownloadListCtrl::GetRowLabel(const wxDataViewItem &item) const
 {
-	switch (GetSortColumn()) {
-	case ColumnTransferred:
-	case ColumnCompleted:
-	case ColumnSpeed:
-	case ColumnProgress:
-	case ColumnSources:
-	case ColumnTimeRemaining:
-	case ColumnLastSeenComplete:
-	case ColumnLastReception:
-		return true;
-	default:
-		return false;
+	// Column 0 is the part number here, not the name -- unlike every other
+	// ported list, so the base's "column 0 is the label" default would make
+	// type-to-select match part numbers. GetModel() is always the
+	// wxDataViewIndexListModel AssociateVirtualModel() installed.
+	const wxDataViewListModel *model = static_cast<const wxDataViewListModel *>(GetModel());
+	const wxUIntPtr data = ItemAt(static_cast<long>(model->GetRow(item)));
+	if (!data) {
+		return wxEmptyString;
 	}
+	return GetItemColumnText(data, COLUMN_DL_NAME);
 }
 
-CDownloadListCtrl::~CDownloadListCtrl()
-{
-	while (!m_ListItems.empty()) {
-		delete m_ListItems.begin()->second;
-		m_ListItems.erase(m_ListItems.begin());
-	}
-}
+CDownloadListCtrl::~CDownloadListCtrl() {}
 
 void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 {
 	wxASSERT(file);
 
 	// Avoid duplicate entries of files
-	if (m_ListItems.find(file) == m_ListItems.end()) {
-		FileCtrlItem_Struct *newitem = new FileCtrlItem_Struct;
-		newitem->SetContents(file);
-
-		m_ListItems.insert(ListItemsPair(file, newitem));
-
-		// During a bulk load (remote GUI first sync) the caller defers
-		// the display: showing and, above all, re-sorting the list on
-		// every one of thousands of files is O(n^2) and freezes the GUI
-		// (issue #414). ShowFileList() shows and sorts the whole list
-		// once afterwards, mirroring the shared-files view.
+	if (m_files.insert(file).second) {
+		// During a bulk load (remote GUI first sync) the caller defers the
+		// display: showing and, above all, re-sorting the list on every one
+		// of thousands of files is O(n^2) and freezes the GUI (issue #414).
+		// ShowFileList() shows and sorts the whole list once afterwards.
 		if (deferView) {
 			return;
 		}
 
-		// Check if the new file is visible in the current category (and
-		// passes the active text filter).
 		if (IsVisibleInCat(file, m_category)) {
 			ShowFile(file, true);
 			if (file->IsCompleted()) {
 				CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(true);
 			}
-			// During a batch update (a reconnect resync — issue #444) the
-			// row is still appended, but the per-item sort is deferred to
+			// During a batch update (a reconnect resync -- issue #444) the row
+			// is still appended, but the per-item sort is deferred to
 			// EndBatchUpdate()'s single SortList() so a large add stays
 			// O(n log n) instead of O(n^2).
 			if (!m_batchUpdate) {
@@ -250,11 +268,10 @@ void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 
 void CDownloadListCtrl::BeginBatchUpdate()
 {
-	// Coalesce a burst of AddFile()/UpdateItem() calls into a single
-	// repaint (Freeze) and suppress the per-item SortList; EndBatchUpdate()
-	// sorts once. Used when reconciling the whole list against a fresh
-	// server snapshot after a reconnect (issue #444) — a 10k library would
-	// otherwise pay 10k row repaints + O(n^2) sorts.
+	// Coalesce a burst of AddFile()/UpdateItem() calls into a single repaint
+	// (Freeze) and suppress the per-item SortList; EndBatchUpdate() sorts
+	// once. Used when reconciling the whole list against a fresh server
+	// snapshot after a reconnect (issue #444).
 	Freeze();
 	m_batchUpdate = true;
 }
@@ -272,24 +289,12 @@ void CDownloadListCtrl::EndBatchUpdate(bool doSort)
 
 void CDownloadListCtrl::RebuildVisibleList()
 {
-	// Batch counterpart to AddFile()'s per-item path: drop the visible rows and
-	// re-append every model item that passes the current category + text
-	// filter, then sort once.
-	//
-	// Doing this incrementally instead -- ShowFile(file, false) per row that
-	// should disappear -- costs a full RebuildRowIndex() inside
-	// RemoveItemData() for *every* removal, i.e. O(n^2) overall. On a 10k
-	// queue that is seconds of frozen GUI per keystroke in the filter field
-	// (issue #669). Appending into a cleared model and finishing with a single
-	// FinishBulkLoad() (one SetItemCount + one index rebuild + one sort) is
-	// O(n log n) and a single repaint. Mirrors CSharedFilesCtrl::ShowFileList().
+	// Batch counterpart to AddFile()'s per-item path: drop the visible rows
+	// and re-append every model item that passes the current category + text
+	// filter, then sort once. Mirrors CSharedFilesCtrl::ShowFileList().
 	Freeze();
 
-	// The rebuild renumbers every row, so keep selection + focus by item
-	// identity (the incremental path kept them for free by leaving surviving
-	// rows untouched).
-	wxUIntPtr focused = 0;
-	const std::vector<wxUIntPtr> selected = SaveSelection(focused);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
 	ClearItemData();
 
@@ -297,12 +302,11 @@ void CDownloadListCtrl::RebuildVisibleList()
 	int shown = 0;
 	uint64 totalSize = 0;
 
-	for (const auto &entry : m_ListItems) {
-		CPartFile *file = entry.second->GetFile();
+	for (CPartFile *file : m_files) {
 		if (!IsVisibleInCat(file, m_category)) {
 			continue;
 		}
-		AppendItemData(reinterpret_cast<wxUIntPtr>(entry.second));
+		AppendItemData(reinterpret_cast<wxUIntPtr>(file));
 		++shown;
 		totalSize += file->GetFileSize();
 		if (file->IsCompleted()) {
@@ -311,7 +315,7 @@ void CDownloadListCtrl::RebuildVisibleList()
 	}
 
 	FinishBulkLoad();
-	RestoreSelection(selected, focused);
+	SetSelectedItemData(selected);
 
 	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(hasCompletedDownloads);
 	SetFilesCount(shown);
@@ -322,8 +326,8 @@ void CDownloadListCtrl::RebuildVisibleList()
 
 void CDownloadListCtrl::ShowFileList()
 {
-	// Used after a deferred bulk load (remote GUI first sync), where the model
-	// is populated but no rows are shown yet.
+	// Used after a deferred bulk load (remote GUI first sync), where the
+	// model is populated but no rows are shown yet.
 	RebuildVisibleList();
 }
 
@@ -331,85 +335,62 @@ void CDownloadListCtrl::RemoveFile(CPartFile *file)
 {
 	wxASSERT(file);
 
-	// Ensure that any list-entries are removed
+	// Ensure that any list-entry is removed.
 	ShowFile(file, false);
-
-	// Find the associated list-item
-	ListItems::iterator it = m_ListItems.find(file);
-
-	if (it != m_ListItems.end()) {
-		delete it->second;
-
-		m_ListItems.erase(it);
-	}
+	m_files.erase(file);
 }
 
 void CDownloadListCtrl::UpdateItem(const void *toupdate)
 {
-	// Retrieve all entries matching the source
-	ListIteratorPair rangeIt = m_ListItems.equal_range(toupdate);
+	CPartFile *file = const_cast<CPartFile *>(static_cast<const CPartFile *>(toupdate));
+	if (m_files.find(file) == m_files.end()) {
+		return;
+	}
 
-	for (ListItems::iterator it = rangeIt.first; it != rangeIt.second; ++it) {
-		FileCtrlItem_Struct *item = it->second;
+	const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(file);
+	const bool show = IsVisibleInCat(file, m_category);
 
-		const long index = RowOfData(reinterpret_cast<wxUIntPtr>(item));
-
-		// Determine if the file should be shown in the current category
-
-		CPartFile *file = item->GetFile();
-
-		bool show = IsVisibleInCat(file, m_category);
-
-		if (index != -1) {
-			if (show) {
-				item->dwUpdated = 0;
-
-				// Virtual list: repaints only the row if visible; base
-				// also schedules a live re-sort when sorted by a live column.
-				RefreshItemData(reinterpret_cast<wxUIntPtr>(item));
-			} else {
-				// Item should no longer be shown in
-				// the current category
-				ShowFile(file, false);
-			}
-		} else if (show) {
-			// Item has been hidden but new status means
-			// that it should it should be shown in the
-			// current category
-			ShowFile(file, true);
+	if (HasItemData(data)) {
+		if (show) {
+			// Repaints the row and, if sorted by a live column, schedules the
+			// throttled+idle-gated re-sort.
+			RefreshItemData(data);
+		} else {
+			// No longer shown in the current category.
+			ShowFile(file, false);
 		}
+	} else if (show) {
+		// Was hidden, but its new status means it belongs in the current
+		// category now.
+		ShowFile(file, true);
+	}
 
-		if (file->IsCompleted() && show) {
-			CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(true);
-		}
+	if (file->IsCompleted() && show) {
+		CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(true);
 	}
 }
 
 void CDownloadListCtrl::ShowFile(CPartFile *file, bool show)
 {
 	wxASSERT(file);
+	if (m_files.find(file) == m_files.end()) {
+		return;
+	}
 
-	ListItems::iterator it = m_ListItems.find(file);
-
-	if (it != m_ListItems.end()) {
-		FileCtrlItem_Struct *item = it->second;
-
-		const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(item);
-		if (show) {
-			// Add the row unless it is already being displayed. Appended at
-			// the end (unsorted); the caller sorts once afterwards.
-			if (RowOfData(data) == -1) {
-				AppendItemDataNow(data);
-				ShowFilesCount(1);
-				SetTotalSize(m_shownSize + file->GetFileSize());
-			}
-		} else {
-			// Remove the row if present.
-			if (RowOfData(data) != -1) {
-				RemoveItemData(data);
-				ShowFilesCount(-1);
-				SetTotalSize(m_shownSize - file->GetFileSize());
-			}
+	const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(file);
+	if (show) {
+		// Add the row unless it is already being displayed. Appended at the
+		// end (unsorted); the caller sorts once afterwards.
+		if (!HasItemData(data)) {
+			AppendItemDataNow(data);
+			ShowFilesCount(1);
+			SetTotalSize(m_shownSize + file->GetFileSize());
+		}
+	} else {
+		if (HasItemData(data)) {
+			RemoveItemData(data);
+			ShowFilesCount(-1);
+			SetTotalSize(m_shownSize - file->GetFileSize());
 		}
 	}
 }
@@ -424,11 +405,6 @@ void CDownloadListCtrl::ChangeCategory(int newCategory)
 	RebuildVisibleList();
 }
 
-uint8 CDownloadListCtrl::GetCategory() const
-{
-	return m_category;
-}
-
 bool CDownloadListCtrl::IsVisibleInCat(CPartFile *file, int category) const
 {
 	return file->CheckShowItemInGivenCat(category) && MatchesFilter(file->GetFileName().GetPrintable());
@@ -436,65 +412,165 @@ bool CDownloadListCtrl::IsVisibleInCat(CPartFile *file, int category) const
 
 void CDownloadListCtrl::RebuildFilteredView()
 {
-	// Filter hook from CMuleVirtualListCtrl: the model in m_ListItems always
-	// holds every file, so the visible set is rebuilt from it in one pass.
+	// Filter hook from CMuleVirtualDataViewCtrl: m_files always holds every
+	// download, so the visible set is rebuilt from it in one pass.
 	RebuildVisibleList();
 }
 
-/**
- * Helper-function: This function is used to gather selected items.
- *
- * @param list A pointer to the list to gather items from.
- * @return A list containing the selected items.
- */
-static ItemList GetSelectedItems(CDownloadListCtrl *list)
+void CDownloadListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 {
-	ItemList results;
-
-	long index = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	while (index > -1) {
-		FileCtrlItem_Struct *item = reinterpret_cast<FileCtrlItem_Struct *>(list->ItemAt(index));
-		results.push_back(item);
-
-		index = list->GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	if (event.GetItem().IsOk()) {
+		wxDataViewItemArray selection;
+		GetSelections(selection);
+		if (selection.Index(event.GetItem()) == wxNOT_FOUND) {
+			UnselectAll();
+			Select(event.GetItem());
+		}
 	}
 
-	return results;
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.empty()) {
+		return;
+	}
+	// Bound re-checked by the handlers that use it (OnPreviewFile,
+	// OnShowInFolder): PopupMenu runs a nested event loop, so the queue can
+	// mutate while the menu is open.
+	m_menuItem = selected.front();
+	CPartFile *file = reinterpret_cast<CPartFile *>(m_menuItem);
+
+	delete m_menu;
+	m_menu = new wxMenu(_("Downloads"));
+
+	wxMenu *priomenu = new wxMenu();
+	priomenu->AppendCheckItem(MP_PRIOLOW, _("Low"));
+	priomenu->AppendCheckItem(MP_PRIONORMAL, _("Normal"));
+	priomenu->AppendCheckItem(MP_PRIOHIGH, _("High"));
+	priomenu->AppendCheckItem(MP_PRIOAUTO, _("Auto"));
+
+	m_menu->Append(MP_MENU_PRIO, _("Priority"), priomenu);
+	m_menu->Append(MP_CANCEL, _("Cancel"));
+	m_menu->Append(MP_STOP, _("&Stop"));
+	m_menu->Append(MP_PAUSE, _("&Pause"));
+	m_menu->Append(MP_RESUME, _("&Resume"));
+	m_menu->Append(MP_CLEARCOMPLETED, _("C&lear completed"));
+	m_menu->AppendSeparator();
+	wxMenu *extendedmenu = new wxMenu();
+	extendedmenu->Append(MP_SWAP_A4AF_TO_THIS, _("Swap every A4AF to this file now"));
+	extendedmenu->AppendCheckItem(MP_SWAP_A4AF_TO_THIS_AUTO, _("Swap every A4AF to this file (Auto)"));
+	extendedmenu->AppendSeparator();
+	extendedmenu->Append(MP_SWAP_A4AF_TO_ANY_OTHER, _("Swap every A4AF to any other file now"));
+	m_menu->Append(MP_MENU_EXTD, _("Extended Options"), extendedmenu);
+	m_menu->AppendSeparator();
+
+	m_menu->Append(MP_VIEW, _("Preview"));
+	m_menu->Append(MP_SHOWINFOLDER, _("Show in file manager"));
+	m_menu->Append(MP_METINFO, _("Show file &details"));
+	m_menu->Append(MP_VIEWFILECOMMENTS, _("Show all comments"));
+	m_menu->AppendSeparator();
+	m_menu->Append(MP_GETMAGNETLINK, _("Copy magnet URI to clipboard"));
+	m_menu->Append(MP_GETED2KLINK, _("Copy eD2k &link to clipboard"));
+	m_menu->Append(MP_WS, _("Copy feedback to clipboard"));
+	m_menu->AppendSeparator();
+
+	wxMenu *cats = new wxMenu(_("Category"));
+	if (theApp->glob_prefs->GetCatCount() > 1) {
+		for (uint32 i = 0; i < theApp->glob_prefs->GetCatCount(); i++) {
+			if (i == 0) {
+				cats->Append(MP_ASSIGNCAT, _("unassign"));
+			} else {
+				cats->Append(MP_ASSIGNCAT + i, theApp->glob_prefs->GetCategory(i)->title);
+			}
+		}
+	}
+	m_menu->Append(MP_MENU_CATS, _("Assign to category"), cats);
+	m_menu->Enable(MP_MENU_CATS, (theApp->glob_prefs->GetCatCount() > 1));
+
+	bool canStop;
+	bool canPause;
+	bool canCancel;
+	bool fileResumable;
+	if (file->GetStatus(true) != PS_ALLOCATING) {
+		const uint8_t fileStatus = file->GetStatus();
+		canStop = (fileStatus != PS_ERROR) && (fileStatus != PS_COMPLETE) &&
+			  (file->IsStopped() != true);
+		canPause = (file->GetStatus() != PS_PAUSED) && canStop;
+		fileResumable = (fileStatus == PS_PAUSED) || (fileStatus == PS_ERROR) ||
+				(fileStatus == PS_INSUFFICIENT);
+		canCancel = fileStatus != PS_COMPLETE;
+	} else {
+		canStop = canPause = canCancel = fileResumable = false;
+	}
+
+	m_menu->Enable(MP_CANCEL, canCancel);
+	m_menu->Enable(MP_PAUSE, canPause);
+	m_menu->Enable(MP_STOP, canStop);
+	m_menu->Enable(MP_RESUME, fileResumable);
+	m_menu->Enable(MP_CLEARCOMPLETED, CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->IsEnabled());
+
+	wxString view;
+	if (file->IsPartFile()) {
+		view = CFormat("%s [%s]") % _("Preview") % file->GetPartMetFileName().RemoveExt();
+	} else {
+		view = _("&Open the file");
+	}
+	m_menu->SetLabel(MP_VIEW, view);
+	const bool previewable = file->IsPartFile() ? file->PreviewAvailable() : true;
+	bool canOpen = false;
+	bool canReveal = false;
+	FileLaunch::GetAvailability(file, canOpen, canReveal);
+	m_menu->Enable(MP_VIEW, previewable && canOpen);
+	m_menu->Enable(MP_SHOWINFOLDER, canReveal);
+
+	FileRatingList ratingList;
+	file->GetRatingAndComments(ratingList);
+	// Enable when there are source comments to show, or when Kad is connected
+	// so the dialog's "Get from Kad" lookup can retrieve community notes
+	// (#434) even for a file that has no per-source comments yet.
+	m_menu->Enable(MP_VIEWFILECOMMENTS, !ratingList.empty() || theApp->IsConnectedKad());
+
+	m_menu->Check(MP_SWAP_A4AF_TO_THIS_AUTO, file->IsA4AFAuto());
+
+	int priority = file->IsAutoDownPriority() ? PR_AUTO : file->GetDownPriority();
+	priomenu->Check(MP_PRIOHIGH, priority == PR_HIGH);
+	priomenu->Check(MP_PRIONORMAL, priority == PR_NORMAL);
+	priomenu->Check(MP_PRIOLOW, priority == PR_LOW);
+	priomenu->Check(MP_PRIOAUTO, priority == PR_AUTO);
+
+	m_menu->Enable(MP_MENU_EXTD, canPause);
+
+	PopupMenu(m_menu);
+
+	delete m_menu;
+	m_menu = nullptr;
 }
 
 void CDownloadListCtrl::OnCancelFile(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList files = ::GetSelectedItems(this);
-	for (ItemList::iterator it = files.begin(); it != files.end();) {
-		ItemList::iterator it1 = it++;
-		CPartFile *file = (*it1)->GetFile();
-		if (file) {
-			switch (file->GetStatus()) {
-			case PS_WAITING_FOR_HASH:
-			case PS_HASHING:
-			case PS_COMPLETING:
-			case PS_COMPLETE:
-				files.erase(it1);
-				break;
-			}
-		}
+	std::vector<wxUIntPtr> files = GetSelectedItemData();
+	files.erase(std::remove_if(files.begin(),
+			    files.end(),
+			    [](wxUIntPtr data) {
+				    switch (reinterpret_cast<CPartFile *>(data)->GetStatus()) {
+				    case PS_WAITING_FOR_HASH:
+				    case PS_HASHING:
+				    case PS_COMPLETING:
+				    case PS_COMPLETE:
+					    return true;
+				    default:
+					    return false;
+				    }
+			    }),
+		files.end());
+	if (files.empty()) {
+		return;
 	}
-	if (!files.empty()) {
-		wxString question;
-		if (files.size() == 1) {
-			question = _("Are you sure that you wish to delete the selected file?");
-		} else {
-			question = _("Are you sure that you wish to delete the selected files?");
-		}
-		if (wxMessageBox(question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) ==
-			wxYES) {
-			for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
-				CPartFile *file = (*it)->GetFile();
-				if (file) {
-					CoreNotify_PartFile_Delete(file);
-				}
-			}
+
+	const wxString question =
+		files.size() == 1 ? wxString(_("Are you sure that you wish to delete the selected file?"))
+				  : wxString(_("Are you sure that you wish to delete the selected files?"));
+	if (wxMessageBox(question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES) {
+		for (wxUIntPtr data : files) {
+			CoreNotify_PartFile_Delete(reinterpret_cast<CPartFile *>(data));
 		}
 	}
 }
@@ -519,16 +595,12 @@ void CDownloadListCtrl::OnSetPriority(wxCommandEvent &event)
 		wxFAIL;
 	}
 
-	ItemList files = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
-		CPartFile *file = (*it)->GetFile();
-
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CPartFile *file = reinterpret_cast<CPartFile *>(data);
 		if (priority == PR_AUTO) {
 			CoreNotify_PartFile_PrioAuto(file, true);
 		} else {
 			CoreNotify_PartFile_PrioAuto(file, false);
-
 			CoreNotify_PartFile_PrioSet(file, priority, true);
 		}
 	}
@@ -536,20 +608,15 @@ void CDownloadListCtrl::OnSetPriority(wxCommandEvent &event)
 
 void CDownloadListCtrl::OnSwapSources(wxCommandEvent &event)
 {
-	ItemList files = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
-		CPartFile *file = (*it)->GetFile();
-
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CPartFile *file = reinterpret_cast<CPartFile *>(data);
 		switch (event.GetId()) {
 		case MP_SWAP_A4AF_TO_THIS:
 			CoreNotify_PartFile_Swap_A4AF(file);
 			break;
-
 		case MP_SWAP_A4AF_TO_THIS_AUTO:
 			CoreNotify_PartFile_Swap_A4AF_Auto(file);
 			break;
-
 		case MP_SWAP_A4AF_TO_ANY_OTHER:
 			CoreNotify_PartFile_Swap_A4AF_Others(file);
 			break;
@@ -559,14 +626,12 @@ void CDownloadListCtrl::OnSwapSources(wxCommandEvent &event)
 
 void CDownloadListCtrl::OnSetCategory(wxCommandEvent &event)
 {
-	ItemList files = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
-		CoreNotify_PartFile_SetCat((*it)->GetFile(), event.GetId() - MP_ASSIGNCAT);
-		ShowFile((*it)->GetFile(), false);
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CPartFile *file = reinterpret_cast<CPartFile *>(data);
+		CoreNotify_PartFile_SetCat(file, event.GetId() - MP_ASSIGNCAT);
+		ShowFile(file, false);
 	}
-	wxListEvent ev;
-	OnItemSelectionChanged(ev); // clear clients that may have been shown
+	DoItemSelectionChanged(); // clear clients that may have been shown
 
 	ChangeCategory(m_category); // This only updates the visibility of the clear completed button
 	theApp->amuledlg->m_transferwnd->UpdateCatTabTitles();
@@ -574,20 +639,15 @@ void CDownloadListCtrl::OnSetCategory(wxCommandEvent &event)
 
 void CDownloadListCtrl::OnSetStatus(wxCommandEvent &event)
 {
-	ItemList files = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
-		CPartFile *file = (*it)->GetFile();
-
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CPartFile *file = reinterpret_cast<CPartFile *>(data);
 		switch (event.GetId()) {
 		case MP_PAUSE:
 			CoreNotify_PartFile_Pause(file);
 			break;
-
 		case MP_RESUME:
 			CoreNotify_PartFile_Resume(file);
 			break;
-
 		case MP_STOP:
 			CoreNotify_PartFile_Stop(file);
 			break;
@@ -602,20 +662,15 @@ void CDownloadListCtrl::OnClearCompleted(wxCommandEvent &WXUNUSED(event))
 
 void CDownloadListCtrl::OnGetLink(wxCommandEvent &event)
 {
-	ItemList files = ::GetSelectedItems(this);
-
 	wxString URIs;
-
-	for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
-		CPartFile *file = (*it)->GetFile();
-
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CPartFile *file = reinterpret_cast<CPartFile *>(data);
 		if (event.GetId() == MP_GETED2KLINK) {
 			URIs += theApp->CreateED2kLink(file) + "\n";
 		} else {
 			URIs += theApp->CreateMagnetLink(file) + "\n";
 		}
 	}
-
 	if (!URIs.IsEmpty()) {
 		theApp->CopyTextToClipboard(URIs.BeforeLast('\n'));
 	}
@@ -624,18 +679,15 @@ void CDownloadListCtrl::OnGetLink(wxCommandEvent &event)
 void CDownloadListCtrl::OnGetFeedback(wxCommandEvent &WXUNUSED(event))
 {
 	wxString feed;
-	ItemList files = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
+	for (wxUIntPtr data : GetSelectedItemData()) {
 		if (feed.IsEmpty()) {
 			feed = CFormat(_("Feedback from: %s (%s)\n\n")) % thePrefs::GetUserNick() %
 			       theApp->GetFullMuleVersion();
 		} else {
 			feed += "\n";
 		}
-		feed += (*it)->GetFile()->GetFeedback();
+		feed += reinterpret_cast<CPartFile *>(data)->GetFeedback();
 	}
-
 	if (!feed.IsEmpty()) {
 		theApp->CopyTextToClipboard(feed);
 	}
@@ -643,68 +695,72 @@ void CDownloadListCtrl::OnGetFeedback(wxCommandEvent &WXUNUSED(event))
 
 void CDownloadListCtrl::OnViewFileInfo(wxCommandEvent &WXUNUSED(event))
 {
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	if (index >= 0) {
-		ShowFileDetailDialog(index);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (!selected.empty()) {
+		ShowFileDetailDialog(RowOfData(selected.front()));
 	}
 }
 
 void CDownloadListCtrl::OnViewFileComments(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList files = ::GetSelectedItems(this);
-
-	if (files.size() == 1) {
-		CCommentDialogLst dialog(this, files.front()->GetFile());
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.size() == 1) {
+		CCommentDialogLst dialog(this, reinterpret_cast<CPartFile *>(selected.front()));
 		dialog.ShowModal();
 	}
 }
 
 void CDownloadListCtrl::OnPreviewFile(wxCommandEvent &WXUNUSED(event))
 {
-	// The clicked row, matching how the menu's enabled state was decided. With
-	// several rows selected, taking the selection would act on a different file
-	// than the one the entry was enabled for.
-	//
-	// The bound is re-checked because PopupMenu runs a nested event loop: a
-	// completed download can be cleared out from under the open menu, and
-	// HasItemData() pins the item's identity, so a row removed above this
-	// one cannot silently redirect the click to its neighbour.
+	// The clicked row, matching how the menu's enabled state was decided.
+	// With several rows selected, taking the selection would act on a
+	// different file than the one the entry was enabled for.
 	if (m_menuItem != 0 && HasItemData(m_menuItem)) {
-		FileLaunch::Open(reinterpret_cast<FileCtrlItem_Struct *>(m_menuItem)->GetFile(), this);
+		FileLaunch::Open(reinterpret_cast<CPartFile *>(m_menuItem), this);
 	}
 }
 
 void CDownloadListCtrl::OnShowInFolder(wxCommandEvent &WXUNUSED(event))
 {
 	if (m_menuItem != 0 && HasItemData(m_menuItem)) {
-		FileLaunch::Reveal(reinterpret_cast<FileCtrlItem_Struct *>(m_menuItem)->GetFile(), this);
+		FileLaunch::Reveal(reinterpret_cast<CPartFile *>(m_menuItem), this);
 	}
 }
 
-void CDownloadListCtrl::OnItemActivated(wxListEvent &evt)
+void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)
 {
-	CPartFile *file = reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(evt.GetIndex()))->GetFile();
+	if (!event.GetItem().IsOk()) {
+		return;
+	}
+	UnselectAll();
+	Select(event.GetItem());
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.empty()) {
+		return;
+	}
+	CPartFile *file = reinterpret_cast<CPartFile *>(selected.front());
 
-	// Double-click is media-only: it is an easy gesture to trigger by accident,
-	// and handing a completed .exe or .desktop to the platform opener that way
-	// is not a thing to do silently. The menu's Open is the broad one.
+	// Double-click is media-only: it is an easy gesture to trigger by
+	// accident, and handing a completed .exe or .desktop to the platform
+	// opener that way is not a thing to do silently. The menu's Open is the
+	// broad one.
 	//
-	// It does now cover an in-progress download once enough of the media is on
-	// disk to play -- PreviewAvailable()'s own test -- where the previous
+	// It does now cover an in-progress download once enough of the media is
+	// on disk to play -- PreviewAvailable()'s own test -- where the previous
 	// condition also required completion. That is the classic eMule gesture,
 	// and it matches what the menu's Preview entry offers for the same row.
-	// Anything else opens the file-details modal, as the shared-files table does.
+	// Anything else opens the file-details modal, as the shared-files table
+	// does.
 	if (file->PreviewAvailable() && FileLaunch::CanOpen(file)) {
 		FileLaunch::Open(file, this);
 	} else {
-		ShowFileDetailDialog(evt.GetIndex());
+		ShowFileDetailDialog(RowOfData(selected.front()));
 	}
 }
 
-void CDownloadListCtrl::OnItemSelectionChanged(wxListEvent &)
+void CDownloadListCtrl::OnSelectionChanged(wxDataViewEvent &WXUNUSED(event))
 {
-	if (!m_ItemSelectionChangePending && !IsSorting()) {
+	if (!m_ItemSelectionChangePending) {
 		m_ItemSelectionChangePending = true;
 		Notify_DownloadCtrlDoItemSelectionChanged();
 	}
@@ -714,630 +770,343 @@ void CDownloadListCtrl::DoItemSelectionChanged()
 {
 	m_ItemSelectionChangePending = false;
 	CKnownFileVector filesVector;
-	filesVector.reserve(GetSelectedItemCount());
-
-	long index = GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	while (index > -1) {
-		CPartFile *file = reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(index))->GetFile();
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	filesVector.reserve(selected.size());
+	for (wxUIntPtr data : selected) {
+		CPartFile *file = reinterpret_cast<CPartFile *>(data);
 		if (file->IsPartFile()) {
 			filesVector.push_back(file);
 		}
-		index = GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	}
-
 	std::sort(filesVector.begin(), filesVector.end());
 	theApp->amuledlg->m_transferwnd->clientlistctrl->ShowSources(filesVector);
 }
 
-void CDownloadListCtrl::OnMouseRightClick(wxListEvent &evt)
+void CDownloadListCtrl::ShowFileDetailDialog(long row)
 {
-	long index = CheckSelection(evt);
-	m_menuItem = (index != -1) ? ItemAt(index) : 0;
-	if (index < 0) {
+	if (row < 0) {
 		return;
 	}
-
-	delete m_menu;
-	m_menu = NULL;
-
-	FileCtrlItem_Struct *item = reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(index));
-	m_menu = new wxMenu(_("Downloads"));
-
-	wxMenu *priomenu = new wxMenu();
-	priomenu->AppendCheckItem(MP_PRIOLOW, _("Low"));
-	priomenu->AppendCheckItem(MP_PRIONORMAL, _("Normal"));
-	priomenu->AppendCheckItem(MP_PRIOHIGH, _("High"));
-	priomenu->AppendCheckItem(MP_PRIOAUTO, _("Auto"));
-
-	m_menu->Append(MP_MENU_PRIO, _("Priority"), priomenu);
-	m_menu->Append(MP_CANCEL, _("Cancel"));
-	m_menu->Append(MP_STOP, _("&Stop"));
-	m_menu->Append(MP_PAUSE, _("&Pause"));
-	m_menu->Append(MP_RESUME, _("&Resume"));
-	m_menu->Append(MP_CLEARCOMPLETED, _("C&lear completed"));
-	//-----------------------------------------------------
-	m_menu->AppendSeparator();
-	//-----------------------------------------------------
-	wxMenu *extendedmenu = new wxMenu();
-	extendedmenu->Append(MP_SWAP_A4AF_TO_THIS, _("Swap every A4AF to this file now"));
-	extendedmenu->AppendCheckItem(MP_SWAP_A4AF_TO_THIS_AUTO, _("Swap every A4AF to this file (Auto)"));
-	//-----------------------------------------------------
-	extendedmenu->AppendSeparator();
-	//-----------------------------------------------------
-	extendedmenu->Append(MP_SWAP_A4AF_TO_ANY_OTHER, _("Swap every A4AF to any other file now"));
-	//-----------------------------------------------------
-	m_menu->Append(MP_MENU_EXTD, _("Extended Options"), extendedmenu);
-	//-----------------------------------------------------
-	m_menu->AppendSeparator();
-	//-----------------------------------------------------
-
-	m_menu->Append(MP_VIEW, _("Preview"));
-	m_menu->Append(MP_SHOWINFOLDER, _("Show in file manager"));
-	m_menu->Append(MP_METINFO, _("Show file &details"));
-	m_menu->Append(MP_VIEWFILECOMMENTS, _("Show all comments"));
-	//-----------------------------------------------------
-	m_menu->AppendSeparator();
-	//-----------------------------------------------------
-	m_menu->Append(MP_GETMAGNETLINK, _("Copy magnet URI to clipboard"));
-	m_menu->Append(MP_GETED2KLINK, _("Copy eD2k &link to clipboard"));
-	m_menu->Append(MP_WS, _("Copy feedback to clipboard"));
-	//-----------------------------------------------------
-	m_menu->AppendSeparator();
-	//-----------------------------------------------------
-	// Add dynamic entries
-	wxMenu *cats = new wxMenu(_("Category"));
-	if (theApp->glob_prefs->GetCatCount() > 1) {
-		for (uint32 i = 0; i < theApp->glob_prefs->GetCatCount(); i++) {
-			if (i == 0) {
-				cats->Append(MP_ASSIGNCAT, _("unassign"));
-			} else {
-				cats->Append(MP_ASSIGNCAT + i, theApp->glob_prefs->GetCategory(i)->title);
-			}
-		}
-	}
-	m_menu->Append(MP_MENU_CATS, _("Assign to category"), cats);
-	m_menu->Enable(MP_MENU_CATS, (theApp->glob_prefs->GetCatCount() > 1));
-
-	CPartFile *file = item->GetFile();
-	// then set state
-	bool canStop;
-	bool canPause;
-	bool canCancel;
-	bool fileResumable;
-	if (file->GetStatus(true) != PS_ALLOCATING) {
-		const uint8_t fileStatus = file->GetStatus();
-		canStop = (fileStatus != PS_ERROR) && (fileStatus != PS_COMPLETE) &&
-			  (file->IsStopped() != true);
-		canPause = (file->GetStatus() != PS_PAUSED) && canStop;
-		fileResumable = (fileStatus == PS_PAUSED) || (fileStatus == PS_ERROR) ||
-				(fileStatus == PS_INSUFFICIENT);
-		canCancel = fileStatus != PS_COMPLETE;
-	} else {
-		canStop = canPause = canCancel = fileResumable = false;
-	}
-
-	m_menu->Enable(MP_CANCEL, canCancel);
-	m_menu->Enable(MP_PAUSE, canPause);
-	m_menu->Enable(MP_STOP, canStop);
-	m_menu->Enable(MP_RESUME, fileResumable);
-	m_menu->Enable(MP_CLEARCOMPLETED, CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->IsEnabled());
-
-	// IsPartFile() is `status != PS_COMPLETE`, so these two cases are
-	// exhaustive -- but spell the fallback out rather than leaving the label
-	// empty if a third status is ever added.
-	wxString view;
-	if (file->IsPartFile()) {
-		view = CFormat("%s [%s]") % _("Preview") % file->GetPartMetFileName().RemoveExt();
-	} else {
-		view = _("&Open the file");
-	}
-	m_menu->SetLabel(MP_VIEW, view);
-	// Offered when the file is actually reachable from this host, which covers
-	// the monolithic app, amulegui sharing the daemon's filesystem, and the
-	// case a build-variant check could never see: a local file since moved or
-	// deleted. PreviewAvailable() still gates the unfinished case, where it
-	// answers "is enough of the media on disk to play".
-	const bool previewable = file->IsPartFile() ? file->PreviewAvailable() : true;
-	// One filesystem check for both entries; see FileLaunch::GetAvailability.
-	bool canOpen = false;
-	bool canReveal = false;
-	FileLaunch::GetAvailability(file, canOpen, canReveal);
-	m_menu->Enable(MP_VIEW, previewable && canOpen);
-	m_menu->Enable(MP_SHOWINFOLDER, canReveal);
-
-	FileRatingList ratingList;
-	item->GetFile()->GetRatingAndComments(ratingList);
-	// Enable when there are source comments to show, or when Kad is connected so
-	// the dialog's "Get from Kad" lookup can retrieve community notes (#434) even
-	// for a file that has no per-source comments yet.
-	m_menu->Enable(MP_VIEWFILECOMMENTS, !ratingList.empty() || theApp->IsConnectedKad());
-
-	m_menu->Check(MP_SWAP_A4AF_TO_THIS_AUTO, file->IsA4AFAuto());
-
-	int priority = file->IsAutoDownPriority() ? PR_AUTO : file->GetDownPriority();
-
-	priomenu->Check(MP_PRIOHIGH, priority == PR_HIGH);
-	priomenu->Check(MP_PRIONORMAL, priority == PR_NORMAL);
-	priomenu->Check(MP_PRIOLOW, priority == PR_LOW);
-	priomenu->Check(MP_PRIOAUTO, priority == PR_AUTO);
-
-	m_menu->Enable(MP_MENU_EXTD, canPause);
-
-	PopupMenu(m_menu, evt.GetPoint());
-
-	delete m_menu;
-	m_menu = NULL;
-}
-
-void CDownloadListCtrl::OnMouseMiddleClick(wxListEvent &evt)
-{
-	// Check if clicked item is selected. If not, unselect all and select it.
-	long index = CheckSelection(evt);
-	if (index >= 0) {
-		ShowFileDetailDialog(index);
-	}
-}
-
-void CDownloadListCtrl::ShowFileDetailDialog(long index)
-{
 	// Make list of part files in control (CFileDetailDialog takes CKnownFile*;
 	// a CPartFile upcasts, and the dialog shows download rows from its state).
 	std::vector<CKnownFile *> files;
-	int nrItems = GetItemCount();
+	const long nrItems = ItemDataCount();
 	files.reserve(nrItems);
-	for (int i = 0; i < nrItems; i++) {
-		files.push_back(reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(i))->GetFile());
+	for (long i = 0; i < nrItems; i++) {
+		files.push_back(reinterpret_cast<CPartFile *>(ItemAt(i)));
 	}
-	CFileDetailDialog(this, files, index).ShowModal();
+	CFileDetailDialog(this, files, static_cast<int>(row)).ShowModal();
 }
 
-void CDownloadListCtrl::OnKeyPressed(wxKeyEvent &event)
+bool CDownloadListCtrl::OnListKey(wxKeyEvent &event)
 {
-	// Check if delete was pressed
 	switch (event.GetKeyCode()) {
 	case WXK_NUMPAD_DELETE:
 	case WXK_DELETE: {
 		wxCommandEvent evt;
 		OnCancelFile(evt);
-		break;
+		return true;
 	}
 	case WXK_F2: {
-		ItemList files = ::GetSelectedItems(this);
-		if (files.size() == 1) {
-			CPartFile *file = files.front()->GetFile();
-
+		const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+		if (selected.size() == 1) {
+			CPartFile *file = reinterpret_cast<CPartFile *>(selected.front());
 			// Currently renaming of completed files causes problem with kad
 			if (file->IsPartFile()) {
 				wxString strNewName = ::wxGetTextFromUser(_("Enter new name for this file:"),
 					_("File rename"),
 					file->GetFileName().GetPrintable());
-
 				CPath newName = CPath(strNewName);
 				if (newName.IsOk() && (newName != file->GetFileName())) {
 					theApp->sharedfiles->RenameFile(file, newName);
 				}
 			}
 		}
-		break;
+		return true;
 	}
 	default:
-		event.Skip();
+		return false;
 	}
 }
 
-void CDownloadListCtrl::OnDrawItem(
-	int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted)
+wxString CDownloadListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) const
 {
-	// Don't do any drawing if there's nobody to see it.
-	if (!theApp->amuledlg->IsDialogVisible(CamuleDlg::DT_TRANSFER_WND)) {
-		return;
-	}
+	CPartFile *file = reinterpret_cast<CPartFile *>(item);
 
-	FileCtrlItem_Struct *content = reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(item));
-
-	// Define text-color and background
-	// and the border of the drawn area
-	if (highlighted) {
-		CMuleColour colour;
-		if (GetFocus()) {
-			dc->SetBackground(m_hilightBrush);
-			colour = m_hilightBrush.GetColour();
-		} else {
-			dc->SetBackground(m_hilightUnfocusBrush);
-			colour = m_hilightUnfocusBrush.GetColour();
-		}
-		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
-		dc->SetPen(colour.Blend(65).GetPen());
-	} else {
-		dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(
-			wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxBRUSHSTYLE_SOLID)));
-		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-		dc->SetPen(*wxTRANSPARENT_PEN);
-	}
-	dc->SetBrush(dc->GetBackground());
-
-	dc->DrawRectangle(rectHL.x, rectHL.y, rectHL.width, rectHL.height);
-
-	dc->SetPen(*wxTRANSPARENT_PEN);
-
-	if (!highlighted || !GetFocus()) {
-		// If we have category, override textforeground with what category tells us.
-		CPartFile *file = content->GetFile();
-		if (file->GetCategory()) {
-			dc->SetTextForeground(
-				CMuleColour(theApp->glob_prefs->GetCatColor(file->GetCategory())));
-		}
-	}
-
-	// Various constant values we use
-	const int iTextOffset = (rect.GetHeight() - dc->GetCharHeight()) / 2;
-	const int iOffset = 4;
-
-	wxRect cur_rec(iOffset, rect.y, 0, rect.height);
-	for (int i = 0; i < GetColumnCount(); i++) {
-		wxListItem listitem;
-		GetColumn(i, listitem);
-
-		if (listitem.GetWidth() > 2 * iOffset) {
-			cur_rec.width = listitem.GetWidth() - 2 * iOffset;
-
-			// Make a copy of the current rectangle so we can apply specific tweaks
-			wxRect target_rec = cur_rec;
-			if (i == ColumnProgress) {
-				// Double the offset to make room for the cirle-marker
-				target_rec.x += iOffset;
-				target_rec.width -= iOffset;
-			} else {
-				// will ensure that text is about in the middle ;)
-				target_rec.y += iTextOffset;
-			}
-
-			// Draw the item
-			DrawFileItem(dc, i, target_rec, content);
-		}
-
-		// Increment to the next column
-		cur_rec.x += listitem.GetWidth();
-	}
-}
-
-void CDownloadListCtrl::DrawFileItem(
-	wxDC *dc, int nColumn, const wxRect &rect, FileCtrlItem_Struct *item) const
-{
-	wxDCClipper clipper(*dc, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-
-	const CPartFile *file = item->GetFile();
-
-	// Used to contain the contenst of cells that dont need any fancy drawing, just text.
-	wxString text;
-
-	switch (nColumn) {
-	// Part Number
-	case ColumnPart: {
+	switch (column) {
+	case COLUMN_DL_PART:
 		if (file->IsPartFile() && !file->IsCompleted()) {
-			text = CFormat("%03d") % file->GetPartMetNumber();
+			return CFormat("%03d") % file->GetPartMetNumber();
 		}
-		break;
-	}
-	// Filename
-	case ColumnFileName: {
-		wxString filename = file->GetFileName().GetPrintable();
+		return wxEmptyString;
 
-		if (file->HasRating() || file->HasComment()) {
-			int image = Client_CommentOnly_Smiley;
-			if (file->HasRating()) {
-				image = Client_InvalidRating_Smiley + file->UserRating() - 1;
-			}
+	case COLUMN_DL_NAME:
+		// The rating/comment smiley is the icon on this column, not part of
+		// the text -- see GetItemIcon().
+		return file->GetFileName().GetPrintable();
 
-			wxASSERT(image >= Client_InvalidRating_Smiley);
-			wxASSERT(image <= Client_CommentOnly_Smiley);
+	case COLUMN_DL_SIZE:
+		return CastItoXBytes(file->GetFileSize());
 
-			int imgWidth = 16;
+	case COLUMN_DL_TRANSFERRED:
+		return CastItoXBytes(file->GetTransferred());
 
-			// it's already centered by OnDrawItem() ...
-			m_ImageList.Draw(
-				image, *dc, rect.GetX(), rect.GetY() - 1, wxIMAGELIST_DRAW_TRANSPARENT);
-			dc->DrawText(filename, rect.GetX() + imgWidth + 4, rect.GetY());
-		} else {
-			dc->DrawText(filename, rect.GetX(), rect.GetY());
-		}
-		break;
-	}
+	case COLUMN_DL_COMPLETED:
+		return CastItoXBytes(file->GetCompletedSize());
 
-	// Filesize
-	case ColumnSize:
-		text = CastItoXBytes(file->GetFileSize());
-		break;
-
-	// Transferred
-	case ColumnTransferred:
-		text = CastItoXBytes(file->GetTransferred());
-		break;
-
-	// Completed
-	case ColumnCompleted:
-		text = CastItoXBytes(file->GetCompletedSize());
-		break;
-
-	// Speed
-	case ColumnSpeed:
+	case COLUMN_DL_SPEED:
 		if (file->GetTransferingSrcCount()) {
 			if (file->GetKBpsDown() >= 1024) {
-				text = CFormat(_("%.1f MB/s")) % (file->GetKBpsDown() / 1024.0);
-			} else {
-				text = CFormat(_("%.1f kB/s")) % file->GetKBpsDown();
+				return CFormat(_("%.1f MB/s")) % (file->GetKBpsDown() / 1024.0);
 			}
+			return CFormat(_("%.1f kB/s")) % file->GetKBpsDown();
 		}
-		break;
+		return wxEmptyString;
 
-	// Progress
-	case ColumnProgress: {
-		if (thePrefs::ShowProgBar()) {
-			int iWidth = rect.GetWidth() - 2;
-			int iHeight = rect.GetHeight() - 2;
-
-			// DO NOT DRAW IT ALL THE TIME
-			uint64 dwTicks = GetTickCount64();
-
-			wxMemoryDC cdcStatus;
-
-			if (item->dwUpdated < dwTicks || file->GetHashingProgress() > 0 || !item->status ||
-				iWidth != item->status->GetWidth()) {
-				if (item->status == NULL) {
-					item->status = new wxBitmap(iWidth, iHeight);
-				} else if (item->status->GetWidth() != iWidth) {
-					// Only recreate if the size has changed
-					item->status->Create(iWidth, iHeight);
-				}
-
-				cdcStatus.SelectObject(*item->status);
-
-				if (thePrefs::UseFlatBar()) {
-					DrawFileStatusBar(
-						file, &cdcStatus, wxRect(0, 0, iWidth, iHeight), true);
-				} else {
-					DrawFileStatusBar(file,
-						&cdcStatus,
-						wxRect(1, 1, iWidth - 2, iHeight - 2),
-						false);
-
-					// Draw black border
-					cdcStatus.SetPen(*wxBLACK_PEN);
-					cdcStatus.SetBrush(*wxTRANSPARENT_BRUSH);
-					cdcStatus.DrawRectangle(0, 0, iWidth, iHeight);
-				}
-
-				item->dwUpdated = dwTicks + 5000; // Plus five seconds
-			} else {
-				cdcStatus.SelectObject(*item->status);
-			}
-
-			dc->Blit(rect.GetX(), rect.GetY() + 1, iWidth, iHeight, &cdcStatus, 0, 0);
-
-			if (thePrefs::ShowPercent()) {
-				// Percentage of completing or hashing
-				uint16 hashingProgress = file->GetHashingProgress();
-				double percent = hashingProgress == 0 ? file->GetPercentCompleted()
-								      : 100.0 * hashingProgress * PARTSIZE /
-										file->GetFileSize();
-				if (file->IsCompleted()) {
-					percent = 100.0;
-				} else if (percent > 99.9) {
-					percent = 99.9;
-				}
-				wxString buffer = CFormat("%.1f%%") % percent;
-				int middlex = (2 * rect.GetX() + rect.GetWidth()) >> 1;
-				int middley = (2 * rect.GetY() + rect.GetHeight()) >> 1;
-
-				wxCoord textwidth, textheight;
-
-				dc->GetTextExtent(buffer, &textwidth, &textheight);
-				wxColour AktColor = dc->GetTextForeground();
-				// Ordinary progress bar: white percentage
-				// Hashing progressbar (green/yellow): black percentage
-				if (thePrefs::ShowProgBar() && hashingProgress == 0) {
-					dc->SetTextForeground(*wxWHITE);
-				} else {
-					dc->SetTextForeground(*wxBLACK);
-				}
-				dc->DrawText(buffer, middlex - (textwidth >> 1), middley - (textheight >> 1));
-				dc->SetTextForeground(AktColor);
-			}
-		}
-
-		break;
-	}
-
-	// Sources
-	case ColumnSources: {
-		uint16 sc = file->GetSourceCount();
-		uint16 ncsc = file->GetNotCurrentSourcesCount();
-		if (ncsc) {
-			text = CFormat("%i/%i") % (sc - ncsc) % sc;
-		} else {
-			text = CFormat("%i") % sc;
-		}
-
+	case COLUMN_DL_SOURCES: {
+		const uint16 sc = file->GetSourceCount();
+		const uint16 ncsc = file->GetNotCurrentSourcesCount();
+		wxString text = ncsc ? CFormat("%i/%i") % (sc - ncsc) % sc : CFormat("%i") % sc;
 		if (file->GetSrcA4AFCount()) {
 			text += CFormat("+%i") % file->GetSrcA4AFCount();
 		}
-
 		if (file->GetTransferingSrcCount()) {
 			text += CFormat(" (%i)") % file->GetTransferingSrcCount();
 		}
-
-		break;
+		return text;
 	}
 
-	// Priority
-	case ColumnPriority:
-		text = PriorityToStr(file->GetDownPriority(), file->IsAutoDownPriority());
-		break;
+	case COLUMN_DL_PRIORITY:
+		return PriorityToStr(file->GetDownPriority(), file->IsAutoDownPriority());
 
-	// File-status
-	case ColumnStatus:
-		text = file->getPartfileStatus();
-		break;
+	case COLUMN_DL_STATUS:
+		return file->getPartfileStatus();
 
-	// Remaining
-	case ColumnTimeRemaining: {
+	case COLUMN_DL_TIMEREMAINING: {
 		if ((file->GetStatus() != PS_COMPLETING) && file->IsPartFile()) {
-			uint64 remainSize = file->GetFileSize() - file->GetCompletedSize();
-			sint32 remainTime = file->getTimeRemaining();
-
-			if (remainTime >= 0) {
-				text = CastSecondsToHM(remainTime);
-			} else {
-				text = _("Unknown");
-			}
-
+			const uint64 remainSize = file->GetFileSize() - file->GetCompletedSize();
+			const sint32 remainTime = file->getTimeRemaining();
+			wxString text =
+				(remainTime >= 0) ? CastSecondsToHM(remainTime) : wxString(_("Unknown"));
 			text += " (" + CastItoXBytes(remainSize) + ")";
+			return text;
 		}
-		break;
+		return wxEmptyString;
 	}
 
-	// Last seen completed
-	case ColumnLastSeenComplete: {
+	case COLUMN_DL_LASTSEENCOMPLETE:
 		if (file->lastseencomplete) {
-			text = wxDateTime(file->lastseencomplete).Format(_("%y/%m/%d %H:%M:%S"));
-		} else {
-			text = _("Unknown");
+			return wxDateTime(file->lastseencomplete).Format(_("%y/%m/%d %H:%M:%S"));
 		}
-		break;
-	}
+		return _("Unknown");
 
-	// Last received
-	case ColumnLastReception: {
+	case COLUMN_DL_LASTRECEPTION: {
 		const time_t lastReceived = file->GetLastChangeDatetime();
 		if (lastReceived) {
-			text = wxDateTime(lastReceived).Format(_("%y/%m/%d %H:%M:%S"));
+			return wxDateTime(lastReceived).Format(_("%y/%m/%d %H:%M:%S"));
+		}
+		return _("Unknown");
+	}
+
+	default:
+		return wxEmptyString;
+	}
+}
+
+bool CDownloadListCtrl::GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const
+{
+	if (column != COLUMN_DL_NAME) {
+		return false;
+	}
+	CPartFile *file = reinterpret_cast<CPartFile *>(item);
+	if (!file->HasRating() && !file->HasComment()) {
+		return false;
+	}
+	int image = Client_CommentOnly_Smiley;
+	if (file->HasRating()) {
+		image = Client_InvalidRating_Smiley + file->UserRating() - 1;
+	}
+	wxASSERT(image >= Client_InvalidRating_Smiley);
+	wxASSERT(image <= Client_CommentOnly_Smiley);
+	icon = theApp->amuledlg->m_imagelist.GetIcon(image);
+	return true;
+}
+
+void CDownloadListCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const
+{
+	if (column != COLUMN_DL_PROGRESS || !thePrefs::ShowProgBar()) {
+		return;
+	}
+	CPartFile *file = reinterpret_cast<CPartFile *>(item);
+	if (file->GetFileSize() == 0) {
+		return;
+	}
+
+	std::vector<CBarFillSpan> spans;
+	const bool bFlat = thePrefs::UseFlatBar();
+
+	if (file->IsCompleted() || file->GetStatus() == PS_COMPLETING) {
+		spans.push_back({ 0, file->GetFileSize() - 1, bFlat ? crFlatProgress : crProgress });
+		out = CBarFillSpec(item, file->GetFileSize(), std::move(spans));
+		return;
+	}
+
+	if (file->GetHashingProgress() > 0) {
+		uint64 left = file->GetHashingProgress() * PARTSIZE;
+		if (left < file->GetFileSize() - 1) {
+			spans.push_back(
+				{ left + 1, file->GetFileSize() - 1, bFlat ? crFlatPending : crPending });
 		} else {
-			text = _("Unknown");
+			left = file->GetFileSize() - 1;
+		}
+		spans.push_back({ 0, left, bFlat ? crFlatProgress : crProgress });
+		out = CBarFillSpec(item, file->GetFileSize(), std::move(spans));
+		return;
+	}
+
+	// Part availability (of missing parts).
+	const CGapList &gaplist = file->GetGapList();
+	uint64 lastGapEnd = 0;
+	for (CGapList::const_iterator it = gaplist.begin(); it != gaplist.end(); ++it) {
+		const uint64 start = it.start() / PARTSIZE;
+		if (it.start()) {
+			spans.push_back({ lastGapEnd + 1, it.start() - 1, bFlat ? crFlatHave : crHave });
+		}
+		lastGapEnd = it.end();
+		uint64 end = (it.end() / PARTSIZE) + 1;
+		if (end > file->GetPartCount()) {
+			end = file->GetPartCount();
+		}
+
+		// Place each gap, one PART at a time.
+		for (uint64 i = start; i < end; ++i) {
+			CMuleColour colour;
+			if (i < file->m_SrcpartFrequency.size() && file->m_SrcpartFrequency[i]) {
+				const int blue = 210 - (22 * (file->m_SrcpartFrequency[i] - 1));
+				colour.Set(0, static_cast<uint8_t>(blue < 0 ? 0 : blue), 255);
+			} else {
+				colour = crMissing;
+			}
+			if (file->IsStopped()) {
+				colour.Blend(50);
+			}
+			const uint64 gap_begin = (i == start ? it.start() : PARTSIZE * i);
+			const uint64 gap_end = (i == end - 1 ? it.end() : PARTSIZE * (i + 1) - 1);
+			spans.push_back({ gap_begin, gap_end, colour });
 		}
 	}
+	// Fill the last Have-part (between this gap and the last).
+	spans.push_back({ lastGapEnd + 1, file->GetFileSize() - 1, bFlat ? crFlatHave : crHave });
+
+	// Pending parts. Adjacent pending parts must be joined to avoid bright
+	// lines between them.
+	const CPartFile::CReqBlockPtrList requestedBlocks = file->GetRequestedBlockList();
+	uint64 lastStartOffset = 0;
+	uint64 lastEndOffset = 0;
+	CMuleColour pendingColour = bFlat ? crFlatPending : crPending;
+	if (file->IsStopped()) {
+		pendingColour.Blend(50);
 	}
+	for (const Requested_Block_Struct *block : requestedBlocks) {
+		if (block->StartOffset > lastEndOffset + 1) {
+			spans.push_back({ lastStartOffset, lastEndOffset, pendingColour });
+			lastStartOffset = block->StartOffset;
+			lastEndOffset = block->EndOffset;
+		} else {
+			lastEndOffset = block->EndOffset;
+		}
+	}
+	spans.push_back({ lastStartOffset, lastEndOffset, pendingColour });
 
-	if (!text.IsEmpty()) {
-		dc->DrawText(text, rect.GetX(), rect.GetY());
+	out = CBarFillSpec(item, file->GetFileSize(), std::move(spans));
+}
+
+bool CDownloadListCtrl::IsLiveSortColumn() const
+{
+	if (m_sort_orders.empty()) {
+		return false;
+	}
+	switch (static_cast<int>(m_sort_orders.front().first)) {
+	case COLUMN_DL_TRANSFERRED:
+	case COLUMN_DL_COMPLETED:
+	case COLUMN_DL_SPEED:
+	case COLUMN_DL_PROGRESS:
+	case COLUMN_DL_SOURCES:
+	case COLUMN_DL_TIMEREMAINING:
+	case COLUMN_DL_LASTSEENCOMPLETE:
+	case COLUMN_DL_LASTRECEPTION:
+		return true;
+	default:
+		return false;
 	}
 }
 
-wxString CDownloadListCtrl::GetTTSText(unsigned item) const
+int CDownloadListCtrl::CompareItemData(
+	wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool WXUNUSED(alt), int modifier) const
 {
-	return reinterpret_cast<FileCtrlItem_Struct *>(ItemAt(item))->GetFile()->GetFileName().GetPrintable();
-}
+	const CPartFile *file1 = reinterpret_cast<const CPartFile *>(data1);
+	const CPartFile *file2 = reinterpret_cast<const CPartFile *>(data2);
+	const int mod = modifier;
 
-int CDownloadListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
-{
-	FileCtrlItem_Struct *item1 = reinterpret_cast<FileCtrlItem_Struct *>(param1);
-	FileCtrlItem_Struct *item2 = reinterpret_cast<FileCtrlItem_Struct *>(param2);
+	switch (column) {
+	case COLUMN_DL_PART:
+		return mod * CmpAny(file1->GetPartMetNumber(), file2->GetPartMetNumber());
 
-	int sortMod = (sortData & CMuleListCtrl::SORT_DES) ? -1 : 1;
-	sortData &= CMuleListCtrl::COLUMN_MASK;
+	case COLUMN_DL_NAME:
+		return mod * CmpAny(file1->GetFileName(), file2->GetFileName());
 
-	// We modify the result so that it matches with ascending or descending
-	return sortMod * Compare(item1->GetFile(), item2->GetFile(), sortData);
-}
+	case COLUMN_DL_SIZE:
+		return mod * CmpAny(file1->GetFileSize(), file2->GetFileSize());
 
-int CDownloadListCtrl::Compare(const CPartFile *file1, const CPartFile *file2, long lParamSort)
-{
-	int result = 0;
+	case COLUMN_DL_TRANSFERRED:
+		return mod * CmpAny(file1->GetTransferred(), file2->GetTransferred());
 
-	switch (lParamSort) {
-	// Sort by part number
-	case ColumnPart:
-		result = CmpAny(file1->GetPartMetNumber(), file2->GetPartMetNumber());
-		break;
+	case COLUMN_DL_COMPLETED:
+		return mod * CmpAny(file1->GetCompletedSize(), file2->GetCompletedSize());
 
-	// Sort by filename
-	case ColumnFileName:
-		result = CmpAny(file1->GetFileName(), file2->GetFileName());
-		break;
+	case COLUMN_DL_SPEED:
+		return mod * CmpAny(file1->GetKBpsDown(), file2->GetKBpsDown());
 
-	// Sort by size
-	case ColumnSize:
-		result = CmpAny(file1->GetFileSize(), file2->GetFileSize());
-		break;
+	case COLUMN_DL_PROGRESS:
+		return mod * CmpAny(file1->GetPercentCompleted(), file2->GetPercentCompleted());
 
-	// Sort by transferred
-	case ColumnTransferred:
-		result = CmpAny(file1->GetTransferred(), file2->GetTransferred());
-		break;
+	case COLUMN_DL_SOURCES:
+		return mod * CmpAny(file1->GetSourceCount(), file2->GetSourceCount());
 
-	// Sort by completed
-	case ColumnCompleted:
-		result = CmpAny(file1->GetCompletedSize(), file2->GetCompletedSize());
-		break;
+	case COLUMN_DL_PRIORITY:
+		return mod * CmpAny(file1->GetDownPriority(), file2->GetDownPriority());
 
-	// Sort by speed
-	case ColumnSpeed:
-		result = CmpAny(file1->GetKBpsDown() * 1024, file2->GetKBpsDown() * 1024);
-		break;
+	case COLUMN_DL_STATUS:
+		return mod * CmpAny(file1->getPartfileStatusRang(), file2->getPartfileStatusRang());
 
-	// Sort by percentage completed
-	case ColumnProgress:
-		result = CmpAny(file1->GetPercentCompleted(), file2->GetPercentCompleted());
-		break;
-
-	// Sort by number of sources
-	case ColumnSources:
-		result = CmpAny(file1->GetSourceCount(), file2->GetSourceCount());
-		break;
-
-	// Sort by priority
-	case ColumnPriority:
-		result = CmpAny(file1->GetDownPriority(), file2->GetDownPriority());
-		break;
-
-	// Sort by status
-	case ColumnStatus:
-		result = CmpAny(file1->getPartfileStatusRang(), file2->getPartfileStatusRang());
-		break;
-
-	// Sort by remaining time
-	case ColumnTimeRemaining:
+	case COLUMN_DL_TIMEREMAINING:
+		// -1 ("unknown") always sorts last, regardless of direction -- `mod`
+		// is deliberately not applied to this branch.
 		if (file1->getTimeRemaining() == -1) {
-			if (file2->getTimeRemaining() == -1) {
-				result = 0;
-			} else {
-				result = 1;
-			}
-		} else {
-			if (file2->getTimeRemaining() == -1) {
-				result = -1;
-			} else {
-				result = CmpAny(file1->getTimeRemaining(), file2->getTimeRemaining());
-			}
+			return (file2->getTimeRemaining() == -1) ? 0 : 1;
 		}
-		break;
+		if (file2->getTimeRemaining() == -1) {
+			return -1;
+		}
+		return mod * CmpAny(file1->getTimeRemaining(), file2->getTimeRemaining());
 
-	// Sort by last seen complete
-	case ColumnLastSeenComplete:
-		result = CmpAny(file1->lastseencomplete, file2->lastseencomplete);
-		break;
+	case COLUMN_DL_LASTSEENCOMPLETE:
+		return mod * CmpAny(file1->lastseencomplete, file2->lastseencomplete);
 
-	// Sort by last reception
-	case ColumnLastReception:
-		result = CmpAny(file1->GetLastChangeDatetime(), file2->GetLastChangeDatetime());
-		break;
+	case COLUMN_DL_LASTRECEPTION:
+		return mod * CmpAny(file1->GetLastChangeDatetime(), file2->GetLastChangeDatetime());
+
+	default:
+		return 0;
 	}
-
-	return result;
 }
 
 void CDownloadListCtrl::ClearCompleted()
 {
 	CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(false);
 
-	// Search for completed files
 	ListOfUInts32 toClear;
-	for (ListItems::iterator it = m_ListItems.begin(); it != m_ListItems.end();) {
-		FileCtrlItem_Struct *item = it->second;
-		++it;
-
-		CPartFile *file = item->GetFile();
-
+	for (CPartFile *file : m_files) {
 		if (file->IsCompleted() && file->CheckShowItemInGivenCat(m_category)) {
 			toClear.push_back(file->ECID());
 		}
@@ -1357,7 +1126,6 @@ void CDownloadListCtrl::SetFilesCount(int count)
 	m_filecount = count;
 
 	wxStaticText *label = CastByName("downloadsLabel", GetParent(), wxStaticText);
-
 	label->SetLabel(CFormat(_("Downloads (%i)")) % m_filecount);
 	label->GetParent()->Layout();
 }
@@ -1409,8 +1177,7 @@ void CDownloadListCtrl::UpdateFreeSpace()
 	// is nothing to warn about, and this walks the whole queue.
 	uint64 remaining = 0;
 	if (freeSpace != FREE_SPACE_UNKNOWN) {
-		for (const auto &entry : m_ListItems) {
-			const CPartFile *file = entry.second->GetFile();
+		for (CPartFile *file : m_files) {
 			if (file->IsCompleted()) {
 				continue;
 			}
@@ -1422,144 +1189,9 @@ void CDownloadListCtrl::UpdateFreeSpace()
 		}
 	}
 
-	const bool warn = (freeSpace != FREE_SPACE_UNKNOWN) && ((uint64)freeSpace < remaining);
+	const bool warn = (freeSpace != FREE_SPACE_UNKNOWN) && (static_cast<uint64>(freeSpace) < remaining);
 	// Continues the "Total queue size:" label to its left.
 	CamuleDlg::SetFreeSpaceLabel(m_freeSpaceLabel, freeSpace, warn, " | ");
-}
-
-static const CMuleColour crHave(104, 104, 104);
-static const CMuleColour crFlatHave(0, 0, 0);
-
-static const CMuleColour crPending(255, 208, 0);
-static const CMuleColour crFlatPending(255, 255, 100);
-
-static const CMuleColour crProgress(0, 224, 0);
-static const CMuleColour crFlatProgress(0, 150, 0);
-
-static const CMuleColour crMissing(255, 0, 0);
-
-void CDownloadListCtrl::DrawFileStatusBar(
-	const CPartFile *file, wxDC *dc, const wxRect &rect, bool bFlat) const
-{
-	static CBarShader s_ChunkBar(16);
-
-	s_ChunkBar.SetHeight(rect.height);
-	s_ChunkBar.SetWidth(rect.width);
-	s_ChunkBar.SetFileSize(file->GetFileSize());
-	s_ChunkBar.Set3dDepth(thePrefs::Get3DDepth());
-
-	if (file->IsCompleted() || file->GetStatus() == PS_COMPLETING) {
-		s_ChunkBar.Fill(bFlat ? crFlatProgress : crProgress);
-		s_ChunkBar.Draw(dc, rect.x, rect.y, bFlat);
-		return;
-	} else if (file->GetHashingProgress() > 0) {
-		uint64 left = file->GetHashingProgress() * PARTSIZE;
-		if (left < file->GetFileSize() - 1) {
-			// Fill the amount not yet hashed with yellow
-			s_ChunkBar.FillRange(
-				left + 1, file->GetFileSize() - 1, bFlat ? crFlatPending : crPending);
-		} else {
-			left = file->GetFileSize() - 1;
-		}
-		// Fill the amount already hashed with green
-		s_ChunkBar.FillRange(0, left, bFlat ? crFlatProgress : crProgress);
-		s_ChunkBar.Draw(dc, rect.x, rect.y, bFlat);
-		return;
-	}
-	// Part availability ( of missing parts )
-	const CGapList &gaplist = file->GetGapList();
-	CGapList::const_iterator it = gaplist.begin();
-	uint64 lastGapEnd = 0;
-	CMuleColour colour;
-
-	for (; it != gaplist.end(); ++it) {
-
-		// Start position
-		uint32 start = (it.start() / PARTSIZE);
-		// fill the Have-Part (between this gap and the last)
-		if (it.start()) {
-			s_ChunkBar.FillRange(lastGapEnd + 1, it.start() - 1, bFlat ? crFlatHave : crHave);
-		}
-		lastGapEnd = it.end();
-		// End position
-		uint32 end = (it.end() / PARTSIZE) + 1;
-
-		// Avoid going past the filesize. Dunno if this can happen, but the old code did check.
-		if (end > file->GetPartCount()) {
-			end = file->GetPartCount();
-		}
-
-		// Place each gap, one PART at a time
-		for (uint64 i = start; i < end; ++i) {
-			if (i < file->m_SrcpartFrequency.size() && file->m_SrcpartFrequency[i]) {
-				int blue = 210 - (22 * (file->m_SrcpartFrequency[i] - 1));
-				colour.Set(0, (blue < 0 ? 0 : blue), 255);
-			} else {
-				colour = crMissing;
-			}
-
-			if (file->IsStopped()) {
-				colour.Blend(50);
-			}
-
-			uint64 gap_begin = (i == start ? it.start() : PARTSIZE * i);
-			uint64 gap_end = (i == end - 1 ? it.end() : PARTSIZE * (i + 1) - 1);
-
-			s_ChunkBar.FillRange(gap_begin, gap_end, colour);
-		}
-	}
-
-	// fill the last Have-Part (between this gap and the last)
-	s_ChunkBar.FillRange(lastGapEnd + 1, file->GetFileSize() - 1, bFlat ? crFlatHave : crHave);
-
-	// Pending parts
-	const CPartFile::CReqBlockPtrList &requestedblocks_list = file->GetRequestedBlockList();
-	CPartFile::CReqBlockPtrList::const_iterator it2 = requestedblocks_list.begin();
-	// adjacing pending parts must be joined to avoid bright lines between them
-	uint64 lastStartOffset = 0;
-	uint64 lastEndOffset = 0;
-
-	colour = bFlat ? crFlatPending : crPending;
-
-	if (file->IsStopped()) {
-		colour.Blend(50);
-	}
-
-	for (; it2 != requestedblocks_list.end(); ++it2) {
-
-		if ((*it2)->StartOffset > lastEndOffset + 1) {
-			// not adjacing, draw last block
-			s_ChunkBar.FillRange(lastStartOffset, lastEndOffset, colour);
-			lastStartOffset = (*it2)->StartOffset;
-			lastEndOffset = (*it2)->EndOffset;
-		} else {
-			// adjacing, grow block
-			lastEndOffset = (*it2)->EndOffset;
-		}
-	}
-
-	s_ChunkBar.FillRange(lastStartOffset, lastEndOffset, colour);
-
-	// Draw the progress-bar
-	s_ChunkBar.Draw(dc, rect.x, rect.y, bFlat);
-
-	// Green progressbar width
-	int width = (int)(((float)rect.width / (float)file->GetFileSize()) * file->GetCompletedSize());
-
-	if (bFlat) {
-		dc->SetBrush(crFlatProgress.GetBrush());
-
-		dc->DrawRectangle(rect.x, rect.y, width, 3);
-	} else {
-		// Draw the two black lines for 3d-effect
-		dc->SetPen(*wxBLACK_PEN);
-		dc->DrawLine(rect.x, rect.y + 0, rect.x + width, rect.y + 0);
-		dc->DrawLine(rect.x, rect.y + 2, rect.x + width, rect.y + 2);
-
-		// Draw the green line
-		dc->SetPen(*(wxThePenList->FindOrCreatePen(crProgress, 1, wxPENSTYLE_SOLID)));
-		dc->DrawLine(rect.x, rect.y + 1, rect.x + width, rect.y + 1);
-	}
 }
 
 // File_checked_for_headers

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -105,6 +105,13 @@ private:
 								   static_cast<double>(file->GetFileSize())) *
 							   static_cast<double>(file->GetCompletedSize()));
 			if (bFlat) {
+				// Deliberately no outline: master drew this strip into a fresh
+				// wxMemoryDC, whose default black pen gave it one, but that was
+				// incidental -- nothing set the pen on purpose, so it would
+				// have carried over whatever the list's own DC last used had
+				// this been drawn there instead. Transparent is the
+				// intentional, deterministic choice; wxBLACK_PEN would
+				// reproduce the old look if that turns out to be preferred.
 				dc->SetPen(*wxTRANSPARENT_PEN);
 				dc->SetBrush(crFlatProgress.GetBrush());
 				dc->DrawRectangle(barRect.x, barRect.y, width, 3);
@@ -335,7 +342,9 @@ void CDownloadListCtrl::RemoveFile(CPartFile *file)
 {
 	wxASSERT(file);
 
-	// Ensure that any list-entry is removed.
+	// Order matters: ShowFile() early-returns once `file` is no longer in
+	// m_files, so the erase has to come after it -- swapped, the row would
+	// stay in the model holding a pointer the caller is about to free.
 	ShowFile(file, false);
 	m_files.erase(file);
 }
@@ -733,13 +742,18 @@ void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)
 	if (!event.GetItem().IsOk()) {
 		return;
 	}
-	UnselectAll();
-	Select(event.GetItem());
-	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
-	if (selected.empty()) {
+	// Read the row straight off the event, the way GetRowLabel() does --
+	// touching the selection here (as an earlier version of this did) would
+	// discard whatever multi-selection the user already had, and firing
+	// EVT_DATAVIEW_SELECTION_CHANGED as a side effect of a double-click would
+	// rebuild the sources panel for no reason.
+	const wxDataViewListModel *model = static_cast<const wxDataViewListModel *>(GetModel());
+	const long row = static_cast<long>(model->GetRow(event.GetItem()));
+	const wxUIntPtr data = ItemAt(row);
+	if (!data) {
 		return;
 	}
-	CPartFile *file = reinterpret_cast<CPartFile *>(selected.front());
+	CPartFile *file = reinterpret_cast<CPartFile *>(data);
 
 	// Double-click is media-only: it is an easy gesture to trigger by
 	// accident, and handing a completed .exe or .desktop to the platform
@@ -755,7 +769,7 @@ void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)
 	if (file->PreviewAvailable() && FileLaunch::CanOpen(file)) {
 		FileLaunch::Open(file, this);
 	} else {
-		ShowFileDetailDialog(RowOfData(selected.front()));
+		ShowFileDetailDialog(row);
 	}
 }
 

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -26,30 +26,45 @@
 #ifndef DOWNLOADLISTCTRL_H
 #define DOWNLOADLISTCTRL_H
 
-#include <map> // Needed for std::multimap
-#include <wx/brush.h>
+#include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
 
-#include "Types.h"               // Needed for uint8
-#include "Constants.h"           // Needed for DownloadItemType
-#include "MuleVirtualListCtrl.h" // Needed for CMuleVirtualListCtrl
+#include <set> // Needed for std::set
+
+#define COLUMN_DL_PART 0
+#define COLUMN_DL_NAME 1
+#define COLUMN_DL_SIZE 2
+#define COLUMN_DL_TRANSFERRED 3
+#define COLUMN_DL_COMPLETED 4
+#define COLUMN_DL_SPEED 5
+#define COLUMN_DL_PROGRESS 6
+#define COLUMN_DL_SOURCES 7
+#define COLUMN_DL_PRIORITY 8
+#define COLUMN_DL_STATUS 9
+#define COLUMN_DL_TIMEREMAINING 10
+#define COLUMN_DL_LASTSEENCOMPLETE 11
+#define COLUMN_DL_LASTRECEPTION 12
+//! Always empty. Absorbs the macOS trailing-column sizing; see
+//! CMuleDataViewCtrl::AppendSpacerColumn().
+#define COLUMN_DL_SPACER 13
 
 class CPartFile;
-class wxBitmap;
-class wxRect;
-class wxDC;
+class wxMenu;
 class wxStaticText;
-
-struct FileCtrlItem_Struct;
 
 /**
  * This class is responsible for representing the download queue.
  *
- * The CDownlodListCtrl class is responsible for drawing files being downloaded.
- * It is in many ways primary widget within the application, since it is here that
- * users can inspect and manipulate their current downloads.
+ * The CDownloadListCtrl class is responsible for drawing files being
+ * downloaded. It is in many ways the primary widget within the application,
+ * since it is here that users can inspect and manipulate their current
+ * downloads.
  *
+ * Rows are addressed by CPartFile* identity, same as CSharedFilesCtrl's by
+ * CKnownFile*. The Progress column is the one graphic cell (a CBarShader
+ * chunk/gap bar plus a completed-progress overlay and percent text); see
+ * CDownloadBarRenderer in the .cpp.
  */
-class CDownloadListCtrl : public CMuleVirtualListCtrl
+class CDownloadListCtrl : public CMuleVirtualDataViewCtrl
 {
 public:
 	/**
@@ -58,17 +73,16 @@ public:
 	 * @see CMuleListCtrl::CMuleListCtrl for documentation of parameters.
 	 */
 	CDownloadListCtrl(wxWindow *parent,
-		wxWindowID winid = -1,
+		wxWindowID winid = wxID_ANY,
 		const wxPoint &pos = wxDefaultPosition,
 		const wxSize &size = wxDefaultSize,
-		long style = wxLC_ICON,
-		const wxValidator &validator = wxDefaultValidator,
+		long style = 0,
 		const wxString &name = "downloadlistctrl");
 
 	/**
 	 * Destructor.
 	 */
-	virtual ~CDownloadListCtrl();
+	~CDownloadListCtrl();
 
 	/**
 	 * Adds a file to the list, but it wont show unless it matches the current category.
@@ -96,9 +110,10 @@ public:
 	void ShowFileList();
 
 	// The live text filter (SetFilterText) is inherited from
-	// CMuleVirtualListCtrl; here it is AND-ed with the current category, and
-	// the rebuild it triggers is RebuildFilteredView() below. Purely GUI-side,
-	// so it behaves the same in the monolithic app and the remote GUI.
+	// CMuleVirtualDataViewCtrl; here it is AND-ed with the current category,
+	// and the rebuild it triggers is RebuildFilteredView() below. Purely
+	// GUI-side, so it behaves the same in the monolithic app and the remote
+	// GUI.
 
 	/**
 	 * Bracket a burst of AddFile()/UpdateItem() calls (a reconnect resync —
@@ -115,36 +130,34 @@ public:
 	 * Removes the specified file from the list.
 	 *
 	 * @param file A valid pointer of the file to be removed.
-	 *
-	 * This function also removes any sources associated with the file.
 	 */
 	void RemoveFile(CPartFile *file);
 
 	/**
-	 * Shows or hides the sources of a specific file.
+	 * Shows or hides a file's own row, depending on whether it currently
+	 * passes the category + text filter.
 	 *
 	 * @param file A valid pointer to the file to be shown/hidden.
-	 * @param show Whenever or not to show the file.
-	 *
-	 * If the file is hidden, then its sources will also be hidden.
+	 * @param show Whether to show the file.
 	 */
 	void ShowFile(CPartFile *file, bool show);
 
 	/**
-	 * Updates the state of the specified item, possibly causing a redrawing.
+	 * Updates the state of the specified file, possibly causing a redrawing.
 	 *
-	 * @param toupdate The source or file to be updated.
+	 * @param toupdate The file to be updated (always a CPartFile*, kept as
+	 *                 const void* for source-compatibility with existing
+	 *                 callers -- see GuiEvents.cpp's DownloadCtrlUpdateItem).
 	 *
-	 * Calling this function with a file as the argument will ensure that the
-	 * file is hidden/shown depending on its state and the currently selected
-	 * category.
+	 * Calling this function ensures that the file is hidden/shown depending
+	 * on its state and the currently selected category.
 	 */
 	void UpdateItem(const void *toupdate);
 
 	/**
 	 * Returns the current category.
 	 */
-	uint8 GetCategory() const;
+	uint8 GetCategory() const { return m_category; }
 
 	/**
 	 * Changes the displayed category and updates the list of shown files.
@@ -181,9 +194,57 @@ public:
 
 protected:
 	/// Return old column order.
-	wxString GetOldColumnOrder() const;
+	wxString GetOldColumnOrder() const override;
+
+	/**
+	 * Type-ahead matches against the filename, not column 0: column 0 is
+	 * the part number here, unlike every other ported list where it's the
+	 * name. The base's default (GetItemColumnText(item, 0)) would make
+	 * type-to-select match part numbers instead.
+	 */
+	wxString GetRowLabel(const wxDataViewItem &item) const override;
+
+	/// Text of one cell, pulled on demand for the cells being drawn.
+	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
+
+	/// Rating/comment smiley on the File Name column, nothing elsewhere.
+	bool GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const override;
+
+	/// Chunk/gap-bar spans for the Progress column.
+	void GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const override;
+
+	/** Live auto-sort: re-order when sorted by a column whose value changes
+	 *  as a download progresses (transferred, completed, speed, progress,
+	 *  sources, time remaining, last seen complete, last reception). Static
+	 *  columns don't auto-resort. */
+	bool IsLiveSortColumn() const override;
+
+	/** Pause live auto-sort while the context menu is open. */
+	bool IsMenuOpen() const override { return m_menu != nullptr; }
+
+	/// Single-column comparison for the base's sort chain.
+	int CompareItemData(
+		wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const override;
+
+	/**
+	 * @see CMuleVirtualDataViewCtrl::RebuildFilteredView
+	 */
+	void RebuildFilteredView() override;
 
 private:
+	/**
+	 * Rebuilds the visible rows from the model in a single pass, keeping the
+	 * files that pass the current category + text filter. Used whenever the
+	 * visible set changes wholesale (category switch, filter edit, or a
+	 * deferred bulk load's first ShowFileList()).
+	 */
+	void RebuildVisibleList();
+
+	//! Whether @a file should be displayed in @a category: the category
+	//! predicate AND-ed with the text filter. Takes a non-const file because
+	//! CPartFile::CheckShowItemInGivenCat() is not const.
+	bool IsVisibleInCat(CPartFile *file, int category) const;
+
 	/**
 	 * Updates the displayed number representing the amount of files currently shown.
 	 */
@@ -195,56 +256,15 @@ private:
 	void SetFilesCount(int count);
 
 	/**
-	 * Sets the "Total size:" label to the combined size of the currently
-	 * shown files (category + text filter). Kept in step with the visible
-	 * set the same way as the file count: reset in bulk by RebuildVisibleList
-	 * and adjusted by GetFileSize() as ShowFile() adds/removes a row.
+	 * Sets the "Total queue size:" label to the combined size of the
+	 * currently shown files (category + text filter).
 	 */
 	void SetTotalSize(uint64 total);
 
 	/**
-	 * Rebuilds the visible rows from the model in a single pass, keeping the
-	 * files that pass the current category + text filter. Used whenever the
-	 * visible set changes wholesale (category switch, filter edit).
+	 * Delete/F2 key handling; see CMuleDataViewCtrl::OnListKey.
 	 */
-	void RebuildVisibleList();
-
-	/**
-	 * @see CMuleVirtualListCtrl::RebuildFilteredView
-	 */
-	virtual void RebuildFilteredView();
-
-	/**
-	 * @see CMuleListCtrl::GetTTSText
-	 */
-	virtual wxString GetTTSText(unsigned item) const;
-
-	/** Live auto-sort: re-order when sorted by a column whose value changes
-	 *  as a download progresses (transferred, completed, speed, progress,
-	 *  sources, time remaining). Static columns don't auto-resort. */
-	virtual bool IsLiveSortColumn() const;
-
-	/** Pause live auto-sort while the context menu is open. */
-	virtual bool IsMenuOpen() const { return m_menu != nullptr; }
-
-	/**
-	 * Overloaded function needed for custom drawing of items.
-	 */
-	virtual void OnDrawItem(
-		int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted);
-
-	/**
-	 * Draws a file item.
-	 */
-	void DrawFileItem(wxDC *dc, int nColumn, const wxRect &rect, FileCtrlItem_Struct *item) const;
-
-	/**
-	 * Draws the status (chunk) bar for a file.
-	 */
-	void DrawFileStatusBar(const CPartFile *file, wxDC *dc, const wxRect &rect, bool bFlat) const;
-
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
-	static int Compare(const CPartFile *file1, const CPartFile *file2, long lParamSort);
+	bool OnListKey(wxKeyEvent &event) override;
 
 	// Event-handlers for files
 	void OnCancelFile(wxCommandEvent &event);
@@ -272,59 +292,45 @@ private:
 	 */
 	wxUIntPtr m_menuItem = 0;
 
-	// Misc event-handlers
-	void OnItemActivated(wxListEvent &event);
-	void OnMouseRightClick(wxListEvent &event);
-	void OnMouseMiddleClick(wxListEvent &event);
-	void OnKeyPressed(wxKeyEvent &event);
-	void OnItemSelectionChanged(wxListEvent &event);
+	void OnItemActivated(wxDataViewEvent &event);
+	void OnItemRightClicked(wxDataViewEvent &event);
 
 	/**
-	 * Show file detail dialog for item at index
+	 * Fires DoItemSelectionChanged() (which rebuilds the sources panel), but
+	 * only if a notification isn't already pending -- m_ItemSelectionChangePending
+	 * guards against a burst of selection events (e.g. a rubber-band
+	 * selecting many rows) scheduling more than one.
 	 */
-	void ShowFileDetailDialog(long index);
+	void OnSelectionChanged(wxDataViewEvent &event);
+	//! Set while a DoItemSelectionChanged() notification is pending, so a
+	//! burst of selection events schedules only one.
+	bool m_ItemSelectionChangePending = false;
 
-	//! The type of list used to store items on the listctrl.
-	typedef std::multimap<const void *, FileCtrlItem_Struct *> ListItems;
-	//! Shortcut to the pair-type used on the list.
-	typedef ListItems::value_type ListItemsPair;
-	//! This pair is used when searching for equal-ranges.
-	typedef std::pair<ListItems::iterator, ListItems::iterator> ListIteratorPair;
+	/**
+	 * Show file detail dialog for the given row.
+	 */
+	void ShowFileDetailDialog(long row);
 
-	//! This list contains everything shown on the list. Sources are only to
-	//! be found on this list if they are being displayed, whereas files can
-	//! always be found on this list, even if they are currently hidden.
-	ListItems m_ListItems;
+	//! Every known download, shown or hidden by the current category/filter.
+	//! RebuildVisibleList() walks this to decide what to show; AddFile() uses
+	//! it to reject duplicates.
+	std::set<CPartFile *> m_files;
 
 	//! Pointer to the current menu object, used to avoid multiple menus.
-	wxMenu *m_menu;
-	//! Cached brush object.
-	wxBrush m_hilightBrush;
-	//! Cached brush object.
-	wxBrush m_hilightUnfocusBrush;
+	wxMenu *m_menu = nullptr;
 
 	//! The currently displayed category
-	uint8 m_category;
-
-	//! True if @a file passes the current text filter (name substring match).
-
-	//! Whether @a file should be displayed in @a category: the category
-	//! predicate AND-ed with the text filter. Takes a non-const file because
-	//! CPartFile::CheckShowItemInGivenCat() is not const.
-	bool IsVisibleInCat(CPartFile *file, int category) const;
-
-	//! Flag if change of item selection is pending
-	bool m_ItemSelectionChangePending;
+	uint8 m_category = 0;
 
 	//! True between BeginBatchUpdate()/EndBatchUpdate(): AddFile() appends
 	//! rows but defers the per-item SortList to one final sort (issue #444).
 	bool m_batchUpdate = false;
 
 	//! The number of displayed files
-	int m_filecount;
+	int m_filecount = 0;
 
-	//! Combined size of the displayed files (drives the "Total size:" label)
-	uint64 m_shownSize;
+	//! Combined size of the displayed files (drives the "Total queue size:" label)
+	uint64 m_shownSize = 0;
 
 	//! The "Free space:" label, resolved by name on first use. Lives in the
 	//! sources pane, so it cannot be reached through GetParent().

--- a/src/MuleBarRenderer.cpp
+++ b/src/MuleBarRenderer.cpp
@@ -77,15 +77,9 @@ bool CMuleBarRenderer::Render(wxRect cell, wxDC *dc, int WXUNUSED(state))
 
 	const bool bFlat = thePrefs::UseFlatBar();
 
-	wxRect barRect = cell;
-	if (!bFlat) {
-		// Round bar has a black border; the bar itself is inset by one pixel
-		// on each side -- matches every pre-port CBarShader caller.
-		barRect.x++;
-		barRect.y++;
-		barRect.width -= 2;
-		barRect.height -= 2;
-	}
+	// Round bar has a black border; the bar itself is inset by one pixel on
+	// each side -- matches every pre-port CBarShader caller.
+	const wxRect barRect = InsetForBar(cell, bFlat);
 	if (barRect.GetWidth() <= 0 || barRect.GetHeight() <= 0) {
 		return true;
 	}

--- a/src/MuleBarRenderer.h
+++ b/src/MuleBarRenderer.h
@@ -65,12 +65,23 @@ class CBarFillSpec : public wxObject
 {
 public:
 	CBarFillSpec() = default;
-	CBarFillSpec(uint64 fileSize, std::vector<CBarFillSpan> spans)
-	: m_fileSize(fileSize)
+	CBarFillSpec(wxUIntPtr identity, uint64 fileSize, std::vector<CBarFillSpan> spans)
+	: m_identity(identity)
+	, m_fileSize(fileSize)
 	, m_spans(std::move(spans))
 	{
 	}
 
+	/**
+	 * The row's own item-data pointer, carried through only so a renderer
+	 * subclass can cast it back to its domain type for extra per-list
+	 * drawing (e.g. CDownloadBarRenderer -> CPartFile*). Safe to dereference
+	 * only synchronously inside Render(): GetValueByRow() is the sole
+	 * producer of a CBarFillSpec and only runs for rows currently in the
+	 * model, so liveness holds for that call -- this is not a cache key and
+	 * must never be stored past one Render() call.
+	 */
+	wxUIntPtr GetIdentity() const { return m_identity; }
 	uint64 GetFileSize() const { return m_fileSize; }
 	const std::vector<CBarFillSpan> &GetSpans() const { return m_spans; }
 
@@ -80,6 +91,7 @@ public:
 	}
 
 private:
+	wxUIntPtr m_identity = 0;
 	uint64 m_fileSize = 0;
 	std::vector<CBarFillSpan> m_spans;
 
@@ -124,6 +136,30 @@ public:
 
 	bool Render(wxRect cell, wxDC *dc, int state) override;
 	wxSize GetSize() const override;
+
+protected:
+	//! For a subclass that draws more than the chunk bar (e.g.
+	//! CDownloadBarRenderer's completed-strip and percent text) and needs
+	//! back the data SetValue() already unpacked.
+	const CBarFillSpec &GetSpec() const { return m_spec; }
+
+	/**
+	 * The rect CBarShader is actually drawn into for a given cell -- inset by
+	 * one pixel a side in round (non-flat) mode, to leave room for the black
+	 * border. A subclass overlay (e.g. a completed-progress strip) must draw
+	 * into this same rect, not the raw cell, or it will not line up with the
+	 * bar underneath it.
+	 */
+	static wxRect InsetForBar(wxRect cell, bool bFlat)
+	{
+		if (!bFlat) {
+			cell.x++;
+			cell.y++;
+			cell.width -= 2;
+			cell.height -= 2;
+		}
+		return cell;
+	}
 
 private:
 	CBarFillSpec m_spec;

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -100,10 +100,11 @@ void CMuleDataViewCtrl::AppendSpacerColumn(unsigned modelColumn)
 #endif
 }
 
-void CMuleDataViewCtrl::AppendBarColumn(const wxString &title, unsigned modelColumn, int width, int flags)
+void CMuleDataViewCtrl::AppendBarColumn(
+	const wxString &title, unsigned modelColumn, int width, int flags, CMuleBarRenderer *renderer)
 {
-	wxDataViewColumn *column =
-		new wxDataViewColumn(title, new CMuleBarRenderer(), modelColumn, width, wxALIGN_LEFT, flags);
+	wxDataViewColumn *column = new wxDataViewColumn(
+		title, renderer ? renderer : new CMuleBarRenderer(), modelColumn, width, wxALIGN_LEFT, flags);
 	AppendColumn(column);
 }
 
@@ -136,10 +137,14 @@ void CMuleDataViewCtrl::AddIconTextColumn(const wxString &label,
 	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
 }
 
-void CMuleDataViewCtrl::AddBarColumn(
-	const wxString &label, unsigned modelColumn, const wxString &key, int width, int flags)
+void CMuleDataViewCtrl::AddBarColumn(const wxString &label,
+	unsigned modelColumn,
+	const wxString &key,
+	int width,
+	int flags,
+	CMuleBarRenderer *renderer)
 {
-	AppendBarColumn(label, modelColumn, width, flags);
+	AppendBarColumn(label, modelColumn, width, flags, renderer);
 	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
 }
 

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -34,6 +34,8 @@
 #include <utility>
 #include <vector>
 
+class CMuleBarRenderer;
+
 /**
  * Shared behaviour for aMule's wxDataViewCtrl-backed lists.
  *
@@ -198,11 +200,17 @@ protected:
 	 * bar), for lists that used to paint one with direct wxDC calls in an
 	 * owner-drawn OnDrawItem(). The subclass supplies the per-row fill data
 	 * through CMuleVirtualDataViewCtrl::GetItemBarFill().
+	 *
+	 * @a renderer lets a subclass draw more than the plain chunk bar (e.g.
+	 * CDownloadListCtrl's CDownloadBarRenderer, which adds a completed-progress
+	 * overlay and percent text) by passing its own CMuleBarRenderer subclass;
+	 * null constructs a plain one, today's behaviour.
 	 */
 	void AppendBarColumn(const wxString &title,
 		unsigned modelColumn,
 		int width,
-		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE,
+		CMuleBarRenderer *renderer = nullptr);
 
 	/**
 	 * Append a column and register it for persistence, in one call.
@@ -255,7 +263,8 @@ protected:
 		unsigned modelColumn,
 		const wxString &key,
 		int width,
-		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+		int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE,
+		CMuleBarRenderer *renderer = nullptr);
 
 	/**
 	 * Sizes the per-column state and snapshots the current widths. Call

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -485,7 +485,7 @@ void CSharedFilesCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillS
 		spans.push_back({ end + 1, file->GetFileSize() - 1, CMuleColour(255, 0, 0) });
 	}
 
-	out = CBarFillSpec(file->GetFileSize(), std::move(spans));
+	out = CBarFillSpec(item, file->GetFileSize(), std::move(spans));
 }
 
 bool CSharedFilesCtrl::AltSortAllowed(unsigned column) const

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -413,7 +413,7 @@ wxSizer *transferTopPane( wxWindow *parent, bool call_fit, bool set_sizer )
     wxTextCtrl *itemDlFilter = new wxTextCtrl( parent, IDC_TRANSFER_FILTER, "", wxDefaultPosition, wxSize(150,-1), 0 );
     item1->Add( itemDlFilter, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
-    CDownloadListCtrl *item5 = new CDownloadListCtrl( parent, ID_DLOADLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
+    CDownloadListCtrl *item5 = new CDownloadListCtrl( parent, ID_DLOADLIST, wxDefaultPosition, wxDefaultSize, 0 );
     item5->SetName( "downloadList" );
     item0->Add( item5, wxSizerFlags(1).Expand().CenterVertical() );
     if (set_sizer)


### PR DESCRIPTION
## Summary

Continues #180/#801's `wxListCtrl` → `wxDataViewCtrl` migration. Ports `CDownloadListCtrl`, the second and larger of the two remaining `CBarShader`-consuming lists, onto the `CMuleBarRenderer` bridge added in #842. Two design decisions were sketched on #801 before writing this, since both touch the shared `CMuleBarRenderer`/`CMuleDataViewCtrl` base: https://github.com/amule-org/amule/issues/801#issuecomment-5219484717

- **The Progress cell is composite, not a plain chunk bar.** `DrawFileStatusBar` draws the chunk/gap bar, then a completed-progress overlay strip, and separately a live percentage string is drawn on top — none of which either `CGenericClientListCtrl` bar (`DrawSourceStatusBar`/`DrawStatusBar`) uses. Handled as `CDownloadBarRenderer : public CMuleBarRenderer` (in `DownloadListCtrl.cpp`, not the shared renderer file — one consumer), which draws the base chunk bar then adds its own overlay. `CBarFillSpec` gained one generically-useful field for this: `identity` (the row's own item-data pointer, copied through so a renderer subclass can cast back to its domain type — safe because `GetValueByRow()` only ever produces a spec for a row currently in the model). `AddBarColumn()`/`AppendBarColumn()` take an optional renderer override; `CSharedFilesCtrl` is unaffected by either addition.
- **Not carrying forward the 5-second-TTL cached `wxBitmap` per row.** Measured `CBarShader::Draw()`'s actual cost — microseconds at this cell size for the ~30 rows visible at once — and `CGenericClientListCtrl::DrawStatusBar`'s uncached path plus Shared Files' uncached bar are two live precedents against needing one. A content-equality cache keyed by row identity (the first design) turned out unsafe on its own: identity is a raw `CPartFile*`, and a freed file's address can be reused by an unrelated later file, colliding with a stale cache entry and blitting the wrong bar — same bug family as the row-index-as-pointer crash from the Friends port (#830).

## Other notable changes

- `FileCtrlItem_Struct` (a wrapper that existed only to hold the now-dropped cache fields) is deleted; item data is `CPartFile*` directly, matching `CSharedFilesCtrl`'s `CKnownFile*`.
- `m_ListItems`, a `std::multimap<const void*, FileCtrlItem_Struct*>` whose doc comment reads like it might back per-file "source" child rows, becomes a plain `std::set<CPartFile*>` — there's exactly one insert site, always keyed by the file pointer, so it never backed a real tree/hierarchy.
- `GetRowLabel()` is overridden to return the filename: the base's default assumes column 0 is the name (true for every other ported list), but here column 0 is the part number — without this, type-to-select would match part numbers instead of filenames.
- `OnItemActivated` resolves the activated row through the selection rather than casting the `wxDataViewItem`'s ID directly (a row index on this model, not the item pointer — the Friends-port lesson).
- The `IsSorting()` reentrancy guard on the selection-changed handler is dropped, same as `SharedFilesWnd.cpp`'s two guards: it defended against `wxListCtrl`'s callback-driven `SortItems()`, which the model-driven `SortList()` has no equivalent hazard for.
- `muuli_wdr.cpp`'s construction flags drop `wxLC_REPORT|wxSUNKEN_BORDER` for `0`, matching got3nks's `71bdb1a` fix for the four already-ported lists (`wxLC_REPORT == 0x0020 == wxDV_VARIABLE_LINE_HEIGHT`) — Downloads wasn't in that commit only because it wasn't ported yet.

## Test plan

- [x] Built `amule` (monolithic) and `amulegui` (`-DBUILD_REMOTEGUI=ON`) clean from a fresh CMake configure, both locally (wx 3.3.3) and in the `amule-ci-local` replica (wx 3.2.4)
- [x] Formatted with the pinned `clang-format:18` Docker image
- [x] `clang-tidy` Tier-1 (whole-tree) and Tier-2 (changed-lines) clean via the local CI replica — Tier-1's only findings are pre-existing `unittests/` warnings unrelated to this branch
- [x] Grepped for orphaned call sites (`FileCtrlItem_Struct`, `OnDrawItem`, `DrawFileStatusBar`, `SortProc`, `IsSorting`, row-index `wxLIST_*` API against `downloadlistctrl`) — none remain; all 8 external callers (`TransferWnd`, `CatDialog`, `GuiEvents`, `amule.cpp`, `amule-remote-gui.cpp`, `amuleDlg.cpp`) call by name only, already name-compatible, none needed changes
- [x] Manual: progress bar renders correctly (chunk colours, completed-strip, percent text) compared against current release build, `ShowProgBar()`/`ShowPercent()` preferences still gate correctly, category switching and text filter still work, sort by every column (including Time Remaining's unknown-sorts-last case), type-ahead selects by filename (not part number), context menu actions (priority, cancel/pause/resume, clear completed, category assignment, A4AF swap, preview, copy links), VoiceOver spot-check
