### PR TITLE
fix(gui): tighten icon+text cells and let the chunk bar fill its cell

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -952,6 +952,7 @@ if (NEED_LIB_MULEAPPGUI)
 		FileDetailListCtrl.cpp
 		ListColumnStore.cpp
 		MuleBarRenderer.cpp
+		MuleIconTextRenderer.cpp
 		MuleColour.cpp
 		MuleGifCtrl.cpp
 		MuleDataViewCtrl.cpp

--- a/src/MuleBarRenderer.cpp
+++ b/src/MuleBarRenderer.cpp
@@ -60,7 +60,13 @@ wxSize CMuleBarRenderer::GetSize() const
 	if (const wxDataViewColumn *column = GetOwner()) {
 		width = std::max(width, column->GetWidth());
 	}
-	return wxSize(width, GetTextExtent("Xg").GetHeight());
+	// Height is deliberately wxDefaultCoord: wxDataViewCustomRendererBase::
+	// WXCallRender() only applies its vertical alignment -- which shrinks the
+	// rect it hands Render() down to GetSize().y -- when the height is >= 0.
+	// Reporting a concrete height there means a row taller than that (the
+	// generic backend pads rows past the text extent) draws the bar at the top
+	// with a gap under it. Opting out leaves the bar the full cell.
+	return wxSize(width, wxDefaultCoord);
 }
 
 bool CMuleBarRenderer::Render(wxRect cell, wxDC *dc, int WXUNUSED(state))

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -31,8 +31,9 @@
 
 #include <common/MenuIDs.h> // Needed for MP_LISTCOL_1 .. MP_LISTCOL_15
 
-#include "GetTickCount.h"    // Needed for GetTickCount64()
-#include "MuleBarRenderer.h" // Needed for CMuleBarRenderer
+#include "GetTickCount.h"         // Needed for GetTickCount64()
+#include "MuleBarRenderer.h"      // Needed for CMuleBarRenderer
+#include "MuleIconTextRenderer.h" // Needed for CMuleIconTextRenderer
 
 namespace
 {
@@ -126,7 +127,12 @@ void CMuleDataViewCtrl::AddIconTextColumn(const wxString &label,
 	int flags,
 	wxDataViewCellMode mode)
 {
-	AppendIconTextColumn(label, modelColumn, mode, width, align, flags);
+	// CMuleIconTextRenderer rather than wx's, which reserves the icon slot on
+	// every row whether or not that row has an icon -- see the class comment.
+	CMuleIconTextRenderer *renderer = new CMuleIconTextRenderer();
+	renderer->SetMode(mode);
+	renderer->SetAlignment(align);
+	AppendColumn(new wxDataViewColumn(label, renderer, modelColumn, width, align, flags));
 	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
 }
 

--- a/src/MuleIconTextRenderer.cpp
+++ b/src/MuleIconTextRenderer.cpp
@@ -1,0 +1,82 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "MuleIconTextRenderer.h" // Interface declarations
+
+#include <wx/dc.h>   // Needed for wxDC (not pulled in by dataview.h on GTK)
+#include <wx/icon.h> // Needed for wxIcon
+
+#include <algorithm> // Needed for std::max
+
+CMuleIconTextRenderer::CMuleIconTextRenderer()
+: wxDataViewCustomRenderer("wxDataViewIconText", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT)
+{
+}
+
+bool CMuleIconTextRenderer::SetValue(const wxVariant &value)
+{
+	m_value << value;
+	return true;
+}
+
+bool CMuleIconTextRenderer::GetValue(wxVariant &value) const
+{
+	value << m_value;
+	return true;
+}
+
+bool CMuleIconTextRenderer::Render(wxRect cell, wxDC *dc, int state)
+{
+	int xoffset = 0;
+
+	const wxIcon &icon = m_value.GetIcon();
+	if (icon.IsOk()) {
+		// Centred vertically: the icon is a fixed size while the row height
+		// follows the font, so the two rarely match.
+		const int y = cell.y + std::max(0, (cell.height - icon.GetHeight()) / 2);
+		dc->DrawIcon(icon, cell.x, y);
+		xoffset = icon.GetWidth() + kIconTextGap;
+	}
+
+	// A row with no icon passes xoffset 0 and starts at the cell edge -- the
+	// whole point of not using wx's renderer here.
+	RenderText(m_value.GetText(), xoffset, cell, dc, state);
+	return true;
+}
+
+wxSize CMuleIconTextRenderer::GetSize() const
+{
+	// Measured from a non-empty string when the cell has no text: an empty
+	// extent would report zero height, and on the native macOS backend this
+	// height is what the row is sized from.
+	const wxString &text = m_value.GetText();
+	wxSize size = GetTextExtent(text.IsEmpty() ? wxString("Xg") : text);
+
+	const wxIcon &icon = m_value.GetIcon();
+	if (icon.IsOk()) {
+		size.x += icon.GetWidth() + kIconTextGap;
+		size.y = std::max(size.y, icon.GetHeight());
+	}
+	return size;
+}

--- a/src/MuleIconTextRenderer.h
+++ b/src/MuleIconTextRenderer.h
@@ -1,0 +1,65 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef MULEICONTEXTRENDERER_H
+#define MULEICONTEXTRENDERER_H
+
+#include <wx/dataview.h> // Needed for wxDataViewCustomRenderer, wxDataViewIconText
+
+/**
+ * Draws a wxDataViewIconText cell, but only reserves room for the icon on the
+ * rows that actually have one.
+ *
+ * wx's own icon+text renderer reserves the icon slot unconditionally, so in a
+ * column where the icon is the exception rather than the rule -- a rating
+ * smiley on the handful of files that carry one -- every other row's text is
+ * indented past an empty gap. On the native macOS cell the reserved width is
+ * not even adjustable: wxImageTextCell hardcodes a 5px leading shift, a 5px
+ * icon-to-text gap and a 16x16 icon as private ivars, none of them reachable
+ * from C++.
+ *
+ * Text is drawn through wxDataViewCustomRenderer::RenderText(), so ellipsizing,
+ * the selected-row foreground colour and RTL layout stay exactly as the stock
+ * renderers do them; only the icon placement is ours.
+ */
+class CMuleIconTextRenderer : public wxDataViewCustomRenderer
+{
+public:
+	CMuleIconTextRenderer();
+
+	bool SetValue(const wxVariant &value) override;
+	bool GetValue(wxVariant &value) const override;
+
+	bool Render(wxRect cell, wxDC *dc, int state) override;
+	wxSize GetSize() const override;
+
+private:
+	//! Gap between the icon and the text. No leading inset: the icon starts at
+	//! the cell edge, which is what keeps an icon row aligned with a bare one.
+	static const int kIconTextGap = 4;
+
+	wxDataViewIconText m_value;
+};
+
+#endif // MULEICONTEXTRENDERER_H

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -46,7 +46,6 @@
 #include "Preferences.h"      // Needed for thePrefs
 #include "MuleBarRenderer.h"  // Needed for CBarFillSpec, CBarFillSpan
 #include "DataToText.h"       // Needed for PriorityToStr
-#include "OtherFunctions.h"   // Needed for GetRateString
 #include "Statistics.h"       // Needed for theStats (incoming free space)
 #include "GuiEvents.h"        // Needed for CoreNotify_*
 #include "MuleCollection.h"   // Needed for CMuleCollection
@@ -94,14 +93,13 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 {
 	m_menu = nullptr;
 
-	// Rating is the smiley plus its label and sorts by rating value; Obtained
-	// Parts is the availability bar; the rest are plain text. File Name is
-	// deliberately plain text, not icon+text: an icon renderer in the first
-	// column reserves the icon slot on every row, indenting names that have no
-	// icon of their own.
+	// File Name carries the rating/comment smiley through CMuleIconTextRenderer,
+	// which reserves the icon slot only on the rows that have one -- wx's own
+	// icon+text renderer indents every row without a smiley, which is why this
+	// briefly lived in a column of its own. Obtained Parts is the availability
+	// bar; the rest are plain text.
 	const int colFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
-	AddTextColumn(_("File Name"), COLUMN_SHARED_NAME, "N", 400, wxALIGN_LEFT, colFlags);
-	AddIconTextColumn(_("Rating"), COLUMN_SHARED_RATING, "G", 80, wxALIGN_LEFT, colFlags);
+	AddIconTextColumn(_("File Name"), COLUMN_SHARED_NAME, "N", 400, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Size"), COLUMN_SHARED_SIZE, "Z", 100, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Type"), COLUMN_SHARED_TYPE, "Y", 90, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Priority"), COLUMN_SHARED_PRIO, "p", 70, wxALIGN_LEFT, colFlags);
@@ -341,12 +339,6 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 	case COLUMN_SHARED_NAME:
 		return file->GetFileName().GetPrintable();
 
-	case COLUMN_SHARED_RATING:
-		// The smiley comes from GetItemIcon(); the label names it. Unrated
-		// files stay blank rather than repeating "Not rated" down the column --
-		// a comment with no rating still shows its icon.
-		return file->GetFileRating() ? GetRateString(file->GetFileRating()) : wxString();
-
 	case COLUMN_SHARED_SIZE:
 		return CastItoXBytes(file->GetFileSize());
 
@@ -424,7 +416,7 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 
 bool CSharedFilesCtrl::GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const
 {
-	if (column != COLUMN_SHARED_RATING) {
+	if (column != COLUMN_SHARED_NAME) {
 		return false;
 	}
 	CKnownFile *file = reinterpret_cast<CKnownFile *>(item);
@@ -840,20 +832,6 @@ int CSharedFilesCtrl::CompareItemData(
 	// Sort by filename.
 	case COLUMN_SHARED_NAME:
 		return mod * CmpAny(file1->GetFileName(), file2->GetFileName());
-
-	// Sort by rating. The cell text is blank for unrated files, so sorting on
-	// it would lump them together; rank explicitly instead -- rated files order
-	// by rating, a comment with no rating ranks just below the lowest rating,
-	// and files with neither come last.
-	case COLUMN_SHARED_RATING: {
-		const int rank1 = file1->GetFileRating()             ? file1->GetFileRating()
-				  : file1->GetFileComment().Length() ? 0
-								     : -1;
-		const int rank2 = file2->GetFileRating()             ? file2->GetFileRating()
-				  : file2->GetFileComment().Length() ? 0
-								     : -1;
-		return mod * CmpAny(rank1, rank2);
-	}
 
 	// Sort by filesize.
 	case COLUMN_SHARED_SIZE:

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -29,23 +29,22 @@
 #include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
 
 #define COLUMN_SHARED_NAME 0
-#define COLUMN_SHARED_RATING 1
-#define COLUMN_SHARED_SIZE 2
-#define COLUMN_SHARED_TYPE 3
-#define COLUMN_SHARED_PRIO 4
-#define COLUMN_SHARED_REQ 5
-#define COLUMN_SHARED_AREQ 6
-#define COLUMN_SHARED_TRA 7
-#define COLUMN_SHARED_RTIO 8
-#define COLUMN_SHARED_PART 9
-#define COLUMN_SHARED_CMPL 10
-#define COLUMN_SHARED_SPEED 11
-#define COLUMN_SHARED_SINCE 12
-#define COLUMN_SHARED_LASTUP 13
-#define COLUMN_SHARED_PATH 14
+#define COLUMN_SHARED_SIZE 1
+#define COLUMN_SHARED_TYPE 2
+#define COLUMN_SHARED_PRIO 3
+#define COLUMN_SHARED_REQ 4
+#define COLUMN_SHARED_AREQ 5
+#define COLUMN_SHARED_TRA 6
+#define COLUMN_SHARED_RTIO 7
+#define COLUMN_SHARED_PART 8
+#define COLUMN_SHARED_CMPL 9
+#define COLUMN_SHARED_SPEED 10
+#define COLUMN_SHARED_SINCE 11
+#define COLUMN_SHARED_LASTUP 12
+#define COLUMN_SHARED_PATH 13
 //! Always empty. Absorbs the macOS trailing-column sizing; see
 //! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_SHARED_SPACER 15
+#define COLUMN_SHARED_SPACER 14
 
 class CSharedFileList;
 class CKnownFile;
@@ -149,7 +148,7 @@ protected:
 	/// Text of one cell, pulled on demand for the cells being drawn.
 	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
 
-	/// Rating/comment smiley on the Rating column, nothing elsewhere.
+	/// Rating/comment smiley on the Name column, nothing elsewhere.
 	bool GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const override;
 
 	/// Availability-bar spans for the Obtained Parts column.


### PR DESCRIPTION
Two rendering fixes in the wxDataViewCtrl lists, plus the shared-files column change that the first one makes possible.

## Icon+text cells no longer reserve space for absent icons

wx's icon+text renderer reserves the icon slot on every row, whether or not that row has an icon. In a column where the icon is the exception rather than the rule -- a rating smiley on the few files that carry one -- every other row's text sits indented past an empty gap.

On the native macOS cell the reserved width is not even adjustable: `wxImageTextCell` hardcodes a 5px leading shift, a 5px icon-to-text gap and a 16x16 icon as private ivars, none of them reachable from C++.

`CMuleIconTextRenderer` draws the icon only when there is one and passes the resulting offset -- zero on a bare row -- to `wxDataViewCustomRenderer::RenderText()`, which keeps ellipsizing, the selected-row foreground colour and RTL layout exactly as the stock renderers do them. Only the icon placement is ours. `AddIconTextColumn()` installs it, so every icon+text column gets the tighter padding: Shared Files' File Name, Servers' Server Name, Search's Rating.

## The chunk bar fills the full height of its cell

`CMuleBarRenderer::GetSize()` reported the text extent as its height. `wxDataViewCustomRendererBase::WXCallRender()` shrinks the rect it hands `Render()` down to that height whenever the row is taller, and with alignment defaulting to top the bar was drawn at the top of the row with a gap underneath.

This only showed on the generic backend. The native macOS cell derives its height from the same value, so there the row matched what was reported and the clamp never fired -- measured on both platforms before changing anything, which is also why the first diagnosis (macOS-only) was wrong.

`WXCallRender()` applies the vertical adjustment only for a height `>= 0`, so reporting `wxDefaultCoord` opts out of it and leaves `Render()` the whole cell. The width stays as it was: the native backend does use that one as the cell width.

A hairline gap remains under the bar on GTK. It is not reachable from the renderer -- the generic backend deflates the cell rect horizontally only (`Deflate(x, 0)`) -- so it is row geometry rather than padding, and not worth fighting the layout for.

## The shared-files rating column goes away

The smiley moves back onto File Name. It was split into a column of its own precisely because the reserved icon slot indented every unrated row, which is no longer true. Its sort comparator goes with it: that existed only because an icon-only cell has no text to sort on.

A profile that ran the intermediate build has a stale `G` entry in `TableWidthsShared`. `GetColumnIndex()` returns `-1` for it and `LoadSettings()` skips it, so it is inert. `GetOldColumnOrder()` is unchanged -- `G` was never part of the legacy set.

## Testing

`amule` and `amulegui` build clean on macOS (wx 3.3.3) and Ubuntu ARM64 (wx 3.2), Debug, both after a fresh configure. clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors, re-run after the last edit.

Visual check on both platforms: unrated rows start flush with the column edge, rated rows unchanged, and the bar fills its cell.

The first push built on macOS and failed on GTK -- `wx/dataview.h` pulls in `wx/dc.h` transitively on one and not the other. Fixed with explicit includes before this went up.
