### PR TITLE
feat(gui): port CGenericClientListCtrl to wxDataViewCtrl (#180, #801)

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2520,10 +2520,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6868,6 +6864,10 @@ msgstr ""
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2551,10 +2551,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6986,6 +6982,10 @@ msgstr "مجموع حجم ملفات المشاركة : %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "اسم الملف"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr ""
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2606,10 +2606,6 @@ msgstr "Unviar mensax"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambia esti ficheru"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7095,6 +7091,10 @@ msgstr "Tamañu total de ficheros compartíos: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Nome de ficheru"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2548,10 +2548,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6960,6 +6956,10 @@ msgstr "Общ размер на споределните файлове : %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Име на файл"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr ""
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2519,10 +2519,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6867,6 +6863,10 @@ msgstr ""
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2600,10 +2600,6 @@ msgstr "Envia un missatge"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercanvia cap a aquest fitxer"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7054,6 +7050,10 @@ msgstr "Mida total dels fitxers compartits: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom de fitxer remot"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2592,10 +2592,6 @@ msgstr "Poslat zprávu"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7079,6 +7075,10 @@ msgstr "Celková velikost sdílených souborů: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Název souboru"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2557,10 +2557,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7004,6 +7000,10 @@ msgstr "Total Størrelse Af Delte Filer: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Fil Navn"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr ""
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2605,10 +2605,6 @@ msgstr "Sende Nachricht"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Zu dieser Datei verschieben"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7049,6 +7045,10 @@ msgstr "Gesamtgröße der freigegebenen Dateien: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Ferndateiname"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2615,10 +2615,6 @@ msgstr "Αποστολή μηνύματος"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Εναλλαγή σε αυτό το αρχείο"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7112,6 +7108,10 @@ msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων:
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Όνομα αρχείου"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2520,10 +2520,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6868,6 +6864,10 @@ msgstr ""
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2608,10 +2608,6 @@ msgstr "Enviar un mensaje"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambiar a este archivo"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7031,6 +7027,10 @@ msgstr "Tamaño total de los archivos compartidos: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nombre del archivo remoto"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2601,10 +2601,6 @@ msgstr "Saada teade"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Tõsta selle faili külge"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7064,6 +7060,10 @@ msgstr "Jagatud failide suurus kokku: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Kaugfaili nimi"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2602,10 +2602,6 @@ msgstr "Mezua bidali"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Swap fitxategi honentzat"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7060,6 +7056,10 @@ msgstr "Guztira partekatutako fitxategi tamaina: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Urruneko fitxategiaren izena"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2602,10 +2602,6 @@ msgstr "Lähetä viesti"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Vaihda tähän tiedostoon"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7060,6 +7056,10 @@ msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Tiedoston nimi etäpäässä"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2606,10 +2606,6 @@ msgstr "Envoyer un message"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Échanger vers ce fichier"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7023,6 +7019,10 @@ msgstr "Taille totale des Fichiers Partagés : %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nom du fichier à distance"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2618,10 +2618,6 @@ msgstr "Enviar mensaxe"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambiar a este ficheiro"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7064,6 +7060,10 @@ msgstr "Tamaño total dos ficheiros compartidos: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome remoto do ficheiro"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2570,10 +2570,6 @@ msgstr "שלך הודעה"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "החלף לקובץ זה"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7039,6 +7035,10 @@ msgstr "גודל כולל של קבצים משותפים: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "שם קובץ"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2567,10 +2567,6 @@ msgstr "Pošalji poruku"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7036,6 +7032,10 @@ msgstr "Ukupna velicina dijeljenih fajlova: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Ime fajla"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2592,10 +2592,6 @@ msgstr "Üzenet küldése"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Csere ehhez a fájlhoz"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7022,6 +7018,10 @@ msgstr "Megosztott fájlok teljes mérete: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Távoli fájlnév"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2617,10 +2617,6 @@ msgstr "Invia messaggio"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Sposta su questo file"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7016,6 +7012,10 @@ msgstr "Dimensione totale file condivisi: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome file remoto"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2600,10 +2600,6 @@ msgstr "メッセージを送る"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "このファイルへ交換する"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7062,6 +7058,10 @@ msgstr "共有ファイルの合計サイズ： %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "ファイル名"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2616,10 +2616,6 @@ msgstr "메시지 보내기"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "파일을 교환"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7111,6 +7107,10 @@ msgstr "공유파일의 전체 크기: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "파일 이름"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2623,10 +2623,6 @@ msgstr "Siųsti žinutę"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Keisti į šį failą"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "Ats. kitą failą"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7136,6 +7132,10 @@ msgstr "Bendras dalinamų failų dydis: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Failo pavadinimas"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "Ats. kitą failą"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2537,10 +2537,6 @@ msgstr "Sūtīt ziņojumu"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -6915,6 +6911,10 @@ msgstr "Kopīgoto datņu kopējais izmērs: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2604,10 +2604,6 @@ msgstr "Verstuur bericht"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Wissel uit naar dit bestand"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7059,6 +7055,10 @@ msgstr "Totale grootte van gedeelde bestanden: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Bestandsnaam op afstand"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2614,10 +2614,6 @@ msgstr "Send melding"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Byt til denne fila"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7105,6 +7101,10 @@ msgstr "Total storleik på delte filer: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Filnamn"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2611,10 +2611,6 @@ msgstr "Wyślij wiadomość"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Zamień na ten plik"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7106,6 +7102,10 @@ msgstr "Łączny rozmiar udostępnianych plików: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Nazwa pliku"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2613,10 +2613,6 @@ msgstr "Enviar mensagem"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Trocar para esse arquivo"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7012,6 +7008,10 @@ msgstr "Tamanho total de compartilhados: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do arquivo remoto"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2608,10 +2608,6 @@ msgstr "Enviar mensagem"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Mudar para este ficheiro"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7068,6 +7064,10 @@ msgstr "Tamanho total dos Ficheiros Partilhados: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nome do Ficheiro Remoto"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2606,10 +2606,6 @@ msgstr "Trimite mesaj"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Schimbă la acest fișier"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7083,6 +7079,10 @@ msgstr "Dimensiunea totală a fișierelor partajate: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Nume fișier distant"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2627,10 +2627,6 @@ msgstr "Отправить сообщение"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Переключить на этот файл"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7073,6 +7069,10 @@ msgstr "Общий размер публикуемых файлов: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Удалённое имя файла"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2621,10 +2621,6 @@ msgstr "Pošlji sporočilo"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Prenesi k tej datoteki"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "PZDD"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7125,6 +7121,10 @@ msgstr "Skupna velikost deljenih datotek: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Oddaljeno ime datoteke"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "PZDD"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2608,10 +2608,6 @@ msgstr "Dergo mesazh"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Sposto tek ky fail"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7095,6 +7091,10 @@ msgstr "Totali i madhesise se faileve te ndara: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Emri i failit"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2600,10 +2600,6 @@ msgstr "Skicka meddelande"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Växla till den här filen"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7054,6 +7050,10 @@ msgstr "Total storlek på Delade filer: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Fjärrfilnamn"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2519,10 +2519,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6867,6 +6863,10 @@ msgstr ""
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2599,10 +2599,6 @@ msgstr "İleti Gönder"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Bu dosyaya geçir"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7016,6 +7012,10 @@ msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "Dosya Adı"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2618,10 +2618,6 @@ msgstr "Надіслати повідомлення"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Перемкнути на цей файл"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7135,6 +7131,10 @@ msgstr "Загальний розмір спільних файлів: %s"
 #, fuzzy
 msgid "Remote File Name"
 msgstr "Назва файлу"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2518,10 +2518,6 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -6865,6 +6861,10 @@ msgstr ""
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
 msgstr ""
 
 #: src/Statistics.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2609,10 +2609,6 @@ msgstr "发送消息"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "转移到这个文件"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7009,6 +7005,10 @@ msgstr "共享文件大小总和：%s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "远程文件名"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 21:37+0200\n"
+"POT-Creation-Date: 2026-08-07 23:15+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2598,10 +2598,6 @@ msgstr "傳送訊息"
 #: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "轉移到這個檔案"
-
-#: src/GenericClientListCtrl.cpp
-msgid "A4AF"
-msgstr "A4AF"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7034,6 +7030,10 @@ msgstr "檔案總容量：%s"
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
 msgstr "遠端檔案名稱"
+
+#: src/SourceListCtrl.cpp
+msgid "A4AF"
+msgstr "A4AF"
 
 #: src/Statistics.cpp
 #, c-format

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -231,10 +231,8 @@ wxString CDownloadListCtrl::GetRowLabel(const wxDataViewItem &item) const
 {
 	// Column 0 is the part number here, not the name -- unlike every other
 	// ported list, so the base's "column 0 is the label" default would make
-	// type-to-select match part numbers. GetModel() is always the
-	// wxDataViewIndexListModel AssociateVirtualModel() installed.
-	const wxDataViewListModel *model = static_cast<const wxDataViewListModel *>(GetModel());
-	const wxUIntPtr data = ItemAt(static_cast<long>(model->GetRow(item)));
+	// type-to-select match part numbers.
+	const wxUIntPtr data = ItemAt(GetModelRow(item));
 	if (!data) {
 		return wxEmptyString;
 	}
@@ -747,8 +745,7 @@ void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)
 	// discard whatever multi-selection the user already had, and firing
 	// EVT_DATAVIEW_SELECTION_CHANGED as a side effect of a double-click would
 	// rebuild the sources panel for no reason.
-	const wxDataViewListModel *model = static_cast<const wxDataViewListModel *>(GetModel());
-	const long row = static_cast<long>(model->GetRow(event.GetItem()));
+	const long row = GetModelRow(event.GetItem());
 	const wxUIntPtr data = ItemAt(row);
 	if (!data) {
 		return;

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -37,14 +37,15 @@
 #include "CommentDialogLst.h"   // Needed for CCommentDialogLst
 #include "DataToText.h"         // Needed for PriorityToStr
 #include "FileDetailDialog.h"   // Needed for CFileDetailDialog
-#include "GetTickCount.h"       // Needed for GetTickCount64
 #include "GuiEvents.h"          // Needed for CoreNotify_*
 #ifdef GEOIP_GUI
 #include "CountryFlags.h"   // Needed for CCountryFlags (flag bitmaps)
 #include "CountryDisplay.h" // Needed for GetDisplayCountryCode
 #endif
-#include "muuli_wdr.h" // Needed for ID_DLOADLIST
-#include "PartFile.h"  // Needed for CPartFile
+#include "MuleBarRenderer.h" // Needed for CBarFillSpec, CBarFillSpan, CMuleBarRenderer
+#include "MuleListCtrl.h"    // Needed for IsListBackgroundDark
+#include "muuli_wdr.h"       // Needed for ID_CLIENTCOUNT
+#include "PartFile.h"        // Needed for CPartFile
 #include "Preferences.h"
 #include "SharedFileList.h" // Needed for CSharedFileList
 #include "ClientRef.h"      // Needed for CClientRef
@@ -59,50 +60,177 @@
 #endif
 #include "FriendList.h"
 
-struct ClientCtrlItem_Struct
+namespace
 {
-	ClientCtrlItem_Struct()
-	: dwUpdated(0)
-	, status(NULL)
-	, m_owner(NULL)
-	, m_type(UNAVAILABLE_SOURCE)
+/**
+ * Renders the User Name column: a cluster of status/software/credential
+ * badge icons followed by an optional country flag and the username text.
+ *
+ * Not a literal bar -- this reuses CMuleBarRenderer's identity-carrying
+ * CBarFillSpec/GetItemBarFill() extension point (see CBarFillSpec::GetIdentity())
+ * to reach the row's ClientCtrlItem_Struct, the same way CDownloadBarRenderer
+ * reaches its CPartFile*. Registered via AddBarColumn() rather than growing a
+ * new column-registration entry point for a single, list-local column.
+ * Replaces DrawClientItem's ColumnUserName case exactly, including the
+ * two-icons-then-text x-advance (several badges stack at the *same* x).
+ */
+class CClientNameRenderer : public CMuleBarRenderer
+{
+public:
+	bool Render(wxRect cell, wxDC *dc, int WXUNUSED(state)) override
 	{
+		ClientCtrlItem_Struct *item =
+			reinterpret_cast<ClientCtrlItem_Struct *>(GetSpec().GetIdentity());
+		if (!item || cell.GetWidth() <= 0 || cell.GetHeight() <= 0) {
+			return true;
+		}
+		CClientRef &client = item->GetSource();
+
+		wxDCClipper clipper(*dc, cell);
+
+		wxImageList &imageList = theApp->amuledlg->m_imagelist;
+		int imageXSize = 0;
+		int imageYSize = 0;
+		if (!imageList.GetSize(0, imageXSize, imageYSize)) {
+			return true;
+		}
+		imageXSize += 2; // Padding, matches DrawClientItem's iBitmapXSize.
+		const int imageYOffset = ((cell.GetHeight() - imageYSize) / 2) + 1 /* Fixes rounding */;
+
+		wxPoint point(cell.GetX(), cell.GetY());
+
+		uint8 image = Client_Grey_Smiley;
+		if (item->GetType() != A4AF_SOURCE) {
+			switch (client.GetDownloadState()) {
+			case DS_CONNECTING:
+			case DS_CONNECTED:
+			case DS_WAITCALLBACK:
+			case DS_TOOMANYCONNS:
+				image = Client_Red_Smiley;
+				break;
+			case DS_ONQUEUE:
+				image = client.IsRemoteQueueFull() ? Client_Grey_Smiley
+								   : Client_Yellow_Smiley;
+				break;
+			case DS_DOWNLOADING:
+			case DS_REQHASHSET:
+				image = Client_Green_Smiley;
+				break;
+			case DS_NONEEDEDPARTS:
+			case DS_LOWTOLOWIP:
+				image = Client_Grey_Smiley; // Redundant
+				break;
+			default: // DS_NONE i.e.
+				image = Client_White_Smiley;
+			}
+		} // else: default (Client_Grey_Smiley)
+
+		imageList.Draw(image, *dc, point.x, point.y + imageYOffset, wxIMAGELIST_DRAW_TRANSPARENT);
+		point.x += imageXSize;
+
+		uint8 clientImage = Client_Unknown;
+		if (client.IsFriend()) {
+			clientImage = Client_Friend_Smiley;
+		} else {
+			switch (client.GetClientSoft()) {
+			case SO_AMULE:
+				clientImage = Client_aMule_Smiley;
+				break;
+			case SO_MLDONKEY:
+			case SO_NEW_MLDONKEY:
+			case SO_NEW2_MLDONKEY:
+				clientImage = Client_mlDonkey_Smiley;
+				break;
+			case SO_EDONKEY:
+			case SO_EDONKEYHYBRID:
+				clientImage = Client_eDonkeyHybrid_Smiley;
+				break;
+			case SO_EMULE:
+				clientImage = Client_eMule_Smiley;
+				break;
+			case SO_LPHANT:
+				clientImage = Client_lphant_Smiley;
+				break;
+			case SO_SHAREAZA:
+			case SO_NEW_SHAREAZA:
+			case SO_NEW2_SHAREAZA:
+				clientImage = Client_Shareaza_Smiley;
+				break;
+			case SO_LXMULE:
+				clientImage = Client_xMule_Smiley;
+				break;
+			default:
+				// cDonkey, Compatible, Unknown: no icon for those yet;
+				// falls back to Client_Unknown.
+				break;
+			}
+		}
+
+		const int realY = point.y + imageYOffset;
+		imageList.Draw(clientImage, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
+
+		if (client.GetScoreRatio() > 1) {
+			imageList.Draw(Client_CreditsYellow_Smiley,
+				*dc,
+				point.x,
+				realY,
+				wxIMAGELIST_DRAW_TRANSPARENT);
+		} else if (!client.ExtProtocolAvailable()) {
+			imageList.Draw(Client_ExtendedProtocol_Smiley,
+				*dc,
+				point.x,
+				realY,
+				wxIMAGELIST_DRAW_TRANSPARENT);
+		}
+
+		if (client.IsIdentified()) {
+			imageList.Draw(
+				Client_SecIdent_Smiley, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
+		} else if (client.IsBadGuy()) {
+			imageList.Draw(
+				Client_BadGuy_Smiley, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
+		}
+
+		if (client.GetObfuscationStatus() == OBST_ENABLED) {
+			imageList.Draw(
+				Client_Encryption_Smiley, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
+		}
+
+		point.x += imageXSize;
+
+#ifdef GEOIP_GUI
+		// Country flag; GetDisplayCountryCode() holds the shared gate (see
+		// CountryDisplay.h) so this list and the server list stay in step.
+		wxString code;
+		const bool haveCountry = GetDisplayCountryCode(client.GetClient()->IsCountryFromCore(),
+			client.GetClient()->GetCountryCode(),
+			client.GetClient()->GetFullIPNumeric(),
+			code);
+		if (haveCountry && !code.IsEmpty()) {
+			const wxImage &flag = theApp->GetCountryFlags()->GetFlag(code);
+			const int flagY =
+				point.y + (cell.GetHeight() - flag.GetHeight()) / 2 + 1 /* floor() */;
+			dc->DrawBitmap(flag, point.x, flagY, true);
+			point.x += flag.GetWidth() + 2 /* Padding */;
+		}
+#endif // GEOIP_GUI
+
+		const wxString userName =
+			client.GetUserName().IsEmpty() ? wxString("?") : client.GetUserName();
+		const int textOffset =
+			((cell.GetHeight() - dc->GetCharHeight()) / 2) + 1 /* Fixes rounding */;
+		dc->DrawText(userName, point.x, cell.GetY() + textOffset);
+		return true;
 	}
-
-	~ClientCtrlItem_Struct() { delete status; }
-
-	SourceItemType GetType() const { return m_type; }
-
-	CKnownFile *GetOwner() const { return m_owner; }
-
-	CClientRef &GetSource() { return m_sourceValue; }
-
-	void SetContents(CKnownFile *owner, const CClientRef &source, SourceItemType type)
-	{
-		m_owner = owner;
-		m_sourceValue = source;
-		m_type = type;
-	}
-
-	void SetType(SourceItemType type) { m_type = type; }
-
-	uint64 dwUpdated;
-	wxBitmap *status;
-
-private:
-	CKnownFile *m_owner;
-	CClientRef m_sourceValue;
-	SourceItemType m_type;
 };
+} // namespace
 
 #define m_ImageList theApp->amuledlg->m_imagelist
 
-wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualListCtrl)
-	EVT_LIST_ITEM_ACTIVATED(wxID_ANY, CGenericClientListCtrl::OnItemActivated)
-	EVT_LIST_ITEM_RIGHT_CLICK(wxID_ANY, CGenericClientListCtrl::OnMouseRightClick)
-	EVT_LIST_ITEM_MIDDLE_CLICK(wxID_ANY, CGenericClientListCtrl::OnMouseMiddleClick)
-
-	EVT_CHAR(CGenericClientListCtrl::OnKeyPressed)
+wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualDataViewCtrl)
+	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CGenericClientListCtrl::OnItemActivated)
+	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CGenericClientListCtrl::OnItemRightClicked)
+	EVT_MIDDLE_DOWN(CGenericClientListCtrl::OnMouseMiddleClick)
 
 	EVT_MENU(MP_CHANGE2FILE, CGenericClientListCtrl::OnSwapSource)
 	EVT_MENU(MP_SHOWLIST, CGenericClientListCtrl::OnViewFiles)
@@ -112,35 +240,20 @@ wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualListCtrl)
 	EVT_MENU(MP_DETAIL, CGenericClientListCtrl::OnViewClientInfo)
 wxEND_EVENT_TABLE()
 
-//! This listtype is used when gathering the selected items.
-typedef std::list<ClientCtrlItem_Struct *> ItemList;
-
 CGenericClientListCtrl::CGenericClientListCtrl(const wxString &tablename,
 	wxWindow *parent,
 	wxWindowID winid,
 	const wxPoint &pos,
 	const wxSize &size,
 	long style,
-	const wxValidator &validator,
 	const wxString &name)
-: CMuleVirtualListCtrl(
-	  parent, winid, pos, size, style | wxLC_OWNERDRAW | wxLC_VRULES | wxLC_HRULES, validator, name)
+: CMuleVirtualDataViewCtrl(parent, winid, pos, size, style, name)
 , m_columndata(0, NULL)
+, m_menu(NULL)
+, m_clientcount(0)
+, m_showing(false)
 {
-	// Setting the sorter function must be done in the derived class, to use the translation function
-	// correctly. SetSortFunc( SortProc );
-
-	// Set the table-name (for loading and saving preferences).
-	SetTableName(tablename);
-
-	m_menu = NULL;
-	m_showing = false;
-
-	m_highlightBrush = CMuleColour(wxSYS_COLOUR_HIGHLIGHT) /*.Blend(125)*/.GetBrush();
-
-	m_highlightUnfocusBrush = CMuleColour(CMuleColour::GetUnfocusedHighlight()).GetBrush();
-
-	m_clientcount = 0;
+	m_columnStore.SetTableName(tablename);
 }
 
 wxString CGenericClientListCtrl::TranslateCIDToName(GenericColumnEnum cid)
@@ -204,7 +317,10 @@ wxString CGenericClientListCtrl::TranslateCIDToName(GenericColumnEnum cid)
 
 bool CGenericClientListCtrl::IsLiveSortColumn() const
 {
-	const int col = static_cast<int>(GetSortColumn());
+	if (m_sort_orders.empty()) {
+		return false;
+	}
+	const int col = static_cast<int>(m_sort_orders.front().first);
 	if (col < 0 || col >= m_columndata.n_columns) {
 		return false;
 	}
@@ -229,24 +345,52 @@ void CGenericClientListCtrl::InitColumnData()
 		throw wxString("CRITICAL: Initialization of the column data lacks subclass information");
 	}
 
+	const int baseFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+
 	for (int i = 0; i < m_columndata.n_columns; ++i) {
-		InsertColumn(i,
-			wxGetTranslation(m_columndata.columns[i].title),
-			wxLIST_FORMAT_LEFT,
-			m_columndata.columns[i].width,
-			TranslateCIDToName(m_columndata.columns[i].cid));
+		const GenericColumnEnum cid = m_columndata.columns[i].cid;
+		const wxString title = wxGetTranslation(m_columndata.columns[i].title);
+		const wxString key = TranslateCIDToName(cid);
+		const int width = m_columndata.columns[i].width;
+
+		switch (cid) {
+		case ColumnUserName:
+			// See CClientNameRenderer: a composite icon-cluster + text cell,
+			// not a literal bar.
+			AddBarColumn(title, i, key, width, baseFlags, new CClientNameRenderer());
+			break;
+		case ColumnUserProgress:
+			AddBarColumn(title, i, key, width, baseFlags, CreateProgressBarRenderer());
+			break;
+		case ColumnUserAvailable:
+			// No Compare() case exists for this column (matches the
+			// pre-port behaviour, where it was never sortable either) --
+			// SORTABLE is deliberately left off so no non-functional sort
+			// caret is shown.
+			AddBarColumn(title, i, key, width, wxDATAVIEW_COL_RESIZABLE, nullptr);
+			break;
+		default:
+			AddTextColumn(title, i, key, width, wxALIGN_LEFT, baseFlags);
+			break;
+		}
 	}
 
-	LoadSettings();
+	AssociateVirtualModel();
+	ApplySorting(0, 0);
+
+	LoadColumnSettings();
+	InitColumnState();
 }
 
 CGenericClientListCtrl::~CGenericClientListCtrl()
 {
+	delete m_menu;
 	while (!m_ListItems.empty()) {
 		delete m_ListItems.begin()->second;
 		m_ListItems.erase(m_ListItems.begin());
 	}
 }
+
 void CGenericClientListCtrl::RawAddSource(CKnownFile *owner, CClientRef source, SourceItemType type)
 {
 	ClientCtrlItem_Struct *newitem = new ClientCtrlItem_Struct;
@@ -254,9 +398,9 @@ void CGenericClientListCtrl::RawAddSource(CKnownFile *owner, CClientRef source, 
 
 	m_ListItems.insert(ListItemsPair(source.ECID(), newitem));
 
-	// Virtual list: append at the end (unsorted); ShowSources() sorts once at
-	// the end of a bulk add, a single runtime add just shows at the bottom —
-	// same as the old InsertItem(GetItemCount()) behaviour.
+	// Append at the end (unsorted); ShowSources() sorts once at the end of a
+	// bulk add, a single runtime add just shows at the bottom -- same as the
+	// old InsertItem(GetItemCount()) behaviour.
 	AppendItemDataNow(reinterpret_cast<wxUIntPtr>(newitem));
 }
 
@@ -282,12 +426,10 @@ void CGenericClientListCtrl::AddSource(CKnownFile *owner, const CClientRef &sour
 			} else {
 				cur_item->SetContents(owner, source, type);
 			}
-			cur_item->dwUpdated = 0;
 			bFound = true;
 		} else if (type == AVAILABLE_SOURCE) {
 			// The state 'Available' is exclusive
 			cur_item->SetContents(cur_item->GetOwner(), source, A4AF_SOURCE);
-			cur_item->dwUpdated = 0;
 		}
 	}
 
@@ -357,10 +499,8 @@ void CGenericClientListCtrl::UpdateItem(uint32 toupdate, SourceItemType type)
 				item->SetType(type);
 			}
 
-			item->dwUpdated = 0;
-
-			// Virtual list: repaints only the row if visible; base also
-			// schedules a live re-sort when sorted by a live column.
+			// Repaints the row and, if sorted by a live column, schedules
+			// the throttled+idle-gated re-sort.
 			RefreshItemData(reinterpret_cast<wxUIntPtr>(item));
 		}
 	}
@@ -489,9 +629,8 @@ void CGenericClientListCtrl::RemoveKnownFile(CKnownFile *file)
 
 	// Drop the cached "currently showing sources for" entry. This is
 	// #755's crash site: without this, the next ShowSources() loop
-	// at GenericClientListCtrl.cpp:355-359 walks the dangling entry
-	// and writes 1 byte into the recycled heap region via
-	// SetShowSources(file, false).
+	// would walk the dangling entry and write into the recycled heap
+	// region via SetShowSources(file, false).
 	CKnownFileVector::iterator kf = std::find(m_knownfiles.begin(), m_knownfiles.end(), file);
 	if (kf != m_knownfiles.end()) {
 		m_knownfiles.erase(kf);
@@ -499,8 +638,7 @@ void CGenericClientListCtrl::RemoveKnownFile(CKnownFile *file)
 
 	// Strip any per-row state whose m_owner matches. We have to walk
 	// the multimap once because m_ListItems is keyed by client ECID,
-	// not by file. wxListCtrl rows associated with those items are
-	// removed in the same pass via DeleteItem.
+	// not by file.
 	for (ListItems::iterator it = m_ListItems.begin(); it != m_ListItems.end(); /* manual ++ */) {
 		ClientCtrlItem_Struct *item = it->second;
 		if (item && item->GetOwner() == file) {
@@ -515,53 +653,38 @@ void CGenericClientListCtrl::RemoveKnownFile(CKnownFile *file)
 	}
 }
 
-/**
- * Helper-function: This function is used to gather selected items.
- *
- * @param list A pointer to the list to gather items from.
- * @return A list containing the selected items of the chosen types.
- */
-static ItemList GetSelectedItems(CGenericClientListCtrl *list)
+void CGenericClientListCtrl::ShowSourcesCount(int diff)
 {
-	ItemList results;
+	m_clientcount += diff;
+	wxStaticText *label = CastByID(ID_CLIENTCOUNT, GetParent(), wxStaticText);
 
-	long index = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-	while (index > -1) {
-		ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(list->ItemAt(index));
-
-		results.push_back(item);
-
-		index = list->GetNextItem(index, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	if (label) {
+		label->SetLabel(CFormat("%i") % m_clientcount);
+		label->GetParent()->Layout();
 	}
-
-	return results;
 }
 
 void CGenericClientListCtrl::OnSwapSource(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList sources = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = sources.begin(); it != sources.end(); ++it) {
-		CKnownFile *kf = (*it)->GetOwner();
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		ClientCtrlItem_Struct *source = reinterpret_cast<ClientCtrlItem_Struct *>(data);
+		CKnownFile *kf = source->GetOwner();
 		if (!kf->IsPartFile()) {
 			wxFAIL_MSG("File is not a partfile when swapping sources");
 			continue;
 		}
-		(*it)->GetSource().SwapToAnotherFile(true, false, false, dynamic_cast<CPartFile *>(kf));
+		source->GetSource().SwapToAnotherFile(true, false, false, dynamic_cast<CPartFile *>(kf));
 	}
 }
 
 void CGenericClientListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList sources = ::GetSelectedItems(this);
-
 	// Browse each selected peer, opening one result tab per peer. If a peer's
 	// listing is already open in the Search panel, switch to that tab instead
 	// of re-requesting -- a second request would duplicate the results in the
 	// existing tab. Only once the tab is closed does a fresh request go out.
-	for (ClientCtrlItem_Struct *source : sources) {
-		CClientRef &client = source->GetSource();
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CClientRef &client = reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource();
 		if (!(theApp->amuledlg && theApp->amuledlg->m_searchwnd &&
 			    theApp->amuledlg->m_searchwnd->ActivateBrowseTabIfOpen(client.ECID()))) {
 			client.RequestSharedFileList();
@@ -571,10 +694,8 @@ void CGenericClientListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 
 void CGenericClientListCtrl::OnAddFriend(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList sources = ::GetSelectedItems(this);
-
-	for (ItemList::iterator it = sources.begin(); it != sources.end(); ++it) {
-		CClientRef &client = (*it)->GetSource();
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CClientRef &client = reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource();
 		if (client.IsFriend()) {
 			theApp->friendlist->RemoveFriend(client.GetFriend());
 		} else {
@@ -585,15 +706,13 @@ void CGenericClientListCtrl::OnAddFriend(wxCommandEvent &WXUNUSED(event))
 
 void CGenericClientListCtrl::OnSetFriendslot(wxCommandEvent &evt)
 {
-	ItemList sources = ::GetSelectedItems(this);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
-	ItemList::iterator it = sources.begin();
-	if (it != sources.end()) {
-		CClientRef &client = (*it)->GetSource();
+	if (!selected.empty()) {
+		CClientRef &client = reinterpret_cast<ClientCtrlItem_Struct *>(selected.front())->GetSource();
 		theApp->friendlist->SetFriendSlot(client.GetFriend(), evt.IsChecked());
-		++it;
 	}
-	if (it != sources.end()) {
+	if (selected.size() > 1) {
 		wxMessageBox(_("You are not allowed to set more than one friend slot.\n Only one slot was "
 			       "assigned."),
 			_("Multiple selection"),
@@ -604,10 +723,10 @@ void CGenericClientListCtrl::OnSetFriendslot(wxCommandEvent &evt)
 
 void CGenericClientListCtrl::OnSendMessage(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList sources = ::GetSelectedItems(this);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
-	if (sources.size() == 1) {
-		CClientRef &source = (sources.front())->GetSource();
+	if (selected.size() == 1) {
+		CClientRef &source = reinterpret_cast<ClientCtrlItem_Struct *>(selected.front())->GetSource();
 
 		// These values are cached, since calling wxGetTextFromUser will
 		// start an event-loop, in which the client may be deleted.
@@ -623,33 +742,71 @@ void CGenericClientListCtrl::OnSendMessage(wxCommandEvent &WXUNUSED(event))
 
 void CGenericClientListCtrl::OnViewClientInfo(wxCommandEvent &WXUNUSED(event))
 {
-	ItemList sources = ::GetSelectedItems(this);
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
-	if (sources.size() == 1) {
-		CClientDetailDialog(this, sources.front()->GetSource()).ShowModal();
+	if (selected.size() == 1) {
+		CClientDetailDialog(
+			this, reinterpret_cast<ClientCtrlItem_Struct *>(selected.front())->GetSource())
+			.ShowModal();
 	}
 }
 
-void CGenericClientListCtrl::OnItemActivated(wxListEvent &evt)
+void CGenericClientListCtrl::OnItemActivated(wxDataViewEvent &event)
 {
-	CClientDetailDialog(
-		this, reinterpret_cast<ClientCtrlItem_Struct *>(ItemAt(evt.GetIndex()))->GetSource())
-		.ShowModal();
+	if (!event.GetItem().IsOk()) {
+		return;
+	}
+	const wxUIntPtr data = ItemAt(GetModelRow(event.GetItem()));
+	if (!data) {
+		return;
+	}
+	CClientDetailDialog(this, reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource()).ShowModal();
 }
 
-void CGenericClientListCtrl::OnMouseRightClick(wxListEvent &evt)
+void CGenericClientListCtrl::OnMouseMiddleClick(wxMouseEvent &event)
 {
-	long index = CheckSelection(evt);
-	if (index < 0) {
+	wxDataViewItem hitItem;
+	wxDataViewColumn *hitColumn = nullptr;
+	HitTest(event.GetPosition(), hitItem, hitColumn);
+	if (!hitItem.IsOk()) {
+		event.Skip();
 		return;
 	}
 
-	delete m_menu;
-	m_menu = NULL;
+	wxDataViewItemArray selection;
+	GetSelections(selection);
+	if (selection.Index(hitItem) == wxNOT_FOUND) {
+		UnselectAll();
+		Select(hitItem);
+	}
 
-	ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(ItemAt(index));
+	const wxUIntPtr data = ItemAt(GetModelRow(hitItem));
+	if (!data) {
+		return;
+	}
+	CClientDetailDialog(this, reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource()).ShowModal();
+}
+
+void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
+{
+	if (event.GetItem().IsOk()) {
+		wxDataViewItemArray selection;
+		GetSelections(selection);
+		if (selection.Index(event.GetItem()) == wxNOT_FOUND) {
+			UnselectAll();
+			Select(event.GetItem());
+		}
+	}
+
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	if (selected.empty()) {
+		return;
+	}
+	m_menuItem = selected.front();
+	ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(m_menuItem);
 	CClientRef &client = item->GetSource();
 
+	delete m_menu;
 	m_menu = new wxMenu(_("Clients"));
 	m_menu->Append(MP_DETAIL, _("Show &Details"));
 	m_menu->Append(MP_ADDFRIEND, client.IsFriend() ? _("Remove from friends") : _("Add to Friends"));
@@ -674,597 +831,319 @@ void CGenericClientListCtrl::OnMouseRightClick(wxListEvent &evt)
 
 	m_menu->Enable(MP_SHOWLIST, !client.HasDisabledSharedFiles());
 
-	PopupMenu(m_menu, evt.GetPoint());
+	PopupMenu(m_menu);
 
 	delete m_menu;
 	m_menu = NULL;
 }
 
-void CGenericClientListCtrl::OnMouseMiddleClick(wxListEvent &evt)
+wxString CGenericClientListCtrl::GetItemColumnText(wxUIntPtr data, unsigned column) const
 {
-	// Check if clicked item is selected. If not, unselect all and select it.
-	long index = CheckSelection(evt);
-	if (index < 0) {
-		return;
+	if (column >= static_cast<unsigned>(m_columndata.n_columns)) {
+		return wxEmptyString;
 	}
+	ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(data);
+	CClientRef &client = item->GetSource();
+	const bool notA4AF = item->GetType() != A4AF_SOURCE;
 
-	CClientDetailDialog(this, reinterpret_cast<ClientCtrlItem_Struct *>(ItemAt(index))->GetSource())
-		.ShowModal();
-}
-
-void CGenericClientListCtrl::OnKeyPressed(wxKeyEvent &event)
-{
-	// No actions right now.
-	// switch (event.GetKeyCode()) {
-	//	default:
-	event.Skip();
-	//}
-}
-
-void CGenericClientListCtrl::OnDrawItem(
-	int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted)
-{
-	// Don't do any drawing if there's nobody to see it.
-	if (!theApp->amuledlg->IsDialogVisible(GetParentDialog())) {
-		return;
-	}
-
-	ClientCtrlItem_Struct *content = reinterpret_cast<ClientCtrlItem_Struct *>(ItemAt(item));
-
-	// Define text-color and background
-	// and the border of the drawn area
-	if (highlighted) {
-		CMuleColour colour;
-		if (GetFocus()) {
-			dc->SetBackground(m_highlightBrush);
-			colour = m_highlightBrush.GetColour();
-		} else {
-			dc->SetBackground(m_highlightUnfocusBrush);
-			colour = m_highlightUnfocusBrush.GetColour();
-		}
-		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
-		dc->SetPen(colour.Blend(65).GetPen());
-	} else {
-		dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(
-			wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxBRUSHSTYLE_SOLID)));
-		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-		dc->SetPen(*wxTRANSPARENT_PEN);
-	}
-	dc->SetBrush(dc->GetBackground());
-
-	dc->DrawRectangle(rectHL.x, rectHL.y, rectHL.width, rectHL.height);
-
-	dc->SetPen(*wxTRANSPARENT_PEN);
-
-	// Various constant values we use
-	const int iTextOffset = ((rect.GetHeight() - dc->GetCharHeight()) / 2) +
-				1 /* Fixes rounding in the centering math, much easier than floor() */;
-	const int iOffset = 2;
-	wxASSERT(m_ImageList.GetImageCount() > 0);
-	int imageListBitmapYOffset = 0;
-	int imageListBitmapXSize = 0;
-	if (m_ImageList.GetSize(0, imageListBitmapXSize, imageListBitmapYOffset)) {
-		imageListBitmapXSize += 2; // Padding.
-		imageListBitmapYOffset =
-			((rect.GetHeight() - imageListBitmapYOffset) / 2) + 1 /* Fixes rounding like above */;
-	} else {
-		wxFAIL;
-	}
-
-	wxRect cur_rec(iOffset, rect.y, 0, rect.height);
-
-	for (int i = 0; i < GetColumnCount(); ++i) {
-
-		int columnWidth = GetColumnWidth(i);
-
-		if (columnWidth > 2 * iOffset) {
-			// Make a copy of the current rectangle so we can apply specific tweaks
-			wxRect target_rec = cur_rec;
-			target_rec.width = columnWidth - 2 * iOffset;
-
-			GenericColumnEnum cid = m_columndata.columns[i].cid;
-
-			// Draw the item
-			DrawClientItem(dc,
-				cid,
-				target_rec,
-				content,
-				iTextOffset,
-				imageListBitmapYOffset,
-				imageListBitmapXSize);
-		}
-
-		// Increment to the next column
-		cur_rec.x += columnWidth;
-	}
-}
-
-void CGenericClientListCtrl::DrawClientItem(wxDC *dc,
-	int nColumn,
-	const wxRect &rect,
-	ClientCtrlItem_Struct *item,
-	int iTextOffset,
-	int iBitmapOffset,
-	int iBitmapXSize) const
-{
-	wxDCClipper clipper(*dc, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	wxString buffer;
-
-	const CClientRef &client = item->GetSource();
-
-	switch (nColumn) {
-	// Client name + various icons
-	case ColumnUserName: {
-		// Point will get shifted per drawing.
-
-		wxPoint point(rect.GetX(), rect.GetY());
-
-		uint8 image = Client_Grey_Smiley;
-
-		if (item->GetType() != A4AF_SOURCE) {
-
-			switch (client.GetDownloadState()) {
-			case DS_CONNECTING:
-			case DS_CONNECTED:
-			case DS_WAITCALLBACK:
-			case DS_TOOMANYCONNS:
-				image = Client_Red_Smiley;
-				break;
-			case DS_ONQUEUE:
-				if (client.IsRemoteQueueFull()) {
-					image = Client_Grey_Smiley;
-				} else {
-					image = Client_Yellow_Smiley;
-				}
-				break;
-			case DS_DOWNLOADING:
-			case DS_REQHASHSET:
-				image = Client_Green_Smiley;
-				break;
-			case DS_NONEEDEDPARTS:
-			case DS_LOWTOLOWIP:
-				image = Client_Grey_Smiley; // Redundant
-				break;
-			default: // DS_NONE i.e.
-				image = Client_White_Smiley;
-			}
-
-		} else {
-			// Default (Client_Grey_Smiley)
-		}
-
-		m_ImageList.Draw(image, *dc, point.x, point.y + iBitmapOffset, wxIMAGELIST_DRAW_TRANSPARENT);
-
-		// Next
-
-		point.x += iBitmapXSize;
-
-		uint8 clientImage = Client_Unknown;
-
-		if (client.IsFriend()) {
-			clientImage = Client_Friend_Smiley;
-		} else {
-			switch (client.GetClientSoft()) {
-			case SO_AMULE:
-				clientImage = Client_aMule_Smiley;
-				break;
-			case SO_MLDONKEY:
-			case SO_NEW_MLDONKEY:
-			case SO_NEW2_MLDONKEY:
-				clientImage = Client_mlDonkey_Smiley;
-				break;
-			case SO_EDONKEY:
-			case SO_EDONKEYHYBRID:
-				clientImage = Client_eDonkeyHybrid_Smiley;
-				break;
-			case SO_EMULE:
-				clientImage = Client_eMule_Smiley;
-				break;
-			case SO_LPHANT:
-				clientImage = Client_lphant_Smiley;
-				break;
-			case SO_SHAREAZA:
-			case SO_NEW_SHAREAZA:
-			case SO_NEW2_SHAREAZA:
-				clientImage = Client_Shareaza_Smiley;
-				break;
-			case SO_LXMULE:
-				clientImage = Client_xMule_Smiley;
-				break;
-			default:
-				// cDonkey, Compatible, Unknown
-				// No icon for those yet.
-				// Using the eMule one + '?'
-				// Which is a failback to the default (Client_Unknown)
-				break;
-			}
-		}
-
-		int realY = point.y + iBitmapOffset;
-		m_ImageList.Draw(clientImage, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
-
-		if (client.GetScoreRatio() > 1) {
-			// Has credits, draw the gold star
-			m_ImageList.Draw(Client_CreditsYellow_Smiley,
-				*dc,
-				point.x,
-				realY,
-				wxIMAGELIST_DRAW_TRANSPARENT);
-		} else if (!client.ExtProtocolAvailable()) {
-			// No Ext protocol -> Draw the '-'
-			m_ImageList.Draw(Client_ExtendedProtocol_Smiley,
-				*dc,
-				point.x,
-				realY,
-				wxIMAGELIST_DRAW_TRANSPARENT);
-		}
-
-		if (client.IsIdentified()) {
-			// the 'v'
-			m_ImageList.Draw(
-				Client_SecIdent_Smiley, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
-		} else if (client.IsBadGuy()) {
-			// the 'X'
-			m_ImageList.Draw(
-				Client_BadGuy_Smiley, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
-		}
-
-		if (client.GetObfuscationStatus() == OBST_ENABLED) {
-			// the "¿" except it's a key
-			m_ImageList.Draw(
-				Client_Encryption_Smiley, *dc, point.x, realY, wxIMAGELIST_DRAW_TRANSPARENT);
-		}
-
-		// Next
-
-		point.x += iBitmapXSize;
-
-		wxString userName;
-#ifdef GEOIP_GUI
-		// Country flag; GetDisplayCountryCode() holds the shared gate (see
-		// CountryDisplay.h) so this list and the server list stay in step. The
-		// flag cache then turns the code into a bitmap.
-		wxString code;
-		const bool haveCountry = GetDisplayCountryCode(client.GetClient()->IsCountryFromCore(),
-			client.GetClient()->GetCountryCode(),
-			client.GetClient()->GetFullIPNumeric(),
-			code);
-		// Draw the country flag only — no textual code. An unknown / unresolved
-		// peer (empty code) gets neither flag nor prefix.
-		if (haveCountry && !code.IsEmpty()) {
-			// Size can't be precached.
-			const wxImage &flag = theApp->GetCountryFlags()->GetFlag(code);
-			realY = point.y + (rect.GetHeight() - flag.GetHeight()) / 2 + 1 /* floor() */;
-			dc->DrawBitmap(flag, point.x, realY, true);
-			point.x += flag.GetWidth() + 2 /*Padding*/;
-		}
-#endif // GEOIP_GUI
-		if (client.GetUserName().IsEmpty()) {
-			userName << "?";
-		} else {
-			userName << client.GetUserName();
-		}
-
-		dc->DrawText(userName, point.x, rect.GetY() + iTextOffset);
-	} break;
+	switch (m_columndata.columns[column].cid) {
+	case ColumnUserName:
+		// Not drawn through this path (see CClientNameRenderer), but still
+		// answered for type-ahead / accessible row label (#180).
+		return client.GetUserName().IsEmpty() ? wxString("?") : client.GetUserName();
 
 	case ColumnUserDownloaded:
-		if (item->GetType() != A4AF_SOURCE && client.GetTransferredDown()) {
-			buffer = CastItoXBytes(client.GetTransferredDown());
-			dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		}
-		break;
+		return (notA4AF && client.GetTransferredDown()) ? CastItoXBytes(client.GetTransferredDown())
+								: wxString();
+
 	case ColumnUserUploaded:
-		if (item->GetType() != A4AF_SOURCE && client.GetTransferredUp()) {
-			buffer = CastItoXBytes(client.GetTransferredUp());
-			dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		}
-		break;
+		return (notA4AF && client.GetTransferredUp()) ? CastItoXBytes(client.GetTransferredUp())
+							      : wxString();
+
 	case ColumnUserSpeedDown:
-		if (item->GetType() != A4AF_SOURCE && client.GetKBpsDown() > 0.001) {
+		if (notA4AF && client.GetKBpsDown() > 0.001) {
 			if (client.GetKBpsDown() >= 1024) {
-				buffer = CFormat(_("%.1f MB/s")) % (client.GetKBpsDown() / 1024.0);
-			} else {
-				buffer = CFormat(_("%.1f kB/s")) % client.GetKBpsDown();
+				return CFormat(_("%.1f MB/s")) % (client.GetKBpsDown() / 1024.0);
 			}
-			dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
+			return CFormat(_("%.1f kB/s")) % client.GetKBpsDown();
 		}
-		break;
+		return wxEmptyString;
+
 	case ColumnUserSpeedUp:
 		// Datarate is in bytes.
-		if (item->GetType() != A4AF_SOURCE && client.GetUploadDatarate() >= 1024) {
+		if (notA4AF && client.GetUploadDatarate() >= 1024) {
 			if (client.GetUploadDatarate() >= 1048576) {
-				buffer = CFormat(_("%.1f MB/s")) % (client.GetUploadDatarate() / 1048576.0);
-			} else {
-				buffer = CFormat(_("%.1f kB/s")) % (client.GetUploadDatarate() / 1024.0);
+				return CFormat(_("%.1f MB/s")) % (client.GetUploadDatarate() / 1048576.0);
 			}
-			dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
+			return CFormat(_("%.1f kB/s")) % (client.GetUploadDatarate() / 1024.0);
 		}
-		break;
-	case ColumnUserProgress:
-		if (thePrefs::ShowProgBar()) {
-			int iWidth = rect.GetWidth() - 2;
-			int iHeight = rect.GetHeight() - 2;
+		return wxEmptyString;
 
-			// don't draw Text beyond the bar
-			dc->SetClippingRegion(rect.GetX(), rect.GetY() + 1, iWidth, iHeight);
-
-			if (item->GetType() != A4AF_SOURCE) {
-				uint64 dwTicks = GetTickCount64();
-
-				wxMemoryDC cdcStatus;
-
-				if (item->dwUpdated < dwTicks || !item->status ||
-					iWidth != item->status->GetWidth()) {
-
-					if (item->status == NULL) {
-						item->status = new wxBitmap(iWidth, iHeight);
-					} else if (item->status->GetWidth() != iWidth) {
-						// Only recreate if size has changed
-						item->status->Create(iWidth, iHeight);
-					}
-
-					cdcStatus.SelectObject(*(item->status));
-
-					if (thePrefs::UseFlatBar()) {
-						DrawSourceStatusBar(client,
-							&cdcStatus,
-							wxRect(0, 0, iWidth, iHeight),
-							true);
-					} else {
-						DrawSourceStatusBar(client,
-							&cdcStatus,
-							wxRect(1, 1, iWidth - 2, iHeight - 2),
-							false);
-
-						// Draw black border
-						cdcStatus.SetPen(*wxBLACK_PEN);
-						cdcStatus.SetBrush(*wxTRANSPARENT_BRUSH);
-						cdcStatus.DrawRectangle(0, 0, iWidth, iHeight);
-					}
-
-					// Plus ten seconds
-					item->dwUpdated = dwTicks + 10000;
-				} else {
-					cdcStatus.SelectObject(*(item->status));
-				}
-
-				dc->Blit(rect.GetX(), rect.GetY() + 1, iWidth, iHeight, &cdcStatus, 0, 0);
-			} else {
-				wxString a4af;
-				CPartFile *p = client.GetRequestFile();
-				if (p) {
-					a4af = p->GetFileName().GetPrintable();
-				} else {
-					a4af = "?";
-				}
-				buffer = CFormat("%s: %s") % _("A4AF") % a4af;
-
-				int mid_x = (2 * rect.GetX() + rect.GetWidth()) >> 1;
-				int mid_y = (2 * rect.GetY() + rect.GetHeight()) >> 1;
-
-				wxCoord txtwidth, txtheight;
-
-				dc->GetTextExtent(buffer, &txtwidth, &txtheight);
-
-				// Theme-aware text + border colour (was *wxBLACK / *wxBLACK_PEN
-				// which was invisible on dark themes -- the badge sits on
-				// the row stripe, not on a known light background).
-				const wxColour badgeColour =
-					wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
-				dc->SetTextForeground(badgeColour);
-				dc->DrawText(buffer,
-					wxMax(rect.GetX() + 2, mid_x - (txtwidth >> 1)),
-					mid_y - (txtheight >> 1));
-
-				dc->SetPen(wxPen(badgeColour));
-				dc->SetBrush(*wxTRANSPARENT_BRUSH);
-				dc->DrawRectangle(rect.GetX(), rect.GetY() + 1, iWidth, iHeight);
-			}
-		}
-		break;
-
-	case ColumnUserAvailable: {
-		if (client.GetUpPartCount()) {
-			DrawStatusBar(client, dc, rect);
-		}
-		break;
-	}
-
-	case ColumnUserVersion: {
-		dc->DrawText(client.GetClientVerString(), rect.GetX(), rect.GetY() + iTextOffset);
-		break;
-	}
+	case ColumnUserVersion:
+		return client.GetClientVerString();
 
 	case ColumnUserQueueRankRemote: {
-		sint16 qrDiff = 0;
-		wxColour savedColour = dc->GetTextForeground();
-		// We only show the queue rank for sources actually queued for that file
-		if (item->GetType() != A4AF_SOURCE && client.GetDownloadState() == DS_ONQUEUE) {
+		if (notA4AF && client.GetDownloadState() == DS_ONQUEUE) {
 			if (client.IsRemoteQueueFull()) {
-				buffer = _("Queue Full");
-			} else {
-				uint16 rank = client.GetRemoteQueueRank();
-				if (rank) {
-					qrDiff = rank - client.GetOldRemoteQueueRank();
-					if (qrDiff == rank) {
-						qrDiff = 0;
-					}
-					// Queue rank change cue: down (good) = blue, up (bad) = red.
-					// Pure *wxBLUE / *wxRED were unreadable on dark themes;
-					// swap to a hand-tuned palette that contrasts on both.
-					const bool isDark = IsListBackgroundDark(this);
-					if (qrDiff < 0) {
-						dc->SetTextForeground(isDark ? wxColour(120, 170, 255)
-									     : wxColour(0, 80, 200));
-					}
-					if (qrDiff > 0) {
-						dc->SetTextForeground(isDark ? wxColour(255, 100, 100)
-									     : wxColour(220, 0, 0));
-					}
-					buffer = CFormat(_("On Queue: %u (%i)")) % rank % qrDiff;
-				} else {
-					buffer = _("On Queue");
-				}
+				return _("Queue Full");
 			}
-		} else {
-			if (item->GetType() != A4AF_SOURCE) {
-				buffer = DownloadStateToStr(
-					client.GetDownloadState(), client.IsRemoteQueueFull());
-			} else {
-				buffer = _("Asked for another file");
-				if (client.GetRequestFile() &&
-					client.GetRequestFile()->GetFileName().IsOk()) {
-					buffer += CFormat(" (%s)") % client.GetRequestFile()->GetFileName();
+			const uint16 rank = client.GetRemoteQueueRank();
+			if (rank) {
+				sint16 qrDiff = static_cast<sint16>(rank - client.GetOldRemoteQueueRank());
+				if (qrDiff == rank) {
+					qrDiff = 0;
 				}
+				return CFormat(_("On Queue: %u (%i)")) % rank % qrDiff;
 			}
+			return _("On Queue");
 		}
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		if (qrDiff) {
-			dc->SetTextForeground(savedColour);
+		if (notA4AF) {
+			return DownloadStateToStr(client.GetDownloadState(), client.IsRemoteQueueFull());
 		}
-		break;
+		wxString buffer = _("Asked for another file");
+		if (client.GetRequestFile() && client.GetRequestFile()->GetFileName().IsOk()) {
+			buffer += CFormat(" (%s)") % client.GetRequestFile()->GetFileName();
+		}
+		return buffer;
 	}
+
 	case ColumnUserQueueRankLocal:
-		if (item->GetType() != A4AF_SOURCE) {
-			if (client.GetUploadState() == US_ONUPLOADQUEUE) {
-				uint16 nRank = client.GetUploadQueueWaitingPosition();
-				if (nRank == 0) {
-					buffer = _("Waiting for upload slot");
-				} else {
-					buffer = CFormat(_("On Queue: %u")) % nRank;
-				}
-			} else if (client.GetUploadState() == US_UPLOADING) {
-				buffer = _("Uploading");
-			} else {
-				buffer = _("None");
-			}
-		} else {
-			buffer = _("Asked for another file");
+		if (!notA4AF) {
+			return _("Asked for another file");
 		}
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		break;
-	// Source comes from?
-	case ColumnUserOrigin: {
-		buffer = wxGetTranslation(OriginToText(client.GetSourceFrom()));
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		break;
-	}
-	// Local file name to identify on multi select
-	case ColumnUserFileNameDownload: {
-		const CPartFile *pf = client.GetRequestFile();
-		if (pf) {
-			buffer = pf->GetFileName().GetPrintable();
-		} else {
-			buffer = _("Unknown");
-			buffer = "[" + buffer + "]";
+		if (client.GetUploadState() == US_ONUPLOADQUEUE) {
+			const uint16 nRank = client.GetUploadQueueWaitingPosition();
+			return nRank == 0 ? wxString(_("Waiting for upload slot"))
+					  : wxString(CFormat(_("On Queue: %u")) % nRank);
 		}
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		break;
-	}
-	case ColumnUserFileNameUpload: {
-		const CKnownFile *kf = client.GetUploadFile();
-		if (kf) {
-			buffer = kf->GetFileName().GetPrintable();
-		} else {
-			buffer = _("Unknown");
-			buffer = "[" + buffer + "]";
+		if (client.GetUploadState() == US_UPLOADING) {
+			return _("Uploading");
 		}
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		break;
+		return _("None");
+
+	case ColumnUserOrigin:
+		return wxGetTranslation(OriginToText(client.GetSourceFrom()));
+
+	case ColumnUserFileNameDownload:
+		if (const CPartFile *pf = client.GetRequestFile()) {
+			return pf->GetFileName().GetPrintable();
+		}
+		return "[" + wxString(_("Unknown")) + "]";
+
+	case ColumnUserFileNameUpload:
+		if (const CKnownFile *kf = client.GetUploadFile()) {
+			return kf->GetFileName().GetPrintable();
+		}
+		return "[" + wxString(_("Unknown")) + "]";
+
+	case ColumnUserFileNameDownloadRemote:
+		if (client.GetClientFilename().IsEmpty() || !notA4AF) {
+			return "[" + wxString(_("Unknown")) + "]";
+		}
+		return client.GetClientFilename();
+
+	case ColumnUserSharedFiles:
+		return client.HasDisabledSharedFiles() ? _("No") : _("Yes");
+
+	default:
+		return wxEmptyString;
 	}
+}
+
+bool CGenericClientListCtrl::GetItemAttr(wxUIntPtr data, unsigned column, wxDataViewItemAttr &attr) const
+{
+	if (column >= static_cast<unsigned>(m_columndata.n_columns)) {
+		return false;
+	}
+	ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(data);
+	CClientRef &client = item->GetSource();
+	const bool isDark = IsListBackgroundDark(this);
+
+	switch (m_columndata.columns[column].cid) {
+	case ColumnUserQueueRankRemote: {
+		if (item->GetType() == A4AF_SOURCE || client.GetDownloadState() != DS_ONQUEUE ||
+			client.IsRemoteQueueFull()) {
+			return false;
+		}
+		const uint16 rank = client.GetRemoteQueueRank();
+		if (!rank) {
+			return false;
+		}
+		sint16 qrDiff = static_cast<sint16>(rank - client.GetOldRemoteQueueRank());
+		if (qrDiff == static_cast<sint16>(rank)) {
+			qrDiff = 0;
+		}
+		// Queue rank change cue: down (good) = blue, up (bad) = red. Pure
+		// *wxBLUE / *wxRED were unreadable on dark themes.
+		if (qrDiff < 0) {
+			attr.SetColour(isDark ? wxColour(120, 170, 255) : wxColour(0, 80, 200));
+			return true;
+		}
+		if (qrDiff > 0) {
+			attr.SetColour(isDark ? wxColour(255, 100, 100) : wxColour(220, 0, 0));
+			return true;
+		}
+		return false;
+	}
+
 	case ColumnUserFileNameDownloadRemote: {
-		bool nameMismatch = false;
-		wxColour savedColour = dc->GetTextForeground();
 		if (client.GetClientFilename().IsEmpty() || item->GetType() == A4AF_SOURCE) {
-			buffer = _("Unknown");
-			buffer = "[" + buffer + "]";
-		} else {
-			buffer = client.GetClientFilename();
-			const CPartFile *pf = client.GetRequestFile();
-			if (pf && (pf->GetFileName().GetPrintable().CmpNoCase(buffer) != 0)) {
-				nameMismatch = true;
-				// "watch out: peer is advertising a different name for
-				// this hash" warning cue. Pure *wxRED was unreadable on
-				// dark themes.
-				const bool isDark = IsListBackgroundDark(this);
-				dc->SetTextForeground(isDark ? wxColour(255, 100, 100) : wxColour(220, 0, 0));
+			return false;
+		}
+		const CPartFile *pf = client.GetRequestFile();
+		if (pf && (pf->GetFileName().GetPrintable().CmpNoCase(client.GetClientFilename()) != 0)) {
+			// "watch out: peer is advertising a different name for this
+			// hash" warning cue. Pure *wxRED was unreadable on dark themes.
+			attr.SetColour(isDark ? wxColour(255, 100, 100) : wxColour(220, 0, 0));
+			return true;
+		}
+		return false;
+	}
+
+	default:
+		return false;
+	}
+}
+
+namespace
+{
+const CMuleColour crBoth(0, 192, 0);
+const CMuleColour crFlatBoth(0, 150, 0);
+
+const CMuleColour crNeither(240, 240, 240);
+const CMuleColour crFlatNeither(224, 224, 224);
+
+const CMuleColour crClientOnly(104, 104, 104);
+const CMuleColour crFlatClientOnly(0, 0, 0);
+
+const CMuleColour crPending(255, 208, 0);
+const CMuleColour crNextPending(255, 255, 100);
+
+const CMuleColour crUnavailable(240, 240, 240);
+const CMuleColour crFlatUnavailable(224, 224, 224);
+
+const CMuleColour crAvailable(104, 104, 104);
+const CMuleColour crFlatAvailable(0, 0, 0);
+} // namespace
+
+void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBarFillSpec &out) const
+{
+	if (column >= static_cast<unsigned>(m_columndata.n_columns)) {
+		return;
+	}
+	ClientCtrlItem_Struct *item = reinterpret_cast<ClientCtrlItem_Struct *>(data);
+
+	switch (m_columndata.columns[column].cid) {
+	case ColumnUserName:
+		// CClientNameRenderer only needs the identity; it draws straight
+		// off the live CClientRef, not off spans.
+		out = CBarFillSpec(data, 0, {});
+		return;
+
+	case ColumnUserProgress: {
+		// Gate mirrors DrawClientItem's ColumnUserProgress case: nothing is
+		// computed (or drawn, including the A4AF badge) with the pref off --
+		// see CSourceBarRenderer::Render() for the matching gate.
+		if (!thePrefs::ShowProgBar()) {
+			return;
+		}
+		CClientRef &client = item->GetSource();
+		CPartFile *reqfile = client.GetRequestFile();
+		const BitVector &partStatus = client.GetPartStatus();
+		const bool bFlat = thePrefs::UseFlatBar();
+
+		std::vector<CBarFillSpan> spans;
+		uint64 fileSize = 1;
+
+		if (reqfile && reqfile->GetPartCount() == partStatus.size()) {
+			fileSize = reqfile->GetFileSize();
+			const uint16 lastDownloadingPart = client.GetDownloadState() == DS_DOWNLOADING
+								   ? client.GetLastDownloadingPart()
+								   : 0xffff;
+			const uint16 nextRequestedPart = client.GetNextRequestedPart();
+			const bool stopped = reqfile->IsStopped();
+
+			for (uint32 i = 0; i < partStatus.size(); i++) {
+				const uint64 uStart = PARTSIZE * i;
+				const uint64 uEnd = uStart + reqfile->GetPartSize(static_cast<uint16>(i)) - 1;
+
+				CMuleColour colour;
+				if (!partStatus.get(i)) {
+					colour = bFlat ? crFlatNeither : crNeither;
+				} else if (reqfile->IsComplete(static_cast<uint16>(i))) {
+					colour = bFlat ? crFlatBoth : crBoth;
+				} else if (lastDownloadingPart == static_cast<uint16>(i)) {
+					colour = crPending;
+				} else if (nextRequestedPart == static_cast<uint16>(i)) {
+					colour = crNextPending;
+				} else {
+					colour = bFlat ? crFlatClientOnly : crClientOnly;
+				}
+				if (stopped) {
+					colour.Blend(50);
+				}
+				spans.push_back({ uStart, uEnd, colour });
 			}
-		}
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		if (nameMismatch) {
-			dc->SetTextForeground(savedColour);
-		}
-		break;
-	}
-	case ColumnUserSharedFiles: {
-		if (client.HasDisabledSharedFiles()) {
-			buffer = _("No");
 		} else {
-			buffer = _("Yes");
+			spans.push_back({ 0, 1, bFlat ? crFlatNeither : crNeither });
 		}
-		dc->DrawText(buffer, rect.GetX(), rect.GetY() + iTextOffset);
-		break;
+
+		out = CBarFillSpec(data, fileSize, std::move(spans));
+		return;
 	}
+
+	case ColumnUserAvailable: {
+		CClientRef &client = item->GetSource();
+		const uint32 partCount = client.GetUpPartCount();
+		if (!partCount) {
+			// Matches DrawStatusBar's caller, which skips drawing (border
+			// included) entirely when there is nothing to show.
+			return;
+		}
+		const bool bFlat = thePrefs::UseFlatBar();
+
+		std::vector<CBarFillSpan> spans;
+		for (uint64 i = 0; i < partCount; i++) {
+			const uint64 uStart = PARTSIZE * i;
+			const uint64 uEnd = uStart + PARTSIZE - 1;
+			spans.push_back({ uStart,
+				uEnd,
+				client.IsUpPartAvailable(i) ? (bFlat ? crFlatAvailable : crAvailable)
+							    : (bFlat ? crFlatUnavailable : crUnavailable) });
+		}
+		out = CBarFillSpec(data, static_cast<uint64>(partCount) * PARTSIZE, std::move(spans));
+		return;
+	}
+
+	default:
+		return;
 	}
 }
 
-int CGenericClientListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
+int CGenericClientListCtrl::CompareByCid(
+	GenericColumnEnum cid, const CClientRef &client1, const CClientRef &client2) const
 {
-	ClientCtrlItem_Struct *item1 = reinterpret_cast<ClientCtrlItem_Struct *>(param1);
-	ClientCtrlItem_Struct *item2 = reinterpret_cast<ClientCtrlItem_Struct *>(param2);
-
-	int sortMod = (sortData & CMuleListCtrl::SORT_DES) ? -1 : 1;
-	sortData &= CMuleListCtrl::COLUMN_MASK;
-	int comp = 0;
-
-	// Two sources, some different possibilities
-	// Available sources first, if we have both an
-	// available and an unavailable
-	comp = (item2->GetType() - item1->GetType());
-
-	if (comp) {
-		// unavailable and available. The order is fixed regardless of sort-order.
-		return comp;
-	} else {
-		comp = Compare(item1->GetSource(), item2->GetSource(), sortData);
-	}
-
-	// We modify the result so that it matches with ascending or descending
-	return sortMod * comp;
-}
-
-int CGenericClientListCtrl::Compare(const CClientRef &client1, const CClientRef &client2, long lParamSort)
-{
-	switch (lParamSort) {
-	// Sort by name
+	switch (cid) {
 	case ColumnUserName:
 		return CmpAny(client1.GetUserName(), client2.GetUserName());
 
-	// Sort by transferred in the following fields
 	case ColumnUserDownloaded:
 		return CmpAny(client1.GetTransferredDown(), client2.GetTransferredDown());
 
-	// Sort by transferred in the following fields
 	case ColumnUserUploaded:
 		return CmpAny(client1.GetTransferredUp(), client2.GetTransferredUp());
 
-	// Sort by speed
 	case ColumnUserSpeedDown:
 		return CmpAny(client1.GetKBpsDown(), client2.GetKBpsDown());
 
-	// Sort by speed
 	case ColumnUserSpeedUp:
 		return CmpAny(client1.GetUploadDatarate(), client2.GetUploadDatarate());
 
-	// Sort by parts offered
 	case ColumnUserProgress:
 		return CmpAny(client1.GetAvailablePartCount(), client2.GetAvailablePartCount());
 
-	// Sort by client version
 	case ColumnUserVersion: {
 		int cmp = client1.GetSoftStr().Cmp(client2.GetSoftStr());
-
 		if (cmp == 0) {
 			cmp = CmpAny(client1.GetVersion(), client2.GetVersion());
 		}
@@ -1274,264 +1153,104 @@ int CGenericClientListCtrl::Compare(const CClientRef &client1, const CClientRef 
 		return cmp;
 	}
 
-	// Sort by Queue-Rank
 	case ColumnUserQueueRankRemote: {
-		// This will sort by download state: Downloading, OnQueue, Connecting ...
-		// However, Asked For Another will always be placed last, due to
-		// sorting in SortProc
+		// This will sort by download state: Downloading, OnQueue, Connecting...
+		// However, Asked For Another will always be placed last, due to the
+		// type-precedence pre-check in CompareItemData().
 		if (client1.GetDownloadState() != client2.GetDownloadState()) {
 			return client1.GetDownloadState() - client2.GetDownloadState();
 		}
-
 		// Placing items on queue before items on full queues
 		if (client1.IsRemoteQueueFull()) {
-			if (client2.IsRemoteQueueFull()) {
-				return 0;
-			} else {
-				return 1;
-			}
-		} else if (client2.IsRemoteQueueFull()) {
-			return -1;
-		} else {
-			if (client1.GetRemoteQueueRank()) {
-				if (client2.GetRemoteQueueRank()) {
-					return CmpAny(
-						client1.GetRemoteQueueRank(), client2.GetRemoteQueueRank());
-				} else {
-					return -1;
-				}
-			} else {
-				if (client2.GetRemoteQueueRank()) {
-					return 1;
-				} else {
-					return 0;
-				}
-			}
+			return client2.IsRemoteQueueFull() ? 0 : 1;
 		}
+		if (client2.IsRemoteQueueFull()) {
+			return -1;
+		}
+		if (client1.GetRemoteQueueRank()) {
+			return client2.GetRemoteQueueRank()
+				       ? CmpAny(client1.GetRemoteQueueRank(), client2.GetRemoteQueueRank())
+				       : -1;
+		}
+		return client2.GetRemoteQueueRank() ? 1 : 0;
 	}
 
-	// Sort by Queue-Rank
 	case ColumnUserQueueRankLocal: {
-		// This will sort by download state: Downloading, OnQueue, Connecting ...
-		// However, Asked For Another will always be placed last, due to
-		// sorting in SortProc
 		if (client1.GetUploadState() != client2.GetUploadState()) {
 			return client1.GetUploadState() - client2.GetUploadState();
 		}
-
-		uint16 rank1 = client1.GetUploadQueueWaitingPosition();
-		uint16 rank2 = client2.GetUploadQueueWaitingPosition();
-		// Placing items on queue before items on full queues
+		const uint16 rank1 = client1.GetUploadQueueWaitingPosition();
+		const uint16 rank2 = client2.GetUploadQueueWaitingPosition();
 		if (!rank1) {
-			if (!rank2) {
-				return 0;
-			} else {
-				return 1;
-			}
-		} else if (!rank2) {
-			return -1;
-		} else {
-			if (rank1) {
-				if (rank2) {
-					return CmpAny(rank1, rank2);
-				} else {
-					return -1;
-				}
-			} else {
-				if (rank2) {
-					return 1;
-				} else {
-					return 0;
-				}
-			}
+			return !rank2 ? 0 : 1;
 		}
+		if (!rank2) {
+			return -1;
+		}
+		return CmpAny(rank1, rank2);
 	}
 
-	// Source of source ;)
 	case ColumnUserOrigin:
 		return CmpAny(client1.GetSourceFrom(), client2.GetSourceFrom());
 
-	// Sort by local filename (download)
 	case ColumnUserFileNameDownload: {
 		wxString buffer1, buffer2;
-		const CPartFile *pf1 = client1.GetRequestFile();
-		if (pf1) {
+		if (const CPartFile *pf1 = client1.GetRequestFile()) {
 			buffer1 = pf1->GetFileName().GetPrintable();
 		}
-		const CPartFile *pf2 = client2.GetRequestFile();
-		if (pf2) {
+		if (const CPartFile *pf2 = client2.GetRequestFile()) {
 			buffer2 = pf2->GetFileName().GetPrintable();
 		}
 		return CmpAny(buffer1, buffer2);
 	}
 
-	// Sort by local filename (upload)
 	case ColumnUserFileNameUpload: {
 		wxString buffer1, buffer2;
-		const CKnownFile *kf1 = client1.GetUploadFile();
-		if (kf1) {
+		if (const CKnownFile *kf1 = client1.GetUploadFile()) {
 			buffer1 = kf1->GetFileName().GetPrintable();
 		}
-		const CKnownFile *kf2 = client2.GetUploadFile();
-		if (kf2) {
+		if (const CKnownFile *kf2 = client2.GetUploadFile()) {
 			buffer2 = kf2->GetFileName().GetPrintable();
 		}
 		return CmpAny(buffer1, buffer2);
 	}
 
-	case ColumnUserFileNameDownloadRemote: {
+	case ColumnUserFileNameDownloadRemote:
 		return CmpAny(client1.GetClientFilename(), client2.GetClientFilename());
-	}
 
-	case ColumnUserSharedFiles: {
+	case ColumnUserSharedFiles:
 		return CmpAny(client1.HasDisabledSharedFiles(), client2.HasDisabledSharedFiles());
-	}
 
+	// ColumnUserAvailable intentionally has no case: unsortable, matching
+	// the pre-port behaviour (see InitColumnData()'s SORTABLE-less
+	// registration for this column).
 	default:
 		return 0;
 	}
 }
 
-void CGenericClientListCtrl::ShowSourcesCount(int diff)
+int CGenericClientListCtrl::CompareItemData(
+	wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool WXUNUSED(alt), int modifier) const
 {
-	m_clientcount += diff;
-	wxStaticText *label = CastByID(ID_CLIENTCOUNT, GetParent(), wxStaticText);
+	ClientCtrlItem_Struct *item1 = reinterpret_cast<ClientCtrlItem_Struct *>(data1);
+	ClientCtrlItem_Struct *item2 = reinterpret_cast<ClientCtrlItem_Struct *>(data2);
 
-	if (label) {
-		label->SetLabel(CFormat("%i") % m_clientcount);
-		label->GetParent()->Layout();
-	}
-}
-
-static const CMuleColour crBoth(0, 192, 0);
-static const CMuleColour crFlatBoth(0, 150, 0);
-
-static const CMuleColour crNeither(240, 240, 240);
-static const CMuleColour crFlatNeither(224, 224, 224);
-
-static const CMuleColour crClientOnly(104, 104, 104);
-static const CMuleColour crFlatClientOnly(0, 0, 0);
-
-static const CMuleColour crPending(255, 208, 0);
-static const CMuleColour crNextPending(255, 255, 100);
-
-void CGenericClientListCtrl::DrawSourceStatusBar(
-	const CClientRef &source, wxDC *dc, const wxRect &rect, bool bFlat) const
-{
-	static CBarShader s_StatusBar(16);
-
-	CPartFile *reqfile = source.GetRequestFile();
-
-	s_StatusBar.SetHeight(rect.height);
-	s_StatusBar.SetWidth(rect.width);
-	s_StatusBar.Set3dDepth(thePrefs::Get3DDepth());
-	const BitVector &partStatus = source.GetPartStatus();
-
-	if (reqfile && reqfile->GetPartCount() == partStatus.size()) {
-		s_StatusBar.SetFileSize(reqfile->GetFileSize());
-		uint16 lastDownloadingPart = source.GetDownloadState() == DS_DOWNLOADING
-						     ? source.GetLastDownloadingPart()
-						     : 0xffff;
-		uint16 nextRequestedPart = source.GetNextRequestedPart();
-
-		for (uint32 i = 0; i < partStatus.size(); i++) {
-			uint64 uStart = PARTSIZE * i;
-			uint64 uEnd = uStart + reqfile->GetPartSize(static_cast<uint16>(i)) - 1;
-
-			CMuleColour colour;
-			if (!partStatus.get(i)) {
-				// client does not have this part
-				// light grey
-				colour = bFlat ? crFlatNeither : crNeither;
-			} else if (reqfile->IsComplete(static_cast<uint16>(i))) {
-				// completed part
-				// green
-				colour = bFlat ? crFlatBoth : crBoth;
-			} else if (lastDownloadingPart == static_cast<uint16>(i)) {
-				// downloading part
-				// yellow
-				colour = crPending;
-			} else if (nextRequestedPart == static_cast<uint16>(i)) {
-				// requested part
-				// light yellow
-				colour = crNextPending;
-			} else {
-				// client has this part, we need it
-				// black
-				colour = bFlat ? crFlatClientOnly : crClientOnly;
-			}
-
-			if (source.GetRequestFile()->IsStopped()) {
-				colour.Blend(50);
-			}
-
-			s_StatusBar.FillRange(uStart, uEnd, colour);
-		}
-	} else {
-		s_StatusBar.SetFileSize(1);
-		s_StatusBar.FillRange(0, 1, bFlat ? crFlatNeither : crNeither);
+	// Available sources first, if we have both an available and an
+	// unavailable one -- the order is fixed regardless of sort direction, so
+	// `modifier` is deliberately not applied here. Runs identically at every
+	// level of a multi-column sort chain (CompareItemsFull calls this once
+	// per level with the same two items); harmless, since it always agrees
+	// with itself.
+	const int typeOrder = item2->GetType() - item1->GetType();
+	if (typeOrder) {
+		return typeOrder;
 	}
 
-	s_StatusBar.Draw(dc, rect.x, rect.y, bFlat);
-}
-
-static const CMuleColour crUnavailable(240, 240, 240);
-static const CMuleColour crFlatUnavailable(224, 224, 224);
-
-static const CMuleColour crAvailable(104, 104, 104);
-static const CMuleColour crFlatAvailable(0, 0, 0);
-
-void CGenericClientListCtrl::DrawStatusBar(const CClientRef &client, wxDC *dc, const wxRect &rect1) const
-{
-	wxRect rect = rect1;
-	rect.y += 1;
-	rect.height -= 2;
-
-	wxPen old_pen = dc->GetPen();
-	wxBrush old_brush = dc->GetBrush();
-	bool bFlat = thePrefs::UseFlatBar();
-
-	wxRect barRect = rect;
-	if (!bFlat) { // round bar has a black border, the bar itself is 1 pixel less on each border
-		barRect.x++;
-		barRect.y++;
-		barRect.height -= 2;
-		barRect.width -= 2;
+	if (column >= static_cast<unsigned>(m_columndata.n_columns)) {
+		return 0;
 	}
-	static CBarShader s_StatusBar(16);
-
-	uint32 partCount = client.GetUpPartCount();
-
-	// Seems the partfile in the client object is not necessarily valid when bar is drawn for the first
-	// time. Keep it simple and make all parts same size.
-	s_StatusBar.SetFileSize(partCount * PARTSIZE);
-	s_StatusBar.SetHeight(barRect.height);
-	s_StatusBar.SetWidth(barRect.width);
-	s_StatusBar.Set3dDepth(thePrefs::Get3DDepth());
-
-	uint64 uEnd = 0;
-	for (uint64 i = 0; i < partCount; i++) {
-		uint64 uStart = PARTSIZE * i;
-		uEnd = uStart + PARTSIZE - 1;
-
-		s_StatusBar.FillRange(uStart,
-			uEnd,
-			client.IsUpPartAvailable(i) ? (bFlat ? crFlatAvailable : crAvailable)
-						    : (bFlat ? crFlatUnavailable : crUnavailable));
-	}
-	// fill the rest (if partStatus is empty)
-	s_StatusBar.FillRange(uEnd + 1, partCount * PARTSIZE - 1, bFlat ? crFlatUnavailable : crUnavailable);
-	s_StatusBar.Draw(dc, barRect.x, barRect.y, bFlat);
-
-	if (!bFlat) {
-		// Draw black border
-		dc->SetPen(*wxBLACK_PEN);
-		dc->SetBrush(*wxTRANSPARENT_BRUSH);
-		dc->DrawRectangle(rect);
-	}
-
-	dc->SetPen(old_pen);
-	dc->SetBrush(old_brush);
+	return modifier *
+	       CompareByCid(m_columndata.columns[column].cid, item1->GetSource(), item2->GetSource());
 }
 
 // File_checked_for_headers

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -248,8 +248,8 @@ CGenericClientListCtrl::CGenericClientListCtrl(const wxString &tablename,
 	long style,
 	const wxString &name)
 : CMuleVirtualDataViewCtrl(parent, winid, pos, size, style, name)
-, m_columndata(0, NULL)
-, m_menu(NULL)
+, m_columndata(0, nullptr)
+, m_menu(nullptr)
 , m_clientcount(0)
 , m_showing(false)
 {
@@ -469,7 +469,7 @@ void CGenericClientListCtrl::RemoveSource(uint32 source, const CKnownFile *owner
 	for (ListItems::iterator it = rangeIt.first; it != rangeIt.second; /* no ++, it happens later */) {
 		ListItems::iterator tmp = it++;
 
-		if (owner == NULL || owner == tmp->second->GetOwner()) {
+		if (owner == nullptr || owner == tmp->second->GetOwner()) {
 
 			RawRemoveSource(tmp);
 
@@ -623,7 +623,7 @@ void CGenericClientListCtrl::RemoveKnownFile(CKnownFile *file)
 	// We must never dereference it; we only need its value as a key
 	// to drop from m_knownfiles and m_ListItems. See
 	// MuleNotify::KnownFileBeingDestroyed in GuiEvents.cpp.
-	if (file == NULL) {
+	if (file == nullptr) {
 		return;
 	}
 
@@ -834,7 +834,7 @@ void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	PopupMenu(m_menu);
 
 	delete m_menu;
-	m_menu = NULL;
+	m_menu = nullptr;
 }
 
 wxString CGenericClientListCtrl::GetItemColumnText(wxUIntPtr data, unsigned column) const

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -51,7 +51,7 @@ class wxMenu;
 struct ClientCtrlItem_Struct
 {
 	ClientCtrlItem_Struct()
-	: m_owner(NULL)
+	: m_owner(nullptr)
 	, m_type(UNAVAILABLE_SOURCE)
 	{
 	}

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -27,20 +27,55 @@
 
 #include <map>    // Needed for std::multimap
 #include <vector> // Needed for std::vector
-#include <wx/brush.h>
 
-#include "Types.h"               // Needed for uint8
-#include "Constants.h"           // Needed for DownloadItemType
-#include "MuleVirtualListCtrl.h" // Needed for CMuleVirtualListCtrl
-#include "amuleDlg.h"            // Needed for CamuleDlg::DialogType
+#include "Types.h"                   // Needed for uint8
+#include "Constants.h"               // Needed for DownloadItemType
+#include "ClientRef.h"               // Needed for CClientRef (stored by value below)
+#include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
+#include "amuleDlg.h"                // Needed for CamuleDlg::DialogType
 
 class CPartFile;
-class CClientRef;
-class wxBitmap;
-class wxRect;
-class wxDC;
+class CMuleBarRenderer;
+class wxMenu;
 
-struct ClientCtrlItem_Struct;
+/**
+ * One row: a client together with the file it is a source/peer of and
+ * whether it is a current or A4AF source. Not just a cache-avoidance
+ * wrapper like the pre-port CDownloadListCtrl's FileCtrlItem_Struct was --
+ * genuinely necessary here, since one client (ECID) can be a source/peer of
+ * more than one file at once, so identity has to be the (client, owner,
+ * type) tuple, not the CClientRef alone. Public (not file-local to
+ * GenericClientListCtrl.cpp) because CSourceBarRenderer, in the leaf's own
+ * .cpp, needs to read it back from a CBarFillSpec identity.
+ */
+struct ClientCtrlItem_Struct
+{
+	ClientCtrlItem_Struct()
+	: m_owner(NULL)
+	, m_type(UNAVAILABLE_SOURCE)
+	{
+	}
+
+	SourceItemType GetType() const { return m_type; }
+
+	CKnownFile *GetOwner() const { return m_owner; }
+
+	CClientRef &GetSource() { return m_sourceValue; }
+
+	void SetContents(CKnownFile *owner, const CClientRef &source, SourceItemType type)
+	{
+		m_owner = owner;
+		m_sourceValue = source;
+		m_type = type;
+	}
+
+	void SetType(SourceItemType type) { m_type = type; }
+
+private:
+	CKnownFile *m_owner;
+	CClientRef m_sourceValue;
+	SourceItemType m_type;
+};
 
 enum GenericColumnEnum
 {
@@ -82,15 +117,20 @@ typedef std::vector<CKnownFile *> CKnownFileVector;
 
 /**
  * This class is responsible for representing clients in a generic way.
+ *
+ * Rows are addressed by ClientCtrlItem_Struct* identity -- unlike every other
+ * ported list, that wrapper survives the port: a client (ECID) can be a
+ * source/peer of more than one file at once, so each row needs the client
+ * together with its owner file and A4AF/available type, not just the
+ * CClientRef alone. See ClientCtrlItem_Struct in the .cpp.
  */
-
-class CGenericClientListCtrl : public CMuleVirtualListCtrl
+class CGenericClientListCtrl : public CMuleVirtualDataViewCtrl
 {
 public:
 	/**
 	 * Constructor.
 	 *
-	 * @see CMuleListCtrl::CMuleListCtrl for documentation of parameters.
+	 * @see CMuleVirtualDataViewCtrl::CMuleVirtualDataViewCtrl for documentation of parameters.
 	 */
 	CGenericClientListCtrl(const wxString &tablename,
 		wxWindow *parent,
@@ -98,7 +138,6 @@ public:
 		const wxPoint &pos,
 		const wxSize &size,
 		long style,
-		const wxValidator &validator,
 		const wxString &name);
 
 	/**
@@ -174,7 +213,36 @@ public:
 protected:
 	// The columns with their attributes; MUST be defined by the derived class.
 	GenericColumnInfo m_columndata;
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
+
+	/// Text of one cell, pulled on demand for the cells being drawn.
+	wxString GetItemColumnText(wxUIntPtr item, unsigned column) const override;
+
+	/// Per-row/per-column display attributes: the queue-rank-diff and
+	/// filename-mismatch colour cues DrawClientItem used to set on the wxDC.
+	bool GetItemAttr(wxUIntPtr item, unsigned column, wxDataViewItemAttr &attr) const override;
+
+	/// Fill data for the Name column's composite icon+text renderer (see
+	/// CClientNameRenderer) and for a leaf's own bar column.
+	void GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const override;
+
+	/// Single-column comparison for the base's sort chain, after the
+	/// type-precedence pre-check (A4AF sources always last).
+	int CompareItemData(
+		wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const override;
+
+	/** Live auto-sort: re-order when sorted by a column whose value changes
+	 *  during transfer (speed, progress, up/downloaded, availability, queue
+	 *  rank). Static columns (name, version, filename, ...) don't auto-resort. */
+	bool IsLiveSortColumn() const override;
+
+	/** Pause live auto-sort while the context menu is open. */
+	bool IsMenuOpen() const override { return m_menu != nullptr; }
+
+	//! Renderer for a leaf's own bar column (ColumnUserProgress for Sources,
+	//! ColumnUserAvailable for Peers). Sources overrides this to opt into the
+	//! A4AF-badge-drawing subclass; Peers' plain 2-state bar needs no
+	//! subclass, so the default (nullptr) is a plain CMuleBarRenderer.
+	virtual CMuleBarRenderer *CreateProgressBarRenderer() const { return nullptr; }
 
 private:
 	/**
@@ -191,58 +259,16 @@ private:
 	void ShowSourcesCount(int diff);
 
 	/**
-	 * Overloaded function needed for custom drawing of items.
-	 */
-	virtual void OnDrawItem(
-		int item, wxDC *dc, const wxRect &rect, const wxRect &rectHL, bool highlighted);
-
-	/**
-	 * Draws a client item.
-	 */
-	void DrawClientItem(wxDC *dc,
-		int nColumn,
-		const wxRect &rect,
-		ClientCtrlItem_Struct *item,
-		int iTextOffset,
-		int iBitmapOffset,
-		int iBitmapXSize) const;
-
-	/**
-	 * Draws the download status (chunk) bar for a client.
-	 */
-	void DrawSourceStatusBar(const CClientRef &source, wxDC *dc, const wxRect &rect, bool bFlat) const;
-
-	/**
-	 * Draaws the file parts bar for a client.
-	 */
-	void DrawStatusBar(const CClientRef &client, wxDC *dc, const wxRect &rect1) const;
-
-	/**
-	 * @see CMuleListCtrl::GetTTSText
-	 * Just a dummy
-	 */
-	virtual wxString GetTTSText(unsigned) const { return ""; }
-
-	/** Live auto-sort: re-order when sorted by a column whose value changes
-	 *  during transfer (speed, progress, up/downloaded, availability, queue
-	 *  rank). Static columns (name, version, filename, ...) don't auto-resort. */
-	virtual bool IsLiveSortColumn() const;
-
-	/** Pause live auto-sort while the context menu is open. */
-	virtual bool IsMenuOpen() const { return m_menu != nullptr; }
-
-	/**
 	 * Set "show sources" or "show peers" flag in Known File
 	 */
 	virtual void SetShowSources(CKnownFile *, bool) const = 0;
 
 	/**
 	 * Translate the CID to a unique string for saving column sizes
-	 * @see CMuleListCtrl::InsertColumn
 	 */
 	wxString TranslateCIDToName(GenericColumnEnum cid);
 
-	static int Compare(const CClientRef &client1, const CClientRef &client2, long lParamColumnSort);
+	int CompareByCid(GenericColumnEnum cid, const CClientRef &client1, const CClientRef &client2) const;
 
 	// Event-handlers for clients.
 	void OnSwapSource(wxCommandEvent &event);
@@ -253,10 +279,24 @@ private:
 	void OnViewClientInfo(wxCommandEvent &event);
 
 	// Misc event-handlers
-	void OnItemActivated(wxListEvent &event);
-	void OnMouseRightClick(wxListEvent &event);
-	void OnMouseMiddleClick(wxListEvent &event);
-	void OnKeyPressed(wxKeyEvent &event);
+	void OnItemActivated(wxDataViewEvent &event);
+	void OnItemRightClicked(wxDataViewEvent &event);
+	/**
+	 * Shows the client detail dialog for the row under the pointer.
+	 * wxDataViewCtrl has no dedicated middle-click item event, unlike
+	 * wxListCtrl's EVT_LIST_ITEM_MIDDLE_CLICK, so this is a raw mouse event
+	 * resolved through HitTest() -- see CDownloadListCtrl::OnItemActivated
+	 * for why an event's item is resolved rather than read off the
+	 * selection.
+	 */
+	void OnMouseMiddleClick(wxMouseEvent &event);
+
+	/**
+	 * The item the context menu was built for, by identity rather than row —
+	 * see the identical field on CDownloadListCtrl for why (PopupMenu runs a
+	 * nested event loop, so a row index would not survive it).
+	 */
+	wxUIntPtr m_menuItem = 0;
 
 	//! The type of list used to store items on the listctrl. We use the unique ECID as key.
 	typedef std::multimap<uint32, ClientCtrlItem_Struct *> ListItems;
@@ -271,10 +311,6 @@ private:
 
 	//! Pointer to the current menu object, used to avoid multiple menus.
 	wxMenu *m_menu;
-	//! Cached brush object.
-	wxBrush m_highlightBrush;
-	//! Cached brush object.
-	wxBrush m_highlightUnfocusBrush;
 
 	//! The number of displayed sources
 	int m_clientcount;

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -105,6 +105,20 @@ public:
 	wxUIntPtr ItemAt(long row) const;
 	long ItemDataCount() const { return static_cast<long>(m_items.size()); }
 
+	/**
+	 * Resolves a wxDataViewItem from an event (e.g. an activation or
+	 * context-menu event) back to its row, through the
+	 * wxDataViewIndexListModel AssociateVirtualModel() installed.
+	 *
+	 * A wxDataViewItem's ID *is* the row number for this model, but that
+	 * detail is model-internal; going through GetRow() rather than casting
+	 * the ID directly is what stays correct if that ever changes.
+	 */
+	long GetModelRow(const wxDataViewItem &item) const
+	{
+		return static_cast<long>(static_cast<const wxDataViewListModel *>(GetModel())->GetRow(item));
+	}
+
 	//! Cheap "is anything selected" test, avoiding a full selection copy.
 	bool HasSelection() const
 	{

--- a/src/SharedFilePeersListCtrl.cpp
+++ b/src/SharedFilePeersListCtrl.cpp
@@ -24,8 +24,9 @@
 #include "SharedFilePeersListCtrl.h"
 #include "KnownFile.h" // Do_not_auto_remove
 
-static CGenericClientListCtrlColumn s_sources_column_info[] = {
-	{ ColumnUserName, wxTRANSLATE("User Name"), 260 },
+namespace
+{
+CGenericClientListCtrlColumn s_sources_column_info[] = { { ColumnUserName, wxTRANSLATE("User Name"), 260 },
 	{ ColumnUserDownloaded, wxTRANSLATE("Downloaded"), 65 },
 	{ ColumnUserSpeedDown, wxTRANSLATE("Download Speed"), 65 },
 	{ ColumnUserUploaded, wxTRANSLATE("Uploaded"), 65 },
@@ -36,24 +37,17 @@ static CGenericClientListCtrlColumn s_sources_column_info[] = {
 	{ ColumnUserQueueRankRemote, wxTRANSLATE("Download Status"), 70 },
 	{ ColumnUserOrigin, wxTRANSLATE("Origin"), 110 },
 	{ ColumnUserFileNameUpload, wxTRANSLATE("Local File Name"), 200 },
-	{ ColumnUserSharedFiles, wxTRANSLATE("Shares File List"), 100 }
-};
-
-wxBEGIN_EVENT_TABLE(CSharedFilePeersListCtrl, CGenericClientListCtrl)
-wxEND_EVENT_TABLE()
+	{ ColumnUserSharedFiles, wxTRANSLATE("Shares File List"), 100 } };
+} // namespace
 
 CSharedFilePeersListCtrl::CSharedFilePeersListCtrl(wxWindow *parent,
 	wxWindowID winid,
 	const wxPoint &pos,
 	const wxSize &size,
 	long style,
-	const wxValidator &validator,
 	const wxString &name)
-: CGenericClientListCtrl("Peers", parent, winid, pos, size, style | wxLC_OWNERDRAW, validator, name)
+: CGenericClientListCtrl("Peers", parent, winid, pos, size, style, name)
 {
-	// Setting the sorter function.
-	SetSortFunc(SourceSortProc);
-
 	m_columndata.n_columns = sizeof(s_sources_column_info) / sizeof(CGenericClientListCtrlColumn);
 	m_columndata.columns = s_sources_column_info;
 
@@ -61,14 +55,6 @@ CSharedFilePeersListCtrl::CSharedFilePeersListCtrl(wxWindow *parent,
 }
 
 CSharedFilePeersListCtrl::~CSharedFilePeersListCtrl() {}
-
-int CSharedFilePeersListCtrl::SourceSortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
-{
-	return CGenericClientListCtrl::SortProc(param1,
-		param2,
-		s_sources_column_info[sortData & CMuleListCtrl::COLUMN_MASK].cid |
-			(sortData & CMuleListCtrl::SORT_DES));
-}
 
 void CSharedFilePeersListCtrl::SetShowSources(CKnownFile *f, bool b) const
 {

--- a/src/SharedFilePeersListCtrl.h
+++ b/src/SharedFilePeersListCtrl.h
@@ -39,11 +39,10 @@ public:
 	 * @see CGenericClientListCtrl::CGenericClientListCtrl for documentation of parameters.
 	 */
 	CSharedFilePeersListCtrl(wxWindow *parent,
-		wxWindowID winid = -1,
+		wxWindowID winid = wxID_ANY,
 		const wxPoint &pos = wxDefaultPosition,
 		const wxSize &size = wxDefaultSize,
-		long style = wxLC_ICON,
-		const wxValidator &validator = wxDefaultValidator,
+		long style = 0,
 		const wxString &name = "peerslistctrl");
 
 	/**
@@ -52,15 +51,12 @@ public:
 	virtual ~CSharedFilePeersListCtrl();
 
 private:
-	virtual CamuleDlg::DialogType GetParentDialog() { return CamuleDlg::DT_SHARED_WND; }
+	CamuleDlg::DialogType GetParentDialog() override { return CamuleDlg::DT_SHARED_WND; }
 
-	virtual void SetShowSources(CKnownFile *f, bool b) const;
+	void SetShowSources(CKnownFile *f, bool b) const override;
 
-	static int wxCALLBACK SourceSortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
-
-	bool IsShowingDownloadSources() const { return false; }
-
-	wxDECLARE_EVENT_TABLE();
+	bool IsShowingDownloadSources() const override { return false; }
 };
 
 #endif
+// File_checked_for_headers

--- a/src/SourceListCtrl.cpp
+++ b/src/SourceListCtrl.cpp
@@ -22,8 +22,17 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 #include "SourceListCtrl.h"
-#include "KnownFile.h"
 
+#include <common/Format.h> // Needed for CFormat
+
+#include "ClientRef.h" // Needed for CClientRef
+#include "KnownFile.h"
+#include "MuleBarRenderer.h" // Needed for CMuleBarRenderer, CBarFillSpec
+#include "PartFile.h"        // Needed for CPartFile
+#include "Preferences.h"     // Needed for thePrefs::ShowProgBar()
+
+namespace
+{
 static CGenericClientListCtrlColumn s_sources_column_info[] = {
 	{ ColumnUserName, wxTRANSLATE("User Name"), 260 },
 	{ ColumnUserDownloaded, wxTRANSLATE("Downloaded"), 65 },
@@ -38,21 +47,80 @@ static CGenericClientListCtrlColumn s_sources_column_info[] = {
 	{ ColumnUserSharedFiles, wxTRANSLATE("Shares File List"), 100 }
 };
 
-wxBEGIN_EVENT_TABLE(CSourceListCtrl, CGenericClientListCtrl)
-wxEND_EVENT_TABLE()
+/**
+ * Renders ColumnUserProgress: a client's per-part chunk bar (5 states: no
+ * part / have-complete / downloading / next-requested / have-but-need), or,
+ * for an A4AF row, a bordered "A4AF: <filename>" text badge instead of a bar
+ * -- a real per-row renderer branch (not a bar overlay), replacing
+ * DrawSourceStatusBar's A4AF case (GenericClientListCtrl.cpp, pre-port)
+ * exactly, including its own themed border (own SetPen, not the base's black
+ * one -- the base's Render() is not called for this branch at all).
+ */
+class CSourceBarRenderer : public CMuleBarRenderer
+{
+public:
+	bool Render(wxRect cell, wxDC *dc, int state) override
+	{
+		// Gates the whole cell -- bar and A4AF badge alike -- exactly as the
+		// pre-port ColumnUserProgress case did.
+		if (!thePrefs::ShowProgBar()) {
+			return true;
+		}
+		ClientCtrlItem_Struct *item =
+			reinterpret_cast<ClientCtrlItem_Struct *>(GetSpec().GetIdentity());
+		if (!item) {
+			return true;
+		}
+		if (item->GetType() == A4AF_SOURCE) {
+			DrawA4AFBadge(cell, dc, item);
+			return true;
+		}
+		return CMuleBarRenderer::Render(cell, dc, state);
+	}
+
+private:
+	static void DrawA4AFBadge(wxRect cell, wxDC *dc, ClientCtrlItem_Struct *item)
+	{
+		const int iWidth = cell.GetWidth() - 2;
+		const int iHeight = cell.GetHeight() - 2;
+		if (iWidth <= 0 || iHeight <= 0) {
+			return;
+		}
+		wxDCClipper clipper(*dc, cell.GetX(), cell.GetY() + 1, iWidth, iHeight);
+
+		CPartFile *p = item->GetSource().GetRequestFile();
+		const wxString a4af = p ? p->GetFileName().GetPrintable() : wxString("?");
+		const wxString buffer = CFormat("%s: %s") % _("A4AF") % a4af;
+
+		const int mid_x = (2 * cell.GetX() + cell.GetWidth()) >> 1;
+		const int mid_y = (2 * cell.GetY() + cell.GetHeight()) >> 1;
+		wxCoord txtwidth;
+		wxCoord txtheight;
+		dc->GetTextExtent(buffer, &txtwidth, &txtheight);
+
+		// Theme-aware text + border colour (was *wxBLACK / *wxBLACK_PEN,
+		// invisible on dark themes -- the badge sits on the row stripe, not
+		// on a known light background).
+		const wxColour badgeColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+		dc->SetTextForeground(badgeColour);
+		dc->DrawText(
+			buffer, wxMax(cell.GetX() + 2, mid_x - (txtwidth >> 1)), mid_y - (txtheight >> 1));
+
+		dc->SetPen(wxPen(badgeColour));
+		dc->SetBrush(*wxTRANSPARENT_BRUSH);
+		dc->DrawRectangle(cell.GetX(), cell.GetY() + 1, iWidth, iHeight);
+	}
+};
+} // namespace
 
 CSourceListCtrl::CSourceListCtrl(wxWindow *parent,
 	wxWindowID winid,
 	const wxPoint &pos,
 	const wxSize &size,
 	long style,
-	const wxValidator &validator,
 	const wxString &name)
-: CGenericClientListCtrl("Sources", parent, winid, pos, size, style | wxLC_OWNERDRAW, validator, name)
+: CGenericClientListCtrl("Sources", parent, winid, pos, size, style, name)
 {
-	// Setting the sorter function.
-	SetSortFunc(SourceSortProc);
-
 	m_columndata.n_columns = sizeof(s_sources_column_info) / sizeof(CGenericClientListCtrlColumn);
 	m_columndata.columns = s_sources_column_info;
 
@@ -61,12 +129,9 @@ CSourceListCtrl::CSourceListCtrl(wxWindow *parent,
 
 CSourceListCtrl::~CSourceListCtrl() {}
 
-int CSourceListCtrl::SourceSortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
+CMuleBarRenderer *CSourceListCtrl::CreateProgressBarRenderer() const
 {
-	return CGenericClientListCtrl::SortProc(param1,
-		param2,
-		s_sources_column_info[sortData & CMuleListCtrl::COLUMN_MASK].cid |
-			(sortData & CMuleListCtrl::SORT_DES));
+	return new CSourceBarRenderer();
 }
 
 void CSourceListCtrl::SetShowSources(CKnownFile *f, bool b) const

--- a/src/SourceListCtrl.h
+++ b/src/SourceListCtrl.h
@@ -29,7 +29,6 @@
 
 /**
  * This class is responsible for representing the sources for a file.
-
  */
 class CSourceListCtrl : public CGenericClientListCtrl
 {
@@ -40,11 +39,10 @@ public:
 	 * @see CGenericClientListCtrl::CGenericClientListCtrl for documentation of parameters.
 	 */
 	CSourceListCtrl(wxWindow *parent,
-		wxWindowID winid = -1,
+		wxWindowID winid = wxID_ANY,
 		const wxPoint &pos = wxDefaultPosition,
 		const wxSize &size = wxDefaultSize,
-		long style = wxLC_ICON,
-		const wxValidator &validator = wxDefaultValidator,
+		long style = 0,
 		const wxString &name = "sourcelistctrl");
 
 	/**
@@ -53,15 +51,13 @@ public:
 	virtual ~CSourceListCtrl();
 
 private:
-	virtual CamuleDlg::DialogType GetParentDialog() { return CamuleDlg::DT_TRANSFER_WND; }
+	CamuleDlg::DialogType GetParentDialog() override { return CamuleDlg::DT_TRANSFER_WND; }
 
-	virtual void SetShowSources(CKnownFile *f, bool b) const;
+	void SetShowSources(CKnownFile *f, bool b) const override;
 
-	static int wxCALLBACK SourceSortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
+	CMuleBarRenderer *CreateProgressBarRenderer() const override;
 
-	bool IsShowingDownloadSources() const { return true; }
-
-	wxDECLARE_EVENT_TABLE();
+	bool IsShowingDownloadSources() const override { return true; }
 };
 
 #endif

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -62,6 +62,7 @@
 
 // Custom source
 #include <common/Format.h> // Needed for CFormat (SetConnectButtonState)
+#include "MuleListCtrl.h" // Needed for CMuleListCtrl (commentLstDlg)
 #include "ServerListCtrl.h"
 #include "DownloadListCtrl.h"
 #include "SourceListCtrl.h"
@@ -473,7 +474,7 @@ wxSizer *transferBottomPane( wxWindow *parent, bool call_fit, bool set_sizer )
     item1->Add( item5a, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
 
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical() );
-    CSourceListCtrl *item6 = new CSourceListCtrl( parent, ID_CLIENTLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
+    CSourceListCtrl *item6 = new CSourceListCtrl( parent, ID_CLIENTLIST, wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item6, wxSizerFlags(1).Expand() );
 
     if (set_sizer)
@@ -3377,7 +3378,7 @@ wxSizer *sharedfilesBottomDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item0->Add( item2, wxSizerFlags().Expand().CenterVertical() );
     wxStaticLine *item17 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add( item17, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    CSharedFilePeersListCtrl *item18 = new CSharedFilePeersListCtrl( parent, ID_SHAREDCLIENTLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
+    CSharedFilePeersListCtrl *item18 = new CSharedFilePeersListCtrl( parent, ID_SHAREDCLIENTLIST, wxDefaultPosition, wxDefaultSize, 0 );
     item18->SetName( "sharedFilesSrcCt" );
     item0->Add( item18, wxSizerFlags(1).Expand().CenterVertical() );
     if (set_sizer)


### PR DESCRIPTION
Last remaining piece of #801's `wxListCtrl` → `wxDataViewCtrl` migration: the shared base feeding `CSourceListCtrl` (download sources) and `CSharedFilePeersListCtrl` (shared-file peers).

## Design notes

Unlike every prior port, `ClientCtrlItem_Struct` survives rather than being deleted: it's not a cache-avoidance wrapper, it's structurally required — one client (ECID) can be a source/peer of more than one file at once, so row identity has to be the `(client, owner, type)` tuple. Its `dwUpdated`/`status` fields (a 10s-TTL cached `wxBitmap*`) are dropped, matching the no-cache precedent from the Shared Files and Downloads ports — `DrawStatusBar`'s `ColumnUserAvailable` path already shipped fully uncached.

**Two bar columns, two renderers:**
- `ColumnUserProgress` (Sources only): `CSourceBarRenderer` draws the 5-state chunk bar via the base `CMuleBarRenderer`, except for A4AF rows, which get a bordered "A4AF: \<filename\>" text badge instead of a bar entirely — a real per-row renderer branch, not an overlay.
- `ColumnUserAvailable` (Peers only): the plain base renderer is enough (2-state, no per-row branching). It has no `Compare()` case, matching pre-port behaviour where it was never sortable, so it's registered without `wxDATAVIEW_COL_SORTABLE` rather than showing a caret that does nothing.

**The User Name column** is a composite icon-cluster (status/software/credits/ext-protocol/identified/badguy/encryption badges) plus an optional country flag plus text — no single-icon `AddIconTextColumn()` cell can carry that. `CClientNameRenderer` reuses `CMuleBarRenderer`'s identity-carrying `CBarFillSpec`/`GetItemBarFill()` extension point to reach the row's `ClientCtrlItem_Struct` and replay the whole cluster, the same mechanism `CDownloadBarRenderer` uses for its `CPartFile*` overlay — registered via `AddBarColumn()` since it isn't a literal bar. `GetItemColumnText()` still answers the plain username for this column, so type-ahead and the accessible row label (the actual point of #180) work off real text rather than the pre-port `GetTTSText()`'s hardcoded `""`.

`CompareItemData()` replicates the original `SortProc`'s type-precedence pre-check (A4AF sources always sort last, direction-independent, not just per selected column) before dispatching to the per-column comparison.

Also: `CMuleVirtualDataViewCtrl` gains a `GetModelRow()` helper (wraps the `wxDataViewIndexListModel::GetRow()` cast); `CDownloadListCtrl`'s two hand-rolled instances of the same cast now use it. `muuli_wdr.cpp`'s two construction sites for these lists drop the legacy `wxLC_REPORT|wxSUNKEN_BORDER` flags (`wxLC_REPORT` aliases `wxDV_VARIABLE_LINE_HEIGHT`), matching every other ported list.

## Verification

- `amule` and `amulegui` build clean from a fresh CMake configure (wx 3.3.3)
- Pinned clang-format v18 clean
- Tier-1/Tier-2 clang-tidy clean via the local CI replica (wx 3.2.4) — the only Tier-1 hits are 13 pre-existing, unrelated warnings in `unittests/tests/`
- Grepped for every orphaned pre-port symbol (`DrawClientItem`, `DrawSourceStatusBar`, `DrawStatusBar`, `SortProc`, `dwUpdated`/`status`) and confirmed every external caller (`TransferWnd.cpp`, `SharedFilesWnd.cpp`, `GuiEvents.cpp`, `amuleDlg.cpp`) still compiles unchanged against the same public API (`AddSource`/`RemoveSource`/`ShowSources`/`UpdateItem`/`SetShowing`/`RemoveKnownFile`)
- Manually tested against a live daemon: Name column icon cluster + flag + username render correctly aligned, "Parti disponibili" bar shows plausible green/black/yellow chunk states, Version/Download Status/Origin columns populate

No translatable strings were added or changed, so po/ catalogs are not regenerated.