### PR TITLE
refactor(gui): drop the macOS spacer column from the dataview lists

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -210,7 +210,6 @@ CDownloadListCtrl::CDownloadListCtrl(wxWindow *parent,
 	AddTextColumn(_("Last Seen Complete"), COLUMN_DL_LASTSEENCOMPLETE, "c", 220, wxALIGN_LEFT, flags);
 	AddTextColumn(_("Last Reception"), COLUMN_DL_LASTRECEPTION, "R", 220, wxALIGN_LEFT, flags);
 
-	AppendSpacerColumn(COLUMN_DL_SPACER);
 	AssociateVirtualModel();
 
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -43,9 +43,6 @@
 #define COLUMN_DL_TIMEREMAINING 10
 #define COLUMN_DL_LASTSEENCOMPLETE 11
 #define COLUMN_DL_LASTRECEPTION 12
-//! Always empty. Absorbs the macOS trailing-column sizing; see
-//! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_DL_SPACER 13
 
 class CPartFile;
 class wxMenu;

--- a/src/FileDetailListCtrl.cpp
+++ b/src/FileDetailListCtrl.cpp
@@ -41,7 +41,6 @@ CFileDetailListCtrl::CFileDetailListCtrl(wxWindow *&parent, int id, const wxPoin
 	AddTextColumn(_("File Name"), COLUMN_FILEDETAIL_NAME, "N", 370, wxALIGN_LEFT, columnFlags);
 	AddTextColumn(_("Sources"), COLUMN_FILEDETAIL_SOURCES, "S", 70, wxALIGN_LEFT, columnFlags);
 
-	AppendSpacerColumn(COLUMN_FILEDETAIL_SPACER);
 	AssociateVirtualModel();
 
 	// Initial sorting: Sources descending, matching the pre-port default.

--- a/src/FileDetailListCtrl.h
+++ b/src/FileDetailListCtrl.h
@@ -30,9 +30,6 @@
 
 #define COLUMN_FILEDETAIL_NAME 0
 #define COLUMN_FILEDETAIL_SOURCES 1
-//! Always empty. Absorbs the macOS trailing-column sizing; see
-//! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_FILEDETAIL_SPACER 2
 
 class SourcenameItem;
 

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -65,7 +65,6 @@ CFriendListCtrl::CFriendListCtrl(wxWindow *parent, int id, const wxPoint &pos, w
 
 	// Absorbs the macOS trailing-column sizing; the model answers any column
 	// past the real one with an empty value.
-	AppendSpacerColumn(COLUMN_FRIEND_SPACER);
 	AssociateVirtualModel();
 
 	// One-letter name so CListColumnStore has something to write under

--- a/src/FriendListCtrl.h
+++ b/src/FriendListCtrl.h
@@ -30,9 +30,6 @@
 #include "MD4Hash.h"
 
 #define COLUMN_FRIEND_NAME 0
-//! Always empty. Absorbs the macOS trailing-column sizing; see
-//! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_FRIEND_SPACER 1
 
 class wxString;
 class CFriend;

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -76,28 +76,13 @@ int CMuleDataViewCtrl::ColumnWidthAdapter::GetColumnWidth(int col) const
 	if (width > 0) {
 		return width;
 	}
-	// A visible column should never report zero -- the spacer appended on
-	// macOS exists so the trailing-column sizing lands there instead. This
-	// is the backstop if it ever does anyway: CListColumnStore reads a width
-	// <= 0 as hidden and persists it negative, so a stray zero would hide a
-	// real column on the next launch, then do the same to whichever column
-	// became last, losing one per restart.
+	// A visible column should never report zero, but this is the backstop if
+	// one ever does: CListColumnStore reads a width <= 0 as hidden and
+	// persists it negative, so a stray zero would hide a real column on the
+	// next launch, then do the same to whichever column became last, losing
+	// one per restart.
 	const int cached = m_ctrl->m_columnStore.GetCachedWidth(col);
 	return (cached > 0) ? cached : m_ctrl->m_columnStore.GetColumnDefaultWidth(col);
-}
-
-void CMuleDataViewCtrl::AppendSpacerColumn(unsigned modelColumn)
-{
-#ifdef __WXOSX__
-	// Resizable is load-bearing: macOS hands the leftover space to the last
-	// *resizable* column, so a fixed spacer cannot shrink and the collapse
-	// falls through to the last real column instead.
-	AppendTextColumn(
-		wxEmptyString, modelColumn, wxDATAVIEW_CELL_INERT, 1, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
-	m_hasSpacer = true;
-#else
-	(void)modelColumn;
-#endif
 }
 
 void CMuleDataViewCtrl::AppendBarColumn(
@@ -150,11 +135,7 @@ void CMuleDataViewCtrl::AddBarColumn(const wxString &label,
 
 unsigned CMuleDataViewCtrl::RealColumnCount() const
 {
-	const unsigned columns = GetColumnCount();
-	if (m_hasSpacer && columns > 0) {
-		return columns - 1;
-	}
-	return columns;
+	return GetColumnCount();
 }
 
 void CMuleDataViewCtrl::InitColumnState()

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -86,11 +86,8 @@ public:
 	//! Hide or show a column; width is the one to restore when showing.
 	void SetColumnHidden(int col, bool hidden, int width);
 
-	/**
-	 * Columns the user owns, excluding the macOS spacer (see the
-	 * constructor), which must stay out of the header menu, the persisted
-	 * widths and any cross-list synchronisation.
-	 */
+	//! Number of columns; the header menu, persisted widths and any
+	//! cross-list synchronisation are all keyed by this.
 	unsigned RealColumnCount() const;
 
 protected:
@@ -182,18 +179,6 @@ protected:
 
 	//! Keeps the expander on the leftmost visible column.
 	void UpdateExpanderColumn();
-
-	/**
-	 * Appends the trailing spacer column on macOS.
-	 *
-	 * Must be called by the subclass after its own columns are appended and
-	 * before LoadColumnSettings(): macOS sizes the last *resizable* column
-	 * to the leftover space, collapsing it to nothing once the columns are
-	 * wider than the control, so a spacer takes that role instead of a
-	 * column the user cares about. `modelColumn` is an always-empty column
-	 * the subclass' model must answer for.
-	 */
-	void AppendSpacerColumn(unsigned modelColumn);
 
 	/**
 	 * Appends a column rendered by a CMuleBarRenderer (a CBarShader chunk
@@ -318,9 +303,6 @@ private:
 
 	//! Last-seen widths, for detecting a drag-resize (no portable event).
 	std::vector<int> m_lastKnownWidths;
-
-	//! True once AppendSpacerColumn() has run (macOS only).
-	bool m_hasSpacer = false;
 
 	// Type-ahead state.
 	wxString m_ttsText;

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -74,8 +74,7 @@ public:
 		const bool iconText = (type == "wxDataViewIconText");
 		const bool barFill = (type == "CBarFillSpec");
 		if (row >= m_owner->m_items.size() || col >= m_owner->RealColumnCount()) {
-			// Out of range, or the trailing spacer column, which is always
-			// empty by construction.
+			// Out of range.
 			if (iconText) {
 				variant << wxDataViewIconText(wxEmptyString, wxIcon());
 			} else if (barFill) {

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -171,10 +171,6 @@ CSearchListCtrl::CSearchListCtrl(
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 
-	// Absorbs the macOS trailing-column sizing; the model answers COL_SPACER
-	// with an empty string.
-	AppendSpacerColumn(CSearchListModel::COL_SPACER);
-
 	// Default sort is by name, ascending.
 	m_sort_orders.emplace_back(CSearchListModel::COL_NAME, 0);
 	GetColumn(CSearchListModel::COL_NAME)->SetSortOrder(true);

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -325,8 +325,8 @@ protected:
 	//! Keeps the group expander on the leftmost visible column.
 
 	/**
-	 * Columns the user owns, excluding the macOS spacer, which must stay
-	 * out of the header menu, the persisted widths and the cross-tab sync.
+	 * Columns the user owns -- the header menu, the persisted widths and
+	 * the cross-tab sync are all keyed by this.
 	 */
 
 public:

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -103,12 +103,6 @@ public:
 		COL_BITRATE,
 		COL_CODEC,
 		COL_DIRECTORY,
-		//! Always empty. macOS sizes the trailing column to the leftover
-		//! space, collapsing it to nothing once the columns are wider than
-		//! the control; a spacer at the end takes that role so no real
-		//! column is ever the one that disappears. Only appended there --
-		//! GTK and MSW lay the columns out without it.
-		COL_SPACER,
 		COL_COUNT
 	};
 

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -115,7 +115,6 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 
 	// Absorbs the macOS trailing-column sizing; the model answers any column
 	// past the real ones with an empty value.
-	AppendSpacerColumn(COLUMN_SERVER_SPACER);
 	AssociateVirtualModel();
 
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it

--- a/src/ServerListCtrl.h
+++ b/src/ServerListCtrl.h
@@ -56,9 +56,6 @@
 #define COLUMN_SERVER_HARDFILES 13
 #define COLUMN_SERVER_TCPFLAGS 14
 #define COLUMN_SERVER_UDPFLAGS 15
-//! Always empty. Absorbs the macOS trailing-column sizing; see
-//! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_SERVER_SPACER 16
 
 class CServer;
 class CServerList;

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -117,8 +117,6 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	AddTextColumn(_("Last upload"), COLUMN_SHARED_LASTUP, "L", 130, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Directory Path"), COLUMN_SHARED_PATH, "D", 430, wxALIGN_LEFT, colFlags);
 
-	AppendSpacerColumn(COLUMN_SHARED_SPACER);
-
 	AssociateVirtualModel();
 
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -42,9 +42,6 @@
 #define COLUMN_SHARED_SINCE 11
 #define COLUMN_SHARED_LASTUP 12
 #define COLUMN_SHARED_PATH 13
-//! Always empty. Absorbs the macOS trailing-column sizing; see
-//! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_SHARED_SPACER 14
 
 class CSharedFileList;
 class CKnownFile;


### PR DESCRIPTION
Every ported list appended a 1px trailing spacer on macOS. The reasoning was that macOS hands leftover width to the last *resizable* column and collapses it to nothing once the columns are wider than the control, so a throwaway column should absorb that instead of one the user cares about.

## Why it looks unnecessary now

`CGenericClientListCtrl` (#850) shipped without a spacer and doesn't collapse, which prompted checking the rest.

The spacer dates from the first base commit, when every list was still constructed with the legacy `wxLC_REPORT|wxSUNKEN_BORDER` flags — and `wxLC_REPORT` is the same bit as `wxDV_VARIABLE_LINE_HEIGHT`, so those lists were silently running with variable line height. Those flags came off in `71bdb1a` and #849, and with them gone a spacer-less build shows no collapse.

So the spacer appears to have been treating a symptom of the flags rather than a macOS sizing rule.

## What goes

The six call sites, `AppendSpacerColumn()`, `m_hasSpacer`, `RealColumnCount()`'s adjustment, and five `COLUMN_*_SPACER` ids plus `CSearchListModel::COL_SPACER` — each of which every model had to answer for.

`RealColumnCount()` stays as the accessor, now simply `GetColumnCount()`. Inlining it across its ~18 call sites is a separate change.

## Testing

macOS Debug, `amule` + `amulegui`, 34/34 tests, clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Visual check on macOS across the ported lists. The specific thing to watch when reviewing: narrow a list until its columns are wider than the control and confirm the **last** column doesn't collapse — that is the behaviour the spacer existed to prevent. Sources and Peers are the panes most often narrow; Search additionally syncs columns across tabs.

The spacer was `#ifdef __WXOSX__`, so GTK and MSW never had one and removal is a no-op there.
