### PR TITLE
fix(gui): give the clients list the macOS spacer column, and assert on it

### DIFF
--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -375,6 +375,12 @@ void CGenericClientListCtrl::InitColumnData()
 		}
 	}
 
+	// Absorbs the macOS trailing-column sizing, which would otherwise fall on
+	// the last real column and collapse it once the columns are wider than the
+	// control. n_columns is the id to use: the model answers every column past
+	// its own table with an empty value already.
+	AppendSpacerColumn(m_columndata.n_columns);
+
 	AssociateVirtualModel();
 	ApplySorting(0, 0);
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -172,6 +172,15 @@ void CMuleDataViewCtrl::InitColumnState()
 			"column ids must be declared in the order the columns are appended");
 	}
 
+#ifdef __WXOSX__
+	// Forgetting the spacer costs the last column: macOS gives the leftover
+	// width to the last *resizable* one, which collapses it to nothing as soon
+	// as the columns outgrow the control. Nothing about that is visible until
+	// somebody narrows the list far enough, which is how the clients list
+	// shipped without one -- so fail loudly here instead.
+	wxASSERT_MSG(m_hasSpacer, "every list must AppendSpacerColumn() before InitColumnState()");
+#endif
+
 	m_columnHidden.resize(RealColumnCount(), false);
 	m_lastKnownWidths.clear();
 	for (unsigned i = 0; i < RealColumnCount(); ++i) {


### PR DESCRIPTION
Two commits: the missing spacer on the clients list, and an assert so the next list cannot forget it.

## The clients list had no spacer

`CGenericClientListCtrl` is the only list ported to `wxDataViewCtrl` that never got one. macOS hands leftover width to the last *resizable* column, so once the columns are wider than the control that column collapses to nothing. For Sources and Peers that is "Shares File List", and both panes sit in splitters that are routinely narrow.

One line: `AppendSpacerColumn(m_columndata.n_columns)`. That id needs no further handling — `GetItemColumnText()`, `GetItemBarFill()` and `CompareItemData()` all already guard `column >= n_columns`.

## Why the spacer is kept rather than removed

The obvious alternative was to drop the mechanism from all seven lists, on the theory that it was a workaround for the legacy `wxLC_REPORT|wxSUNKEN_BORDER` flags — `wxLC_REPORT` being the same bit as `wxDV_VARIABLE_LINE_HEIGHT` — which came off in `71bdb1a` and #849.

A spacer-less build was tried and the collapse still reproduces, so that theory is wrong. The file-details list looked immune only because its two columns (370 + 70) do not overflow its dialog at their default widths, and columns are user-resizable, so that is a property of the defaults rather than of the list. #851 has the details.

## The assert

Forgetting the spacer is invisible until somebody narrows a list far enough, which is how the clients list shipped without one. `InitColumnState()` is the single hook every list reaches unconditionally, so the check goes there, beside the existing column-id assert — both being failures that look like rendering bugs rather than programming errors.

Appending the spacer from the base instead was considered and does not work: it has to happen after the subclass' columns and before `LoadColumnSettings()`, and `CSearchListCtrl` calls `LoadColumnSettings()` only for its first tab, so every later tab would silently lose its spacer. `CSearchListCtrl` also derives from `CMuleDataViewCtrl` directly rather than through `CMuleVirtualDataViewCtrl`; `InitColumnState()` is common to both, so one assert covers all seven lists.

## Testing

macOS Debug, `amule` + `amulegui`. Narrowing Sources and Peers until the columns overflow no longer collapses the last column. Every list opened once with the assert live — Downloads, Sources, Servers, Search including a second tab, Shared Files, Peers, Friends and the file-details dialog — with no assert raised. clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Both the spacer and the assert are `__WXOSX__`-only, so GTK and MSW are unaffected.
