### PR TITLE
feat(gui): amuleGUI remote-to-local path mappings (#843)

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4164,6 +4164,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
@@ -5542,6 +5566,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5560,6 +5588,10 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
@@ -6030,6 +6062,26 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -4213,6 +4213,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "رسم بياني"
 
@@ -5615,6 +5639,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5634,6 +5662,10 @@ msgstr "اتصال"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "مجلدات"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6118,6 +6150,27 @@ msgstr ""
 #, fuzzy
 msgid "Shared folder"
 msgstr "ملفات مشاركة"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "احذف صديق"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -4282,6 +4282,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Sirvidor remotu"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Sirvidor llocal"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
@@ -5698,6 +5724,11 @@ msgid "no options available"
 msgstr "opciones non disponibles"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Categoría inválida alcontrada, saltando"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida alcontrada, saltando"
 
@@ -5717,6 +5748,10 @@ msgstr "Conexón"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direutorios"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6229,6 +6264,29 @@ msgstr "Recargar llista de ficheros compartíos."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartíes"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Sirvidor remotu"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Sirvidor llocal"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Escueye una carpeta pa %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -4205,6 +4205,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Диаграми"
 
@@ -5596,6 +5620,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5615,6 +5643,10 @@ msgstr "Връзка"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Директории"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6094,6 +6126,27 @@ msgstr ""
 #, fuzzy
 msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Изтриване на приятел"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4163,6 +4163,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
@@ -5541,6 +5565,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5559,6 +5587,10 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
@@ -6029,6 +6061,26 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -4270,6 +4270,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Servidor remot"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Servidor local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gràfics"
 
@@ -5673,6 +5699,11 @@ msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Categoria invàlida trobada, omitint"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoria invàlida trobada, omitint"
 
@@ -5692,6 +5723,10 @@ msgstr "Connexió"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directoris"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6203,6 +6238,29 @@ msgstr "Recarrega la llista de fitxers compartits."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Carpetes compartides"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Servidor remot"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Servidor local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Carpeta per a %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -4267,6 +4267,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Vzdálený server"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Lokální server"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafy"
 
@@ -5680,6 +5706,11 @@ msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Nalezena neplatná kategorie, přeskakuji"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Nalezena neplatná kategorie, přeskakuji"
 
@@ -5699,6 +5730,10 @@ msgstr "Připojení"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Adresáře"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6208,6 +6243,29 @@ msgstr "Znovu načte seznam sdílených souborů."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Sdílené adresáře"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Vzdálený server"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Lokální server"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Zvolte adresář pro %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4226,6 +4226,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafer"
 
@@ -5631,6 +5655,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5650,6 +5678,10 @@ msgstr "Forbindelse"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mapper"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6136,6 +6168,27 @@ msgstr ""
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte Filer"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Fjern Ven"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -4270,6 +4270,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Entfernter Server"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Lokaler Server"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Graphen"
 
@@ -5668,6 +5694,11 @@ msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Ungültige Kategorie gefunden, überspringe."
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Ungültige Kategorie gefunden, überspringe."
 
@@ -5687,6 +5718,10 @@ msgstr "Verbindung"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Verzeichnisse"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6199,6 +6234,29 @@ msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 #, fuzzy
 msgid "Shared folder"
 msgstr "Freigegebene Ordner"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Entfernter Server"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Lokaler Server"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Wähle einen Ordner für %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -4293,6 +4293,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Απομακρυσμένος διακομιστής"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Τοπικός διακομιστής"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Γραφικές Παραστάσεις"
 
@@ -5711,6 +5737,10 @@ msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5730,6 +5760,10 @@ msgstr "Σύνδεση"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Κατάλογοι Αρχείων"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6243,6 +6277,29 @@ msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρ
 #, fuzzy
 msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Απομακρυσμένος διακομιστής"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Τοπικός διακομιστής"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Επιλέξτε κατάλογο για %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4164,6 +4164,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
@@ -5542,6 +5566,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5560,6 +5588,10 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
@@ -6030,6 +6062,26 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -4260,6 +4260,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Servidor remoto"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Servidor local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
@@ -5663,6 +5689,11 @@ msgid "no options available"
 msgstr "no hay opciones disponibles"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Categoría inválida encontrada, se omite"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida encontrada, se omite"
 
@@ -5682,6 +5713,10 @@ msgstr "Conexión"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directorios"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6184,6 +6219,29 @@ msgstr "Recargando archivos compartidos: %u archivos escaneados"
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Carpeta compartida"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Servidor remoto"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Servidor local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Elija una carpeta para %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -4271,6 +4271,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Kaug server"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Kohalik server"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Graafikud"
 
@@ -5675,6 +5701,11 @@ msgid "no options available"
 msgstr "valikud puuduvad"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Leidsin vigase kategooria, ignoreerin"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Leidsin vigase kategooria, ignoreerin"
 
@@ -5694,6 +5725,10 @@ msgstr "Ühendus"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Kataloogid"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6206,6 +6241,29 @@ msgstr "Jagatud failide loetelu taaslaadimine."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jagatud kataloogid"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Kaug server"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Kohalik server"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Vali %s kataloog"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -4272,6 +4272,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Urruneko zerbitzaria"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Zerbitzari lokala"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikak"
 
@@ -5674,6 +5700,11 @@ msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Kategoria baliogabe aurkitua, baztertzen"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Kategoria baliogabe aurkitua, baztertzen"
 
@@ -5693,6 +5724,10 @@ msgstr "Konexioa"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direktorioak"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6205,6 +6240,29 @@ msgstr "Partekatutako fitxategi zerrenda birkargatu."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Partekatutako karpetak"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Urruneko zerbitzaria"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Zerbitzari lokala"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Aukeratu karpeta bat %s-rentzat"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4272,6 +4272,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Etäpalvelin"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Paikallinen Palvelin"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Kuvaajat"
 
@@ -5674,6 +5700,11 @@ msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Löytyi epäkelpo luokka, hypätään yli"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Löytyi epäkelpo luokka, hypätään yli"
 
@@ -5693,6 +5724,10 @@ msgstr "Yhteys"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Kansiot"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6205,6 +6240,29 @@ msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Jaetut kansiot"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Etäpalvelin"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Paikallinen Palvelin"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Valitse kansio kohteelle %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -4258,6 +4258,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Serveur Distant"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Serveur Local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Graphiques"
 
@@ -5657,6 +5683,11 @@ msgid "no options available"
 msgstr "pas d'option disponible"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Catégorie invalide trouvée, on passe"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Catégorie invalide trouvée, on passe"
 
@@ -5676,6 +5707,10 @@ msgstr "Connexion"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Répertoires"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6178,6 +6213,29 @@ msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Dossier partagé"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Serveur Distant"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Serveur Local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Choisir un dossier pour %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -4283,6 +4283,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Servidor remoto"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Servidor local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficas"
 
@@ -5682,6 +5708,11 @@ msgid "no options available"
 msgstr "non hai opcións disponibles"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Categoría inválida atopada, saltandoa"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoría inválida atopada, saltandoa"
 
@@ -5701,6 +5732,10 @@ msgstr "Conexión"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Cartafoles"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6213,6 +6248,29 @@ msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 #, fuzzy
 msgid "Shared folder"
 msgstr "Cartafoles compartidos"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Servidor remoto"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Servidor local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Escolla un cartafol para %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -4240,6 +4240,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "שרת מרוחק"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "שרת מקומי"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
@@ -5648,6 +5674,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5667,6 +5697,10 @@ msgstr "חיבור"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "מלונים"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6171,6 +6205,29 @@ msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 #, fuzzy
 msgid "Shared folder"
 msgstr "קבצים משותפים"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "שרת מרוחק"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "שרת מקומי"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "בחר תיקייה עבור %s"
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -4234,6 +4234,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafovi"
 
@@ -5643,6 +5667,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5662,6 +5690,10 @@ msgstr "Veza"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direktoriji"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6159,6 +6191,27 @@ msgstr ""
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Odstrani prijatelja"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -4253,6 +4253,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Távoli kiszolgáló"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Helyi kiszolgáló"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikonok"
 
@@ -5656,6 +5682,11 @@ msgid "no options available"
 msgstr "nincs elérhető opció"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Érvénytelen kategória találva, mellőzés"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Érvénytelen kategória találva, mellőzés"
 
@@ -5675,6 +5706,10 @@ msgstr "Csatlakozás"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mappák"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6180,6 +6215,29 @@ msgstr "A megosztott fájlok listájának újratöltése."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Megosztott mappák"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Távoli kiszolgáló"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Helyi kiszolgáló"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Válassz egy mappát a %s-nek"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -4264,6 +4264,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Server remoto"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Server locale"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafici"
 
@@ -5657,6 +5683,11 @@ msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Trovata categoria non valida, ignorata"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Trovata categoria non valida, ignorata"
 
@@ -5676,6 +5707,10 @@ msgstr "Connessione"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directory"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6174,6 +6209,29 @@ msgstr "Ricarica file condivisi: %u file analizzati"
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Cartella condivisa"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Server remoto"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Server locale"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Scegli una directory per i %s"
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -4270,6 +4270,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "リモートサーバ"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "ローカルサーバ"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "グラフ"
 
@@ -5681,6 +5707,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5700,6 +5730,10 @@ msgstr "接続"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "ディレクトリ"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6202,6 +6236,29 @@ msgstr "共有ファイル・リストを再ロードします。"
 #, fuzzy
 msgid "Shared folder"
 msgstr "共有ファイル"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "リモートサーバ"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "ローカルサーバ"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr " %s のためのフォルダを選択する"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -4290,6 +4290,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "원격 서버"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "지역 서버"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "그래프"
 
@@ -5706,6 +5732,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5725,6 +5755,10 @@ msgstr "연결"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "폴더"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6235,6 +6269,29 @@ msgstr "공유된 파일 목록을 다시 읽어들입니다."
 #, fuzzy
 msgid "Shared folder"
 msgstr "공유 파일"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "원격 서버"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "지역 서버"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "%s하기 위한 폴더를 선택하세요."
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -4302,6 +4302,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Nutolęs serveris"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Vietinis serveris"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikai"
 
@@ -5722,6 +5748,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5741,6 +5771,10 @@ msgstr "Kanalas"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Aplankai"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6258,6 +6292,29 @@ msgstr "Atnaujinti dalinamų failų sąrašą."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dalinami failai"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Nutolęs serveris"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Vietinis serveris"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Parinkite aplanką %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4186,6 +4186,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafiki"
 
@@ -5571,6 +5595,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5590,6 +5618,10 @@ msgstr "Savienojums"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mapes"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6066,6 +6098,27 @@ msgstr ""
 #, fuzzy
 msgid "Shared folder"
 msgstr "Kopīgotās datnes"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Noņemt no draugu saraksta"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
+msgstr ""
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -4275,6 +4275,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Server op Afstand"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Lokale server"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafieken"
 
@@ -5678,6 +5704,11 @@ msgid "no options available"
 msgstr "geen opties beschikbaar"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Ongeldige categorie gevonden, wordt overgeslagen"
 
@@ -5697,6 +5728,10 @@ msgstr "Verbinding"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mappen"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6208,6 +6243,29 @@ msgstr "Laad gedeelde-bestandenlijst opnieuw."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Gedeelde mappen"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Server op Afstand"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Lokale server"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Kies een map voor %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -4289,6 +4289,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Fjern tenar"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Lokal tenar"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafar"
 
@@ -5705,6 +5731,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5724,6 +5754,10 @@ msgstr "Kopling"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Katalogar"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6236,6 +6270,29 @@ msgstr "Lastar inn att lista over delte filer."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delte filer"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Fjern tenar"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Lokal tenar"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Vel ei mappe for %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -4285,6 +4285,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Serwer zdalny"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Serwer lokalny"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Wykresy"
 
@@ -5699,6 +5725,11 @@ msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Znaleziono nieprawidłową kategorie, pomijam"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Znaleziono nieprawidłową kategorie, pomijam"
 
@@ -5718,6 +5749,10 @@ msgstr "Połączenie"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Katalogi"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6237,6 +6272,29 @@ msgstr "Przeładowuje listę udostępnionych plików."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Udostępnione foldery"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Serwer zdalny"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Serwer lokalny"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Wybierz folder na %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -4260,6 +4260,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Servidor Remoto"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Servidor Local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
@@ -5653,6 +5679,11 @@ msgid "no options available"
 msgstr "nenhuma opção disponível"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Categoria inválida encontrada, pulando"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, pulando"
 
@@ -5672,6 +5703,10 @@ msgstr "Conexão"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Diretórios"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6171,6 +6206,29 @@ msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Pasta compartilhada"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Servidor Remoto"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Servidor Local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Escolha uma pasta para %s"
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -4278,6 +4278,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Servidor Remoto"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Servidor Local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Gráficos"
 
@@ -5682,6 +5708,11 @@ msgid "no options available"
 msgstr "sem opções disponíveis"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Categoria inválida encontrada, a ignorar"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Categoria inválida encontrada, a ignorar"
 
@@ -5701,6 +5732,10 @@ msgstr "Ligação"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directórios"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6213,6 +6248,29 @@ msgstr "Recarrega a lista de ficheiros partilhados."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Pastas partilhadas"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Servidor Remoto"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Servidor Local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Seleccione uma pasta para %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -4280,6 +4280,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Server distant"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Server local"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafice"
 
@@ -5685,6 +5711,11 @@ msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "S-a găsit o categorie nevalidă, se omite"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "S-a găsit o categorie nevalidă, se omite"
 
@@ -5704,6 +5735,10 @@ msgstr "Conexiune"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Directoare"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6220,6 +6255,29 @@ msgstr "Reîncarcă lista fișierelor partajate."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Dosare partajate"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Server distant"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Server local"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Alegeți un dosar pentru %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -4286,6 +4286,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "Показать, сколько общих файлов исключит текущий шаблон."
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Удалённый сервер"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Локальный сервер"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Графики"
 
@@ -5691,6 +5717,11 @@ msgid "no options available"
 msgstr "нет доступных опций"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Обнаружена неверная категория, пропускается"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Обнаружена неверная категория, пропускается"
 
@@ -5710,6 +5741,10 @@ msgstr "Соединение"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Каталоги"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6216,6 +6251,29 @@ msgstr "Перезагрузка общих файлов: просканиров
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Общая папка"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Удалённый сервер"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Локальный сервер"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Выберите каталог для %s"
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -4300,6 +4300,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Oddaljni strežnik"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Krajevni strežnik"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafi"
 
@@ -5713,6 +5739,11 @@ msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Najdena neveljavna kategorija, preskočena"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Najdena neveljavna kategorija, preskočena"
 
@@ -5732,6 +5763,10 @@ msgstr "Povezava"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Mape"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6255,6 +6290,29 @@ msgstr "Ponovno naloži seznam deljenih datotek."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Deljene mape"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Oddaljni strežnik"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Krajevni strežnik"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Izberite mapo za %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -4282,6 +4282,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Server i larget"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Server Lokal"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafiket"
 
@@ -5697,6 +5723,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5716,6 +5746,10 @@ msgstr "Lidhje"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Direktorite"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6226,6 +6260,29 @@ msgstr "Ringarko listen e faileve te ndara."
 #, fuzzy
 msgid "Shared folder"
 msgstr "File te ndara"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Server i larget"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Server Lokal"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Zgjidhni nje kartele per %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -4270,6 +4270,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Fjärrserver"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Lokal server"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Diagram"
 
@@ -5671,6 +5697,11 @@ msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Ogiltig kategori hittad, hoppar över"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Ogiltig kategori hittad, hoppar över"
 
@@ -5690,6 +5721,10 @@ msgstr "Anslutning"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Kataloger"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6201,6 +6236,29 @@ msgstr "Ladda om listan med delade filer."
 #, fuzzy
 msgid "Shared folder"
 msgstr "Delade mappar"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Fjärrserver"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Lokal server"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Välj en mapp för %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4163,6 +4163,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
@@ -5541,6 +5565,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5559,6 +5587,10 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
@@ -6029,6 +6061,26 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -4251,6 +4251,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını göster."
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Uzak Sunucu"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Sunucu"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Grafikler"
 
@@ -5650,6 +5676,11 @@ msgid "no options available"
 msgstr "mevcut seçenek yok"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Geçersiz sınıf bulundu, atlanıyor"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Geçersiz sınıf bulundu, atlanıyor"
 
@@ -5669,6 +5700,10 @@ msgstr "Bağlantı"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Dizinler"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6171,6 +6206,29 @@ msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "Paylaşılan dizin"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Uzak Sunucu"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Sunucu"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "%s için bir dizin seçiniz."
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -4301,6 +4301,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "Віддалений сервер"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "Місцевий сервер"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "Графіки"
 
@@ -5722,6 +5748,11 @@ msgid "no options available"
 msgstr "немає наявних опцій"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "Знайдена помилкова категорія, пропущена"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "Знайдена помилкова категорія, пропущена"
 
@@ -5741,6 +5772,10 @@ msgstr "З'єднання"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "Теки"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6260,6 +6295,29 @@ msgstr "Перезавантажується перелік спільних ф�
 #, fuzzy
 msgid "Shared folder"
 msgstr "Спільні теки"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Віддалений сервер"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "Місцевий сервер"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "Виберіть теку для %s"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4163,6 +4163,30 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Remote prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Local prefix:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr ""
 
@@ -5541,6 +5565,10 @@ msgid "no options available"
 msgstr ""
 
 #: src/Preferences.cpp
+msgid "Invalid path mapping found, skipping"
+msgstr ""
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr ""
 
@@ -5559,6 +5587,10 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
@@ -6029,6 +6061,26 @@ msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Choose the local folder"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -4256,6 +4256,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr "显示当前模式会排除多少共享文件。"
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "远程服务器"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "本地服务器"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "图表"
 
@@ -5649,6 +5675,11 @@ msgid "no options available"
 msgstr "选项不可用"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "发现无效的分类，跳过"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "发现无效的分类，跳过"
 
@@ -5668,6 +5699,10 @@ msgstr "连接"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "目录"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6167,6 +6202,29 @@ msgstr "正重新加载共享文件：扫描了 %u 个文件"
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
 msgstr "共享的文件夹"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "远程服务器"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "本地服务器"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "为%s选择文件夹"
 
 #: src/SearchDlg.cpp
 msgid "Clear Search History"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 10:40+0200\n"
+"POT-Creation-Date: 2026-08-08 13:16+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -4264,6 +4264,32 @@ msgid "Show how many shared files the current pattern would exclude."
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Path mappings"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Remote prefix:"
+msgstr "遠端伺服器"
+
+#: src/muuli_wdr.cpp
+msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Local prefix:"
+msgstr "本地伺服器"
+
+#: src/muuli_wdr.cpp
+msgid "Where that same folder is reachable from this computer, e.g. a mounted network share"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "Graphs"
 msgstr "圖表"
 
@@ -5662,6 +5688,11 @@ msgid "no options available"
 msgstr "沒有選項"
 
 #: src/Preferences.cpp
+#, fuzzy
+msgid "Invalid path mapping found, skipping"
+msgstr "找到無效的分類，略過"
+
+#: src/Preferences.cpp
 msgid "Invalid category found, skipping"
 msgstr "找到無效的分類，略過"
 
@@ -5681,6 +5712,10 @@ msgstr "連線"
 #: src/PrefsUnifiedDlg.cpp src/SearchListCtrl.cpp
 msgid "Directories"
 msgstr "目錄"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
+msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
@@ -6188,6 +6223,29 @@ msgstr "重新載入分享檔案清單。"
 #, fuzzy
 msgid "Shared folder"
 msgstr "分享資料夾"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "遠端伺服器"
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Local prefix"
+msgstr "本地伺服器"
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "Both the remote and local prefix must be filled in."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+msgid "This remote prefix is already mapped."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Choose the local folder"
+msgstr "爲 %s 選擇資料夾"
 
 #: src/SearchDlg.cpp
 #, fuzzy

--- a/src/FileLaunch.cpp
+++ b/src/FileLaunch.cpp
@@ -37,7 +37,10 @@
 #include "MacAppHelper.h" // Needed for mac_reveal_in_finder
 #endif
 
-#include "AppImageEnv.h"        // Needed for GetSanitizedExecEnv
+#include "AppImageEnv.h" // Needed for GetSanitizedExecEnv
+#ifdef CLIENT_GUI
+#include "amule.h" // Needed for theApp->glob_prefs (ApplyPathMapping)
+#endif
 #include "KnownFile.h"          // Needed for CKnownFile
 #include "Logger.h"             // Needed for AddLogLineC
 #include "OtherFunctions.h"     // Needed for GetFiletype
@@ -245,11 +248,27 @@ bool ResolvePath(const CKnownFile *file, CPath &out)
 		return false;
 	}
 
-	const CPath &directory = file->GetFilePath();
-	if (!directory.IsOk()) {
+	const CPath &rawDirectory = file->GetFilePath();
+	if (!rawDirectory.IsOk()) {
 		// amulegui before the daemon has streamed EC_TAG_KNOWNFILE_PATH.
 		return false;
 	}
+
+#ifdef CLIENT_GUI
+	// Rewrite a remote daemon's path into this machine's, per the user's
+	// configured mappings (issue #843) -- e.g. the daemon's
+	// /downloads/incoming reachable here as D:\Downloads\aMule\incoming via
+	// a Samba mount. String substitution on the raw daemon path, done
+	// before it becomes part of a CPath: ApplyPathMapping() never assumes
+	// the remote side uses this host's separator convention. A no-op
+	// (returns the input unchanged) whenever no configured mapping's prefix
+	// matches, including the common case of an empty mapping list -- so
+	// this is a genuine copy only for a build that can actually change it.
+	const CPath directory = CPath(theApp->glob_prefs->ApplyPathMapping(rawDirectory.GetRaw()));
+#else
+	// The monolithic app is its own core: never remapped, so no copy.
+	const CPath &directory = rawDirectory;
+#endif
 
 	// IsPartFile() is `status != PS_COMPLETE` on CPartFile and a constant false
 	// on CKnownFile, so a true answer also establishes the dynamic type -- the

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -29,6 +29,7 @@
 #include <protocol/ed2k/Constants.h>
 #include <common/Constants.h>
 #include <common/DataFileVersion.h>
+#include <common/Path.h> // Needed for StripSeparators (path-mapping prefixes)
 
 #include <wx/config.h>
 #include <wx/dir.h>

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -2185,8 +2185,13 @@ void CPreferences::LoadPathMappings()
 		cfg->SetPath(CFormat("/PathMapping#%li") % i);
 
 		PathMapping mapping;
-		mapping.remotePrefix = cfg->Read("Remote", "");
-		mapping.localPrefix = CPath::FromUniv(cfg->Read("Local", ""));
+		// Stripped here too, not just at entry (OnPathMappingAdd): an
+		// existing config saved before this fix, or one hand-edited, can
+		// still carry a trailing separator, and CPath's constructor does
+		// not strip one -- see ApplyPathMapping()'s substitution.
+		mapping.remotePrefix = StripSeparators(cfg->Read("Remote", ""), wxString::trailing);
+		mapping.localPrefix = CPath(StripSeparators(
+			CPath::FromUniv(cfg->Read("Local", "")).GetRaw(), wxString::trailing));
 
 		if (mapping.remotePrefix.IsEmpty() || !mapping.localPrefix.IsOk()) {
 			AddLogLineN(_("Invalid path mapping found, skipping"));
@@ -2201,9 +2206,20 @@ wxString CPreferences::ApplyPathMapping(const wxString &remotePath) const
 {
 #ifdef CLIENT_GUI
 	for (const PathMapping &mapping : m_pathMappings) {
-		if (!mapping.remotePrefix.IsEmpty() && remotePath.StartsWith(mapping.remotePrefix)) {
-			return mapping.localPrefix.GetRaw() + remotePath.Mid(mapping.remotePrefix.length());
+		if (mapping.remotePrefix.IsEmpty() || !remotePath.StartsWith(mapping.remotePrefix)) {
+			continue;
 		}
+		const size_t prefixLen = mapping.remotePrefix.length();
+		if (remotePath.length() > prefixLen) {
+			// A bare StartsWith() also matches "/mnt/data-old/f" against a
+			// "/mnt/data" mapping. The daemon's OS is not known here, so
+			// accept either separator convention rather than assuming one.
+			const wxChar next = remotePath[prefixLen];
+			if (next != wxT('/') && next != wxT('\\')) {
+				continue;
+			}
+		}
+		return mapping.localPrefix.GetRaw() + remotePath.Mid(prefixLen);
 	}
 #endif
 	return remotePath;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -2190,7 +2190,7 @@ void CPreferences::LoadPathMappings()
 		// existing config saved before this fix, or one hand-edited, can
 		// still carry a trailing separator, and CPath's constructor does
 		// not strip one -- see ApplyPathMapping()'s substitution.
-		mapping.remotePrefix = StripSeparators(cfg->Read("Remote", ""), wxString::trailing);
+		mapping.remotePrefix = TrimRemotePrefix(cfg->Read("Remote", ""));
 		mapping.localPrefix = CPath(StripSeparators(
 			CPath::FromUniv(cfg->Read("Local", "")).GetRaw(), wxString::trailing));
 
@@ -2201,6 +2201,19 @@ void CPreferences::LoadPathMappings()
 		m_pathMappings.push_back(mapping);
 	}
 #endif
+}
+
+wxString CPreferences::TrimRemotePrefix(const wxString &prefix)
+{
+	wxString trimmed = prefix;
+	while (!trimmed.IsEmpty()) {
+		const wxChar last = trimmed.Last();
+		if (last != wxT('/') && last != wxT('\\')) {
+			break;
+		}
+		trimmed.RemoveLast();
+	}
+	return trimmed;
 }
 
 wxString CPreferences::ApplyPathMapping(const wxString &remotePath) const
@@ -2220,7 +2233,19 @@ wxString CPreferences::ApplyPathMapping(const wxString &remotePath) const
 				continue;
 			}
 		}
-		return mapping.localPrefix.GetRaw() + remotePath.Mid(prefixLen);
+		wxString mapped = mapping.localPrefix.GetRaw() + remotePath.Mid(prefixLen);
+#ifdef __WINDOWS__
+		// The remainder is the daemon's, in the daemon's convention, so a
+		// POSIX daemon contributes '/' to a path that is about to be handed
+		// to Win32. Most of Win32 accepts that, but not all of it -- the
+		// "explorer /select," this feature exists to make work is the awkward
+		// one -- so normalise. Safe in this direction only: '/' cannot appear
+		// in a Windows filename, whereas '\\' is a perfectly ordinary
+		// character in a POSIX one, so the mirror rewrite would corrupt
+		// names rather than fix separators.
+		mapped.Replace("/", "\\");
+#endif
+		return mapped;
 	}
 #endif
 	return remotePath;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1258,6 +1258,12 @@ CPreferences::CPreferences()
 	if (slistfile.Open(s_configDir + "addresses.dat", CTextFile::read)) {
 		addresses_list = slistfile.ReadLines();
 	}
+#else
+	// GUI-local only (see LoadPathMappings' declaration): loaded here,
+	// alongside the core's equivalent local-config reads above, rather than
+	// through LoadRemote()'s EC round-trip -- there is no EC round-trip for
+	// this, by design.
+	LoadPathMappings();
 #endif
 }
 
@@ -2026,6 +2032,13 @@ void CPreferences::Save()
 
 	SaveSharedFolders();
 
+	// GUI-local only, see SavePathMappings' declaration -- a no-op body on a
+	// non-CLIENT_GUI build, called here for the same reason SaveSharedFolders
+	// is: PrefsUnifiedDlg::OnOk() harvests the dialog's edits into
+	// glob_prefs before calling Save(), so a successful commit lands here
+	// alongside the rest.
+	SavePathMappings();
+
 	// Apply a possibly-changed MMapEnabled immediately (local prefs dialog or
 	// a remote EC set that routes through Save()); safe to flip with active
 	// transfers -- see CFileArea::SetMMapEnabled. Core/daemon only; the remote
@@ -2138,6 +2151,62 @@ void CPreferences::SaveCats()
 
 		cfg->Flush();
 	}
+}
+
+void CPreferences::SavePathMappings()
+{
+#ifdef CLIENT_GUI
+	wxConfigBase *cfg = wxConfigBase::Get();
+
+	cfg->Write("/PathMappings/Count", (long)m_pathMappings.size());
+
+	for (size_t i = 0; i < m_pathMappings.size(); ++i) {
+		cfg->SetPath(CFormat("/PathMapping#%zu") % (i + 1));
+		cfg->Write("Remote", m_pathMappings[i].remotePrefix);
+		cfg->Write("Local", CPath::ToUniv(m_pathMappings[i].localPrefix));
+	}
+	// Remove any rows left over from a longer list on a previous save.
+	size_t stale = m_pathMappings.size() + 1;
+	while (cfg->DeleteGroup(CFormat("/PathMapping#%zu") % stale++)) {
+	}
+
+	cfg->Flush();
+#endif
+}
+
+void CPreferences::LoadPathMappings()
+{
+#ifdef CLIENT_GUI
+	wxConfigBase *cfg = wxConfigBase::Get();
+
+	m_pathMappings.clear();
+	const long count = cfg->Read("/PathMappings/Count", 0l);
+	for (long i = 1; i <= count; ++i) {
+		cfg->SetPath(CFormat("/PathMapping#%li") % i);
+
+		PathMapping mapping;
+		mapping.remotePrefix = cfg->Read("Remote", "");
+		mapping.localPrefix = CPath::FromUniv(cfg->Read("Local", ""));
+
+		if (mapping.remotePrefix.IsEmpty() || !mapping.localPrefix.IsOk()) {
+			AddLogLineN(_("Invalid path mapping found, skipping"));
+			continue;
+		}
+		m_pathMappings.push_back(mapping);
+	}
+#endif
+}
+
+wxString CPreferences::ApplyPathMapping(const wxString &remotePath) const
+{
+#ifdef CLIENT_GUI
+	for (const PathMapping &mapping : m_pathMappings) {
+		if (!mapping.remotePrefix.IsEmpty() && remotePath.StartsWith(mapping.remotePrefix)) {
+			return mapping.localPrefix.GetRaw() + remotePath.Mid(mapping.remotePrefix.length());
+		}
+	}
+#endif
+	return remotePath;
 }
 
 void CPreferences::LoadPreferences()

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -517,6 +517,20 @@ public:
 	 */
 	wxString ApplyPathMapping(const wxString &remotePath) const;
 
+	/**
+	 * Trims trailing separators from a daemon-supplied path prefix, in either
+	 * OS convention.
+	 *
+	 * Not StripSeparators(), which uses *this* host's separator set: on a
+	 * POSIX build that set has no '\\', so a Windows daemon's "D:\\dl\\" would
+	 * keep its trailing separator and ApplyPathMapping() would run the two
+	 * halves together with nothing between them -- the same corruption the
+	 * trailing-separator trim exists to prevent, surviving in the mirror
+	 * direction. The daemon's OS is not knowable here, which is also why the
+	 * prefix boundary test accepts either character.
+	 */
+	static wxString TrimRemotePrefix(const wxString &prefix);
+
 	static bool AutoConnectStaticOnly() { return s_autoconnectstaticonly; }
 	static void SetAutoConnectStaticOnly(bool val) { s_autoconnectstaticonly = val; }
 	static bool GetUPnPEnabled() { return s_UPnPEnabled; }

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -488,6 +488,35 @@ public:
 
 	wxArrayString addresses_list;
 
+	// A user-configured remote->local path-prefix substitution, for amuleGUI
+	// (CLIENT_GUI) against a daemon on a different machine whose filesystem is
+	// otherwise reachable (a Samba/NFS mount, say). remotePrefix is an opaque
+	// string in the daemon's own OS path syntax -- never wrapped in CPath,
+	// which has no notion of a second machine's separator convention.
+	// localPrefix is a real path on this machine, so it *is* a CPath.
+	struct PathMapping
+	{
+		wxString remotePrefix;
+		CPath localPrefix;
+	};
+	typedef std::vector<PathMapping> PathMappingList;
+
+	const PathMappingList &GetPathMappings() const { return m_pathMappings; }
+	void SetPathMappings(const PathMappingList &mappings) { m_pathMappings = mappings; }
+
+	/**
+	 * Rewrites `remotePath` (as reported by the daemon, e.g. via
+	 * EC_TAG_KNOWNFILE_PATH) through the first configured mapping whose
+	 * remotePrefix is a prefix of it -- list order decides, not prefix
+	 * length. Returns `remotePath` unchanged when no mapping matches
+	 * (including when the list is empty, the default), or when this is a
+	 * non-CLIENT_GUI build (the monolithic app's own paths never need
+	 * remapping). Pure string substitution: the daemon-side comparison
+	 * never goes through CPath, which would silently apply this host's
+	 * separator conventions to a path that isn't this host's.
+	 */
+	wxString ApplyPathMapping(const wxString &remotePath) const;
+
 	static bool AutoConnectStaticOnly() { return s_autoconnectstaticonly; }
 	static void SetAutoConnectStaticOnly(bool val) { s_autoconnectstaticonly = val; }
 	static bool GetUPnPEnabled() { return s_UPnPEnabled; }
@@ -957,6 +986,19 @@ protected:
 private:
 	void LoadPreferences();
 	void SavePreferences();
+
+	// GUI-local only: never read from or written to over EC, unlike
+	// LoadCats()/SaveCats() (daemon-owned, EC-refreshed) or
+	// LoadSharedDirsRemote()/SendSharedDirsToRemote() (daemon round-trip).
+	// Group-per-row shape mirrors SaveCats()'s /Cat#i pattern, but these
+	// read/write wxConfigBase::Get() directly rather than going through
+	// LoadAllItems()/SaveAllItems()'s Cfg_Base walk, which is what
+	// CEC_Prefs_Packet draws from -- kept separate is what keeps path
+	// mappings out of any EC exchange.
+	void LoadPathMappings();
+	void SavePathMappings();
+
+	PathMappingList m_pathMappings;
 
 protected:
 	static wxString s_configDir;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -401,6 +401,7 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	s_openPrefsDlg = this;
 	m_sharedDirsDirty = false;
 	m_sharedDirsLoaded = false;
+	m_pathMappingHintWrapWidth = 0;
 #endif
 	preferencesDlgTop(this, false);
 
@@ -3300,31 +3301,54 @@ void PrefsUnifiedDlg::PopulatePathMappingList()
 		++row;
 	}
 
-	// Bound here (idempotently -- Unbind first) rather than once at dialog
-	// construction: this page's controls, this one included, do not exist
-	// until PreferencesPathMappingTab() builds them, and Populate is the
-	// first point afterwards that this code runs. Size events do not
-	// propagate to a parent's event table the way command events do, so
-	// this has to bind directly on the control rather than add a row to
-	// the wxDECLARE_EVENT_TABLE() above.
+	// muuli_wdr.cpp wraps the paragraph above the list once, so the page has
+	// a sane minimum width; from here on it follows the page. Bound on the
+	// page rather than on the paragraph, and idempotently, since this page's
+	// controls do not exist until PreferencesPathMappingTab() builds them
+	// and Populate is the first point afterwards that runs.
 	if (wxStaticText *hint = CastChild(IDC_PATHMAP_HINT, wxStaticText)) {
-		hint->Unbind(wxEVT_SIZE, &PrefsUnifiedDlg::OnPathMappingHintResize, this);
-		hint->Bind(wxEVT_SIZE, &PrefsUnifiedDlg::OnPathMappingHintResize, this);
-		if (hint->GetClientSize().GetWidth() > 0) {
-			hint->Wrap(hint->GetClientSize().GetWidth());
+		if (m_pathMappingHintText.IsEmpty()) {
+			// Arrives already wrapped, so the breaks come back out: Wrap()
+			// would otherwise keep them forever and could only ever narrow
+			// the text further.
+			m_pathMappingHintText = hint->GetLabel();
+			m_pathMappingHintText.Replace("\n", " ");
 		}
+		if (wxWindow *page = hint->GetParent()) {
+			page->Unbind(wxEVT_SIZE, &PrefsUnifiedDlg::OnPathMappingPageResize, this);
+			page->Bind(wxEVT_SIZE, &PrefsUnifiedDlg::OnPathMappingPageResize, this);
+		}
+		WrapPathMappingHint();
 	}
 }
 
-void PrefsUnifiedDlg::OnPathMappingHintResize(wxSizeEvent &evt)
+void PrefsUnifiedDlg::OnPathMappingPageResize(wxSizeEvent &evt)
 {
-	if (wxStaticText *hint = CastChild(IDC_PATHMAP_HINT, wxStaticText)) {
-		const int width = evt.GetSize().GetWidth();
-		if (width > 0) {
-			hint->Wrap(width);
-		}
-	}
+	WrapPathMappingHint();
 	evt.Skip();
+}
+
+void PrefsUnifiedDlg::WrapPathMappingHint()
+{
+	wxStaticText *hint = CastChild(IDC_PATHMAP_HINT, wxStaticText);
+	if (hint == nullptr || m_pathMappingHintText.IsEmpty()) {
+		return;
+	}
+	wxWindow *page = hint->GetParent();
+	if (page == nullptr) {
+		return;
+	}
+	// The page's width, never the label's: the label's width is whatever the
+	// last SetLabel() made it, which is exactly the feedback this avoids.
+	const int width = page->GetClientSize().GetWidth();
+	if (width <= 0 || width == m_pathMappingHintWrapWidth) {
+		return;
+	}
+	m_pathMappingHintWrapWidth = width;
+	hint->SetLabel(m_pathMappingHintText);
+	hint->Wrap(width);
+	// The paragraph's height has changed, so the rest of the page moves.
+	page->Layout();
 }
 
 void PrefsUnifiedDlg::HarvestPathMappingList()

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -35,6 +35,7 @@
 #include <wx/colordlg.h>
 #include <wx/combobox.h> // network-interface drop-down (bind-to-interface)
 #include <wx/dataview.h> // the page sidebar (m_PrefsIcons)
+#include <wx/dirdlg.h>   // Browse button on the path-mapping editor (remote GUI)
 #include <wx/listctrl.h> // shared-folders editor (remote GUI)
 #include <set>           // set-compare of shared roots (session refresh)
 #include <wx/progdlg.h>
@@ -268,6 +269,9 @@ wxBEGIN_EVENT_TABLE(PrefsUnifiedDlg, wxDialog)
 #ifdef CLIENT_GUI
 	EVT_BUTTON(IDC_SHAREDDIR_ADD, PrefsUnifiedDlg::OnSharedDirAdd)
 	EVT_BUTTON(IDC_SHAREDDIR_REMOVE, PrefsUnifiedDlg::OnSharedDirRemove)
+	EVT_BUTTON(IDC_PATHMAP_ADD, PrefsUnifiedDlg::OnPathMappingAdd)
+	EVT_BUTTON(IDC_PATHMAP_REMOVE, PrefsUnifiedDlg::OnPathMappingRemove)
+	EVT_BUTTON(IDC_PATHMAP_BROWSE, PrefsUnifiedDlg::OnPathMappingBrowse)
 #endif
 	EVT_BUTTON(IDC_SELBROWSER, PrefsUnifiedDlg::OnButtonBrowseApplication)
 	EVT_BUTTON(IDC_MEDIAMETA_FFPROBEBROWSE, PrefsUnifiedDlg::OnButtonBrowseApplication)
@@ -351,6 +355,12 @@ struct PrefsPage
 PrefsPage pages[] = { { wxTRANSLATE("General"), PreferencesGeneralTab, 13, "prefs_general" },
 	{ wxTRANSLATE("Connection"), PreferencesConnectionTab, 14, "prefs_connection" },
 	{ wxTRANSLATE("Directories"), PreferencesDirectoriesTab, 17, "prefs_directories" },
+#ifdef CLIENT_GUI
+	// Remote-only (issue #843): mapping a daemon's path space onto this
+	// machine's has no meaning for the monolithic app, which is its own
+	// daemon. Placed right after Directories, the other page about paths.
+	{ wxTRANSLATE("Path Mappings"), PreferencesPathMappingTab, 17, "prefs_directories" },
+#endif
 	{ wxTRANSLATE("Servers"), PreferencesServerTab, 15, "prefs_servers" },
 	{ wxTRANSLATE("Files"), PreferencesFilesTab, 16, "prefs_files" },
 	{ wxTRANSLATE("Security"), PreferencesSecurityTab, 22, "prefs_security" },
@@ -855,6 +865,10 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	m_sharedDirsLoaded = false;
 	PopulateSharedDirsList();
 	static_cast<CPreferencesRem *>(theApp->glob_prefs)->LoadSharedDirsRemote();
+
+	// Path mappings (#843): purely local, so there is no remote copy to
+	// fetch -- unlike shared dirs, this is the whole refresh.
+	PopulatePathMappingList();
 #else
 	m_ShareSelector->SetSharedDirectories(&theApp->glob_prefs->shareddir_explicit_list);
 	m_ShareSelector->SetRecursiveSharedDirectories(&theApp->glob_prefs->shareddir_recursive_list);
@@ -1381,6 +1395,12 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		thePrefs::SetWSIsEnabled(false);
 		thePrefs::SetAmuleApiIsEnabled(false);
 	}
+#endif
+
+#ifdef CLIENT_GUI
+	// Path mappings (#843): harvest before Save(), same as the shared-dirs
+	// commit above, so this ends up persisted alongside the rest.
+	HarvestPathMappingList();
 #endif
 
 	// save the preferences on ok
@@ -3257,6 +3277,97 @@ void PrefsUnifiedDlg::OnSharedDirRemove(wxCommandEvent &WXUNUSED(evt))
 	if (sel != -1) {
 		list->DeleteItem(sel);
 		m_sharedDirsDirty = true;
+	}
+}
+
+void PrefsUnifiedDlg::PopulatePathMappingList()
+{
+	wxListCtrl *list = CastChild(IDC_PATHMAP_LIST, wxListCtrl);
+	if (list == nullptr) {
+		return;
+	}
+	if (list->GetColumnCount() == 0) {
+		list->InsertColumn(0, _("Remote prefix"), wxLIST_FORMAT_LEFT, 220);
+		list->InsertColumn(1, _("Local prefix"), wxLIST_FORMAT_LEFT, 220);
+	}
+	list->DeleteAllItems();
+
+	long row = 0;
+	for (const CPreferences::PathMapping &mapping : theApp->glob_prefs->GetPathMappings()) {
+		list->InsertItem(row, mapping.remotePrefix);
+		list->SetItem(row, 1, mapping.localPrefix.GetPrintable());
+		++row;
+	}
+}
+
+void PrefsUnifiedDlg::HarvestPathMappingList()
+{
+	wxListCtrl *list = CastChild(IDC_PATHMAP_LIST, wxListCtrl);
+	if (list == nullptr) {
+		return;
+	}
+	CPreferences::PathMappingList mappings;
+	for (long row = 0; row < list->GetItemCount(); ++row) {
+		CPreferences::PathMapping mapping;
+		mapping.remotePrefix = list->GetItemText(row);
+
+		wxListItem field;
+		field.SetId(row);
+		field.SetColumn(1);
+		field.SetMask(wxLIST_MASK_TEXT);
+		list->GetItem(field);
+		mapping.localPrefix = CPath(field.GetText());
+
+		mappings.push_back(mapping);
+	}
+	theApp->glob_prefs->SetPathMappings(mappings);
+}
+
+void PrefsUnifiedDlg::OnPathMappingAdd(wxCommandEvent &WXUNUSED(evt))
+{
+	wxTextCtrl *remoteCtrl = CastChild(IDC_PATHMAP_REMOTE, wxTextCtrl);
+	wxTextCtrl *localCtrl = CastChild(IDC_PATHMAP_LOCAL, wxTextCtrl);
+	wxListCtrl *list = CastChild(IDC_PATHMAP_LIST, wxListCtrl);
+	if (remoteCtrl == nullptr || localCtrl == nullptr || list == nullptr) {
+		return;
+	}
+	const wxString remote = remoteCtrl->GetValue().Strip(wxString::both);
+	const wxString local = localCtrl->GetValue().Strip(wxString::both);
+	if (remote.IsEmpty() || local.IsEmpty()) {
+		return;
+	}
+	for (long row = 0; row < list->GetItemCount(); ++row) {
+		if (list->GetItemText(row) == remote) {
+			return; // already mapped
+		}
+	}
+	const long row = list->InsertItem(list->GetItemCount(), remote);
+	list->SetItem(row, 1, local);
+	remoteCtrl->Clear();
+	localCtrl->Clear();
+}
+
+void PrefsUnifiedDlg::OnPathMappingRemove(wxCommandEvent &WXUNUSED(evt))
+{
+	wxListCtrl *list = CastChild(IDC_PATHMAP_LIST, wxListCtrl);
+	if (list == nullptr) {
+		return;
+	}
+	const long sel = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	if (sel != -1) {
+		list->DeleteItem(sel);
+	}
+}
+
+void PrefsUnifiedDlg::OnPathMappingBrowse(wxCommandEvent &WXUNUSED(evt))
+{
+	wxTextCtrl *localCtrl = CastChild(IDC_PATHMAP_LOCAL, wxTextCtrl);
+	if (localCtrl == nullptr) {
+		return;
+	}
+	wxDirDialog dlg(this, _("Choose the local folder"), localCtrl->GetValue());
+	if (dlg.ShowModal() == wxID_OK) {
+		localCtrl->SetValue(dlg.GetPath());
 	}
 }
 

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -3381,8 +3381,9 @@ void PrefsUnifiedDlg::OnPathMappingAdd(wxCommandEvent &WXUNUSED(evt))
 	// substitutes: a trailing separator on the remote prefix silently
 	// corrupts every path it maps (StartsWith() still matches, but the
 	// join then runs the two halves together with nothing between them).
-	const wxString remote =
-		StripSeparators(remoteCtrl->GetValue().Strip(wxString::both), wxString::trailing);
+	// TrimRemotePrefix() rather than StripSeparators() for the remote side:
+	// the prefix is the daemon's, and its convention is not this host's.
+	const wxString remote = CPreferences::TrimRemotePrefix(remoteCtrl->GetValue().Strip(wxString::both));
 	const wxString local =
 		StripSeparators(localCtrl->GetValue().Strip(wxString::both), wxString::trailing);
 	if (remote.IsEmpty() || local.IsEmpty()) {

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -3291,13 +3291,40 @@ void PrefsUnifiedDlg::PopulatePathMappingList()
 		list->InsertColumn(1, _("Local prefix"), wxLIST_FORMAT_LEFT, 220);
 	}
 	list->DeleteAllItems();
+	m_pathMappingRowPaths.clear();
 
 	long row = 0;
 	for (const CPreferences::PathMapping &mapping : theApp->glob_prefs->GetPathMappings()) {
 		list->InsertItem(row, mapping.remotePrefix);
-		list->SetItem(row, 1, mapping.localPrefix.GetPrintable());
+		SetListRowPath(list, row, 1, mapping.localPrefix, m_pathMappingRowPaths);
 		++row;
 	}
+
+	// Bound here (idempotently -- Unbind first) rather than once at dialog
+	// construction: this page's controls, this one included, do not exist
+	// until PreferencesPathMappingTab() builds them, and Populate is the
+	// first point afterwards that this code runs. Size events do not
+	// propagate to a parent's event table the way command events do, so
+	// this has to bind directly on the control rather than add a row to
+	// the wxDECLARE_EVENT_TABLE() above.
+	if (wxStaticText *hint = CastChild(IDC_PATHMAP_HINT, wxStaticText)) {
+		hint->Unbind(wxEVT_SIZE, &PrefsUnifiedDlg::OnPathMappingHintResize, this);
+		hint->Bind(wxEVT_SIZE, &PrefsUnifiedDlg::OnPathMappingHintResize, this);
+		if (hint->GetClientSize().GetWidth() > 0) {
+			hint->Wrap(hint->GetClientSize().GetWidth());
+		}
+	}
+}
+
+void PrefsUnifiedDlg::OnPathMappingHintResize(wxSizeEvent &evt)
+{
+	if (wxStaticText *hint = CastChild(IDC_PATHMAP_HINT, wxStaticText)) {
+		const int width = evt.GetSize().GetWidth();
+		if (width > 0) {
+			hint->Wrap(width);
+		}
+	}
+	evt.Skip();
 }
 
 void PrefsUnifiedDlg::HarvestPathMappingList()
@@ -3309,15 +3336,10 @@ void PrefsUnifiedDlg::HarvestPathMappingList()
 	CPreferences::PathMappingList mappings;
 	for (long row = 0; row < list->GetItemCount(); ++row) {
 		CPreferences::PathMapping mapping;
+		// The daemon's path, in the daemon's own OS convention -- never a
+		// CPath (see Preferences.h), so the cell text already round-trips.
 		mapping.remotePrefix = list->GetItemText(row);
-
-		wxListItem field;
-		field.SetId(row);
-		field.SetColumn(1);
-		field.SetMask(wxLIST_MASK_TEXT);
-		list->GetItem(field);
-		mapping.localPrefix = CPath(field.GetText());
-
+		mapping.localPrefix = GetListRowPath(list, row, m_pathMappingRowPaths);
 		mappings.push_back(mapping);
 	}
 	theApp->glob_prefs->SetPathMappings(mappings);
@@ -3331,18 +3353,27 @@ void PrefsUnifiedDlg::OnPathMappingAdd(wxCommandEvent &WXUNUSED(evt))
 	if (remoteCtrl == nullptr || localCtrl == nullptr || list == nullptr) {
 		return;
 	}
-	const wxString remote = remoteCtrl->GetValue().Strip(wxString::both);
-	const wxString local = localCtrl->GetValue().Strip(wxString::both);
+	// Stripped here, at entry, rather than only where ApplyPathMapping()
+	// substitutes: a trailing separator on the remote prefix silently
+	// corrupts every path it maps (StartsWith() still matches, but the
+	// join then runs the two halves together with nothing between them).
+	const wxString remote =
+		StripSeparators(remoteCtrl->GetValue().Strip(wxString::both), wxString::trailing);
+	const wxString local =
+		StripSeparators(localCtrl->GetValue().Strip(wxString::both), wxString::trailing);
 	if (remote.IsEmpty() || local.IsEmpty()) {
+		wxMessageBox(
+			_("Both the remote and local prefix must be filled in."), _("Path Mappings"), wxOK);
 		return;
 	}
 	for (long row = 0; row < list->GetItemCount(); ++row) {
 		if (list->GetItemText(row) == remote) {
-			return; // already mapped
+			wxMessageBox(_("This remote prefix is already mapped."), _("Path Mappings"), wxOK);
+			return;
 		}
 	}
 	const long row = list->InsertItem(list->GetItemCount(), remote);
-	list->SetItem(row, 1, local);
+	SetListRowPath(list, row, 1, CPath(local), m_pathMappingRowPaths);
 	remoteCtrl->Clear();
 	localCtrl->Clear();
 }

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -159,13 +159,25 @@ protected:
 	//! sense (it's the daemon's path, nothing here to browse to), but the
 	//! local side is a real folder on this machine.
 	void OnPathMappingBrowse(wxCommandEvent &evt);
-	//! Re-flows the explanatory paragraph above the path-mapping list to
-	//! the control's own (DPI-scaled) width whenever that width actually
-	//! changes -- muuli_wdr.cpp deliberately does not Wrap() it, since a
-	//! one-shot Wrap() at construction bakes fixed line breaks that
-	//! Expand() then stretches without reflowing (the empty right margin
-	//! that motivated this).
-	void OnPathMappingHintResize(wxSizeEvent &evt);
+	//! Re-flows the explanatory paragraph above the path-mapping list when
+	//! the page is resized. Bound on the *page*, not on the paragraph:
+	//! wxStaticText::SetLabel() resizes the control to fit its label, so a
+	//! handler on the paragraph that rewrites the paragraph feeds itself
+	//! (it did -- stack exhaustion inside SetLabel). The page's width is
+	//! set by the dialog and is unmoved by anything the label does, so
+	//! driving the wrap from there cannot loop.
+	void OnPathMappingPageResize(wxSizeEvent &evt);
+	//! Wraps that paragraph to the page's current client width.
+	void WrapPathMappingHint();
+
+	//! The paragraph with no line breaks in it. wxStaticText::Wrap() only
+	//! ever inserts breaks -- it reads the current label and treats any
+	//! newline already there as hard -- so re-flowing to a *wider* page has
+	//! to start from unwrapped text rather than from what is on screen.
+	wxString m_pathMappingHintText;
+	//! Width last wrapped to, so a resize that leaves the width alone (a
+	//! height-only change, say) does no work.
+	int m_pathMappingHintWrapWidth;
 
 public:
 	//! Repaint the editor when a GET_SHARED_DIRS reply lands while the

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -140,6 +140,19 @@ protected:
 	void OnSharedDirAdd(wxCommandEvent &evt);
 	void OnSharedDirRemove(wxCommandEvent &evt);
 
+	//! Fill the path-mapping list widget from glob_prefs' mappings (#843).
+	//! Purely local -- unlike PopulateSharedDirsList, there is no EC reply
+	//! to wait for, so this is the whole refresh.
+	void PopulatePathMappingList();
+	//! Copy the list widget's rows back into glob_prefs' mappings.
+	void HarvestPathMappingList();
+	void OnPathMappingAdd(wxCommandEvent &evt);
+	void OnPathMappingRemove(wxCommandEvent &evt);
+	//! wxDirDialog for the local-prefix field: typing a remote prefix makes
+	//! sense (it's the daemon's path, nothing here to browse to), but the
+	//! local side is a real folder on this machine.
+	void OnPathMappingBrowse(wxCommandEvent &evt);
+
 public:
 	//! Repaint the editor when a GET_SHARED_DIRS reply lands while the
 	//! dialog is open. A no-op when it isn't, so the reply handler never

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -140,6 +140,13 @@ protected:
 	void OnSharedDirAdd(wxCommandEvent &evt);
 	void OnSharedDirRemove(wxCommandEvent &evt);
 
+	//! The path-mapping rows' actual local prefixes, indexed by the row's
+	//! item data -- same rationale as m_sharedDirRowPaths (SetListRowPath()
+	//! in the .cpp): a list cell holds display text, not a round-trippable
+	//! CPath. Rebuilt by PopulatePathMappingList(), appended to by
+	//! OnPathMappingAdd(), read back by HarvestPathMappingList().
+	std::vector<CPath> m_pathMappingRowPaths;
+
 	//! Fill the path-mapping list widget from glob_prefs' mappings (#843).
 	//! Purely local -- unlike PopulateSharedDirsList, there is no EC reply
 	//! to wait for, so this is the whole refresh.
@@ -152,6 +159,13 @@ protected:
 	//! sense (it's the daemon's path, nothing here to browse to), but the
 	//! local side is a real folder on this machine.
 	void OnPathMappingBrowse(wxCommandEvent &evt);
+	//! Re-flows the explanatory paragraph above the path-mapping list to
+	//! the control's own (DPI-scaled) width whenever that width actually
+	//! changes -- muuli_wdr.cpp deliberately does not Wrap() it, since a
+	//! one-shot Wrap() at construction bakes fixed line breaks that
+	//! Expand() then stretches without reflowing (the empty right margin
+	//! that motivated this).
+	void OnPathMappingHintResize(wxSizeEvent &evt);
 
 public:
 	//! Repaint the editor when a GET_SHARED_DIRS reply lands while the

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1859,8 +1859,12 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    wxStaticText *itemHint = new wxStaticText( parent, -1, _("When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."), wxDefaultPosition, wxDefaultSize, 0 );
-    itemHint->Wrap( 380 );
+    // Not Wrap()'d here: that would bake fixed line breaks at construction
+    // time, leaving the sizer's Expand() stretch the control while the text
+    // itself keeps its original width. PrefsUnifiedDlg re-wraps this from
+    // the panel's real, DPI-scaled client width and keeps it current across
+    // resizes (the dialog has wxRESIZE_BORDER).
+    wxStaticText *itemHint = new wxStaticText( parent, IDC_PATHMAP_HINT, _("When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( itemHint, wxSizerFlags().Expand().Border(wxBOTTOM, 6) );
 
     wxStaticBox *itemBox = new wxStaticBox( parent, -1, _("Path mappings") );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1854,6 +1854,60 @@ wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit, bool set_si
     return item0;
 }
 
+#ifdef CLIENT_GUI
+wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_sizer )
+{
+    wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
+
+    wxStaticText *itemHint = new wxStaticText( parent, -1, _("When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."), wxDefaultPosition, wxDefaultSize, 0 );
+    itemHint->Wrap( 380 );
+    item0->Add( itemHint, wxSizerFlags().Expand().Border(wxBOTTOM, 6) );
+
+    wxStaticBox *itemBox = new wxStaticBox( parent, -1, _("Path mappings") );
+    wxStaticBoxSizer *itemBoxSizer = new wxStaticBoxSizer( itemBox, wxVERTICAL );
+
+    wxListCtrl *itemList = new wxListCtrl( parent, IDC_PATHMAP_LIST, wxDefaultPosition, wxSize(100,100), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
+    itemBoxSizer->Add( itemList, wxSizerFlags(1).Expand().CenterVertical() );
+
+    wxBoxSizer *itemRemoteRow = new wxBoxSizer( wxHORIZONTAL );
+    wxStaticText *itemRemoteLabel = new wxStaticText( parent, -1, _("Remote prefix:"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemRemoteRow->Add( itemRemoteLabel, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4) );
+    CMuleTextCtrl *itemRemote = new CMuleTextCtrl( parent, IDC_PATHMAP_REMOTE, "", wxDefaultPosition, wxSize(80,-1), 0 );
+    itemRemote->SetToolTip(_("A path prefix as the core reports it, e.g. /home/user/downloads/incoming"));
+    itemRemoteRow->Add( itemRemote, wxSizerFlags(1).Expand().CenterVertical() );
+    itemBoxSizer->Add( itemRemoteRow, wxSizerFlags().Expand().Border(wxTOP, 4) );
+
+    wxBoxSizer *itemLocalRow = new wxBoxSizer( wxHORIZONTAL );
+    wxStaticText *itemLocalLabel = new wxStaticText( parent, -1, _("Local prefix:"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemLocalRow->Add( itemLocalLabel, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4) );
+    CMuleTextCtrl *itemLocal = new CMuleTextCtrl( parent, IDC_PATHMAP_LOCAL, "", wxDefaultPosition, wxSize(80,-1), 0 );
+    itemLocal->SetToolTip(_("Where that same folder is reachable from this computer, e.g. a mounted network share"));
+    itemLocalRow->Add( itemLocal, wxSizerFlags(1).Expand().CenterVertical() );
+    wxButton *itemBrowse = new wxButton( parent, IDC_PATHMAP_BROWSE, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemLocalRow->Add( itemBrowse, wxSizerFlags().CenterVertical().Border(wxLEFT, 4) );
+    itemBoxSizer->Add( itemLocalRow, wxSizerFlags().Expand().Border(wxTOP, 4) );
+
+    wxBoxSizer *itemButtonRow = new wxBoxSizer( wxHORIZONTAL );
+    itemButtonRow->AddStretchSpacer( 1 );
+    wxButton *itemAdd = new wxButton( parent, IDC_PATHMAP_ADD, _("Add"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemButtonRow->Add( itemAdd, wxSizerFlags().CenterVertical().Border(wxLEFT, 4) );
+    wxButton *itemRemove = new wxButton( parent, IDC_PATHMAP_REMOVE, _("Remove"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemButtonRow->Add( itemRemove, wxSizerFlags().CenterVertical().Border(wxLEFT, 4) );
+    itemBoxSizer->Add( itemButtonRow, wxSizerFlags().Expand().Border(wxTOP, 4) );
+
+    item0->Add( itemBoxSizer, wxSizerFlags(1).Expand().CenterVertical() );
+
+    if (set_sizer)
+    {
+        parent->SetSizer( item0 );
+        if (call_fit)
+            item0->SetSizeHints( parent );
+    }
+
+    return item0;
+}
+#endif
+
 wxSizer *PreferencesStatisticsTab( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1859,12 +1859,15 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    // Not Wrap()'d here: that would bake fixed line breaks at construction
-    // time, leaving the sizer's Expand() stretch the control while the text
-    // itself keeps its original width. PrefsUnifiedDlg re-wraps this from
-    // the panel's real, DPI-scaled client width and keeps it current across
-    // resizes (the dialog has wxRESIZE_BORDER).
     wxStaticText *itemHint = new wxStaticText( parent, IDC_PATHMAP_HINT, _("When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."), wxDefaultPosition, wxDefaultSize, 0 );
+    // An unwrapped wxStaticText reports its whole single line as its best
+    // width, and the sizer turns that into the page's minimum width -- the
+    // dialog comes up as wide as this sentence. So it is wrapped here to
+    // bound that minimum, DPI-scaled rather than a raw pixel count.
+    // PrefsUnifiedDlg then re-flows it to the control's real width and keeps
+    // it current across resizes; it restores this text before each wrap,
+    // since Wrap() can only add line breaks, never remove them.
+    itemHint->Wrap( parent->FromDIP(380) );
     item0->Add( itemHint, wxSizerFlags().Expand().Border(wxBOTTOM, 6) );
 
     wxStaticBox *itemBox = new wxStaticBox( parent, -1, _("Path mappings") );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -503,6 +503,7 @@ wxSizer *aMuleLog(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE)
 #define IDC_PATHMAP_BROWSE 10499
 #define IDC_PATHMAP_ADD 10500
 #define IDC_PATHMAP_REMOVE 10501
+#define IDC_PATHMAP_HINT 10502
 wxSizer *aMuleGuiLog(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 
 #define ID_UPDATELIST 10244

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -366,6 +366,9 @@ wxSizer *PreferencesFilesTab(wxWindow *parent, bool call_fit = TRUE, bool set_si
 #define IDC_OSDIRTEXT 10360
 #define IDC_OSUPDATETEXT 10361
 wxSizer *PreferencesDirectoriesTab(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
+#ifdef CLIENT_GUI
+wxSizer *PreferencesPathMappingTab(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
+#endif
 
 // IP2Country (GeoIP) preferences tab. 10400+ leaves a clear gap above
 // the existing toolbar / button IDs that crowd the 10350-10354 range
@@ -490,6 +493,16 @@ wxSizer *aMuleLog(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE)
 #define IDC_SHAREDDIR_REMOVE 10482
 // Interface (GUI Tweaks) tab: toggle live column auto-sorting of the lists.
 #define IDC_LIVELISTSORT 10483
+// Remote-GUI path-mapping editor (CLIENT_GUI only, issue #843): a
+// user-configured remote->local path-prefix table, so Open/Show-in-folder
+// work against a daemon on a different machine whose filesystem this one can
+// otherwise reach (a Samba/NFS mount, say). See CPreferences::PathMapping.
+#define IDC_PATHMAP_LIST 10496
+#define IDC_PATHMAP_REMOTE 10497
+#define IDC_PATHMAP_LOCAL 10498
+#define IDC_PATHMAP_BROWSE 10499
+#define IDC_PATHMAP_ADD 10500
+#define IDC_PATHMAP_REMOVE 10501
 wxSizer *aMuleGuiLog(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 
 #define ID_UPDATELIST 10244


### PR DESCRIPTION
Closes #843.

## Problem

`FileLaunch::Open()`/`Reveal()` — "open this download", "show in file manager" — silently disable themselves (`FileLaunch::GetAvailability()`) whenever the daemon-reported path doesn't exist verbatim on amuleGUI's own machine. That's always true for a genuinely remote daemon, unless the exact same absolute path happens to be independently mounted. This adds a user-configurable table of `(remote prefix → local prefix)` mappings — e.g. the daemon's `/downloads/incoming` reachable locally as `D:\Downloads\aMule\incoming` via a Samba mount — so those actions work against a remote daemon whose filesystem is otherwise reachable some other way.

## Design

**Storage is genuinely GUI-local.** `CPreferences::PathMapping` / `Load|SavePathMappings()` read and write `wxConfigBase::Get()` directly (already resolves to `remote.conf` under `CLIENT_GUI`), never through `LoadAllItems()`/`SaveAllItems()`'s `Cfg_Base` walk, and never added to `CPreferencesRem`'s `m_exchange_send_selected_prefs`/`m_exchange_recv_selected_prefs` — so this never round-trips over EC. Two existing "list of items" precedents looked reusable but weren't: Categories and the shared-dirs editor both *look* locally persisted but are actually daemon-owned, silently overwritten by the next EC pull. This takes `SaveCats()`'s per-row `wxConfigBase` group shape without its EC-backed data source.

**Applied in `FileLaunch::ResolvePath()`**, the single choke point every Open/Reveal/availability check already goes through (six call sites across `DownloadListCtrl.cpp` and `SharedFilesCtrl.cpp`, none touched). `ApplyPathMapping()` does plain string-prefix substitution on the raw daemon path *before* it becomes a `CPath` — `CPath` has no notion of a second machine's separator convention, so the remote side is compared and rewritten as a string, never parsed as this host's path syntax. First matching prefix in the user's list order wins (no implicit longest-prefix-match).

**New "Path Mappings" Preferences page**, `CLIENT_GUI`-only, modelled on the existing shared-dirs list editor's widget shape (`wxListCtrl` + text entry + Add/Remove) but without its EC round-trip/dirty-flag/session machinery, which exists only to survive a background daemon refresh that cannot happen to a purely local list.

## Known gap

Developed and tested on macOS. The substitution itself is separator-agnostic pure string logic, and mingw-w64 CI confirms the Windows build compiles, but an actual Samba-mounted drive-letter/UNC mapping has not been exercised end-to-end. Flagging this explicitly rather than claiming full cross-platform verification.

## Verification

- `amule` (`CLIENT_GUI` off) and `amulegui` (`CLIENT_GUI` on) build clean from a fresh CMake configure — confirms the new page/storage compile out entirely on the monolithic side
- Pinned clang-format v18 clean
- Tier-1 (whole tree) and Tier-2 (changed lines vs `upstream/master`) clang-tidy clean via the local CI replica — Tier-1 caught and I fixed one real hit: an unconditional `CPath` copy in `ResolvePath()` that was wasted work on the non-`CLIENT_GUI` build, where the mapping branch never runs