### PR TITLE
feat(gui): show the rating smiley and a sort caret in the comments list

### DIFF
--- a/src/CommentDialogLst.cpp
+++ b/src/CommentDialogLst.cpp
@@ -210,8 +210,11 @@ void CCommentDialogLst::UpdateList()
 		if (!thePrefs::IsCommentFiltered(it->Comment)) {
 			m_list->InsertItem(count, it->UserName);
 			m_list->SetItem(count, 1, it->FileName);
-			m_list->SetItem(
-				count, 2, (it->Rating != -1) ? GetRateString(it->Rating) : wxString("on"));
+			// Ratings reach here as 0..5: the wire value is a uint8 that
+			// CUpDownClient clamps to 0 when it exceeds 5, and 0 is a
+			// comment with no rating. The old -1 branch, which drew a
+			// stray untranslated "on", could not be reached.
+			m_list->SetItem(count, 2, GetRateString(it->Rating));
 			const int ratingImage = RatingImage(it->Rating);
 			if (ratingImage >= 0) {
 				m_list->SetItemColumnImage(count, 2, ratingImage);

--- a/src/CommentDialogLst.cpp
+++ b/src/CommentDialogLst.cpp
@@ -28,7 +28,8 @@
 #include "PartFile.h"         // Needed for CAbstractFile / CPartFile
 #include <common/Format.h>    // Needed for CFormat
 #include "Preferences.h"
-#include "amule.h" // Needed for theApp
+#include "amule.h"    // Needed for theApp
+#include "amuleDlg.h" // Needed for CamuleDlg::m_imagelist and the Client_*_Smiley ids
 
 #include <set>
 
@@ -76,6 +77,11 @@ CCommentDialogLst::CCommentDialogLst(wxWindow *parent, CAbstractFile *file)
 	content->Show(this, true);
 
 	m_list = CastChild(IDC_LST, wxListCtrl);
+
+	// Borrowed, not owned: SetImageList() leaves the app's shared list alone,
+	// where AssignImageList() would delete it when this modal closes.
+	m_list->SetImageList(&theApp->amuledlg->m_imagelist, wxIMAGE_LIST_SMALL);
+
 	m_list->InsertColumn(0, _("Username"), wxLIST_FORMAT_LEFT, 130);
 	m_list->InsertColumn(1, _("File Name"), wxLIST_FORMAT_LEFT, 130);
 	m_list->InsertColumn(2, _("Rating"), wxLIST_FORMAT_LEFT, 80);
@@ -178,6 +184,21 @@ void CCommentDialogLst::OnKadRefreshTimer(wxTimerEvent &WXUNUSED(evt))
 	FindWindow(IDC_CMSTATUS)->GetParent()->Layout();
 }
 
+namespace
+{
+//! Smiley for a rating as SFileRating carries it: -1 for absent, otherwise
+//! 0..5 the way GetRateString() reads it. Anything without a real rating gets
+//! no image rather than a "not rated" glyph, so the column stays quiet.
+int RatingImage(sint16 rating)
+{
+	if (rating <= 0) {
+		return -1;
+	}
+	const int image = Client_InvalidRating_Smiley + rating - 1;
+	return (image <= Client_ExcellentRating_Smiley) ? image : -1;
+}
+} // namespace
+
 void CCommentDialogLst::UpdateList()
 {
 	int count = 0;
@@ -191,6 +212,10 @@ void CCommentDialogLst::UpdateList()
 			m_list->SetItem(count, 1, it->FileName);
 			m_list->SetItem(
 				count, 2, (it->Rating != -1) ? GetRateString(it->Rating) : wxString("on"));
+			const int ratingImage = RatingImage(it->Rating);
+			if (ratingImage >= 0) {
+				m_list->SetItemColumnImage(count, 2, ratingImage);
+			}
 			m_list->SetItem(count, 3, it->Comment);
 			m_list->SetItemPtrData(count, reinterpret_cast<wxUIntPtr>(new SFileRating(*it)));
 			++count;
@@ -238,6 +263,12 @@ void CCommentDialogLst::OnColumnClick(wxListEvent &evt)
 	// Column packed into the magnitude (1-based, so column 0 doesn't
 	// collide with a sign), direction into the sign.
 	m_list->SortItems(SortProc, m_sortDescending ? -(col + 1) : (col + 1));
+
+	// Plain wxListCtrl tracks no sort state of its own, so the header glyph has
+	// to be driven explicitly. All three ports draw it: macOS and GTK through
+	// the generic implementation wx/listctrl.h routes them to, Windows through
+	// wxMSW's own override.
+	m_list->ShowSortIndicator(col, !m_sortDescending);
 }
 
 int CCommentDialogLst::SortProc(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData)


### PR DESCRIPTION
Two gaps in the comments/ratings dialog (right-click a file → comments), both surfaced by #855's downgrade from `CMuleListCtrl` to a plain `wxListCtrl`, plus one piece of dead code found alongside them.

## Sort caret

That downgrade dropped the header glyph, since plain `wxListCtrl` tracks no sort state of its own — #855 noted it as an accepted simplification. It only needs driving explicitly: `ShowSortIndicator(col, ascending)` alongside the existing `SortItems()`.

All three ports draw it — macOS and GTK through the generic implementation `wx/listctrl.h` routes them to, Windows through wxMSW's own override.

## Rating smiley

This one was never there, on master either: the column has always been `GetRateString()` text alone, while every other list showing a rating draws the icon beside it.

The smileys are already loaded in the app's shared image list, so it needs `SetImageList()` plus a per-row `SetItemColumnImage()`. Borrowed rather than assigned — `AssignImageList()` would hand this modal ownership of the app's list and delete it when the dialog closes.

Unrated rows stay blank rather than drawing a "not rated" glyph on every one of them, matching how `CSharedFilesCtrl` treats the same case.

## Unreachable rating branch

The cell fell back to an untranslated `"on"` for a rating of `-1`. That value cannot occur: the wire value is a `uint8` and `CUpDownClient` clamps anything above 5 to 0, so the range is 0..5 with 0 meaning a comment carrying no rating. `GetRateString()` answers all of them, and its `default` arm covers anything unexpected.

## Testing

macOS Debug, visual check: ratings show the smiley beside the text, clicking a header draws a caret that flips on a second click, unrated rows stay clean. clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Unrelated and left alone: long filenames show the truncation ellipsis overlapping the text. That is a bug in the generic `wxListCtrl`'s `DrawTextFormatted()`, which positions the ellipsis using a running total of individual glyph widths rather than the shaped string width, so kerning makes it drift left. The Rating column escapes it only because its values fit and never take the truncation branch.