### PR TITLE
fix(gui): show the main window when the scan ends, not when hashing does

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -307,13 +307,6 @@ msgid "Starting up"
 msgstr ""
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -433,11 +426,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6849,6 +6837,13 @@ msgstr ""
 #, c-format
 msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -316,13 +316,6 @@ msgid "Starting up"
 msgstr "ابدء"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -445,11 +438,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "إسم الخادم"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr ""
 
 #: src/amule.cpp
 #, c-format
@@ -6967,6 +6955,13 @@ msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "ملفات مشاركة (%i)"
+msgstr[1] "ملفات مشاركة (%i)"
 
 #: src/SharedFilesCtrl.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -326,13 +326,6 @@ msgid "Starting up"
 msgstr "Entamar"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
@@ -464,11 +457,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome sirvidor notificáu"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Guardando ficheru part %u de %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7078,6 +7066,13 @@ msgstr[0] "Recargar los tos ficheros compartíos"
 msgstr[1] "Recargar los tos ficheros compartíos"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Ficheros Compartíos (%i)"
+msgstr[1] "Ficheros Compartíos (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
@@ -8789,6 +8784,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Guardando ficheru part %u de %u"
 
 #, c-format
 #~ msgid ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:08+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -316,13 +316,6 @@ msgid "Starting up"
 msgstr "Старт"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -443,11 +436,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6941,6 +6929,13 @@ msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Споделени файлове (%i)"
+msgstr[1] "Споделени файлове (%i)"
 
 #: src/SharedFilesCtrl.cpp
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -306,13 +306,6 @@ msgid "Starting up"
 msgstr ""
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -432,11 +425,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6848,6 +6836,13 @@ msgstr ""
 #, c-format
 msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -326,13 +326,6 @@ msgid "Starting up"
 msgstr "Inicia"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Xarxes"
@@ -464,11 +457,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nom del servidor notificat"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Desant fitxer de parts %u de %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7038,6 +7026,13 @@ msgstr[0] "Recarrega els compartits"
 msgstr[1] "Recarrega els compartits"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Fitxers compartits (%i)"
+msgstr[1] "Fitxers compartits (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
@@ -8732,6 +8727,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Desant fitxer de parts %u de %u"
 
 #, c-format
 #~ msgid ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -328,14 +328,6 @@ msgid "Starting up"
 msgstr "Spouštění"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] "Vytváření hashe %u nového souboru"
-msgstr[1] "Vytváření hashe %u nových souborů"
-msgstr[2] "Vytváření hashe %u nových souborů"
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Zavedení sítě"
 
@@ -462,11 +454,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -7062,6 +7049,14 @@ msgstr[1] "Znovu načíst vaše sdílené soubory"
 msgstr[2] "Znovu načíst vaše sdílené soubory"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Sdílené soubory (%i)"
+msgstr[1] "Sdílené soubory (%i)"
+msgstr[2] "Sdílené soubory (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
@@ -8730,6 +8725,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Hashing %u new file"
+#~ msgid_plural "Hashing %u new files"
+#~ msgstr[0] "Vytváření hashe %u nového souboru"
+#~ msgstr[1] "Vytváření hashe %u nových souborů"
+#~ msgstr[2] "Vytváření hashe %u nových souborů"
 
 #~ msgid "Filter Results"
 #~ msgstr "Filtrování výsledků"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:09+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -317,13 +317,6 @@ msgid "Starting up"
 msgstr "Start"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -446,11 +439,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Servernavn :"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr ""
 
 #: src/amule.cpp
 #, c-format
@@ -6985,6 +6973,13 @@ msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Delte Filer (%i)"
+msgstr[1] "Delte Filer (%i)"
 
 #: src/SharedFilesCtrl.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -335,13 +335,6 @@ msgid "Starting up"
 msgstr "Start"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Netzwerk-Bootstrap"
 
@@ -472,11 +465,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Server Hostname benachrichtigt"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Speichere unfertige Datei %u von %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7033,6 +7021,13 @@ msgstr[0] "Freigegebene Dateien neu laden"
 msgstr[1] "Freigegebene Dateien neu laden"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Freigegebene Dateien (%i)"
+msgstr[1] "Freigegebene Dateien (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
@@ -8746,6 +8741,10 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Speichere unfertige Datei %u von %u"
 
 #, c-format
 #~ msgid ""

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:10+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -330,13 +330,6 @@ msgid "Starting up"
 msgstr "Εκκίνηση"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Δίκτυα"
@@ -469,11 +462,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Όνομα διακομιστή:"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Φόρτωση δεδομένων από το παλιό αρχείο κατεβάσματος (%u από %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7095,6 +7083,13 @@ msgstr[0] "Επαναφόρτωση των κοινόχρηστων αρχείω
 msgstr[1] "Επαναφόρτωση των κοινόχρηστων αρχείων"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Κοινόχρηστα αρχεία (%i)"
+msgstr[1] "Κοινόχρηστα αρχεία (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
@@ -8808,6 +8803,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Φόρτωση δεδομένων από το παλιό αρχείο κατεβάσματος (%u από %u)"
 
 #, c-format
 #~ msgid ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -307,13 +307,6 @@ msgid "Starting up"
 msgstr ""
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -433,11 +426,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6849,6 +6837,13 @@ msgstr ""
 #, c-format
 msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -337,13 +337,6 @@ msgid "Starting up"
 msgstr "Comenzar"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Bootstrap de red"
 
@@ -473,11 +466,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nombre de servidor notificado"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Guardando el archivo de partes %u de %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7015,6 +7003,13 @@ msgstr[0] "Recargar los archivos compartidos"
 msgstr[1] "Recargar los archivos compartidos"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Archivos compartidos (%i)"
+msgstr[1] "Archivos compartidos (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
@@ -8727,6 +8722,10 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Guardando el archivo de partes %u de %u"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "la terminal predeterminada de Windows"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -326,13 +326,6 @@ msgid "Starting up"
 msgstr "Alusta"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Võrgud"
@@ -464,11 +457,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Teatatud serveri nimi"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Salvestan osafaili %u %u-st"
 
 #: src/amule.cpp
 #, c-format
@@ -7048,6 +7036,13 @@ msgstr[0] "Lae oma jagatud failid uuesti"
 msgstr[1] "Lae oma jagatud failid uuesti"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Jagatud failid (%i)"
+msgstr[1] "Jagatud failid (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
@@ -8735,6 +8730,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Salvestan osafaili %u %u-st"
 
 #, c-format
 #~ msgid ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -327,13 +327,6 @@ msgid "Starting up"
 msgstr "Hasi"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sareak"
@@ -465,11 +458,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Zerbitzari ostalari-izena notifikatua"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "%u zati fitxategia gordetzen %u-tik"
 
 #: src/amule.cpp
 #, c-format
@@ -7044,6 +7032,13 @@ msgstr[0] "Berritu zure partekatutako fitxategiak"
 msgstr[1] "Berritu zure partekatutako fitxategiak"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Partekatutako fitxategiak (%i)"
+msgstr[1] "Partekatutako fitxategiak (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
@@ -8735,6 +8730,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "%u zati fitxategia gordetzen %u-tik"
 
 #, c-format
 #~ msgid ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:12+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -327,13 +327,6 @@ msgid "Starting up"
 msgstr "Käynnistä haku"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Verkot"
@@ -465,11 +458,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Palvelimen verkkonimi ilmoitettu"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Tallennetaan osatiedostoa %u / %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7044,6 +7032,13 @@ msgstr[0] "Uudelleenlataa jaetut tiedostot"
 msgstr[1] "Uudelleenlataa jaetut tiedostot"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Jaetut tiedostot (%i)"
+msgstr[1] "Jaetut tiedostot (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
@@ -8735,6 +8730,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Tallennetaan osatiedostoa %u / %u"
 
 #, c-format
 #~ msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -333,13 +333,6 @@ msgstr "Rechargement des fichiers partagés…"
 msgid "Starting up"
 msgstr "Démarrer"
 
-#: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
 # AI-GENERATED — please review.
 #: src/amule.cpp
 msgid "Network bootstrap"
@@ -471,11 +464,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nom du serveur signalé"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Enregistrement du fichier .part %u sur %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7007,6 +6995,13 @@ msgstr[0] "Recharge vos fichiers partagés"
 msgstr[1] "Recharge vos fichiers partagés"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Fichiers partagés (%i)"
+msgstr[1] "Fichiers partagés (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
@@ -8719,6 +8714,10 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Enregistrement du fichier .part %u sur %u"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "le gestionnaire par défaut de shell Windows"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:13+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -347,13 +347,6 @@ msgid "Starting up"
 msgstr "Comezar"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Arranque da rede"
 
@@ -485,11 +478,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome do servidor avisado"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Gardando parte %u de %u do ficheiro"
 
 #: src/amule.cpp
 #, c-format
@@ -7048,6 +7036,13 @@ msgstr[0] "Recargar os seus ficheiros compartidos"
 msgstr[1] "Recargar os seus ficheiros compartidos"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Ficheiros compartidos (%i)"
+msgstr[1] "Ficheiros compartidos (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
@@ -8756,6 +8751,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Gardando parte %u de %u do ficheiro"
 
 #, c-format
 #~ msgid ""

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -323,13 +323,6 @@ msgid "Starting up"
 msgstr "התחל"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "רשתות"
@@ -452,11 +445,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "שם שרת:"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "טוען מידע מקובץ הורדות ישן (%u·מ·%u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7022,6 +7010,13 @@ msgstr[0] "טען מחדש את הקבצים המשותפים שלך"
 msgstr[1] "טען מחדש את הקבצים המשותפים שלך"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "קבצים משותפים (%i)"
+msgstr[1] "קבצים משותפים (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
@@ -8710,6 +8705,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "טוען מידע מקובץ הורדות ישן (%u·מ·%u)"
 
 #~ msgid "Filter Results"
 #~ msgstr "תוצאות מסנן"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:14+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -320,14 +320,6 @@ msgid "Starting up"
 msgstr "Start"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -450,11 +442,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Ime servera :"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr ""
 
 #: src/amule.cpp
 #, c-format
@@ -7017,6 +7004,14 @@ msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] "Korisnik %s (%u) dijeli direktorije %s"
 msgstr[1] "Korisnik %s (%u) dijeli direktorije %s"
 msgstr[2] "Korisnik %s (%u) dijeli direktorije %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Dijeljeni fajlovi (%i)"
+msgstr[1] "Dijeljeni fajlovi (%i)"
+msgstr[2] "Dijeljeni fajlovi (%i)"
 
 #: src/SharedFilesCtrl.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -330,12 +330,6 @@ msgid "Starting up"
 msgstr "Indít"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Hálózati bootstrap"
 
@@ -466,11 +460,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Szerver hostname értesítve"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "PartFile mentése %u a(z) %u-ból"
 
 #: src/amule.cpp
 #, c-format
@@ -7006,6 +6995,12 @@ msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] "Megosztott fájlok frissítése"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Megosztott fájlok (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
@@ -8702,6 +8697,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "PartFile mentése %u a(z) %u-ból"
 
 #, c-format
 #~ msgid ""

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -332,13 +332,6 @@ msgstr "Caricamento dei file condivisi (%u)"
 msgid "Starting up"
 msgstr "Avvio in corso"
 
-#: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] "Hashing di %u nuovo file"
-msgstr[1] "Hashing di %u nuovi file"
-
 # AI-GENERATED — please review.
 #: src/amule.cpp
 msgid "Network bootstrap"
@@ -473,11 +466,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome host del server notificato"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Hashing dei nuovi file (%u di %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7000,6 +6988,13 @@ msgstr[0] "Esportato %u file condiviso in '%s'"
 msgstr[1] "Esportati %u file condivisi in '%s'."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "File condivisi (%i)"
+msgstr[1] "File condivisi (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
@@ -8711,6 +8706,16 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#, c-format
+#~ msgid "Hashing %u new file"
+#~ msgid_plural "Hashing %u new files"
+#~ msgstr[0] "Hashing di %u nuovo file"
+#~ msgstr[1] "Hashing di %u nuovi file"
+
+#, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Hashing dei nuovi file (%u di %u)"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "il gestore di shell predefinito di Windows"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -327,12 +327,6 @@ msgid "Starting up"
 msgstr "開始"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "ネットワーク"
@@ -463,11 +457,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "サーバ名："
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "古いダウンロード・ファイル（%uから%u）からデータをロード中です"
 
 #: src/amule.cpp
 #, c-format
@@ -7045,6 +7034,12 @@ msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] "共有ファイルを再ロードする"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "共有ファイル（%i）"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
@@ -8738,6 +8733,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "古いダウンロード・ファイル（%uから%u）からデータをロード中です"
 
 #~ msgid "Filter Results"
 #~ msgstr "フィルタの結果"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -325,13 +325,6 @@ msgid "Starting up"
 msgstr "시작"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "통신망"
@@ -462,11 +455,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "서버 이름:"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "오래된 내려받은 파일로부터 데이터를 읽어들임 (%u (%u의))"
 
 #: src/amule.cpp
 #, c-format
@@ -7094,6 +7082,13 @@ msgstr[0] "공유된 파일을 다시 읽어들임"
 msgstr[1] "공유된 파일을 다시 읽어들임"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "공유된 파일(%i)"
+msgstr[1] "공유된 파일(%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
@@ -8789,6 +8784,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "오래된 내려받은 파일로부터 데이터를 읽어들임 (%u (%u의))"
 
 #~ msgid "Filter Results"
 #~ msgstr "필터링 결과"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:16+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -328,14 +328,6 @@ msgid "Starting up"
 msgstr "Pradėti"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Tinklas"
@@ -469,11 +461,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Serverio pavadinimas:"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Įkeliami duomenys iš seno atsiuntimo failo (%u iš %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7119,6 +7106,14 @@ msgstr[1] "Atnaujinti dalinamų failų sąrašą"
 msgstr[2] "Atnaujinti dalinamų failų sąrašą"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Dalinami failai (%i)"
+msgstr[1] "Dalinami failai (%i)"
+msgstr[2] "Dalinami failai (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
@@ -8827,6 +8822,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Įkeliami duomenys iš seno atsiuntimo failo (%u iš %u)"
 
 #, c-format
 #~ msgid ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -312,14 +312,6 @@ msgid "Starting up"
 msgstr ""
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -440,11 +432,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6897,6 +6884,14 @@ msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Kopīgotās datnes (%i)"
+msgstr[1] "Kopīgotās datnes (%i)"
+msgstr[2] "Kopīgotās datnes (%i)"
 
 #: src/SharedFilesCtrl.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -328,13 +328,6 @@ msgid "Starting up"
 msgstr "Start"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Netwerken"
@@ -466,11 +459,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Server-hostnaam geïnformeerd"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Deelbestand %u van %u wordt bewaard"
 
 #: src/amule.cpp
 #, c-format
@@ -7043,6 +7031,13 @@ msgstr[0] "Laad uw gedeelde bestanden opnieuw"
 msgstr[1] "Laad uw gedeelde bestanden opnieuw"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Gedeelde bestanden (%i)"
+msgstr[1] "Gedeelde bestanden (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
@@ -8741,6 +8736,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Deelbestand %u van %u wordt bewaard"
 
 #, c-format
 #~ msgid ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:17+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -328,13 +328,6 @@ msgid "Starting up"
 msgstr "Start"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nettverk"
@@ -467,11 +460,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Tenarnamn:"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Lastar data frå gamal nedlastingsfil (%u·av·%u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7088,6 +7076,13 @@ msgstr[0] "Lastar inn att delte filer"
 msgstr[1] "Lastar inn att delte filer"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Delte filer (%i)"
+msgstr[1] "Delte filer (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
@@ -8798,6 +8793,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Lastar data frå gamal nedlastingsfil (%u·av·%u)"
 
 #, c-format
 #~ msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -328,14 +328,6 @@ msgid "Starting up"
 msgstr "Start"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Sieci"
@@ -467,11 +459,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Zawiadomiono nazwę hostu serwera"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Zapisywanie pliku części %u z %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7089,6 +7076,14 @@ msgstr[1] "Przeładuj twoje udostępnione pliki"
 msgstr[2] "Przeładuj twoje udostępnione pliki"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Udostępnione pliki (%i)"
+msgstr[1] "Udostępnione pliki (%i)"
+msgstr[2] "Udostępnione pliki (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
@@ -8783,6 +8778,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Zapisywanie pliku części %u z %u"
 
 #, c-format
 #~ msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:18+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -332,13 +332,6 @@ msgid "Starting up"
 msgstr "Iniciando"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] "Calculando o hash de %u novo arquivo"
-msgstr[1] "Calculando os hashes de %u novos arquivos"
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Inicialização da Rede"
 
@@ -469,11 +462,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Nome do servidor notificado"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Calculando o hash de arquivos novos (%u de %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -6996,6 +6984,13 @@ msgstr[0] "Exportado %u arquivo compartilhado para '%s'."
 msgstr[1] "Exportados %u arquivos compartilhados para '%s'."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Arquivos Compartilhados (%i)"
+msgstr[1] "Arquivos Compartilhados (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
@@ -8708,6 +8703,16 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#, c-format
+#~ msgid "Hashing %u new file"
+#~ msgid_plural "Hashing %u new files"
+#~ msgstr[0] "Calculando o hash de %u novo arquivo"
+#~ msgstr[1] "Calculando os hashes de %u novos arquivos"
+
+#, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Calculando o hash de arquivos novos (%u de %u)"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "O manipulador de shell default do Windows"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -333,13 +333,6 @@ msgid "Starting up"
 msgstr "Iniciar"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Redes"
@@ -471,11 +464,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Servidor notificado"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "A gravar Ficheiro Parcial %u de %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7052,6 +7040,13 @@ msgstr[0] "Recarregar os seus ficheiros partilhados"
 msgstr[1] "Recarregar os seus ficheiros partilhados"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Ficheiros Partilhados (%i)"
+msgstr[1] "Ficheiros Partilhados (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
@@ -8744,6 +8739,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "A gravar Ficheiro Parcial %u de %u"
 
 #, c-format
 #~ msgid ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:19+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -325,14 +325,6 @@ msgid "Starting up"
 msgstr "Începe"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rețele"
@@ -464,11 +456,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "S-a notificat numele serverului"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Se salvează fișierul parțial %u of %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7067,6 +7054,14 @@ msgstr[1] "Reîncărcați fișierele partajate"
 msgstr[2] "Reîncărcați fișierele partajate"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Fișiere partajate (%i)"
+msgstr[1] "Fișiere partajate (%i)"
+msgstr[2] "Fișiere partajate (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
@@ -8761,6 +8756,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Se salvează fișierul parțial %u of %u"
 
 #, c-format
 #~ msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -332,14 +332,6 @@ msgid "Starting up"
 msgstr "Запуск"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] "Вычисление хеша для %u нового файла"
-msgstr[1] "Вычисление хеша для %u новых файлов"
-msgstr[2] "Вычисление хеша для %u новых файлов"
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Начальная загрузка сети"
 
@@ -469,11 +461,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Имя сервера подтверждено"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Вычисление хеша для новых файлов (%u из %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7057,6 +7044,14 @@ msgstr[1] "Экспортированы %u общих файла в «%s»."
 msgstr[2] "Экспортировано %u общих файлов в «%s»."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Общие файлы (%i)"
+msgstr[1] "Общие файлы (%i)"
+msgstr[2] "Общие файлы (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Общие файлы (%i)"
@@ -8773,6 +8768,17 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#, c-format
+#~ msgid "Hashing %u new file"
+#~ msgid_plural "Hashing %u new files"
+#~ msgstr[0] "Вычисление хеша для %u нового файла"
+#~ msgstr[1] "Вычисление хеша для %u новых файлов"
+#~ msgstr[2] "Вычисление хеша для %u новых файлов"
+
+#, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Вычисление хеша для новых файлов (%u из %u)"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "стандартный обработчик Windows"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:20+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -327,15 +327,6 @@ msgid "Starting up"
 msgstr "Začni"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Omrežja"
@@ -468,11 +459,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Gostitelj strežnika obveščen"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Shranjevanje delne datoteke %u od %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7109,6 +7095,15 @@ msgstr[2] "Ponovno naloži deljene datoteke"
 msgstr[3] "Ponovno naloži deljene datoteke"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Deljene datoteke (%i)"
+msgstr[1] "Deljene datoteke (%i)"
+msgstr[2] "Deljene datoteke (%i)"
+msgstr[3] "Deljene datoteke (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
@@ -8799,6 +8794,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Shranjevanje delne datoteke %u od %u"
 
 #, c-format
 #~ msgid ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -327,13 +327,6 @@ msgid "Starting up"
 msgstr "Fillo"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Rrjetet"
@@ -464,11 +457,6 @@ msgstr ""
 #, fuzzy
 msgid "Server hostname notified"
 msgstr "Emri i Serverit:"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Duke ngarkuar te dhena nga nje fail i shkarkuar i vjeter (%u te %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7078,6 +7066,13 @@ msgstr[0] "Ringarko failet e ndara"
 msgstr[1] "Ringarko failet e ndara"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Faile te ndara (%i)"
+msgstr[1] "Faile te ndara (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
@@ -8769,6 +8764,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Duke ngarkuar te dhena nga nje fail i shkarkuar i vjeter (%u te %u)"
 
 #~ msgid "Filter Results"
 #~ msgstr "Rezultatet e filterit"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:21+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -325,13 +325,6 @@ msgid "Starting up"
 msgstr "Starta"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Nätverk"
@@ -463,11 +456,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Serverns hostname underrättad"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Sparar PartFile %u av %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7038,6 +7026,13 @@ msgstr[0] "Återladda dina delade filer"
 msgstr[1] "Återladda dina delade filer"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Utdelade filer (%i)"
+msgstr[1] "Utdelade filer (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
@@ -8732,6 +8727,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Sparar PartFile %u av %u"
 
 #, c-format
 #~ msgid ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:25+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -306,13 +306,6 @@ msgid "Starting up"
 msgstr ""
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -432,11 +425,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6850,6 +6838,13 @@ msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] "பயனர் %s (%u) பகிர்ந்த கோப்பகம் '%s'"
 msgstr[1] "பயனர் %s (%u) பகிர்ந்த கோப்பகம் '%s'"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, c-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -328,13 +328,6 @@ msgid "Starting up"
 msgstr "Başlat"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "Ağ başlatması"
 
@@ -464,11 +457,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Sunucu makine adı uyarıldı"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "ParçaDosyası %u, %u'da kaydediliyor"
 
 #: src/amule.cpp
 #, c-format
@@ -7000,6 +6988,13 @@ msgstr[0] "Paylaşılan dosyalarınızı yeniden yükleyin"
 msgstr[1] "Paylaşılan dosyalarınızı yeniden yükleyin"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Paylaşılan Dosyalar (%i)"
+msgstr[1] "Paylaşılan Dosyalar (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
@@ -8712,6 +8707,10 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "ParçaDosyası %u, %u'da kaydediliyor"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "varsayılan Windows kabuk işleyicisi"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:22+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -325,14 +325,6 @@ msgid "Starting up"
 msgstr "Почати"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "Мережі"
@@ -464,11 +456,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "Назва сервера повідомлена"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "Зберігається частковий файл %u з %u"
 
 #: src/amule.cpp
 #, c-format
@@ -7118,6 +7105,14 @@ msgstr[1] "Перезавантажити ваші спільні файли"
 msgstr[2] "Перезавантажити ваші спільні файли"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "Спільні файли (%i)"
+msgstr[1] "Спільні файли (%i)"
+msgstr[2] "Спільні файли (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
@@ -8831,6 +8826,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "Зберігається частковий файл %u з %u"
 
 #, c-format
 #~ msgid ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -306,12 +306,6 @@ msgid "Starting up"
 msgstr ""
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr ""
 
@@ -431,11 +425,6 @@ msgstr ""
 
 #: src/amule.cpp
 msgid "Server hostname notified"
-msgstr ""
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
 msgstr ""
 
 #: src/amule.cpp
@@ -6847,6 +6836,12 @@ msgstr ""
 #, c-format
 msgid "Exported %u shared file to '%s'."
 msgid_plural "Exported %u shared files to '%s'."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -329,13 +329,6 @@ msgid "Starting up"
 msgstr "启动中"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] "正计算 %u 个新文件的哈希值"
-msgstr[1] "正计算 %u 个新文件的哈希值"
-
-#: src/amule.cpp
 msgid "Network bootstrap"
 msgstr "网络引导"
 
@@ -465,11 +458,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "获取服务器名称"
-
-#: src/amule.cpp
-#, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "正计算新文件哈希值（第 %u 个，共 %u 个）"
 
 #: src/amule.cpp
 #, c-format
@@ -6993,6 +6981,13 @@ msgstr[0] "导出了 %u 个共享文件到 '%s'。"
 msgstr[1] "导出了 %u 个共享文件到 '%s'。"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "共享文件 (%i)"
+msgstr[1] "共享文件 (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
@@ -8702,6 +8697,16 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#, c-format
+#~ msgid "Hashing %u new file"
+#~ msgid_plural "Hashing %u new files"
+#~ msgstr[0] "正计算 %u 个新文件的哈希值"
+#~ msgstr[1] "正计算 %u 个新文件的哈希值"
+
+#, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "正计算新文件哈希值（第 %u 个，共 %u 个）"
 
 #~ msgid "the default Windows shell handler"
 #~ msgstr "默认的 Windows 外壳处理器"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-07 23:15+0200\n"
+"POT-Creation-Date: 2026-08-08 10:40+0200\n"
 "PO-Revision-Date: 2026-08-07 10:23+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -331,12 +331,6 @@ msgid "Starting up"
 msgstr "開始"
 
 #: src/amule.cpp
-#, c-format
-msgid "Hashing %u new file"
-msgid_plural "Hashing %u new files"
-msgstr[0] ""
-
-#: src/amule.cpp
 #, fuzzy
 msgid "Network bootstrap"
 msgstr "網路"
@@ -468,11 +462,6 @@ msgstr ""
 #: src/amule.cpp
 msgid "Server hostname notified"
 msgstr "已通伺服器主機名稱"
-
-#: src/amule.cpp
-#, fuzzy, c-format
-msgid "Hashing new files (%u of %u)"
-msgstr "正在儲存暫存檔 (%u / %u)"
 
 #: src/amule.cpp
 #, c-format
@@ -7018,6 +7007,12 @@ msgid_plural "Exported %u shared files to '%s'."
 msgstr[0] "重新載入分享的檔案"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Shared Files (%i, hashing %u more)"
+msgid_plural "Shared Files (%i, hashing %u more)"
+msgstr[0] "分享檔案 (%i)"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
@@ -8708,6 +8703,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Hashing new files (%u of %u)"
+#~ msgstr "正在儲存暫存檔 (%u / %u)"
 
 #, c-format
 #~ msgid ""

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -89,6 +89,9 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 : CMuleVirtualDataViewCtrl(parent, id, pos, size, flags)
 , m_inBulkUpdate(false)
 , m_batchUpdate(false)
+, m_batchFrozen(false)
+, m_hashingRemaining(0)
+, m_batchRowsAppended(false)
 , m_shownSize(0)
 {
 	m_menu = nullptr;
@@ -565,6 +568,35 @@ void CSharedFilesCtrl::BeginBatchUpdate()
 	// (Freeze) and defer the single sort to EndBatchUpdate().
 	Freeze();
 	m_batchUpdate = true;
+	m_batchFrozen = true;
+}
+
+void CSharedFilesCtrl::ThawForDisplay()
+{
+	// Only the freeze ends here; the batch runs on, so rows keep arriving as
+	// O(1) appends. Whoever wants them ordered calls SortList().
+	if (m_batchFrozen) {
+		m_batchFrozen = false;
+		Thaw();
+	}
+}
+
+void CSharedFilesCtrl::SortIfRowsAppended()
+{
+	if (!m_batchRowsAppended) {
+		return;
+	}
+	m_batchRowsAppended = false;
+	SortList();
+}
+
+void CSharedFilesCtrl::SetHashingCount(size_t remaining)
+{
+	if (m_hashingRemaining == remaining) {
+		return;
+	}
+	m_hashingRemaining = remaining;
+	ShowFilesCount();
 }
 
 void CSharedFilesCtrl::EndBatchUpdate(bool doSort)
@@ -575,7 +607,13 @@ void CSharedFilesCtrl::EndBatchUpdate(bool doSort)
 	if (doSort) {
 		SortList();
 	}
-	Thaw();
+	m_batchRowsAppended = false;
+	// Skipped when ThawForDisplay() already ended the freeze: wx counts
+	// Freeze/Thaw and an unbalanced Thaw() asserts.
+	if (m_batchFrozen) {
+		m_batchFrozen = false;
+		Thaw();
+	}
 }
 
 void CSharedFilesCtrl::RemoveFile(CKnownFile *toRemove)
@@ -612,6 +650,7 @@ void CSharedFilesCtrl::ShowFile(CKnownFile *file)
 		const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(file);
 		if (RowOfData(data) == -1) {
 			AppendItemDataNow(data);
+			m_batchRowsAppended = true;
 			m_shownSize += file->GetFileSize();
 			ShowFilesCount();
 		}
@@ -969,7 +1008,17 @@ void CSharedFilesCtrl::ShowFilesCount()
 {
 	wxStaticText *label = CastByName("sharedFilesLabel", GetParent(), wxStaticText);
 
-	label->SetLabel(CFormat(_("Shared Files (%i)")) % ItemDataCount());
+	if (m_hashingRemaining > 0) {
+		// Startup is still hashing files the scan found; they join the list
+		// as each one finishes. Said here rather than in a dialog: it is
+		// progress, not something to acknowledge (#853).
+		label->SetLabel(CFormat(wxPLURAL("Shared Files (%i, hashing %u more)",
+					"Shared Files (%i, hashing %u more)",
+					m_hashingRemaining)) %
+				ItemDataCount() % m_hashingRemaining);
+	} else {
+		label->SetLabel(CFormat(_("Shared Files (%i)")) % ItemDataCount());
+	}
 
 	// Combined size of the shown files. The label lives in the statistics box
 	// (the bottom pane of the shared splitter), a different window from this

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -89,6 +89,36 @@ public:
 	void EndBatchUpdate(bool doSort = true);
 
 	/**
+	 * Ends the repaint freeze without ending the batch.
+	 *
+	 * Startup keeps appending long after the window is worth showing: the
+	 * shared-file scan finishes in seconds, but the files it queued for
+	 * hashing arrive over the following minutes, and each has to stay an
+	 * O(1) append rather than a sorted insert (#853). Thawing separately
+	 * lets those rows be seen as they land while the batch runs on.
+	 */
+	void ThawForDisplay();
+
+	/**
+	 * Number of files still queued for hashing, shown next to the count.
+	 *
+	 * Zero clears it. Only startup sets this, and only until its hash queue
+	 * drains.
+	 */
+	void SetHashingCount(size_t remaining);
+
+	/**
+	 * Sorts only if rows have been appended since the last call.
+	 *
+	 * Startup polls on a timer, but rows arrive on hash completions, and
+	 * hashing cost tracks bytes -- one large file is a single append after
+	 * minutes of nothing. Sorting per tick regardless would be a full
+	 * std::sort plus a row-index rebuild and a model reset, once a second,
+	 * for no reordering (#853).
+	 */
+	void SortIfRowsAppended();
+
+	/**
 	 * Adds the specified file to the list, updating filecount and more.
 	 *
 	 * @param file The new file to be shown.
@@ -293,6 +323,19 @@ private:
 	//! True between BeginBatchUpdate()/EndBatchUpdate(): ShowFile() appends
 	//! the row without sorting; EndBatchUpdate() does the single SortList().
 	bool m_batchUpdate;
+
+	//! Whether the batch's Freeze() is still outstanding. Tracked separately
+	//! from m_batchUpdate because ThawForDisplay() ends one without the
+	//! other, and wx counts Freeze/Thaw -- an unbalanced Thaw() asserts.
+	bool m_batchFrozen;
+
+	//! Files still queued for hashing, appended to the count label while
+	//! non-zero. See SetHashingCount().
+	size_t m_hashingRemaining;
+
+	//! Rows appended since the last SortIfRowsAppended(). The batch appends
+	//! without sorting, so this is what makes a later sort worth running.
+	bool m_batchRowsAppended;
 
 	//! Combined size of the displayed files (drives the "Total size:" label)
 	uint64 m_shownSize;

--- a/src/SplashScreen.cpp
+++ b/src/SplashScreen.cpp
@@ -115,7 +115,6 @@ CSplashScreen::CSplashScreen()
 , m_percent(0)
 , m_shownAt(0)
 , m_lastPaint(0)
-, m_pumpsLoop(true)
 , m_paintCount(0)
 , m_paintMicros(0)
 , m_updateMicros(0)
@@ -233,16 +232,6 @@ void CSplashScreen::SetProgress(const wxString &status, int percent, bool immedi
 
 	Refresh(false);
 
-	if (!m_pumpsLoop) {
-		// The loop is running on its own and will pick the invalidation up
-		// on the next frame. Yielding from here would nest a second loop
-		// inside a handler dispatched by the first, and the work it ran
-		// would be charged to the splash rather than to what is actually
-		// doing it.
-		m_updateMicros += (wxGetUTCTimeMillis() - now);
-		return;
-	}
-
 	// The event loop has to run for the invalidation to reach the screen:
 	// under GTK3, Update() cannot force a synchronous repaint the way it
 	// does elsewhere -- drawing is driven by the frame clock, which only
@@ -258,11 +247,6 @@ void CSplashScreen::SetProgress(const wxString &status, int percent, bool immedi
 	wxSafeYield(this, true);
 
 	m_updateMicros += (wxGetUTCTimeMillis() - now);
-}
-
-void CSplashScreen::SetLoopRunning()
-{
-	m_pumpsLoop = false;
 }
 
 void CSplashScreen::Finish()

--- a/src/SplashScreen.h
+++ b/src/SplashScreen.h
@@ -57,11 +57,6 @@ public:
 	// carry a running count, so their text changes every single time.
 	void SetProgress(const wxString &status, int percent, bool immediate = false);
 
-	// Tell the splash the main event loop is running again, so updates stop
-	// pumping it themselves. Startup reaches this point when the blocking
-	// phases are done and only the asynchronous hashing drain is left.
-	void SetLoopRunning();
-
 	// Close, honouring the minimum on-screen time. A fast startup would
 	// otherwise flash the splash for a few frames, which reads as a glitch
 	// rather than as the application starting.
@@ -98,9 +93,6 @@ private:
 	wxLongLong m_shownAt;
 	// Wall-clock of the last repaint, for the rate limit.
 	wxLongLong m_lastPaint;
-	// Whether an update has to pump the event loop to reach the screen.
-	bool m_pumpsLoop;
-
 	// Cost accounting, reported once at Finish() so what the splash takes
 	// from the work it is reporting on is measurable rather than assumed.
 	// Two figures because they answer different questions: how much was

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -997,7 +997,7 @@ bool CamuleApp::OnInit()
 	constexpr int kPartFileWeight = 2;
 	constexpr int kNetworkBandEnd = 2;
 	constexpr int kTempBandMaxEnd = 40;
-	constexpr int kScanBandEnd = 99;
+	constexpr int kScanBandEnd = 100;
 
 	splash->SetProgress(_("Initializing network"), 0, true);
 #endif
@@ -1058,32 +1058,29 @@ bool CamuleApp::OnInit()
 		    (tempDoneAt - networkDoneAt).GetValue() % (sharedDoneAt - tempDoneAt).GetValue() %
 		    sharedEstimate);
 
-	// Anything the scan found unknown is now queued for hashing, which runs
-	// on the scheduler thread and reports back to OnFinishedHashing on this
-	// one. That drain is the slowest part of a first run by a wide margin --
-	// hashing cost scales with bytes, not files -- and the per-completion
-	// work here (a stat, two map inserts and a list-row insert each) keeps
-	// the main thread busy enough that the UI is unusable until it ends. So
-	// the splash stays up for it rather than closing on a still-frozen app.
-	m_splashHashTotal = CThreadScheduler::GetPendingCount(kSplashHashTaskType);
-	m_splashHashBandStart = scanBandEnd;
-	if (m_splashHashTotal == 0) {
-		splash->SetProgress(_("Starting up"), 100, true);
-		FinishStartupSplash();
+	// The scan has everything it is going to have: the files it recognised are
+	// listed, and the ones it did not are now queued for hashing. That drain is
+	// the slowest part of a first run by a wide margin -- hashing cost scales
+	// with bytes, not files -- and it used to hold the splash up with it, so a
+	// large share of new files left the application unreachable for as long as
+	// it took (issue #853). The window goes up here instead, and the drain
+	// finishes behind it.
+	splash->SetProgress(_("Starting up"), 100, true);
+	ShowMainWindowAfterScan();
+
+	const size_t pendingHashes = CThreadScheduler::GetPendingCount(kSplashHashTaskType);
+	if (pendingHashes == 0) {
+		FinishStartupHashing();
 	} else {
-		splash->SetProgress(
-			CFormat(wxPLURAL("Hashing %u new file", "Hashing %u new files", m_splashHashTotal)) %
-				m_splashHashTotal,
-			scanBandEnd,
-			true);
-		// From here the drain is asynchronous and OnInit is about to
-		// return, so the loop takes over driving the repaints.
-		splash->SetLoopRunning();
-		// Four times a second: fast enough that the count does not visibly
-		// stall, slow enough to be lost in the noise next to hashing.
+		// Each completion appends its row (the batch is still open, so that
+		// stays O(1)) and the tick below sorts them into place, keeping the
+		// list ordered without paying a row-index rebuild per file.
+		UpdateStartupHashProgress();
 		m_splashPollTimer.SetOwner(this, ID_SPLASH_POLL_TIMER);
 		Bind(wxEVT_TIMER, &CamuleApp::OnSplashPollTimer, this, ID_SPLASH_POLL_TIMER);
-		m_splashPollTimer.Start(250);
+		// Once a second: this is the sort cadence now, not a counter
+		// animation, and GetPendingCount() takes the scheduler's lock.
+		m_splashPollTimer.Start(1000);
 	}
 #else
 	downloadqueue->LoadMetFiles(thePrefs::GetTempDir());
@@ -2084,43 +2081,52 @@ void CamuleApp::OnSplashPollTimer(wxTimerEvent &WXUNUSED(evt))
 
 void CamuleApp::UpdateStartupHashProgress()
 {
-	if (m_splash == nullptr) {
-		return;
-	}
-
 	// What the scheduler reports is what remains, so the completed count is
 	// derived rather than tracked -- one fewer thing to keep in step with a
 	// queue that other subsystems also feed.
 	const size_t remaining = CThreadScheduler::GetPendingCount(kSplashHashTaskType);
-	if (remaining == 0) {
-		FinishStartupSplash();
-		return;
+
+	CSharedFilesCtrl *sharedList = (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd)
+					       ? theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl
+					       : nullptr;
+	if (sharedList) {
+		// The count moves every tick; the order only moves when a hash
+		// finished and appended a row. Hashing cost tracks bytes, so a
+		// large file is minutes of nothing followed by one append --
+		// sorting per tick regardless would rebuild the row index and
+		// reset the model once a second for no reordering at all.
+		sharedList->SetHashingCount(remaining);
+		sharedList->SortIfRowsAppended();
 	}
 
-	const size_t done = (m_splashHashTotal > remaining) ? m_splashHashTotal - remaining : 0;
-	const int percent = m_splashHashBandStart +
-			    static_cast<int>(((100 - m_splashHashBandStart) * done) / m_splashHashTotal);
-	m_splash->SetProgress(CFormat(_("Hashing new files (%u of %u)")) % done % m_splashHashTotal, percent);
+	if (remaining == 0) {
+		FinishStartupHashing();
+	}
 }
 
-void CamuleApp::FinishStartupSplash()
+void CamuleApp::ShowMainWindowAfterScan()
 {
-	m_splashPollTimer.Stop();
-
-	// Ends the batches opened at startup. Sorting once here is the whole
-	// point of having held them: the lists get a single ordered pass instead
-	// of one per inserted row.
+	// The download list holds every part file there is going to be, so its
+	// batch is simply over: one sort, one thaw.
 	if (theApp->amuledlg && theApp->amuledlg->m_transferwnd &&
 		theApp->amuledlg->m_transferwnd->downloadlistctrl) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->EndBatchUpdate();
 	}
+
+	// The shared list is not finished -- hashing still has files to hand it --
+	// so its batch stays open and only the freeze ends. Sorting what the scan
+	// found means the list is ordered from the moment it is visible, and the
+	// rows that arrive later are appended and sorted by the poll tick.
 	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd &&
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
-		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->EndBatchUpdate();
+		// Sort-if-dirty rather than an unconditional sort: the scan's files
+		// arrived as appends and set the flag, and the first drain tick runs
+		// moments from here -- sorting outright would leave the flag set and
+		// have that tick repeat the largest sort of the whole startup.
+		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->SortIfRowsAppended();
+		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->ThawForDisplay();
 	}
 
-	// Now the window is worth looking at: the lists are filled and sorted,
-	// and the main thread is free to answer input.
 	if (theApp->amuledlg) {
 		theApp->amuledlg->ShowStartupWindow();
 	}
@@ -2128,6 +2134,26 @@ void CamuleApp::FinishStartupSplash()
 	if (m_splash) {
 		m_splash->Finish();
 		m_splash = nullptr;
+	}
+}
+
+void CamuleApp::FinishStartupHashing()
+{
+	m_splashPollTimer.Stop();
+
+	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd &&
+		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
+		CSharedFilesCtrl *sharedList = theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl;
+		sharedList->SetHashingCount(0);
+		// Ends the batch opened before the scan, without its sort: whatever
+		// was appended has just been sorted, either by the tick that brought
+		// the count to zero or, when nothing needed hashing, at the end of
+		// the scan. Nothing can append in between -- both run synchronously
+		// in one handler, and a completion still queued when the count
+		// reached zero arrives after the batch is closed, so it takes the
+		// sorted-insert path and places itself. The thaw inside is skipped
+		// too: ShowMainWindowAfterScan() already ended the freeze.
+		sharedList->EndBatchUpdate(false);
 	}
 }
 #endif

--- a/src/amule.h
+++ b/src/amule.h
@@ -526,31 +526,28 @@ protected:
 	// Startup splash, kept alive past OnInit because the slowest part of a
 	// first run is the hashing of everything the scan found unknown, and
 	// that drains asynchronously long after OnInit has returned. Null once
-	// the queue has drained and the splash has closed.
+	// the window is up and the splash has closed -- which is now the end of
+	// the scan, not the end of hashing (#853).
 	CSplashScreen *m_splash = nullptr;
-	// Where the bar had reached when the hashing phase took over, i.e. the
-	// start of the band that phase fills. Small on a first run, where there
-	// is no known.met to size the scan against and hashing is most of the
-	// wait; nearly full on a later one, where it is a handful of new files.
-	int m_splashHashBandStart = 0;
-	// Queue depth when the splash took over, i.e. the denominator for the
-	// hashing phase. Zero when nothing needed hashing.
-	size_t m_splashHashTotal = 0;
-	// Drives the hashing phase of the splash. Polled rather than driven from
-	// the completion handlers: the worker clears its current task after the
-	// completion event has been posted, so a handler-driven update can see
-	// the last task still pending and then never run again, leaving the
-	// splash up for good. Polling also covers tasks that finish without
+	// Drives the hashing drain: refreshes the count on the shared-files label
+	// and sorts the rows that arrived since the last tick. Polled rather than
+	// driven from the completion handlers: the worker clears its current task
+	// after the completion event has been posted, so a handler-driven update
+	// can see the last task still pending and then never run again, leaving
+	// the batch open for good. Polling also covers tasks that finish without
 	// reaching a handler here, such as an aborted one.
 	wxTimer m_splashPollTimer;
 
-	// Advances the splash and, once the scheduler queue has drained, closes
-	// it and ends the list batches opened for the duration.
+	// One tick of the drain: label, sort, and finish when the queue empties.
 	void UpdateStartupHashProgress();
 	void OnSplashPollTimer(wxTimerEvent &evt);
-	// Ends the batched list updates and closes the splash. Safe to call when
-	// no splash is up.
-	void FinishStartupSplash();
+	// Ends the download list's batch, sorts and thaws the shared list, shows
+	// the main window and closes the splash. Called when the scan finishes,
+	// with hashing still running behind it.
+	void ShowMainWindowAfterScan();
+	// Ends the shared list's batch with its final sort and stops the poll
+	// timer. Safe to call when nothing needed hashing.
+	void FinishStartupHashing();
 #endif // monolithic only
 
 	// #140 - CMediaProbeTask marshals results back here so we can


### PR DESCRIPTION
Fixes #853.

Starting aMule after new files appeared in a shared folder left the application unreachable for as long as hashing took - half an hour in the report. Preferences was among the things out of reach, so a user could not stop aMule hashing a folder they no longer wanted to share.

**Cause**
`FinishStartupSplash()` did two unrelated things in one breath: it ended the list batches *and* showed the window. It only ran once `CThreadScheduler` reported nothing left to hash, so the window waited on the hash queue. The no-splash path (`#else`) never waited, so this arrived with #760.

**Why waiting wasn't necessary**
The reasoning was that each completion's main-thread work would leave the UI unusable. That is true only once the batch is over: while it is open, `BeginBatchUpdate()` makes `ShowFile()` an O(1) append instead of a sorted insert that rebuilds the row index. The freeze it was avoiding came from ending the batch - which the same function did a few lines earlier.

**Fix**
The two events are separated. When the scan ends, the download list closes its batch as before, the shared list sorts what the scan found and thaws while its batch stays open, and the window goes up. Rows from the drain then arrive as appends, which the poll tick sorts into place once a second - one `O(n log n)` pass per tick rather than an `O(n)` row-index rebuild per file, which is what made sitting through the drain untenable. The tick also reports what is left on the shared-files label, so the count is visible in the window rather than on a splash nobody can see past.

Hashing gets the bar's last band back as a side effect: it had `kScanBandEnd = 99` plus its own band from there, so the longest phase of a first run advanced the bar by one point and read as a hang.

`CSplashScreen::SetLoopRunning()` went with it - it existed so updates would stop pumping the loop once the splash outlived `OnInit()`, which it no longer does, and without it `m_pumpsLoop` could never be false, leaving an unreachable branch in `SetProgress()`.

**Testing**
Built on macOS (amule, amulegui, amuled) and on Ubuntu ARM64. clang-format 18, both clang-tidy tiers and the catalogs all clean; catalog regeneration verified idempotent.

Exercised on Linux against 10000 known shared files plus one 10 GB unknown file: the splash closes at the end of the scan, the window comes up with all 10000 listed and sorted, the label counts the outstanding hash down, Preferences is reachable throughout, and the new row sorts into place when its hash completes.

**Not included**
Unsharing a folder mid-drain does not cancel the `CHashingTask`s already queued for it. That is the other half of the reporter's scenario and wants its own change.
