### PR TITLE
fix(gui): correct what amulegui's shared-folder editor sends to the daemon

### DIFF
--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -3073,6 +3073,48 @@ void PrefsUnifiedDlg::RefreshSharedDirsIfOpen()
 	}
 }
 
+namespace
+{
+
+/**
+ * Puts `path` in a list row: `col` shows it, and the row remembers which
+ * entry of `store` it actually is.
+ *
+ * The indirection is the point. A list cell holds display text, and CPath's
+ * display form is not the path: GetPrintable() renders the name for a human,
+ * which on macOS means the NFD-normalised form wxConvFileName produces, while
+ * the filesystem form keeps whatever composition it was given. So "/Mötorhead"
+ * comes back out of a cell decomposed -- same characters, different bytes --
+ * and a decomposed path does not resolve on a byte-exact filesystem, which is
+ * what a Linux daemon has and what an SMB/NFS mount generally presents.
+ * Rebuilding a CPath from cell text is therefore not a round trip, and no
+ * caller here should do it.
+ *
+ * The index is stored one-based so that wxListCtrl's default item data of 0
+ * reads as "no path recorded" instead of silently aliasing the first entry.
+ */
+void SetListRowPath(wxListCtrl *list, long row, int col, const CPath &path, std::vector<CPath> &store)
+{
+	store.push_back(path);
+	list->SetItem(row, col, path.GetPrintable());
+	list->SetItemData(row, static_cast<long>(store.size()));
+}
+
+/** The path SetListRowPath() recorded for `row`. */
+CPath GetListRowPath(wxListCtrl *list, long row, const std::vector<CPath> &store)
+{
+	const size_t stored = static_cast<size_t>(list->GetItemData(row));
+	if (stored == 0 || stored > store.size()) {
+		// Every row is created through SetListRowPath(), so this is a bug in
+		// the caller rather than a state a user can reach.
+		wxFAIL_MSG("List row has no recorded path");
+		return CPath();
+	}
+	return store[stored - 1];
+}
+
+} // namespace
+
 void PrefsUnifiedDlg::PopulateSharedDirsList()
 {
 	wxListCtrl *list = CastChild(IDC_SHAREDDIRS_LIST, wxListCtrl);
@@ -3084,6 +3126,7 @@ void PrefsUnifiedDlg::PopulateSharedDirsList()
 		list->InsertColumn(1, _("Recursive"), wxLIST_FORMAT_LEFT, 90);
 	}
 	list->DeleteAllItems();
+	m_sharedDirRowPaths.clear();
 
 	const bool supported =
 		theApp->m_connect != nullptr && theApp->m_connect->ServerSupportsSharedDirsConfig();
@@ -3099,12 +3142,14 @@ void PrefsUnifiedDlg::PopulateSharedDirsList()
 
 	long row = 0;
 	for (const CPath &dir : theApp->glob_prefs->shareddir_explicit_list) {
-		list->InsertItem(row, dir.GetPrintable());
+		list->InsertItem(row, wxEmptyString);
+		SetListRowPath(list, row, 0, dir, m_sharedDirRowPaths);
 		list->SetItem(row, 1, wxEmptyString);
 		++row;
 	}
 	for (const CPath &dir : theApp->glob_prefs->shareddir_recursive_list) {
-		list->InsertItem(row, dir.GetPrintable());
+		list->InsertItem(row, wxEmptyString);
+		SetListRowPath(list, row, 0, dir, m_sharedDirRowPaths);
 		list->SetItem(row, 1, _("Yes"));
 		++row;
 	}
@@ -3119,7 +3164,8 @@ void PrefsUnifiedDlg::HarvestSharedDirsList()
 	CPreferences::PathList explicitDirs;
 	CPreferences::PathList recursiveDirs;
 	for (long row = 0; row < list->GetItemCount(); ++row) {
-		const CPath path(list->GetItemText(row));
+		// The recorded path, not the cell text -- see SetListRowPath().
+		const CPath path = GetListRowPath(list, row, m_sharedDirRowPaths);
 		wxListItem field;
 		field.SetId(row);
 		field.SetColumn(1);
@@ -3148,13 +3194,18 @@ void PrefsUnifiedDlg::OnSharedDirAdd(wxCommandEvent &WXUNUSED(evt))
 	}
 	// The path names a folder on the *core's* machine, so it can't be checked
 	// here; the core validates on apply and reports anything it refuses.
+	const CPath newPath(path);
+	// Compared as paths rather than as cell text: the cells show the display
+	// form, which does not always match what was typed (see SetListRowPath),
+	// so a text compare can miss a duplicate.
 	for (long row = 0; row < list->GetItemCount(); ++row) {
-		if (list->GetItemText(row) == path) {
+		if (GetListRowPath(list, row, m_sharedDirRowPaths) == newPath) {
 			return; // already listed
 		}
 	}
 	const bool recursive = CastChild(IDC_SHAREDDIR_RECURSIVE, wxCheckBox)->GetValue();
-	const long row = list->InsertItem(list->GetItemCount(), path);
+	const long row = list->InsertItem(list->GetItemCount(), wxEmptyString);
+	SetListRowPath(list, row, 0, newPath, m_sharedDirRowPaths);
 	list->SetItem(row, 1, recursive ? _("Yes") : wxString(wxEmptyString));
 	pathCtrl->Clear();
 	m_sharedDirsDirty = true;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -2851,6 +2851,18 @@ bool IsSensitiveSharePath(const CPath &path)
 PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithProgress()
 {
 #ifdef CLIENT_GUI
+	// Nothing to send unless the user actually edited the list -- the same
+	// condition the monolithic branch below gets from HasChanged, and not
+	// merely an optimisation. PopulateSharedDirsList() fills the editor from
+	// glob_prefs, which is still empty in the window between connecting and
+	// the first GET_SHARED_DIRS reply landing. Confirming the dialog inside
+	// that window would harvest an empty editor and instruct the daemon to
+	// share nothing, since SendSharedDirsToRemote() declines only for a
+	// daemon that cannot do this at all.
+	if (!m_sharedDirsDirty) {
+		return SharedDirsCommitResult::NothingToCommit;
+	}
+
 	// The core owns the shared-folder files; we just hand it the roots. No
 	// local progress dialog or rescan here — the rescan happens daemon-side,
 	// and any path it refuses comes back as a rejection we surface then.
@@ -3166,6 +3178,12 @@ void PrefsUnifiedDlg::HarvestSharedDirsList()
 	for (long row = 0; row < list->GetItemCount(); ++row) {
 		// The recorded path, not the cell text -- see SetListRowPath().
 		const CPath path = GetListRowPath(list, row, m_sharedDirRowPaths);
+		if (!path.IsOk()) {
+			// GetListRowPath() asserts on this, but the assert is debug-only
+			// and an empty root would go to the daemon as an empty
+			// EC_TAG_SHAREDDIR. Drop the row instead.
+			continue;
+		}
 		wxListItem field;
 		field.SetId(row);
 		field.SetColumn(1);

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -390,6 +390,7 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 #ifdef CLIENT_GUI
 	s_openPrefsDlg = this;
 	m_sharedDirsDirty = false;
+	m_sharedDirsLoaded = false;
 #endif
 	preferencesDlgTop(this, false);
 
@@ -846,8 +847,12 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	// user-selected.
 #ifdef CLIENT_GUI
 	// Remote GUI: no tree to seed. Show whatever roots we already hold and ask
-	// the core for a fresh copy — the reply repaints us via
-	// RefreshSharedDirsIfOpen, so an edit is never made against a stale list.
+	// the core for a fresh copy; the reply repaints us via
+	// RefreshSharedDirsIfOpen. Until it lands the editor's controls stay
+	// disabled, because an edit made before it arrives is an edit against a
+	// list we have not seen -- see m_sharedDirsLoaded. Cleared here rather
+	// than at close: the dialog is created once and reused for every open.
+	m_sharedDirsLoaded = false;
 	PopulateSharedDirsList();
 	static_cast<CPreferencesRem *>(theApp->glob_prefs)->LoadSharedDirsRemote();
 #else
@@ -3078,9 +3083,17 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 
 void PrefsUnifiedDlg::RefreshSharedDirsIfOpen()
 {
+	if (s_openPrefsDlg == nullptr) {
+		return;
+	}
+	// The daemon's list is here, so the editor may be edited from now on. Set
+	// before the repaint below, which reads it to enable the controls.
+	s_openPrefsDlg->m_sharedDirsLoaded = true;
 	// Never repaint over uncommitted edits: the reply may land after the user
-	// has already started adding rows.
-	if (s_openPrefsDlg != nullptr && !s_openPrefsDlg->m_sharedDirsDirty) {
+	// has already started adding rows. That can no longer happen before the
+	// first reply -- the controls were disabled until this point -- so what
+	// this protects is an edit made after one reply against a later one.
+	if (!s_openPrefsDlg->m_sharedDirsDirty) {
 		s_openPrefsDlg->PopulateSharedDirsList();
 	}
 }
@@ -3144,10 +3157,15 @@ void PrefsUnifiedDlg::PopulateSharedDirsList()
 		theApp->m_connect != nullptr && theApp->m_connect->ServerSupportsSharedDirsConfig();
 	// An older core can neither report nor accept these, so leave the editor
 	// inert rather than implying an edit here would reach it.
-	FindWindow(IDC_SHAREDDIR_PATH)->Enable(supported);
-	FindWindow(IDC_SHAREDDIR_RECURSIVE)->Enable(supported);
-	FindWindow(IDC_SHAREDDIR_ADD)->Enable(supported);
-	FindWindow(IDC_SHAREDDIR_REMOVE)->Enable(supported);
+	// Editable only once the daemon's own list is on screen: editing before
+	// then sets m_sharedDirsDirty, which makes the arriving reply be discarded
+	// to protect the edit, and OK would then replace the daemon's shares with
+	// a list assembled without them.
+	const bool editable = supported && m_sharedDirsLoaded;
+	FindWindow(IDC_SHAREDDIR_PATH)->Enable(editable);
+	FindWindow(IDC_SHAREDDIR_RECURSIVE)->Enable(editable);
+	FindWindow(IDC_SHAREDDIR_ADD)->Enable(editable);
+	FindWindow(IDC_SHAREDDIR_REMOVE)->Enable(editable);
 	if (!supported) {
 		return;
 	}

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -117,6 +117,15 @@ protected:
 	//! edits, either by a session refresh or by a late GET_SHARED_DIRS reply.
 	bool m_sharedDirsDirty;
 
+	//! Whether this session's GET_SHARED_DIRS reply has arrived, i.e. whether
+	//! the editor is showing the daemon's list rather than whatever glob_prefs
+	//! happened to hold at open time. The edit controls stay disabled until it
+	//! is true: an edit made before the reply lands sets m_sharedDirsDirty,
+	//! which then makes RefreshSharedDirsIfOpen() discard that very reply to
+	//! protect the edit -- so OK would commit a list built without ever having
+	//! seen the daemon's, replacing its shares with the one row just added.
+	bool m_sharedDirsLoaded;
+
 	//! The shared-folder rows' actual paths, indexed by the row's item data.
 	//! A list cell holds display text, and CPath's display form is not the
 	//! path -- see SetListRowPath() in the .cpp for why one cannot be rebuilt

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -29,6 +29,8 @@
 #include <wx/bmpbndl.h> // Needed for wxBitmapBundle (m_pageIcons)
 #include <wx/dialog.h>  // Needed for wxDialog
 
+#include <common/Path.h> // Needed for CPath (value members of m_sharedDirRowPaths)
+
 #include <vector>
 
 #include "ProtocolHandlerManager.h" // Needed for HandlerTarget enum
@@ -114,6 +116,13 @@ protected:
 	//! Guards the editor against being repainted out from under uncommitted
 	//! edits, either by a session refresh or by a late GET_SHARED_DIRS reply.
 	bool m_sharedDirsDirty;
+
+	//! The shared-folder rows' actual paths, indexed by the row's item data.
+	//! A list cell holds display text, and CPath's display form is not the
+	//! path -- see SetListRowPath() in the .cpp for why one cannot be rebuilt
+	//! from the other. Rebuilt by PopulateSharedDirsList(), appended to by
+	//! OnSharedDirAdd(), read back by HarvestSharedDirsList().
+	std::vector<CPath> m_sharedDirRowPaths;
 
 	//! Fill the shared-folders list widget from glob_prefs' roots.
 	void PopulateSharedDirsList();

--- a/unittests/tests/PathTest.cpp
+++ b/unittests/tests/PathTest.cpp
@@ -396,3 +396,30 @@ TEST(CPath, TruncatePath)
 	ASSERT_EQUALS("t[...]", testPath.TruncatePath(6, true));
 	ASSERT_EQUALS("", testPath.TruncatePath(5, true));
 }
+
+TEST(CPath, UnivRoundTrip)
+{
+	// ToUniv()/FromUniv() stores the filesystem bytes verbatim and is the one
+	// representation guaranteed to reproduce the path. The display form is
+	// not: on macOS wxConvFileName normalises to NFD, so GetPrintable() hands
+	// back a different byte sequence for the same characters, and a CPath
+	// rebuilt from it is a different path to any filesystem that compares
+	// bytes -- a Linux daemon's, or an SMB/NFS mount. Anything carrying a
+	// path through another medium (a config file, a list control's cells)
+	// therefore has to move this pair around rather than what it displayed.
+	const wxString inputs[] = {
+		"/tmp/plain",
+		// Precomposed U+00F6, which is what NFD decomposes.
+		wxString::FromUTF8("/tmp/M\xC3\xB6t"),
+		// CJK has no decomposition, so normalisation leaves it alone.
+		wxString::FromUTF8("/tmp/\xE9\x9F\xB3\xE6\xA5\xBD"),
+		// Not valid UTF-8: the mangled-name case the raw/printable split
+		// exists for in the first place.
+		wxString::From8BitData("/tmp/M\xF6t"),
+	};
+
+	for (const wxString &input : inputs) {
+		const CPath path(input);
+		ASSERT_EQUALS(path.GetRaw(), CPath::FromUniv(CPath::ToUniv(path)).GetRaw());
+	}
+}


### PR DESCRIPTION
Four ways amulegui's shared-folder editor handed the daemon something other than what the user had. All four are on the same commit path, and (2) and (3) are the ones that lose data.

## 1. The paths went through the display form

`PopulateSharedDirsList()` wrote each root's `GetPrintable()` into the list control, and `HarvestSharedDirsList()` rebuilt a `CPath` from that cell text. `GetPrintable()` is the display rendering, not the path: on macOS `wxConvFileName` normalises to NFD, so a precomposed accented character comes back decomposed. Measured on a path holding U+00F6:

```
raw        2F 4D C3 B6 74        <- U+00F6
printable  2F 4D 6F CC 88 74     <- 'o' + U+0308
```

Same characters, different bytes, and a path a byte-exact filesystem does not have.

The duplicate check had the same weakness — it compared the typed string against cell text, so a duplicate could slip past on exactly the paths where the two forms diverge.

The list no longer carries paths at all. `SetListRowPath()` records the `CPath` and tags the row with its index, `GetListRowPath()` reads it back, and the cell text is display only. This is not a new convention: `CDirectoryTreeCtrl`, which the monolithic build uses instead of this editor, has always attached the real `CPath` to each node and used `GetPrintable()` only for the label. The list editor was the odd one out.

The helpers are file-local because the path-mappings editor in #854 needs the same treatment and lives in this file too.

## 2. An untouched OK could tell the daemon to share nothing

`CommitSharedDirsWithProgress()` harvested and sent on every OK with no test for whether anything had changed. The monolithic branch of that same function has always gated on `m_ShareSelector->HasChanged`; the remote branch gated on nothing.

That is reachable rather than merely wasteful. `PopulateSharedDirsList()` fills the editor from `glob_prefs`, which is empty until the first `GET_SHARED_DIRS` reply arrives — `LoadSharedDirsRemote()` is fired straight after the populate, and the reply repaints the editor when it lands. Open Preferences promptly after connecting and confirm before that happens, and the harvest reads an empty editor and sends `EC_OP_SET_SHARED_DIRS` with no directories in it. `SendSharedDirsToRemote()` declines only for a daemon too old to support the operation, so a capable one is told, accurately, to share nothing.

Now gated on `m_sharedDirsDirty`, which Add and Remove already set and `EndSharedDirsSession()` clears. `NothingToCommit` is the right result for the three callers that read it: each only decides whether a reload is still owed, and one is owed precisely when the shares were not committed here.

## 3. An edit made before that reply replaces the daemon's shares

The gate in (2) closes the untouched case but not its edited sibling. `TransferToWindow()` populates the editor from `glob_prefs` and only then asks the daemon for the real list, while `RefreshSharedDirsIfOpen()` deliberately skips the repaint once the editor is dirty, so an in-progress edit is not overwritten. In the pre-reply window those combine badly: adding a folder marks the editor dirty, the arriving reply is then discarded to protect that edit, and OK commits a list holding only the row just added — the daemon's existing shares go.

It needs the add to complete inside one EC round trip, so typing a path makes it unlikely in practice, but nothing rules it out.

The edit controls now come up disabled and are enabled by the reply, the same way they are already gated on the daemon supporting the operation at all. An edit can no longer precede the data it would overwrite, and the dirty-skip goes back to meaning what it says — protecting an edit made after one reply from a later one. The flag resets at the top of `TransferToWindow()`'s remote branch rather than at close, since the dialog is constructed once and reused.

This also corrects the comment there, which claimed the reply repaint meant "an edit is never made against a stale list". That was the intent; the dirty-skip is exactly what broke it.

## 4. The new guard degraded badly in release

`GetListRowPath()` answers a row with no recorded path using `wxFAIL_MSG` and an empty `CPath`. That assert is debug-only, so a release build would have put the empty path into `explicitDirs` and sent it as an empty `EC_TAG_SHAREDDIR`. Every row is created through `SetListRowPath()`, so it is a can't-happen — but one that degrades into corrupting the share list, and one line makes it harmless.

## Scope

Narrower than it looks for (1), wider for (2) and (3).

The display round-trip only bites **amulegui on macOS**: on Linux and Windows the same probe returns `printable == raw` for every input tried, including deliberately locale-invalid byte sequences, because neither normalises. The **monolithic app is unaffected entirely** — it uses `CDirectoryTreeCtrl`, not this editor. The persistence layer was never affected either: `CPath::ToUniv()`/`FromUniv()` round-trips the filesystem bytes exactly, which is why `remote.conf` held the right value while the dialog handed back a different one.

The empty-share send in (2) and the overwrite in (3) are platform-independent and affect any amulegui against a capable daemon.

## Test

`PathTest` gains `UnivRoundTrip`, covering a precomposed accented character, CJK (no decomposition), and a byte sequence that is not valid UTF-8.

To be clear about what it does and does not do: it pins `ToUniv`/`FromUniv` — the dependency the fix rests on, and the part that was already correct — not the defect itself. Nothing in the suite would catch someone reintroducing a `CPath(cell text)` round trip, or either of the commit-path defects; all three live in dialog code that needs GUI harnessing to exercise. It asserts only the round trip and deliberately not that printable differs from raw, since that is macOS-specific and would fail the Linux and Windows legs.

Checked that it is not vacuous: asserting the broken form instead makes it fail with `Expected '/tmp/Möt' but got '/tmp/Möt'`.

## Verification

Built monolithic + amulegui on macOS ARM64 (wx 3.3), Ubuntu ARM64 and Windows ARM64 (wx 3.3.2) — clean, no warnings from `PrefsUnifiedDlg`. `PathTest` passes on all three. clang-format and both clang-tidy tiers clean over the diff.
