### PR TITLE
fix(gui): stop the wxDataViewCtrl lists losing the user's place

### DIFF
--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -54,6 +54,7 @@
 #include "amuleDlg.h"
 #include "ServerWnd.h"
 #include "SearchDlg.h"
+#include "SearchListModel.h" // Needed for CSearchListModel::DropReferencesTo
 #include "TransferWnd.h"
 #include "SharedFilesWnd.h"
 #include "ServerListCtrl.h"
@@ -1036,6 +1037,11 @@ void SearchFileBeingDestroyed(CSearchFile *file)
 	// freed (a new search or result-list rebuild deletes CSearchFile objects
 	// while a modal Kad-notes lookup may still be open on one).
 	CCommentDialogLst::DropReferencesTo(file);
+	// The search models hold arriving results between the notification and
+	// the idle that flushes them, and nothing unlinks a child from its
+	// parent's list -- so this is the only signal that one of those pointers
+	// has stopped being one.
+	CSearchListModel::DropReferencesTo(file);
 #else
 	(void)file;
 #endif

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -521,24 +521,31 @@ void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
 void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
 {
 #ifdef __WXOSX__
-	// NSOutlineView moves the view without touching the selection, so the
-	// shifted navigation keys -- which extend the selection on GTK and MSW
-	// -- do nothing at all here. The unshifted forms are deliberately left
-	// to the platform, which scrolls without moving the selection by
-	// convention.
-	if (evt.ShiftDown()) {
+	// NSOutlineView scrolls the view for these keys without touching either
+	// the selection or the cursor, so on this platform they are ours to
+	// implement -- shifted, where GTK and MSW extend the selection and the
+	// native control does nothing at all, and unshifted too.
+	//
+	// Unshifted was left to the platform at first, on the grounds that
+	// scroll-without-select is the macOS convention. It reads as broken
+	// here: the cursor stays where it was, so the next arrow key jumps the
+	// view straight back to it, and the page key looks like it did nothing.
+	// Moving the cursor with the view is what the other two ports do, and it
+	// is what makes the following arrow key continue from what is on screen.
+	{
+		const bool extend = evt.ShiftDown();
 		switch (evt.GetKeyCode()) {
 		case WXK_PAGEUP:
-			PageExtendSelection(PageMotion::PageUp);
+			MoveByPage(PageMotion::PageUp, extend);
 			return;
 		case WXK_PAGEDOWN:
-			PageExtendSelection(PageMotion::PageDown);
+			MoveByPage(PageMotion::PageDown, extend);
 			return;
 		case WXK_HOME:
-			PageExtendSelection(PageMotion::Home);
+			MoveByPage(PageMotion::Home, extend);
 			return;
 		case WXK_END:
-			PageExtendSelection(PageMotion::End);
+			MoveByPage(PageMotion::End, extend);
 			return;
 		default:
 			break;
@@ -549,7 +556,7 @@ void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
 }
 
 #ifdef __WXOSX__
-void CMuleDataViewCtrl::PageExtendSelection(PageMotion motion)
+void CMuleDataViewCtrl::MoveByPage(PageMotion motion, bool extend)
 {
 	wxDataViewItemArray ordered;
 	GetDisplayOrder(ordered);
@@ -596,20 +603,30 @@ void CMuleDataViewCtrl::PageExtendSelection(PageMotion motion)
 	}
 	}
 
-	// Grow the existing selection to cover everything between where the
-	// cursor was and where it lands, so repeated presses keep extending.
+	const wxDataViewItem targetItem = ordered[target];
+
 	wxDataViewItemArray selection;
-	GetSelections(selection);
-	const int from = std::min(current < 0 ? target : current, target);
-	const int to = std::max(current > last ? target : current, target);
-	for (int i = std::max(0, from); i <= std::min(last, to); ++i) {
-		if (selection.Index(ordered[i]) == wxNOT_FOUND) {
-			selection.Add(ordered[i]);
+	if (extend) {
+		// Grow the existing selection to cover everything between where the
+		// cursor was and where it lands, so repeated presses keep extending.
+		GetSelections(selection);
+		const int from = std::min(current < 0 ? target : current, target);
+		const int to = std::max(current > last ? target : current, target);
+		for (int i = std::max(0, from); i <= std::min(last, to); ++i) {
+			if (selection.Index(ordered[i]) == wxNOT_FOUND) {
+				selection.Add(ordered[i]);
+			}
 		}
+	} else {
+		// Unshifted: the row landed on becomes the selection, as an arrow
+		// key would leave it.
+		selection.Add(targetItem);
 	}
 
-	const wxDataViewItem targetItem = ordered[target];
 	SetSelections(selection);
+	// The cursor, not just the selection: it is what the arrow keys move
+	// from next, and leaving it behind is what made an unshifted page key
+	// look like it had done nothing as soon as one was pressed.
 	SetCurrentItem(targetItem);
 	EnsureVisible(targetItem);
 }

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -336,11 +336,17 @@ private:
 		End
 	};
 	/**
-	 * Extends the selection by a page, or to the start/end of the list.
-	 * GTK and MSW get this from their backends; NSOutlineView moves the
-	 * view without touching the selection.
+	 * Moves the cursor by a page, or to the start/end of the list, and
+	 * brings it into view.
+	 *
+	 * GTK and MSW get this from their backends; NSOutlineView scrolls
+	 * without moving cursor or selection, which leaves the next arrow key
+	 * jumping back to wherever the cursor was left.
+	 *
+	 * @param extend Grow the selection to the row landed on, as Shift does
+	 *               on the other ports, rather than replacing it.
 	 */
-	void PageExtendSelection(PageMotion motion);
+	void MoveByPage(PageMotion motion, bool extend);
 #endif
 
 	wxDECLARE_EVENT_TABLE();

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -425,12 +425,26 @@ void CMuleVirtualDataViewCtrl::SortList()
 	// different items, so it is re-applied from the item data either way.
 	SetSelectedItemData(selected);
 
+	// Only while the row it lands on is already on screen. Measured on GTK
+	// with wx 3.3.3: SetCurrentItem() to a visible row leaves the viewport
+	// alone, but to one off screen it clamps the view onto the cursor -- and
+	// with no row ever clicked the cursor sits at row 0, so restoring it
+	// after a sort dragged the list back to the top, which is the very thing
+	// this function exists to stop. A cursor the user cannot see is one they
+	// are not about to arrow from; a cursor they can see is the one that has
+	// to be right.
 	if (currentData != 0) {
 		const long row = RowOfData(currentData);
-		if (row >= 0) {
-			SetCurrentItem(m_virtualModel->GetItem(static_cast<unsigned>(row)));
+		const wxDataViewItem top = GetTopItem();
+		const int perPage = GetCountPerPage();
+		if (row >= 0 && top.IsOk() && perPage > 0) {
+			const long topRow = static_cast<long>(m_virtualModel->GetRow(top));
+			if (row >= topRow && row < topRow + perPage) {
+				SetCurrentItem(m_virtualModel->GetItem(static_cast<unsigned>(row)));
+			}
 		}
 	}
+
 }
 
 void CMuleVirtualDataViewCtrl::GetDisplayOrder(wxDataViewItemArray &ordered) const

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -398,6 +398,17 @@ void CMuleVirtualDataViewCtrl::SortItems()
 void CMuleVirtualDataViewCtrl::SortList()
 {
 	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+
+	// The cursor is addressed by row, like the selection, and unlike the
+	// selection nothing else puts it back. Reset() used to invalidate it
+	// along with the rest of the view; a repaint leaves it pointing at
+	// whatever item has since moved into that row -- so the next arrow key
+	// steps from the wrong place, a shifted page key extends from the wrong
+	// anchor, and the focus ring can come to rest on an unselected row.
+	const wxDataViewItem currentItem = GetCurrentItem();
+	const wxUIntPtr currentData =
+		currentItem.IsOk() ? ItemAt(static_cast<long>(m_virtualModel->GetRow(currentItem))) : 0;
+
 	SortItems();
 
 	// Repaint, rather than Reset(). A sort reorders rows; it does not replace
@@ -413,6 +424,13 @@ void CMuleVirtualDataViewCtrl::SortList()
 	// The control's selection is a set of rows, and the rows now mean
 	// different items, so it is re-applied from the item data either way.
 	SetSelectedItemData(selected);
+
+	if (currentData != 0) {
+		const long row = RowOfData(currentData);
+		if (row >= 0) {
+			SetCurrentItem(m_virtualModel->GetItem(static_cast<unsigned>(row)));
+		}
+	}
 }
 
 void CMuleVirtualDataViewCtrl::GetDisplayOrder(wxDataViewItemArray &ordered) const

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -444,7 +444,6 @@ void CMuleVirtualDataViewCtrl::SortList()
 			}
 		}
 	}
-
 }
 
 void CMuleVirtualDataViewCtrl::GetDisplayOrder(wxDataViewItemArray &ordered) const

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -330,7 +330,16 @@ void CMuleVirtualDataViewCtrl::RemoveItemDataBatch(const std::vector<wxUIntPtr> 
 
 void CMuleVirtualDataViewCtrl::FinishBulkLoad()
 {
-	SortList();
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	SortItems();
+
+	// Reset() here, unlike SortList(): AppendItemData() adds rows without
+	// telling the control -- that is what makes a bulk load cheap -- so this
+	// is the only notification that the rows exist at all. A repaint would
+	// draw a list the control still believes is the length it was before.
+	m_virtualModel->Reset(static_cast<unsigned>(m_items.size()));
+
+	SetSelectedItemData(selected);
 }
 
 void CMuleVirtualDataViewCtrl::RemoveItemData(wxUIntPtr data)
@@ -378,20 +387,31 @@ void CMuleVirtualDataViewCtrl::ClearItemData()
 	m_virtualModel->Reset(0);
 }
 
-void CMuleVirtualDataViewCtrl::SortList()
+void CMuleVirtualDataViewCtrl::SortItems()
 {
-	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
-
 	std::sort(m_items.begin(), m_items.end(), [this](wxUIntPtr lhs, wxUIntPtr rhs) {
 		return CompareItemsFull(lhs, rhs) < 0;
 	});
 	RebuildRowIndex();
-	// Reset() rather than a per-row notification: with nothing materialised
-	// per row this only re-reads what is on screen.
-	m_virtualModel->Reset(static_cast<unsigned>(m_items.size()));
+}
 
-	// Reset() drops the selection on wxGTK (it survives on macOS), so it is
-	// re-applied from the item data either way.
+void CMuleVirtualDataViewCtrl::SortList()
+{
+	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	SortItems();
+
+	// Repaint, rather than Reset(). A sort reorders rows; it does not replace
+	// them, and the count is the same on both sides of the std::sort above.
+	// Reset() says the model was replaced, which makes every backend rebuild
+	// its view from scratch -- and a rebuilt view starts at the top, so an
+	// auto-sort while the user was reading further down threw them back to
+	// row 0, horizontally as well. Nothing needs telling: rows are addressed
+	// by index and their values are pulled per cell as they are drawn, so the
+	// cells simply render the new order.
+	Refresh();
+
+	// The control's selection is a set of rows, and the rows now mean
+	// different items, so it is re-applied from the item data either way.
 	SetSelectedItemData(selected);
 }
 

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -217,6 +217,10 @@ private:
 	int CompareItemsFull(wxUIntPtr data1, wxUIntPtr data2) const;
 	//! Where `data` belongs under the current sort.
 	long InsertPos(wxUIntPtr data) const;
+	//! Orders m_items and refreshes the row index, telling the control
+	//! nothing -- the caller decides what notification its situation needs.
+	void SortItems();
+
 	//! m_rowOf is a cache of m_items; every structural change rebuilds it.
 	void RebuildRowIndex();
 

--- a/src/SearchFile.cpp
+++ b/src/SearchFile.cpp
@@ -414,6 +414,13 @@ void CSearchFile::AddChild(CSearchFile *file)
 				logSearch, CFormat("Created initial child for result '%s'") % GetFileName());
 			m_children.push_back(new CSearchFile(*this));
 			m_children.back()->m_parent = this;
+			// Announced like any other new row. Without this the group is
+			// formed with two children while only the incoming one is ever
+			// notified, so a view that builds its rows from notifications --
+			// rather than re-reading the model as it draws, which is what
+			// hides this on macOS -- shows a two-variant group holding one
+			// row, and the one missing is the result received first.
+			Notify_Search_Add_Result(m_children.back());
 		}
 	}
 

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -555,12 +555,16 @@ void CSearchListCtrl::OnIdleHook()
 	// notifications with the full model reset a group formation needs left
 	// wxGTK's tree inconsistent, and neither ItemChanged() nor a
 	// delete-and-re-add worked around it -- only wxDataViewModel::Cleared()
-	// reliably makes the control re-derive container-ness. Cleared() throws
-	// away the control's own view state, so selection and expansion are
-	// captured and re-applied around it -- otherwise a result landing
-	// mid-search would deselect whatever the user had picked. Items are
-	// CSearchFile*, still valid across the rebuild; ones that went away are
-	// dropped by re-checking membership against the live tree afterwards.
+	// reliably makes the control re-derive container-ness.
+	//
+	// That is now the fallback rather than the rule: arrivals are reported
+	// incrementally where the backends tolerate it, and only what still
+	// needs a rebuild takes the branch below. Cleared() throws away the
+	// control's own view state, so selection and expansion are captured and
+	// re-applied around it -- otherwise a result landing mid-search would
+	// deselect whatever the user had picked. Items are CSearchFile*, still
+	// valid across the rebuild; ones that went away are dropped by
+	// re-checking membership against the live tree afterwards.
 	if (m_model->HasPending() && !m_model->HasPendingReset()) {
 		// Incremental batch: the control keeps its scroll position, its
 		// selection and its expanded rows, so there is nothing to preserve

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -573,6 +573,15 @@ void CSearchListCtrl::OnIdleHook()
 		// every burst.
 		m_model->FlushPending();
 	} else if (m_model->HasPending()) {
+		// The row the user is looking at, so the rebuild below can be put
+		// back where they left it. Cleared() drops the view to the top, and
+		// on a running search that is every idle -- measured on GTK with wx
+		// 3.3.3, EnsureVisible() afterwards lands it back on the same row
+		// exactly, because the items here are CSearchFile pointers and stay
+		// nameable across the rebuild (the virtual lists cannot do this:
+		// their items are row numbers, which mean nothing afterwards).
+		const wxDataViewItem topBefore = GetTopItem();
+
 		wxDataViewItemArray selected;
 		GetSelections(selected);
 		wxDataViewItemArray expanded;
@@ -603,6 +612,13 @@ void CSearchListCtrl::OnIdleHook()
 		}
 		if (!restore.IsEmpty()) {
 			SetSelections(restore);
+		}
+
+		// After the selection, which does not move the view on any backend,
+		// so this has the last word on where the list sits. Checked against
+		// the live tree first, like everything else restored here.
+		if (topBefore.IsOk() && live.Index(topBefore) != wxNOT_FOUND) {
+			EnsureVisible(topBefore);
 		}
 	}
 }

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -561,7 +561,14 @@ void CSearchListCtrl::OnIdleHook()
 	// mid-search would deselect whatever the user had picked. Items are
 	// CSearchFile*, still valid across the rebuild; ones that went away are
 	// dropped by re-checking membership against the live tree afterwards.
-	if (m_model->HasPending()) {
+	if (m_model->HasPending() && !m_model->HasPendingReset()) {
+		// Incremental batch: the control keeps its scroll position, its
+		// selection and its expanded rows, so there is nothing to preserve
+		// around it. This is the path a search takes while results stream
+		// in, which is why the list no longer jumps back to the top on
+		// every burst.
+		m_model->FlushPending();
+	} else if (m_model->HasPending()) {
 		wxDataViewItemArray selected;
 		GetSelections(selected);
 		wxDataViewItemArray expanded;

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -186,6 +186,19 @@ public:
 	bool PassesFilter(const CSearchFile *file) const;
 
 	/**
+	 * Whether a filter is in force, i.e. whether a row's visibility is a
+	 * live function of its values rather than a constant.
+	 *
+	 * CSearchListModel asks before deciding how to report a change. With no
+	 * filter every result is shown, so an arriving one is purely an addition
+	 * and an updated one keeps its row; with a filter, an update can make a
+	 * row have to appear or disappear (m_filterKnown drops a result the
+	 * moment its download status stops being NEW), which only a full
+	 * re-evaluation of the tree catches.
+	 */
+	bool HasActiveFilter() const { return m_filterEnabled && m_filter.IsValid(); }
+
+	/**
 	 * True if `file` should be exposed as a tree row: it passes the filter
 	 * itself, or (for a parent) at least one of its children does -- in
 	 * which case the parent is still shown as a container, regardless of

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -24,7 +24,9 @@
 
 #include "SearchListModel.h"
 
-#include <algorithm> // Needed for std::min
+#include <algorithm>     // Needed for std::min, std::find
+#include <unordered_map> // Needed for std::unordered_map (additions per parent)
+#include <unordered_set> // Needed for std::unordered_set (live-result check)
 
 #include <common/Format.h> // Needed for CFormat
 #include <tags/FileTags.h> // Needed for FT_MEDIA_LENGTH / _BITRATE / _CODEC
@@ -43,31 +45,140 @@ CSearchListModel::CSearchListModel(CSearchListCtrl *owner)
 {
 }
 
-void CSearchListModel::NotifyFileAdded(CSearchFile *)
+void CSearchListModel::NotifyFileAdded(CSearchFile *file)
 {
-	MarkDirty();
+	// A filter makes every row's visibility a live function of its values,
+	// which only a re-evaluation of the whole tree tracks.
+	if (file == nullptr || m_owner->HasActiveFilter()) {
+		MarkDirty();
+		return;
+	}
+
+#ifndef __WXOSX__
+	// A grouped result -- one that joined an existing one -- is reported by
+	// rebuilding, not incrementally, everywhere except macOS.
+	//
+	// PR #796 already found that GTK and MSW would not re-derive
+	// container-ness from ItemChanged() or a delete-and-re-add. ItemAdded()
+	// under the new parent, which is the notification that actually means
+	// "this row now has a child", does worse than fail on GTK: it aborts the
+	// application inside GtkTreeView's own red-black tree --
+	//
+	//   gtkrbtree.c:471:_gtk_rbtree_insert_after:
+	//     assertion failed: (_gtk_rbtree_is_nil (tree->root))
+	//
+	// -- because the row is inserted into a child tree GTK never built for a
+	// parent it still considers a leaf. Native NSOutlineView has no such
+	// structure to corrupt and re-queries IsContainer() as it draws, which
+	// is why it takes the incremental path happily.
+	//
+	// Only grouping is affected. A plain new result and a value change stay
+	// incremental on every platform, and those are the bulk of what arrives.
+	if (file->GetParent() != nullptr) {
+		MarkDirty();
+		return;
+	}
+#endif
+
+	m_pendingAdded.push_back(file);
 }
 
-void CSearchListModel::NotifyFileUpdated(CSearchFile *)
+void CSearchListModel::NotifyFileUpdated(CSearchFile *file)
 {
-	MarkDirty();
+	if (file == nullptr || m_owner->HasActiveFilter()) {
+		MarkDirty();
+		return;
+	}
+	m_pendingChanged.push_back(file);
 }
 
 void CSearchListModel::NotifyFilterChanged()
 {
 	// User action: reset now rather than waiting for idle.
+	DropPending();
 	m_pendingReset = false;
 	Cleared();
 }
 
+void CSearchListModel::DropPending()
+{
+	m_pendingAdded.clear();
+	m_pendingChanged.clear();
+}
+
 bool CSearchListModel::FlushPending()
 {
-	if (!m_pendingReset) {
+	if (m_pendingReset) {
+		// Supersedes anything queued: Cleared() re-reads the whole tree.
+		DropPending();
+		m_pendingReset = false;
+		Cleared();
+		return true;
+	}
+
+	if (m_pendingAdded.empty() && m_pendingChanged.empty()) {
 		return false;
 	}
-	m_pendingReset = false;
-	Cleared();
-	return true;
+
+	// Results can be freed between the notification and this flush -- a
+	// search being dropped takes its whole list with it -- so nothing is
+	// handed to wx without checking it is still in the live set. The same
+	// re-check the control does for its saved selection, for the same reason.
+	std::unordered_set<const CSearchFile *> live;
+	if (m_owner->GetSearchId()) {
+		const CSearchResultList &results =
+			theApp->searchlist->GetSearchResults(m_owner->GetSearchId());
+		live.insert(results.begin(), results.end());
+	}
+
+	// Additions are reported per parent, since wx takes one parent for a
+	// whole batch: top-level results under the root, grouped ones under the
+	// result they joined. A child is not in the indexed list -- IndexResult()
+	// keeps only top-level results -- so it is vouched for by its parent
+	// being live and still owning it.
+	wxDataViewItemArray addedRoots;
+	std::unordered_map<CSearchFile *, wxDataViewItemArray> addedChildren;
+	for (CSearchFile *file : m_pendingAdded) {
+		CSearchFile *parent = const_cast<CSearchFile *>(file->GetParent());
+		if (parent == nullptr) {
+			if (live.count(file) != 0) {
+				addedRoots.Add(ToItem(file));
+			}
+			continue;
+		}
+		if (live.count(parent) == 0) {
+			continue;
+		}
+		const CSearchResultList &kids = parent->GetChildren();
+		if (std::find(kids.begin(), kids.end(), file) != kids.end()) {
+			addedChildren[parent].Add(ToItem(file));
+		}
+	}
+
+	wxDataViewItemArray changed;
+	for (CSearchFile *file : m_pendingChanged) {
+		CSearchFile *parent = const_cast<CSearchFile *>(file->GetParent());
+		const bool stillThere =
+			(parent == nullptr) ? (live.count(file) != 0) : (live.count(parent) != 0);
+		if (stillThere) {
+			changed.Add(ToItem(file));
+		}
+	}
+	DropPending();
+
+	// Incremental, so the control keeps its scroll position, its selection
+	// and its expanded rows -- which Cleared() destroys, and which used to
+	// go on every burst of arriving results.
+	if (!addedRoots.IsEmpty()) {
+		ItemsAdded(wxDataViewItem(), addedRoots);
+	}
+	for (const auto &entry : addedChildren) {
+		ItemsAdded(ToItem(entry.first), entry.second);
+	}
+	if (!changed.IsEmpty()) {
+		ItemsChanged(changed);
+	}
+	return false;
 }
 
 unsigned int CSearchListModel::GetColumnCount() const

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -40,9 +40,29 @@
 #include "SearchList.h"     // Needed for CSearchList, CSearchResultList
 #include "SearchListCtrl.h"
 
+std::set<CSearchListModel *> CSearchListModel::s_models;
+
 CSearchListModel::CSearchListModel(CSearchListCtrl *owner)
 : m_owner(owner)
 {
+	s_models.insert(this);
+}
+
+CSearchListModel::~CSearchListModel()
+{
+	s_models.erase(this);
+}
+
+void CSearchListModel::DropReferencesTo(CSearchFile *file)
+{
+	for (CSearchListModel *model : s_models) {
+		model->m_pendingAdded.erase(
+			std::remove(model->m_pendingAdded.begin(), model->m_pendingAdded.end(), file),
+			model->m_pendingAdded.end());
+		model->m_pendingChanged.erase(
+			std::remove(model->m_pendingChanged.begin(), model->m_pendingChanged.end(), file),
+			model->m_pendingChanged.end());
+	}
 }
 
 void CSearchListModel::NotifyFileAdded(CSearchFile *file)
@@ -120,47 +140,34 @@ bool CSearchListModel::FlushPending()
 		return false;
 	}
 
-	// Results can be freed between the notification and this flush -- a
-	// search being dropped takes its whole list with it -- so nothing is
-	// handed to wx without checking it is still in the live set. The same
-	// re-check the control does for its saved selection, for the same reason.
-	std::unordered_set<const CSearchFile *> live;
-	if (m_owner->GetSearchId()) {
-		const CSearchResultList &results =
-			theApp->searchlist->GetSearchResults(m_owner->GetSearchId());
-		live.insert(results.begin(), results.end());
-	}
+	// Nothing here can be dangling: DropReferencesTo() removes a result the
+	// moment it is destroyed. Duplicates can be, and are: SetDownloadStatus()
+	// notifies every child of the parent it updated, so one arrival into a
+	// 50-variant group queues 51 entries and a busy idle window multiplies
+	// that. The control is handed each row once.
+	std::unordered_set<const CSearchFile *> seen;
 
 	// Additions are reported per parent, since wx takes one parent for a
 	// whole batch: top-level results under the root, grouped ones under the
-	// result they joined. A child is not in the indexed list -- IndexResult()
-	// keeps only top-level results -- so it is vouched for by its parent
-	// being live and still owning it.
+	// result they joined.
 	wxDataViewItemArray addedRoots;
 	std::unordered_map<CSearchFile *, wxDataViewItemArray> addedChildren;
 	for (CSearchFile *file : m_pendingAdded) {
+		if (!seen.insert(file).second) {
+			continue;
+		}
 		CSearchFile *parent = const_cast<CSearchFile *>(file->GetParent());
 		if (parent == nullptr) {
-			if (live.count(file) != 0) {
-				addedRoots.Add(ToItem(file));
-			}
-			continue;
-		}
-		if (live.count(parent) == 0) {
-			continue;
-		}
-		const CSearchResultList &kids = parent->GetChildren();
-		if (std::find(kids.begin(), kids.end(), file) != kids.end()) {
+			addedRoots.Add(ToItem(file));
+		} else {
 			addedChildren[parent].Add(ToItem(file));
 		}
 	}
 
+	seen.clear();
 	wxDataViewItemArray changed;
 	for (CSearchFile *file : m_pendingChanged) {
-		CSearchFile *parent = const_cast<CSearchFile *>(file->GetParent());
-		const bool stillThere =
-			(parent == nullptr) ? (live.count(file) != 0) : (live.count(parent) != 0);
-		if (stillThere) {
+		if (seen.insert(file).second) {
 			changed.Add(ToItem(file));
 		}
 	}

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -24,9 +24,9 @@
 
 #include "SearchListModel.h"
 
-#include <algorithm>     // Needed for std::min, std::find
+#include <algorithm>     // Needed for std::min, std::remove
 #include <unordered_map> // Needed for std::unordered_map (additions per parent)
-#include <unordered_set> // Needed for std::unordered_set (live-result check)
+#include <unordered_set> // Needed for std::unordered_set (duplicate suppression)
 
 #include <common/Format.h> // Needed for CFormat
 #include <tags/FileTags.h> // Needed for FT_MEDIA_LENGTH / _BITRATE / _CODEC

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -40,6 +40,54 @@
 #include "SearchList.h"     // Needed for CSearchList, CSearchResultList
 #include "SearchListCtrl.h"
 
+namespace
+{
+/**
+ * Whether arrivals may be reported to the control one at a time.
+ *
+ * Only on macOS, and only with no filter in force.
+ *
+ * The filter half is about correctness: m_filterKnown makes a row's
+ * visibility a live function of its download status, so a value change can
+ * require a row to appear or disappear, which only re-evaluating the tree
+ * catches.
+ *
+ * The platform half is about wx. Its GTK backend keeps its own mirror of the
+ * model's tree, and feeding this model's arrivals into it a notification at
+ * a time corrupts GtkTreeView's red-black tree outright --
+ *
+ *   gtkrbtree.c:471:_gtk_rbtree_insert_after:
+ *     assertion failed: (_gtk_rbtree_is_nil (tree->root))
+ *
+ * -- which aborts the application. That was first seen for ItemAdded() under
+ * a newly formed group; confining the incremental path to top-level
+ * additions and value changes did not avoid it, as the same abort came back
+ * from the root batch. PR #796 had already found that neither ItemChanged()
+ * nor a delete-and-re-add made GTK or MSW re-derive container-ness, and
+ * settled on Cleared() for that reason; two aborts from two different
+ * notifications say the constraint is broader than container-ness, so this
+ * stops trying to find the subset GTK tolerates.
+ *
+ * Native NSOutlineView keeps no such structure -- it re-queries the model as
+ * it draws, which is what masked the original #796 defect -- so it takes the
+ * incremental path happily, and that is where the scroll position was being
+ * lost on every burst of results.
+ *
+ * MSW is grouped with GTK deliberately: its generic implementation has tree
+ * bookkeeping of its own, it was never the platform this was tested on, and
+ * keeping today's behaviour there costs nothing but a repaint.
+ */
+bool IncrementalNotificationsUsable(const CSearchListCtrl *owner)
+{
+#ifdef __WXOSX__
+	return !owner->HasActiveFilter();
+#else
+	(void)owner;
+	return false;
+#endif
+}
+} // namespace
+
 std::set<CSearchListModel *> CSearchListModel::s_models;
 
 CSearchListModel::CSearchListModel(CSearchListCtrl *owner)
@@ -67,45 +115,16 @@ void CSearchListModel::DropReferencesTo(CSearchFile *file)
 
 void CSearchListModel::NotifyFileAdded(CSearchFile *file)
 {
-	// A filter makes every row's visibility a live function of its values,
-	// which only a re-evaluation of the whole tree tracks.
-	if (file == nullptr || m_owner->HasActiveFilter()) {
+	if (file == nullptr || !IncrementalNotificationsUsable(m_owner)) {
 		MarkDirty();
 		return;
 	}
-
-#ifndef __WXOSX__
-	// A grouped result -- one that joined an existing one -- is reported by
-	// rebuilding, not incrementally, everywhere except macOS.
-	//
-	// PR #796 already found that GTK and MSW would not re-derive
-	// container-ness from ItemChanged() or a delete-and-re-add. ItemAdded()
-	// under the new parent, which is the notification that actually means
-	// "this row now has a child", does worse than fail on GTK: it aborts the
-	// application inside GtkTreeView's own red-black tree --
-	//
-	//   gtkrbtree.c:471:_gtk_rbtree_insert_after:
-	//     assertion failed: (_gtk_rbtree_is_nil (tree->root))
-	//
-	// -- because the row is inserted into a child tree GTK never built for a
-	// parent it still considers a leaf. Native NSOutlineView has no such
-	// structure to corrupt and re-queries IsContainer() as it draws, which
-	// is why it takes the incremental path happily.
-	//
-	// Only grouping is affected. A plain new result and a value change stay
-	// incremental on every platform, and those are the bulk of what arrives.
-	if (file->GetParent() != nullptr) {
-		MarkDirty();
-		return;
-	}
-#endif
-
 	m_pendingAdded.push_back(file);
 }
 
 void CSearchListModel::NotifyFileUpdated(CSearchFile *file)
 {
-	if (file == nullptr || m_owner->HasActiveFilter()) {
+	if (file == nullptr || !IncrementalNotificationsUsable(m_owner)) {
 		MarkDirty();
 		return;
 	}

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -27,6 +27,7 @@
 
 #include <wx/dataview.h>
 
+#include <set>    // Needed for std::set (the live-model registry)
 #include <vector> // Needed for std::vector (the pending-arrival batches)
 
 class CSearchFile;
@@ -60,6 +61,7 @@ class CSearchListModel : public wxDataViewModel
 {
 public:
 	explicit CSearchListModel(CSearchListCtrl *owner);
+	~CSearchListModel() override;
 
 	//! Notify the control that a new result is now visible (already added
 	//! to CSearchList's own storage by the caller).
@@ -96,6 +98,18 @@ public:
 	//! tree anyway, and for a new result set, whose pending entries point
 	//! into storage that is no longer ours.
 	void DropPending();
+
+	/**
+	 * Forgets @a file, which is about to be freed.
+	 *
+	 * Called for every CSearchFile destruction (MuleNotify::
+	 * SearchFileBeingDestroyed), which is the only liveness signal there is:
+	 * nothing unlinks a child from its parent's m_children, so a pointer
+	 * being listed there says nothing about whether it is still allocated.
+	 * Every live model is asked, since a result belongs to exactly one of
+	 * them and none of them knows which.
+	 */
+	static void DropReferencesTo(CSearchFile *file);
 
 	static CSearchFile *ToFile(const wxDataViewItem &item)
 	{
@@ -157,12 +171,15 @@ private:
 	//! Set when only a full rebuild will do; see MarkDirty().
 	bool m_pendingReset = false;
 
-	//! Arrivals waiting to be reported incrementally: new top-level rows,
-	//! and rows whose values changed. Held as pointers, so every flush
-	//! re-checks them against live storage before handing them to wx -- a
-	//! result can be freed between the notification and the next idle.
+	//! Arrivals waiting to be reported incrementally: new rows, and rows
+	//! whose values changed. Held as pointers between the notification and
+	//! the next idle, and kept honest by DropReferencesTo().
 	std::vector<CSearchFile *> m_pendingAdded;
 	std::vector<CSearchFile *> m_pendingChanged;
+
+	//! Every model that currently exists, for DropReferencesTo(). One per
+	//! search tab, so a handful at most.
+	static std::set<CSearchListModel *> s_models;
 };
 
 #endif // SEARCHLISTMODEL_H

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -27,6 +27,8 @@
 
 #include <wx/dataview.h>
 
+#include <vector> // Needed for std::vector (the pending-arrival batches)
+
 class CSearchFile;
 class CSearchListCtrl;
 
@@ -68,15 +70,32 @@ public:
 	//! tree should be re-evaluated (some rows may appear/disappear).
 	void NotifyFilterChanged();
 
-	//! Results arrive in bursts, and mixing incremental Item* notifications
-	//! with the full Cleared() that a group formation requires leaves the
-	//! control's tree inconsistent on GTK/MSW (got3nks, PR #796 review, after
-	//! ItemChanged() and delete+re-add both failed to make those backends
-	//! re-derive container-ness). Every arrival now just marks the model
-	//! dirty; the control flushes one reset per idle (CSearchListCtrl::OnIdle).
+	//! Forces the next flush to be a full Cleared(). Group formation needs
+	//! one: making an existing result a container leaves the control's tree
+	//! inconsistent on GTK/MSW under any incremental notification (got3nks,
+	//! PR #796 review, after ItemChanged() and delete+re-add both failed to
+	//! make those backends re-derive container-ness).
 	void MarkDirty() { m_pendingReset = true; }
+
+	//! Applies whatever the arrivals since the last flush added up to, one
+	//! batch per idle (CSearchListCtrl::OnIdle). Returns true if it was a
+	//! Cleared(), which costs the control its view state.
 	bool FlushPending();
-	bool HasPending() const { return m_pendingReset; }
+
+	//! Whether anything is waiting, of either kind.
+	bool HasPending() const
+	{
+		return m_pendingReset || !m_pendingAdded.empty() || !m_pendingChanged.empty();
+	}
+
+	//! Whether the next flush will be a Cleared(), so the caller knows to
+	//! save and restore selection and expansion around it.
+	bool HasPendingReset() const { return m_pendingReset; }
+
+	//! Drops everything queued. For the paths that are about to rebuild the
+	//! tree anyway, and for a new result set, whose pending entries point
+	//! into storage that is no longer ours.
+	void DropPending();
 
 	static CSearchFile *ToFile(const wxDataViewItem &item)
 	{
@@ -134,7 +153,16 @@ public:
 
 private:
 	CSearchListCtrl *m_owner;
+
+	//! Set when only a full rebuild will do; see MarkDirty().
 	bool m_pendingReset = false;
+
+	//! Arrivals waiting to be reported incrementally: new top-level rows,
+	//! and rows whose values changed. Held as pointers, so every flush
+	//! re-checks them against live storage before handing them to wx -- a
+	//! result can be freed between the notification and the next idle.
+	std::vector<CSearchFile *> m_pendingAdded;
+	std::vector<CSearchFile *> m_pendingChanged;
 };
 
 #endif // SEARCHLISTMODEL_H


### PR DESCRIPTION
Three ways the wxDataViewCtrl lists lost the user's place, reported against amulegui on macOS, plus the fallout from fixing them.

## 1. A re-sort threw the list back to the top

`CMuleVirtualDataViewCtrl::SortList()` ended in `wxDataViewIndexListModel::Reset()`, which says the model was *replaced*. Every backend answers that by rebuilding its view, and a rebuilt view starts at row 0 — horizontally too. With live sorting on a busy list that fires continuously, so shared files and the clients list could not be read while they updated.

A sort reorders rows; it does not replace them, and the count is identical on both sides of the `std::sort`. Rows are addressed by index and values are pulled per cell as they are drawn, so a repaint is all a reorder needs.

The bulk path cannot use that, and this is the trap worth knowing: `AppendItemData()` adds rows *without* telling the control — that is what makes a bulk load cheap — so `Reset()` was doubling as the only notification that the rows existed. Repainting there draws a list the control still believes is its old length, i.e. empty on a fresh populate. So the sort splits: `SortItems()` orders and reindexes silently, `SortList()` adds the repaint, `FinishBulkLoad()` keeps the `Reset()` it genuinely needs.

Affects servers, shared files, clients, downloads, file details and friends.

## 2. macOS page keys scrolled without taking the cursor

The unshifted page and home/end keys were left to NSOutlineView, on the grounds that scroll-without-select is the macOS convention. In a list it reads as broken: the view jumps, the cursor stays behind, and the next arrow key snaps straight back — so the page key looks like it did nothing.

They now run through the same handler as the shifted ones, which exists because the native control does nothing for those either. Unshifted replaces the selection with the row landed on, as an arrow key would; shifted keeps extending. Both move the cursor, which is the half that makes the following arrow key continue from what is on screen. Matches GTK and MSW, where the backends do this themselves.

## 3. The search list reset on every burst of results

Each arriving result marked the model dirty and the idle flush answered with `Cleared()`. During a search that is continuous, so the list snapped to the top constantly.

Arrivals now batch per idle into `ItemsAdded()` / `ItemsChanged()` — **on macOS only**. On GTK, feeding this model's arrivals in one notification at a time aborts the application inside GtkTreeView's own red-black tree:

```
gtkrbtree.c:471:_gtk_rbtree_insert_after: assertion failed: (_gtk_rbtree_is_nil (tree->root))
```

That was first seen for `ItemAdded()` under a newly formed group, and routing grouped results back through `Cleared()` did not avoid it — the same abort came back from the batch of top-level additions. #796 had already found that neither `ItemChanged()` nor a delete-and-re-add made GTK or MSW re-derive container-ness; two aborts from two different notifications say the constraint is broader than container-ness, so this stops looking for the subset GTK tolerates. MSW is grouped with GTK deliberately: it has tree bookkeeping of its own and was not the platform this was reported on.

Those platforms keep one `Cleared()` per idle, and instead put the view back afterwards — the idle branch already restored the selection and the expanded rows, so the top row joins them. That works here and not in the virtual lists because the items differ: a `CSearchFile` pointer still names the same result after a rebuild, while a `wxDataViewIndexListModel` item is a row number that names whatever has since moved into it.

## Measurements

Each of these was settled by probe rather than by argument, against wx 3.3.3:

| | GTK | macOS |
|---|---|---|
| `Refresh()` / `SetSelections()` | no scroll | no scroll |
| `SetCurrentItem()`, row on screen | no scroll | no scroll |
| `SetCurrentItem()`, row off screen | clamps onto the cursor | — |
| `Cleared()` / `Reset()` | top | top |
| `EnsureVisible()` after `Cleared()` | exact | lands at the bottom |
| `ItemsAdded()` / `ItemsChanged()` | aborts | holds position |

Two consequences. The cursor restore is gated on the row being on screen — with no row ever clicked GTK's cursor sits at row 0, so restoring it unconditionally clamped the view to the top, which is the very thing being fixed. And `GetScrollPos()` is unusable on this control: wx asserts "this window is not scrollable" and answers 0, so an earlier save-and-restore built on it was inert.

## From review

- The synthetic first child of a new group is now announced. `AddChild()` creates a copy of the parent as the first child — the result received first — and notified nobody, so a freshly formed group reported one child where the model had two. macOS hid it by re-reading the model as it draws, which is the same thing that masked the original #796 defect.
- Both batches de-duplicate. `SetDownloadStatus()` notifies every child of the parent it updated, so one arrival into a 50-variant group queued 51 entries and a busy idle window multiplied that.
- Pending pointers are dropped through `MuleNotify::SearchFileBeingDestroyed`, which `CCommentDialogLst` already consumes for this purpose. The previous guard checked membership in a parent's child list, which nothing ever unlinks from — it could not detect a freed child.
- `SortList()` restores the cursor by identity alongside the selection; `Reset()` used to invalidate it, and a repaint does not.

## Verification

Built clean on macOS ARM64, Ubuntu ARM64 and Windows ARM64 — no warnings from project sources. clang-format and both clang-tidy tiers clean over the diff.

Confirmed interactively on amulegui on all three platforms: shared files and clients hold position through auto-sort, the search list holds position while results stream in, group expansion is intact, and the page keys move the cursor with the view on macOS.
