### PR TITLE
fix(gui): amulegui dark mode on Windows, and the restored sort caret on GTK

### DIFF
--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -242,7 +242,51 @@ int CMuleDataViewCtrl::CompareItems(const wxDataViewItem &item1, const wxDataVie
 	return 0;
 }
 
-void CMuleDataViewCtrl::ApplySorting(unsigned column, unsigned order)
+void CMuleDataViewCtrl::ShowSortCaret(unsigned column, unsigned order, SortTrigger trigger)
+{
+	if (column >= RealColumnCount()) {
+		return;
+	}
+
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
+		if (i != column && GetColumn(i)->IsSortKey()) {
+			GetColumn(i)->UnsetAsSortKey();
+		}
+	}
+
+	bool ascending = !(order & SORT_DES);
+
+#ifdef __WXGTK__
+	// Two GTK quirks stack up here, and they only cancel each other out on
+	// the click path -- which is why the caret used to come back up the wrong
+	// way round after a restart, then correct itself the moment a header was
+	// clicked.
+	//
+	// The first is the glyph: with gtk-alternative-sort-arrows off (the
+	// default) GTK draws GTK_SORT_ASCENDING as "pan-down-symbolic", so an A-Z
+	// sort gets a *down* arrow, the opposite of macOS and MSW.
+	//
+	// The second is that GTK sorts on its own. wx makes every sortable column
+	// call gtk_tree_view_column_set_sort_column_id(), which leaves GTK's own
+	// handler connected: on the button *release*, after this control has
+	// already handled the button press and set the caret, GTK flips the order
+	// it finds and writes it back. Two inversions, so a clicked header ends
+	// up looking right.
+	//
+	// Nothing restores a saved sort, so hand wx the flipped value there and
+	// both paths agree. Only the arrow is affected -- rows are ordered from
+	// m_sort_orders, and the model deliberately ignores wx's ascending flag.
+	if (trigger == SortTrigger::Programmatic) {
+		ascending = !ascending;
+	}
+#else
+	wxUnusedVar(trigger);
+#endif
+
+	GetColumn(column)->SetSortOrder(ascending);
+}
+
+void CMuleDataViewCtrl::ApplySorting(unsigned column, unsigned order, SortTrigger trigger)
 {
 	// Push to the front: the most recently clicked column is primary, the
 	// rest stay as tie-breakers, matching CMuleListCtrl::SetSorting().
@@ -254,14 +298,7 @@ void CMuleDataViewCtrl::ApplySorting(unsigned column, unsigned order)
 	}
 	m_sort_orders.emplace_front(column, order);
 
-	if (column < RealColumnCount()) {
-		for (unsigned i = 0; i < RealColumnCount(); ++i) {
-			if (i != column && GetColumn(i)->IsSortKey()) {
-				GetColumn(i)->UnsetAsSortKey();
-			}
-		}
-		GetColumn(column)->SetSortOrder(!(order & SORT_DES));
-	}
+	ShowSortCaret(column, order, trigger);
 
 	OnSortingChanged();
 }
@@ -371,7 +408,7 @@ void CMuleDataViewCtrl::OnColumnHeaderClick(wxDataViewEvent &event)
 		}
 	}
 
-	ApplySorting(column, sort_order);
+	ApplySorting(column, sort_order, SortTrigger::HeaderClick);
 	SaveColumnSettings();
 }
 

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -75,6 +75,18 @@ public:
 	};
 
 	/**
+	 * What asked for a sort, which decides how the header caret is drawn.
+	 *
+	 * Only wxGTK cares, and only because it takes a second run at the caret
+	 * on its own after a header click -- see ShowSortCaret().
+	 */
+	enum class SortTrigger
+	{
+		Programmatic, //!< aMule chose the order: startup, defaults, list sync
+		HeaderClick   //!< the user clicked the header
+	};
+
+	/**
 	 * Whether a column is hidden.
 	 *
 	 * Tracked here rather than derived from the control: a hidden
@@ -164,7 +176,16 @@ protected:
 	int CompareItems(const wxDataViewItem &item1, const wxDataViewItem &item2) const;
 
 	//! Pushes a column to the front of the sort chain and applies the caret.
-	void ApplySorting(unsigned column, unsigned order);
+	void ApplySorting(unsigned column, unsigned order, SortTrigger trigger = SortTrigger::Programmatic);
+
+	/**
+	 * Draws the header caret for `order` on `column` and clears it elsewhere.
+	 *
+	 * Split out of ApplySorting() for the lists that keep the sort chain in
+	 * step by hand (CSearchListCtrl mirrors one list's order onto the others)
+	 * and must not re-enter the chain bookkeeping.
+	 */
+	void ShowSortCaret(unsigned column, unsigned order, SortTrigger trigger = SortTrigger::Programmatic);
 
 	void LoadColumnSettings();
 	void SaveColumnSettings();

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -177,7 +177,7 @@ CSearchListCtrl::CSearchListCtrl(
 
 	// Default sort is by name, ascending.
 	m_sort_orders.emplace_back(CSearchListModel::COL_NAME, 0);
-	GetColumn(CSearchListModel::COL_NAME)->SetSortOrder(true);
+	ShowSortCaret(CSearchListModel::COL_NAME, 0);
 
 	// Only load settings for first list, otherwise sync with current lists
 	if (s_lists.empty()) {
@@ -496,12 +496,7 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 		dst->m_sort_orders = src->m_sort_orders;
 		if (!dst->m_sort_orders.empty()) {
 			const CColPair &primary = dst->m_sort_orders.front();
-			for (unsigned i = 0; i < dst->RealColumnCount(); ++i) {
-				if (i != primary.first && dst->GetColumn(i)->IsSortKey()) {
-					dst->GetColumn(i)->UnsetAsSortKey();
-				}
-			}
-			dst->GetColumn(primary.first)->SetSortOrder(!(primary.second & SORT_DES));
+			dst->ShowSortCaret(primary.first, primary.second);
 			dst->GetModel()->Resort();
 		}
 	}

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -141,6 +141,22 @@ int CamuleGuiBase::ShowAlert(wxString msg, wxString title, int flags)
 	return wxMessageBox(msg, title, flags);
 }
 
+void CamuleGuiBase::FollowSystemAppearance()
+{
+#if wxCHECK_VERSION(3, 3, 0)
+	// Every other platform follows the desktop's light/dark setting by
+	// itself; MSW is the one that has to be asked, which is why aMule looked
+	// native in dark mode on GTK and macOS but not on Windows.
+	//
+	// Not gated on __WXMSW__: Appearance::System is the right request
+	// everywhere and is a no-op where the platform already follows suit.
+	const wxApp::AppearanceResult appearance = wxTheApp->SetAppearance(wxApp::Appearance::System);
+	if (appearance == wxApp::AppearanceResult::Failure) {
+		AddDebugLogLineN(logStandard, "Could not follow the system light/dark appearance");
+	}
+#endif
+}
+
 int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 {
 	// Standard size is 800x600 at position (0,0)
@@ -387,22 +403,9 @@ bool CamuleGuiApp::OnInit()
 	// of the pointer; wx tears the providers down at app exit.
 	wxArtProvider::Push(new CamuleArtProvider());
 
-#if wxCHECK_VERSION(3, 3, 0)
-	// Follow the desktop's light/dark setting. Every other platform does
-	// this by itself; MSW is the one that has to be asked, which is why
-	// aMule looks native in dark mode on GTK and macOS but not on Windows.
-	//
-	// Must happen before any window exists -- wx answers CannotChange once
-	// one does, and the startup splash is created inside CamuleApp::OnInit()
-	// below, so anywhere later would silently do nothing.
-	//
-	// Not gated on __WXMSW__: Appearance::System is the right request
-	// everywhere and is a no-op where the platform already follows suit.
-	const AppearanceResult appearance = SetAppearance(Appearance::System);
-	if (appearance == AppearanceResult::Failure) {
-		AddDebugLogLineN(logStandard, "Could not follow the system light/dark appearance");
-	}
-#endif
+	// Must happen before any window exists, and the startup splash is created
+	// inside CamuleApp::OnInit() below.
+	FollowSystemAppearance();
 
 	if (!CamuleApp::OnInit()) {
 		return false;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -559,6 +559,11 @@ bool CamuleRemoteGuiApp::OnInit()
 	// the providers down at app exit.
 	wxArtProvider::Push(new CamuleArtProvider());
 
+	// Must happen before any window exists; the connect dialog below is the
+	// first one amulegui creates. Without this amulegui stayed light on
+	// Windows while the monolithic amule, which has always asked, went dark.
+	FollowSystemAppearance();
+
 	// Get theApp
 	theApp = &wxGetApp();
 

--- a/src/amule.h
+++ b/src/amule.h
@@ -685,6 +685,15 @@ public:
 	bool CopyTextToClipboard(wxString strText);
 	void ResetTitle();
 
+	/**
+	 * Asks the platform to follow the desktop's light/dark setting.
+	 *
+	 * Must be called from OnInit() before the first window is created: wx
+	 * answers CannotChange once one exists, so anywhere later silently does
+	 * nothing.
+	 */
+	static void FollowSystemAppearance();
+
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
 	virtual int ShowAlert(wxString msg, wxString title, int flags);
 


### PR DESCRIPTION
Two look-and-feel fixes, both about what the GUI does before its first window exists.

## amulegui had no dark mode on Windows

`CamuleGuiApp::OnInit()` asked the platform to follow the desktop light/dark setting; `CamuleRemoteGuiApp::OnInit()` never did. Only MSW has to be asked — GTK and macOS follow the desktop on their own — so the gap showed on Windows only: the monolithic amule went dark while amulegui stayed light.

The request moves to `CamuleGuiBase::FollowSystemAppearance()`, the class both apps already inherit, instead of being spelled out in one `OnInit()` and missing from the other.

## The restored sort caret pointed the wrong way on GTK

After a restart the header caret came back upside down, then corrected itself as soon as any header was clicked. Two GTK behaviours are involved:

- GTK draws `GTK_SORT_ASCENDING` as `pan-down-symbolic` while `gtk-alternative-sort-arrows` is off (the default), so an A→Z sort gets a *down* arrow — the opposite of macOS and MSW.
- GTK also sorts on its own. wx makes every sortable column call `gtk_tree_view_column_set_sort_column_id()`, which leaves GTK's own handler connected: wx raises `HEADER_CLICK` on the button press, and GTK's toggle runs on the release — after this control has already set the caret — flipping the value back.

On a click the two cancel out. Nothing cancels them when a saved sort is restored, which is why only the startup caret was ever wrong. `ShowSortCaret()` now hands wx the flipped value on the restore path, so both paths agree.

Only the arrow is affected either way: rows are ordered from `m_sort_orders`, and the virtual model deliberately ignores wx's `ascending` argument.

The same change folds the three copies of the clear-the-others-then-set-the-caret loop (`ApplySorting()`, plus two in `CSearchListCtrl`) into one helper; no direct `SetSortOrder()` / `UnsetAsSortKey()` callers remain outside it.

## Testing

Built and run on Windows 11 ARM64 (amulegui confirmed dark) and Ubuntu ARM64 / GTK3 (caret confirmed correct across restarts, clicks unchanged). macOS builds clean and is unaffected — the GTK branch compiles out.
