### PR TITLE
i18n: stop asking translators for the same path-mapping string twice

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4167,20 +4167,20 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5590,10 +5590,6 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
@@ -6065,14 +6061,6 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
-msgid "Remote prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6128,10 +6116,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:39+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -4216,20 +4216,21 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
-msgstr ""
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "احذف صديق"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5663,10 +5664,6 @@ msgstr "اتصال"
 msgid "Directories"
 msgstr "مجلدات"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "الخادمات"
@@ -6152,15 +6149,6 @@ msgid "Shared folder"
 msgstr "ملفات مشاركة"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "احذف صديق"
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6217,10 +6205,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:39+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -4285,22 +4285,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Sirvidor remotu"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Sirvidor llocal"
 
 #: src/muuli_wdr.cpp
@@ -5749,10 +5749,6 @@ msgstr "Conexón"
 msgid "Directories"
 msgstr "Direutorios"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Sirvidores"
@@ -6266,16 +6262,6 @@ msgid "Shared folder"
 msgstr "Carpetes compartíes"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Sirvidor remotu"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Sirvidor llocal"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6335,10 +6321,6 @@ msgstr "AVISU: Ficheru de llista de compartíos corruptu, tien una testera invá
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8865,6 +8847,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Sirvidor remotu"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Sirvidor llocal"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:39+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -4208,20 +4208,21 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
-msgstr ""
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Изтриване на приятел"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5644,10 +5645,6 @@ msgstr "Връзка"
 msgid "Directories"
 msgstr "Директории"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Сървъри"
@@ -6128,15 +6125,6 @@ msgid "Shared folder"
 msgstr "Споделени файлове (%i)"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Изтриване на приятел"
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6193,10 +6181,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4166,20 +4166,20 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5589,10 +5589,6 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
@@ -6064,14 +6060,6 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
-msgid "Remote prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6127,10 +6115,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:40+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -4273,22 +4273,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Servidor remot"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Servidor local"
 
 #: src/muuli_wdr.cpp
@@ -5724,10 +5724,6 @@ msgstr "Connexió"
 msgid "Directories"
 msgstr "Directoris"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidors"
@@ -6240,16 +6236,6 @@ msgid "Shared folder"
 msgstr "Carpetes compartides"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Servidor remot"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Servidor local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6309,11 +6295,6 @@ msgstr "ALERTA: Llista de fitxers coneguts malmesa, conté una capçalera no và
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Entrada no vàlida a la llista de fitxers coneguts, el fitxer podria estar corrupte: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Entrada no vàlida a la llista de fitxers coneguts, el fitxer podria estar corrupte: "
 
 #: src/SearchList.cpp
@@ -8810,6 +8791,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Servidor remot"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Servidor local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Entrada no vàlida a la llista de fitxers coneguts, el fitxer podria estar corrupte: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:40+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -4268,22 +4268,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Vzdálený server"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Lokální server"
 
 #: src/muuli_wdr.cpp
@@ -5729,10 +5729,6 @@ msgstr "Připojení"
 msgid "Directories"
 msgstr "Adresáře"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servery"
@@ -6242,16 +6238,6 @@ msgid "Shared folder"
 msgstr "Sdílené adresáře"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Vzdálený server"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Lokální server"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6311,10 +6297,6 @@ msgstr "VAROVÁNÍ: Soubor je porušen, obsahuje neplatnou hlavičku."
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8803,6 +8785,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Vzdálený server"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Lokální server"
 
 #, c-format
 #~ msgid "Hashing %u new file"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:40+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4229,20 +4229,21 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
-msgstr ""
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Fjern Ven"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5679,10 +5680,6 @@ msgstr "Forbindelse"
 msgid "Directories"
 msgstr "Mapper"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servere"
@@ -6170,15 +6167,6 @@ msgid "Shared folder"
 msgstr "Delte Filer"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Fjern Ven"
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6235,10 +6223,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:41+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -4273,22 +4273,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Entfernter Server"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Lokaler Server"
 
 #: src/muuli_wdr.cpp
@@ -5719,10 +5719,6 @@ msgstr "Verbindung"
 msgid "Directories"
 msgstr "Verzeichnisse"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Server"
@@ -6236,16 +6232,6 @@ msgid "Shared folder"
 msgstr "Freigegebene Ordner"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Entfernter Server"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Lokaler Server"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6305,11 +6291,6 @@ msgstr "WARNUNG: Liste der bekannten Dateien korrumpiert, enthält ungültigen H
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Ungültiger Eintrag in der Liste bekannter Dateien, Datei möglicherweise beschädigt: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Ungültiger Eintrag in der Liste bekannter Dateien, Datei möglicherweise beschädigt: "
 
 #: src/SearchList.cpp
@@ -8824,6 +8805,18 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Entfernter Server"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Lokaler Server"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Ungültiger Eintrag in der Liste bekannter Dateien, Datei möglicherweise beschädigt: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:41+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -4296,22 +4296,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Απομακρυσμένος διακομιστής"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Τοπικός διακομιστής"
 
 #: src/muuli_wdr.cpp
@@ -5761,10 +5761,6 @@ msgstr "Σύνδεση"
 msgid "Directories"
 msgstr "Κατάλογοι Αρχείων"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Διακομιστές"
@@ -6279,16 +6275,6 @@ msgid "Shared folder"
 msgstr "Κοινόχρηστα αρχεία"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Απομακρυσμένος διακομιστής"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Τοπικός διακομιστής"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6348,10 +6334,6 @@ msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: η λίστα των γνωστών αρχε
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8883,6 +8865,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Απομακρυσμένος διακομιστής"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Τοπικός διακομιστής"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4167,20 +4167,20 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5590,10 +5590,6 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
@@ -6065,14 +6061,6 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
-msgid "Remote prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6128,10 +6116,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:42+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -4263,22 +4263,22 @@ msgstr "Muestra cuántos archivos compartidos excluiría el patrón actual."
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Servidor remoto"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Servidor local"
 
 #: src/muuli_wdr.cpp
@@ -5714,10 +5714,6 @@ msgstr "Conexión"
 msgid "Directories"
 msgstr "Directorios"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
@@ -6221,16 +6217,6 @@ msgid "Shared folder"
 msgstr "Carpeta compartida"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Servidor remoto"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Servidor local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6290,11 +6276,6 @@ msgstr "AVISO: la lista de archivos conocidos está dañada, contiene una cabece
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Entrada inválida en lista de archivos conocidos, el archivo debe de estar dañado: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Entrada inválida en lista de archivos conocidos, el archivo debe de estar dañado: "
 
 #: src/SearchList.cpp
@@ -8805,6 +8786,18 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Servidor remoto"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Servidor local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Entrada inválida en lista de archivos conocidos, el archivo debe de estar dañado: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -4274,22 +4274,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Kaug server"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Kohalik server"
 
 #: src/muuli_wdr.cpp
@@ -5726,10 +5726,6 @@ msgstr "Ühendus"
 msgid "Directories"
 msgstr "Kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serverid"
@@ -6243,16 +6239,6 @@ msgid "Shared folder"
 msgstr "Jagatud kataloogid"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Kaug server"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Kohalik server"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6313,11 +6299,6 @@ msgstr "HOIATUS: Tuttavate failde loetelu on riknenud, sisaldab riknenud päist.
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Tuntud falide loetelus vigane kirje, fail võib olla vigane: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Tuntud falide loetelus vigane kirje, fail võib olla vigane: "
 
 #: src/SearchList.cpp
@@ -8813,6 +8794,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Kaug server"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Kohalik server"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Tuntud falide loetelus vigane kirje, fail võib olla vigane: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:43+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -4275,22 +4275,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Urruneko zerbitzaria"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Zerbitzari lokala"
 
 #: src/muuli_wdr.cpp
@@ -5725,10 +5725,6 @@ msgstr "Konexioa"
 msgid "Directories"
 msgstr "Direktorioak"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Zerbitzariak"
@@ -6242,16 +6238,6 @@ msgid "Shared folder"
 msgstr "Partekatutako karpetak"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Urruneko zerbitzaria"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Zerbitzari lokala"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6312,11 +6298,6 @@ msgstr "Abisua: Fitxategi ezagun zerrenda hondaturik dago, buru baliogabeak ditu
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Okerreko sarrera fitxategi ezagunen zerrendako fitxategian, hondaturik egon liteke: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Okerreko sarrera fitxategi ezagunen zerrendako fitxategian, hondaturik egon liteke: "
 
 #: src/SearchList.cpp
@@ -8813,6 +8794,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Urruneko zerbitzaria"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Zerbitzari lokala"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Okerreko sarrera fitxategi ezagunen zerrendako fitxategian, hondaturik egon liteke: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:43+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4275,22 +4275,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Etäpalvelin"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Paikallinen Palvelin"
 
 #: src/muuli_wdr.cpp
@@ -5725,10 +5725,6 @@ msgstr "Yhteys"
 msgid "Directories"
 msgstr "Kansiot"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Palvelimet"
@@ -6242,16 +6238,6 @@ msgid "Shared folder"
 msgstr "Jaetut kansiot"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Etäpalvelin"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Paikallinen Palvelin"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6312,11 +6298,6 @@ msgstr "VAROITUS: Tunnettujen tiedostojen lista on turmeltunut, sisältää epä
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Epäkelpo merkintä tunnettujen tiedostojen lista -tiedostossa, tiedosto saattaa olla turmeltunut: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Epäkelpo merkintä tunnettujen tiedostojen lista -tiedostossa, tiedosto saattaa olla turmeltunut: "
 
 #: src/SearchList.cpp
@@ -8813,6 +8794,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Etäpalvelin"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Paikallinen Palvelin"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Epäkelpo merkintä tunnettujen tiedostojen lista -tiedostossa, tiedosto saattaa olla turmeltunut: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:44+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -4261,22 +4261,22 @@ msgstr "Afficher combien de fichiers partagés le motif actuel exclurait."
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Serveur Distant"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Serveur Local"
 
 #: src/muuli_wdr.cpp
@@ -5708,10 +5708,6 @@ msgstr "Connexion"
 msgid "Directories"
 msgstr "Répertoires"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveurs"
@@ -6215,16 +6211,6 @@ msgid "Shared folder"
 msgstr "Dossier partagé"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Serveur Distant"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Serveur Local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6284,11 +6270,6 @@ msgstr "AVERTISSEMENT : La liste de fichiers connus est corrompue, elle contien
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Entrée invalide dans la liste des fichiers connus, le fichier est peut être corrompu : "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Entrée invalide dans la liste des fichiers connus, le fichier est peut être corrompu : "
 
 #: src/SearchList.cpp
@@ -8797,6 +8778,18 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Serveur Distant"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Serveur Local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Entrée invalide dans la liste des fichiers connus, le fichier est peut être corrompu : "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:44+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -4286,22 +4286,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Servidor remoto"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Servidor local"
 
 #: src/muuli_wdr.cpp
@@ -5733,10 +5733,6 @@ msgstr "Conexión"
 msgid "Directories"
 msgstr "Cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
@@ -6250,16 +6246,6 @@ msgid "Shared folder"
 msgstr "Cartafoles compartidos"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Servidor remoto"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Servidor local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6319,11 +6305,6 @@ msgstr "AVISO: A lista de ficheiros coñecidos corrompeuse por mor dunha cabecei
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Campo inválido na lista de ficheiros coñecidos, Pode ser que se corrompera o ficheiro: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Campo inválido na lista de ficheiros coñecidos, Pode ser que se corrompera o ficheiro: "
 
 #: src/SearchList.cpp
@@ -8834,6 +8815,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Servidor remoto"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Servidor local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Campo inválido na lista de ficheiros coñecidos, Pode ser que se corrompera o ficheiro: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:44+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -4243,22 +4243,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "שרת מרוחק"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "שרת מקומי"
 
 #: src/muuli_wdr.cpp
@@ -5698,10 +5698,6 @@ msgstr "חיבור"
 msgid "Directories"
 msgstr "מלונים"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "שרתים"
@@ -6207,16 +6203,6 @@ msgid "Shared folder"
 msgstr "קבצים משותפים"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "שרת מרוחק"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "שרת מקומי"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6275,10 +6261,6 @@ msgstr "אזהרה: רשימת הקבצים-המכורים פגומה, מכיל�
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8785,6 +8767,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "שרת מרוחק"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "שרת מקומי"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:45+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -4237,20 +4237,21 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
-msgstr ""
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Odstrani prijatelja"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5691,10 +5692,6 @@ msgstr "Veza"
 msgid "Directories"
 msgstr "Direktoriji"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveri"
@@ -6193,15 +6190,6 @@ msgid "Shared folder"
 msgstr "Dijeljeni fajlovi"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Odstrani prijatelja"
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6258,10 +6246,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:45+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -4256,22 +4256,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Távoli kiszolgáló"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Helyi kiszolgáló"
 
 #: src/muuli_wdr.cpp
@@ -5707,10 +5707,6 @@ msgstr "Csatlakozás"
 msgid "Directories"
 msgstr "Mappák"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Kiszolgálók"
@@ -6217,16 +6213,6 @@ msgid "Shared folder"
 msgstr "Megosztott mappák"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Távoli kiszolgáló"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Helyi kiszolgáló"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6286,11 +6272,6 @@ msgstr "FIGYELEM: Az ismert fájlok listája sérült, érvénytelen fejlécet t
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Érvénytelen bejegyzés az ismert fájlok listájában, hiba lehet a fájlban: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Érvénytelen bejegyzés az ismert fájlok listájában, hiba lehet a fájlban: "
 
 #: src/SearchList.cpp
@@ -8780,6 +8761,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Távoli kiszolgáló"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Helyi kiszolgáló"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Érvénytelen bejegyzés az ismert fájlok listájában, hiba lehet a fájlban: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 16:05+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -4267,22 +4267,22 @@ msgstr "Mostra quanti file condivisi verrebbero esclusi dal pattern attuale."
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Server remoto"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Server locale"
 
 #: src/muuli_wdr.cpp
@@ -5708,10 +5708,6 @@ msgstr "Connessione"
 msgid "Directories"
 msgstr "Directory"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Server"
@@ -6211,16 +6207,6 @@ msgid "Shared folder"
 msgstr "Cartella condivisa"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Server remoto"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Server locale"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6279,11 +6265,6 @@ msgstr "ATTENZIONE: la lista dei file conosciuti potrebbe essere danneggiata, co
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Voce non valida nella lista dei file conosciuti, il file potrebbe essere corrotto: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Voce non valida nella lista dei file conosciuti, il file potrebbe essere corrotto: "
 
 #: src/SearchList.cpp
@@ -8788,6 +8769,18 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Server remoto"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Server locale"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Voce non valida nella lista dei file conosciuti, il file potrebbe essere corrotto: "
 
 #, c-format
 #~ msgid "Hashing %u new file"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -4273,22 +4273,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "リモートサーバ"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "ローカルサーバ"
 
 #: src/muuli_wdr.cpp
@@ -5731,10 +5731,6 @@ msgstr "接続"
 msgid "Directories"
 msgstr "ディレクトリ"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "サーバ数"
@@ -6238,16 +6234,6 @@ msgid "Shared folder"
 msgstr "共有ファイル"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "リモートサーバ"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "ローカルサーバ"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6307,10 +6293,6 @@ msgstr "警告：Knownfileリストは破損され、不正なヘッダーが含
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8813,6 +8795,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "リモートサーバ"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "ローカルサーバ"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:47+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -4293,22 +4293,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "원격 서버"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "지역 서버"
 
 #: src/muuli_wdr.cpp
@@ -5756,10 +5756,6 @@ msgstr "연결"
 msgid "Directories"
 msgstr "폴더"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "서버"
@@ -6271,16 +6267,6 @@ msgid "Shared folder"
 msgstr "공유 파일"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "원격 서버"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "지역 서버"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6340,10 +6326,6 @@ msgstr "경고: 알려진파일 목록이 손상됨, 유효하지 않는 머리�
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8864,6 +8846,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "원격 서버"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "지역 서버"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:47+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -4305,22 +4305,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Nutolęs serveris"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Vietinis serveris"
 
 #: src/muuli_wdr.cpp
@@ -5772,10 +5772,6 @@ msgstr "Kanalas"
 msgid "Directories"
 msgstr "Aplankai"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveriai"
@@ -6294,16 +6290,6 @@ msgid "Shared folder"
 msgstr "Dalinami failai"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Nutolęs serveris"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Vietinis serveris"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6363,10 +6349,6 @@ msgstr "DĖMESIO: sugadintas known.met, klaidinga antraštė."
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8902,6 +8884,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Nutolęs serveris"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Vietinis serveris"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:56+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4189,20 +4189,21 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
-msgstr ""
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+#, fuzzy
+msgid "Remote prefix"
+msgstr "Noņemt no draugu saraksta"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5619,10 +5620,6 @@ msgstr "Savienojums"
 msgid "Directories"
 msgstr "Mapes"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serveri"
@@ -6100,15 +6097,6 @@ msgid "Shared folder"
 msgstr "Kopīgotās datnes"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Noņemt no draugu saraksta"
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6164,10 +6152,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:47+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -4278,22 +4278,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Server op Afstand"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Lokale server"
 
 #: src/muuli_wdr.cpp
@@ -5729,10 +5729,6 @@ msgstr "Verbinding"
 msgid "Directories"
 msgstr "Mappen"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servers"
@@ -6245,16 +6241,6 @@ msgid "Shared folder"
 msgstr "Gedeelde mappen"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Server op Afstand"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Lokale server"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6314,11 +6300,6 @@ msgstr "WAARSCHUWING: Bekende-bestandenlijst beschadigd, bevat ongeldige header.
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Ongeldige vermelding in bekende-bestandenlijst, bestand kan beschadigd zijn: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Ongeldige vermelding in bekende-bestandenlijst, bestand kan beschadigd zijn: "
 
 #: src/SearchList.cpp
@@ -8819,6 +8800,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Server op Afstand"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Lokale server"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Ongeldige vermelding in bekende-bestandenlijst, bestand kan beschadigd zijn: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:48+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -4292,22 +4292,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Fjern tenar"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Lokal tenar"
 
 #: src/muuli_wdr.cpp
@@ -5755,10 +5755,6 @@ msgstr "Kopling"
 msgid "Directories"
 msgstr "Katalogar"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Tenarar"
@@ -6272,16 +6268,6 @@ msgid "Shared folder"
 msgstr "Delte filer"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Fjern tenar"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Lokal tenar"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6341,10 +6327,6 @@ msgstr "ÅTVARING: Kjendfillista er korrupt; inneheld ugangbar overskrift."
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8873,6 +8855,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Fjern tenar"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Lokal tenar"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:48+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -4288,22 +4288,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Serwer zdalny"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Serwer lokalny"
 
 #: src/muuli_wdr.cpp
@@ -5750,10 +5750,6 @@ msgstr "Połączenie"
 msgid "Directories"
 msgstr "Katalogi"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Serwery"
@@ -6274,16 +6270,6 @@ msgid "Shared folder"
 msgstr "Udostępnione foldery"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Serwer zdalny"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Serwer lokalny"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6344,11 +6330,6 @@ msgstr "OSTRZEŻENIE: Znana lista plików uszkodzona, zawiera nieprawidłowy nag
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Nieprawidłowy wpis w znanej liście plików, plik może być uszkodzony: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Nieprawidłowy wpis w znanej liście plików, plik może być uszkodzony: "
 
 #: src/SearchList.cpp
@@ -8861,6 +8842,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Serwer zdalny"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Serwer lokalny"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Nieprawidłowy wpis w znanej liście plików, plik może być uszkodzony: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:49+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -4263,22 +4263,22 @@ msgstr "Mostra quantos arquivos compartilhados o padrão atual excluiria."
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Servidor Remoto"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Servidor Local"
 
 #: src/muuli_wdr.cpp
@@ -5704,10 +5704,6 @@ msgstr "Conexão"
 msgid "Directories"
 msgstr "Diretórios"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
@@ -6208,16 +6204,6 @@ msgid "Shared folder"
 msgstr "Pasta compartilhada"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Servidor Remoto"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Servidor Local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6276,11 +6262,6 @@ msgstr "ATENÇÃO: Arquivo de lista known corrompido, contém cabeçalho inváli
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Entrada inválida na lista de arquivo known, arquivo pode estar corrompido: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Entrada inválida na lista de arquivo known, arquivo pode estar corrompido: "
 
 #: src/SearchList.cpp
@@ -8786,6 +8767,18 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Servidor Remoto"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Servidor Local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Entrada inválida na lista de arquivo known, arquivo pode estar corrompido: "
 
 #, c-format
 #~ msgid "Hashing %u new file"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:49+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -4281,22 +4281,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Servidor Remoto"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Servidor Local"
 
 #: src/muuli_wdr.cpp
@@ -5733,10 +5733,6 @@ msgstr "Ligação"
 msgid "Directories"
 msgstr "Directórios"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servidores"
@@ -6250,16 +6246,6 @@ msgid "Shared folder"
 msgstr "Pastas partilhadas"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Servidor Remoto"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Servidor Local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6320,11 +6306,6 @@ msgstr "AVISO: Lista de ficheiros conhecidos corrompida, contém cabeçalho inv�
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Entrada inválida na lista de ficheiros conhecidos, o ficheiro pode estar corrompido"
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Entrada inválida na lista de ficheiros conhecidos, o ficheiro pode estar corrompido"
 
 #: src/SearchList.cpp
@@ -8822,6 +8803,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Servidor Remoto"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Servidor Local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Entrada inválida na lista de ficheiros conhecidos, o ficheiro pode estar corrompido"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:50+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -4283,22 +4283,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Server distant"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Server local"
 
 #: src/muuli_wdr.cpp
@@ -5736,10 +5736,6 @@ msgstr "Conexiune"
 msgid "Directories"
 msgstr "Directoare"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servere"
@@ -6257,16 +6253,6 @@ msgid "Shared folder"
 msgstr "Dosare partajate"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Server distant"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Server local"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6327,11 +6313,6 @@ msgstr "ATENȚIE: Lista de fișiere cunoscute este coruptă, conține antet neva
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Intrare nevalidă în lista de fișiere cunoscute, fișierul poate fi corupt:"
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Intrare nevalidă în lista de fișiere cunoscute, fișierul poate fi corupt:"
 
 #: src/SearchList.cpp
@@ -8839,6 +8820,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Server distant"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Server local"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Intrare nevalidă în lista de fișiere cunoscute, fișierul poate fi corupt:"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:51+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -4289,22 +4289,22 @@ msgstr "Показать, сколько общих файлов исключи�
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Удалённый сервер"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Локальный сервер"
 
 #: src/muuli_wdr.cpp
@@ -5742,10 +5742,6 @@ msgstr "Соединение"
 msgid "Directories"
 msgstr "Каталоги"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Серверы"
@@ -6253,16 +6249,6 @@ msgid "Shared folder"
 msgstr "Общая папка"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Удалённый сервер"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Локальный сервер"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6322,11 +6308,6 @@ msgstr "ПРЕДУПРЕЖДЕНИЕ: Список известных файло
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Неверный элемент списка известных файлов, файл возможно повреждён: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Неверный элемент списка известных файлов, файл возможно повреждён: "
 
 #: src/SearchList.cpp
@@ -8851,6 +8832,18 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Удалённый сервер"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Локальный сервер"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Неверный элемент списка известных файлов, файл возможно повреждён: "
 
 #, c-format
 #~ msgid "Hashing %u new file"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:51+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -4303,22 +4303,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Oddaljni strežnik"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Krajevni strežnik"
 
 #: src/muuli_wdr.cpp
@@ -5764,10 +5764,6 @@ msgstr "Povezava"
 msgid "Directories"
 msgstr "Mape"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Strežniki"
@@ -6292,16 +6288,6 @@ msgid "Shared folder"
 msgstr "Deljene mape"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Oddaljni strežnik"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Krajevni strežnik"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6361,11 +6347,6 @@ msgstr "OPOZORILO: seznam znanih datotek je pokvarjen, vsebuje neveljavno glavo.
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Neveljaven vnos na seznamu znanih datotek, datoteka je morda pokvarjena: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Neveljaven vnos na seznamu znanih datotek, datoteka je morda pokvarjena: "
 
 #: src/SearchList.cpp
@@ -8877,6 +8858,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Oddaljni strežnik"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Krajevni strežnik"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Neveljaven vnos na seznamu znanih datotek, datoteka je morda pokvarjena: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:52+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -4285,22 +4285,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Server i larget"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Server Lokal"
 
 #: src/muuli_wdr.cpp
@@ -5747,10 +5747,6 @@ msgstr "Lidhje"
 msgid "Directories"
 msgstr "Direktorite"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servera"
@@ -6262,16 +6258,6 @@ msgid "Shared folder"
 msgstr "File te ndara"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Server i larget"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Server Lokal"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6331,10 +6317,6 @@ msgstr "Kujdes: Lista e faileve te njohur eshte e demtuar, permban nje header te
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8844,6 +8826,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Server i larget"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Server Lokal"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:52+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -4273,22 +4273,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Fjärrserver"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Lokal server"
 
 #: src/muuli_wdr.cpp
@@ -5722,10 +5722,6 @@ msgstr "Anslutning"
 msgid "Directories"
 msgstr "Kataloger"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Servrar"
@@ -6238,16 +6234,6 @@ msgid "Shared folder"
 msgstr "Delade mappar"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Fjärrserver"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Lokal server"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6308,11 +6294,6 @@ msgstr "VARNING: listan med kända filer skadad, innehåller ogiltig header."
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Ogiltig post i filen med kända filer, filen kan vara skadad: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Ogiltig post i filen med kända filer, filen kan vara skadad: "
 
 #: src/SearchList.cpp
@@ -8810,6 +8791,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Fjärrserver"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Lokal server"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Ogiltig post i filen med kända filer, filen kan vara skadad: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:56+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4166,20 +4166,20 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5589,10 +5589,6 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
@@ -6064,14 +6060,6 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
-msgid "Remote prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6127,10 +6115,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -4254,22 +4254,22 @@ msgstr "Güncel örüntünün kaç paylaşılan dosyayı dışlayacağını gös
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Uzak Sunucu"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Sunucu"
 
 #: src/muuli_wdr.cpp
@@ -5701,10 +5701,6 @@ msgstr "Bağlantı"
 msgid "Directories"
 msgstr "Dizinler"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Sunucular"
@@ -6208,16 +6204,6 @@ msgid "Shared folder"
 msgstr "Paylaşılan dizin"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Uzak Sunucu"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Sunucu"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6277,11 +6263,6 @@ msgstr "UYARI: Bilinen dosya listesi bozuk. Geçersiz başlık içeriyor."
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "Bilinen dosyalar listesinde geçersiz girdi bulundu. Dosya bozuk olabilir: "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "Bilinen dosyalar listesinde geçersiz girdi bulundu. Dosya bozuk olabilir: "
 
 #: src/SearchList.cpp
@@ -8790,6 +8771,18 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Uzak Sunucu"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Sunucu"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "Bilinen dosyalar listesinde geçersiz girdi bulundu. Dosya bozuk olabilir: "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:54+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -4304,22 +4304,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "Віддалений сервер"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "Місцевий сервер"
 
 #: src/muuli_wdr.cpp
@@ -5773,10 +5773,6 @@ msgstr "З'єднання"
 msgid "Directories"
 msgstr "Теки"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "Сервери"
@@ -6297,16 +6293,6 @@ msgid "Shared folder"
 msgstr "Спільні теки"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "Віддалений сервер"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "Місцевий сервер"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6366,10 +6352,6 @@ msgstr "ЗАСТЕРЕЖЕННЯ: Перелік відомих файлів з�
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp
@@ -8907,6 +8889,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "Віддалений сервер"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "Місцевий сервер"
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4166,20 +4166,20 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Remote prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Remote prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Local prefix:"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Local prefix"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5589,10 +5589,6 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr ""
@@ -6064,14 +6060,6 @@ msgid "Shared folder"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
-msgid "Remote prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-msgid "Local prefix"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6127,10 +6115,6 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr ""
-
-#: src/SearchList.cpp
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:54+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -4259,22 +4259,22 @@ msgstr "显示当前模式会排除多少共享文件。"
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "远程服务器"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "本地服务器"
 
 #: src/muuli_wdr.cpp
@@ -5700,10 +5700,6 @@ msgstr "连接"
 msgid "Directories"
 msgstr "目录"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "服务器"
@@ -6204,16 +6200,6 @@ msgid "Shared folder"
 msgstr "共享的文件夹"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "远程服务器"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "本地服务器"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6272,11 +6258,6 @@ msgstr "警告: 已知文件列表已经损坏，包含有非法头部。"
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "已知文件列表包含非法条目，文件可能损坏："
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "已知文件列表包含非法条目，文件可能损坏："
 
 #: src/SearchList.cpp
@@ -8779,6 +8760,18 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "远程服务器"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "本地服务器"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "已知文件列表包含非法条目，文件可能损坏："
 
 #, c-format
 #~ msgid "Hashing %u new file"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 15:17+0200\n"
+"POT-Creation-Date: 2026-08-08 18:46+0200\n"
 "PO-Revision-Date: 2026-08-08 15:55+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -4267,22 +4267,22 @@ msgstr ""
 msgid "When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Path mappings"
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
+msgid "Path Mappings"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Remote prefix:"
+msgid "Remote prefix"
 msgstr "遠端伺服器"
 
 #: src/muuli_wdr.cpp
 msgid "A path prefix as the core reports it, e.g. /home/user/downloads/incoming"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/PrefsUnifiedDlg.cpp
 #, fuzzy
-msgid "Local prefix:"
+msgid "Local prefix"
 msgstr "本地伺服器"
 
 #: src/muuli_wdr.cpp
@@ -5713,10 +5713,6 @@ msgstr "連線"
 msgid "Directories"
 msgstr "目錄"
 
-#: src/PrefsUnifiedDlg.cpp
-msgid "Path Mappings"
-msgstr ""
-
 #: src/PrefsUnifiedDlg.cpp src/Statistics.cpp
 msgid "Servers"
 msgstr "伺服器"
@@ -6225,16 +6221,6 @@ msgid "Shared folder"
 msgstr "分享資料夾"
 
 #: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Remote prefix"
-msgstr "遠端伺服器"
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy
-msgid "Local prefix"
-msgstr "本地伺服器"
-
-#: src/PrefsUnifiedDlg.cpp
 msgid "Both the remote and local prefix must be filled in."
 msgstr ""
 
@@ -6295,11 +6281,6 @@ msgstr "警告：已知檔案清單損壞，內有無效標頭。"
 #: src/SearchList.cpp
 #, fuzzy
 msgid "Invalid entry in stored search list, file may be corrupt"
-msgstr "已知檔案清單內有無效的項目，檔案可能有損壞： "
-
-#: src/SearchList.cpp
-#, fuzzy
-msgid "Invalid entry in stored search list, file may be corrupt: "
 msgstr "已知檔案清單內有無效的項目，檔案可能有損壞： "
 
 #: src/SearchList.cpp
@@ -8786,6 +8767,18 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Remote prefix:"
+#~ msgstr "遠端伺服器"
+
+#, fuzzy
+#~ msgid "Local prefix:"
+#~ msgstr "本地伺服器"
+
+#, fuzzy
+#~ msgid "Invalid entry in stored search list, file may be corrupt: "
+#~ msgstr "已知檔案清單內有無效的項目，檔案可能有損壞： "
 
 #, fuzzy, c-format
 #~ msgid "Hashing new files (%u of %u)"

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -509,7 +509,7 @@ std::vector<uint32_t> CSearchList::LoadSearches()
 			loaded.push_back(std::move(entry));
 		}
 	} catch (const CInvalidPacket &e) {
-		AddLogLineC(_("Invalid entry in stored search list, file may be corrupt: ") + e.what());
+		AddLogLineC(_("Invalid entry in stored search list, file may be corrupt") + ": " + e.what());
 		FreeLoaded(loaded);
 		return restored;
 	} catch (const CSafeIOException &e) {

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1870,14 +1870,14 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
     itemHint->Wrap( parent->FromDIP(380) );
     item0->Add( itemHint, wxSizerFlags().Expand().Border(wxBOTTOM, 6) );
 
-    wxStaticBox *itemBox = new wxStaticBox( parent, -1, _("Path mappings") );
+    wxStaticBox *itemBox = new wxStaticBox( parent, -1, _("Path Mappings") );
     wxStaticBoxSizer *itemBoxSizer = new wxStaticBoxSizer( itemBox, wxVERTICAL );
 
     wxListCtrl *itemList = new wxListCtrl( parent, IDC_PATHMAP_LIST, wxDefaultPosition, wxSize(100,100), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
     itemBoxSizer->Add( itemList, wxSizerFlags(1).Expand().CenterVertical() );
 
     wxBoxSizer *itemRemoteRow = new wxBoxSizer( wxHORIZONTAL );
-    wxStaticText *itemRemoteLabel = new wxStaticText( parent, -1, _("Remote prefix:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *itemRemoteLabel = new wxStaticText( parent, -1, _("Remote prefix") + ":", wxDefaultPosition, wxDefaultSize, 0 );
     itemRemoteRow->Add( itemRemoteLabel, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4) );
     CMuleTextCtrl *itemRemote = new CMuleTextCtrl( parent, IDC_PATHMAP_REMOTE, "", wxDefaultPosition, wxSize(80,-1), 0 );
     itemRemote->SetToolTip(_("A path prefix as the core reports it, e.g. /home/user/downloads/incoming"));
@@ -1885,7 +1885,7 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
     itemBoxSizer->Add( itemRemoteRow, wxSizerFlags().Expand().Border(wxTOP, 4) );
 
     wxBoxSizer *itemLocalRow = new wxBoxSizer( wxHORIZONTAL );
-    wxStaticText *itemLocalLabel = new wxStaticText( parent, -1, _("Local prefix:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *itemLocalLabel = new wxStaticText( parent, -1, _("Local prefix") + ":", wxDefaultPosition, wxDefaultSize, 0 );
     itemLocalRow->Add( itemLocalLabel, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4) );
     CMuleTextCtrl *itemLocal = new CMuleTextCtrl( parent, IDC_PATHMAP_LOCAL, "", wxDefaultPosition, wxSize(80,-1), 0 );
     itemLocal->SetToolTip(_("Where that same folder is reachable from this computer, e.g. a mounted network share"));


### PR DESCRIPTION
The path-mapping UI landed with four strings that only differ from one already in the catalog by punctuation or case, so every translator had to render the same words twice:

| Duplicate | Already in the catalog |
|---|---|
| `Remote prefix:` | `Remote prefix` |
| `Local prefix:` | `Local prefix` |
| `Path mappings` | `Path Mappings` |
| `Invalid entry in stored search list, file may be corrupt: ` | same, without the `: ` |

The bare word stays translatable and the punctuation is appended in code — what `KnownFile.cpp` and `PartFile.cpp` already do for their `"Label" + ": " + value` lines.

`Path Mappings` is the spelling the preferences tab and both message boxes already use, and title case matches the other static box titles (`Media Info`, `File Names`, `Statistics Tree`, …).

Four fewer strings to translate, and no catalog loses a translation: the survivors are the ones that were already there. Catalogs regenerated with `scripts/update-po.sh`.

One tradeoff worth flagging: appending `":"` in code takes the spacing away from translators, and French convention puts a space before the colon (`Préfixe distant :`).
