### PR TITLE
fix(gui): drop queued notifications once amulegui's window is gone

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1030,7 +1030,23 @@ void CamuleRemoteGuiApp::OnECInitDone(wxEvent &)
 
 void CamuleRemoteGuiApp::OnNotifyEvent(CMuleGUIEvent &evt)
 {
-	evt.Notify();
+	// Same guard CamuleApp::OnNotifyEvent has, and for the same reason: this
+	// is the queued half of MuleNotify. HandleNotification() runs a
+	// notification inline when it is already on the main thread, and refuses
+	// to when there is no window to update; off the main thread it queues a
+	// CMuleGUIEvent instead, and that one lands here -- possibly long after,
+	// and possibly after the window is gone. amulegui destroys its dialog
+	// whenever the EC link drops (ShutDown() nulls amuledlg), a remote core
+	// restart being the everyday way that happens, and the pending-event
+	// queue is not drained first. The handlers behind Notify() read
+	// theApp->amuledlg->m_transferwnd and friends without checking, so a
+	// notification arriving in that window dereferenced null: reported as
+	// EXC_BAD_ACCESS at 0x3c0, which is exactly CamuleDlg::m_transferwnd's
+	// offset. A notification with no window to update has nothing to do, so
+	// it is dropped rather than delivered.
+	if (amuledlg) {
+		evt.Notify();
+	}
 }
 
 void CamuleRemoteGuiApp::Startup()


### PR DESCRIPTION
amulegui crashes when the remote core is restarted. Reproduced from a crash report on `rev. 3.0.1-495-g285a46a3f`.

## What it is

`CamuleApp::OnNotifyEvent` tests `theApp->amuledlg` before running a queued notification. `CamuleRemoteGuiApp::OnNotifyEvent` did not — and amulegui is the build where the window routinely goes away while the app keeps running.

`MuleNotify` has two halves. On the main thread `HandleNotification()` runs the notification inline, and already declines to when there is no window to update. Off the main thread — the EC socket's thread, for anything the daemon pushes — it queues a `CMuleGUIEvent` instead, and that half had no such check. amulegui destroys its dialog whenever the EC link drops (`ShutDown()` calls `Destroy()` and nulls `amuledlg`), a remote core restart being the everyday way that happens, and the wx pending-event queue is not drained first. Whatever was already queued then runs against a null dialog.

The handlers behind `Notify()` read `theApp->amuledlg->m_transferwnd` and its siblings without checking the dialog itself, so this dereferences null rather than merely doing nothing.

## How the report pins it

```
EXC_BAD_ACCESS (SIGSEGV)
KERN_INVALID_ADDRESS at 0x00000000000003c0

wxEvtHandler::ProcessPendingEvents()
  wxEvtHandler::ProcessEventLocally
    wxEventHashTable::HandleEvent
      wxEvtHandler::ProcessEventIfMatchesId   <- faults here
```

`0x3c0` is 960, and 960 is where `m_transferwnd` sits in `CamuleDlg` under `CLIENT_GUI` (confirmed with `-fdump-record-layouts` against the amulegui compile flags). A *freed* dialog would have faulted on a wild address; a small one means the base pointer was null. `wxEventHashTable::HandleEvent` is the static-event-table path, which is the `EVT_MULE_NOTIFY` entry — this dispatcher.

## The fix

One guard, mirroring the monolithic one.

Deliberately here rather than in each handler: the handlers are only ever reached through `Notify()`, whose two entry points are this dispatcher and the main-thread path that already checks, so a single test covers all of them and keeps the two halves symmetric. Guarding the ~40 call sites in `GuiEvents.cpp` individually would be churn that hides the actual asymmetry.

## Verification

Builds clean on macOS, monolithic and amulegui, no warnings from the touched file; clang-format and both clang-tidy tiers clean over the diff.

Not yet exercised against a live core restart with the window hidden — that is the reproducer, and it is worth running before this is trusted rather than after.
