### PR TITLE
fix(asio): order the read handoff so a completed read cannot be missed

### DIFF
--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -456,7 +456,7 @@ public:
 		m_ErrorCode = 0;
 		m_readBuffer = NULL;
 		m_readBufferSize = 0;
-		m_readPending = false;
+		m_readPending.store(false, std::memory_order_relaxed);
 		m_readBufferContent = 0;
 		m_eventPending = false;
 		m_port = 0;
@@ -640,8 +640,10 @@ public:
 			return 0;
 		}
 
-		if (m_readPending                      // Background read hasn't completed.
-			|| m_readBufferContent == 0) { // shouldn't be if it's not pending
+		// Acquire, pairing with the release in HandleRead: seeing false here
+		// means the buffer state published alongside it is visible too.
+		if (m_readPending.load(std::memory_order_acquire) // Background read hasn't completed.
+			|| m_readBufferContent == 0) {            // shouldn't be if it's not pending
 
 			m_blocksRead = true;
 			AddDebugLogLineF(logAsio, CFormat("Read1 %s %d - Block") % m_IP % bytesToRead);
@@ -958,7 +960,24 @@ private:
 		m_readBufferPtr = m_readBuffer;
 		m_readBufferContent = (uint32)bytes_transferred;
 
-		m_readPending = false;
+		// Release, and after the buffer writes above on purpose. A reader that
+		// acquire-loads this as false is then guaranteed to see the content
+		// and pointer that were written before it.
+		//
+		// Plain stores let the two become visible out of order. The main
+		// thread would see the new content with the pending flag still set,
+		// take the "a background read is still running" branch in Read(),
+		// and return without serving data that was already sitting in the
+		// buffer -- and without arming anything. Since that branch is reached
+		// from an event that has already been consumed, nothing looks again:
+		// the socket stays open with its bytes unread and answers nothing
+		// until the peer gives up. Caught in the act on arm64, where the
+		// reordering is permitted and does happen:
+		//
+		//   handleRead(10)[c=10 p=0]   <- strand: content set, pending cleared
+		//   block(8)     [c=10 p=1]    <- main: new content, stale flag
+		//
+		m_readPending.store(false, std::memory_order_release);
 		m_blocksRead = false;
 		PostReadEvent(2);
 	}
@@ -969,7 +988,7 @@ private:
 
 	void StartBackgroundRead()
 	{
-		m_readPending = true;
+		m_readPending.store(true, std::memory_order_relaxed);
 		m_readBufferContent = 0;
 		auto self = shared_from_this();
 		dispatch(m_strand, [self]() { self->DispatchBackgroundRead(); });
@@ -1180,7 +1199,10 @@ private:
 	char *m_readBuffer;
 	uint32 m_readBufferSize;
 	char *m_readBufferPtr;
-	bool m_readPending;
+	// atomic: cleared on the ASIO thread (HandleRead) and read on the main
+	// thread (Read), and it is the flag that orders the whole read handoff --
+	// see HandleRead for why plain stores were not enough.
+	std::atomic<bool> m_readPending;
 	uint32 m_readBufferContent;
 	bool m_eventPending;
 	std::atomic<char *>


### PR DESCRIPTION
`CAsioSocketImpl` hands a completed read from the asio strand to the main thread through two plain fields: `HandleRead` writes `m_readBufferContent` and then clears `m_readPending`, and `Read()` tests `m_readPending || m_readBufferContent == 0` before serving buffered bytes.

Neither field is atomic, so nothing orders those writes against the reader. On a weakly-ordered target the main thread can observe the new content while still seeing `m_readPending` set. It then takes the "background read still running" branch and returns 0 — without serving the buffered data and without re-arming a read. The receive event for that data has already been consumed, so nothing ever looks at the socket again and the connection wedges silently.

Captured on a live amulegui/amuled pair, both ARM64 (sequence numbers; `M` = main thread, `A` = asio strand; `c` = content, `p` = pending, `e` = event):

```
#1793400M: block(8)      [c=0  p=1 e=1]
#1793402A: handleRead(10)[c=10 p=0 e=1]   <- strand: content set, pending cleared
#1793403M: postSkip(2)   [c=10 p=0 e=1]
#1793404M: block(8)      [c=10 p=1 e=0]   <- main: new content, stale flag
```

Event accounting was exact across the whole capture (`ev_posted=17314 ev_delivered=17314 ev_spurious=0`), which rules out a lost notification: the post was delivered, and the reader simply mis-read the state.

Fix: make `m_readPending` `std::atomic<bool>`, release-store it in `HandleRead` after the buffer writes, and acquire-load it in `Read()`. The release/acquire pair publishes everything written before it, so a cleared flag now implies visible content.

## Testing

LAN transfer, 30 GB file, patched daemon on both ends, alternating against master with a discarded warm-up run to prime the seeder's page cache. Steady-state median over T+30…T+90:

| build | run medians (MB/s) | median | spread |
|---|---|---|---|
| this branch | 111.4, 124.2, 124.7 | 124.2 | 13.4 |
| master | 111.7, 119.6, 124.0, 124.2, 126.1 | 124.0 | 14.4 |

Delta +0.1%, well inside the noise — both distributions have the same shape, including a single low run each, so that outlier belongs to the test rig rather than to either build. No measurable throughput cost.

## Scope

`CAsioSocketImpl` is TCP-only and backs eD2k peers, server links, proxies and EC alike. UDP goes through `CAsioUDPSocketImpl`, which has no `m_readPending`, so Kad is untouched.
