### PR TITLE
fix(gui): centre the name columns' text vertically again

### DIFF
--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -132,7 +132,16 @@ void CMuleDataViewCtrl::AddIconTextColumn(const wxString &label,
 	// every row whether or not that row has an icon -- see the class comment.
 	CMuleIconTextRenderer *renderer = new CMuleIconTextRenderer();
 	renderer->SetMode(mode);
-	renderer->SetAlignment(align);
+	// Supply the vertical half of the alignment when the caller has not.
+	// wx's own text renderer resolves a missing vertical component to its
+	// default, which is centred, but a custom renderer gets exactly what it
+	// is given -- so a plain wxALIGN_LEFT top-aligns the text while the icon
+	// drawn beside it is centred, and the name columns sit visibly higher
+	// than every other column in the same row (#867). wxALIGN_TOP is 0 and
+	// so indistinguishable from "unspecified" (wx says as much in defs.h),
+	// which is why this tests for the two bits that do carry intent.
+	const bool hasVertical = (align & (wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL)) != 0;
+	renderer->SetAlignment(hasVertical ? align : (align | wxALIGN_CENTRE_VERTICAL));
 	AppendColumn(new wxDataViewColumn(label, renderer, modelColumn, width, align, flags));
 	m_columnStore.RegisterColumn(static_cast<int>(modelColumn), width, key);
 }


### PR DESCRIPTION
Fixes the off-centre text reported in #867.

## Why only those columns

wx's own text renderer resolves an alignment with no vertical component to its default, which is centred. A custom renderer gets exactly what it is given, and `AddIconTextColumn()` passes the column's alignment straight through — `wxALIGN_LEFT` at every call site, horizontal only. So `CMuleIconTextRenderer` top-aligns its text while the columns either side of it, drawn by wx's renderer, stay centred.

That is why it shows up on Server Name and File Name and nowhere else: those are the only columns using the custom icon+text renderer. It also explains the second half of the report — `Render()` centres the icon explicitly:

```cpp
const int y = cell.y + std::max(0, (cell.height - icon.GetHeight()) / 2);
```

so on a row carrying a rating smiley the icon is centred while its own text is not, and the two halves of one cell visibly disagree.

## The fix

Supply the vertical half of the alignment when the caller has not asked for one.

`wxALIGN_TOP` is `0` and therefore indistinguishable from "unspecified" — wx says as much in `defs.h` — so the test is for the two bits that do carry intent, `wxALIGN_BOTTOM` and `wxALIGN_CENTRE_VERTICAL`. A caller that names either still gets it; every current call site names neither and now gets centred, matching the plain columns beside it.

The renderer keeps drawing the icon at the cell edge with no leading inset, which is the reason it exists rather than wx's own — an icon row still lines up with a bare one.

## Verification

Built on macOS (monolithic + amulegui); clang-format and both clang-tidy tiers clean over the diff.

Checked visually on the Networks, Downloads and Shared Files panels: the name columns now share a baseline with their neighbours, and icon and text line up within the cell.

Only the alignment is addressed here. The GUI hiccups in the same issue are a separate problem — the cadence matches the once-per-second `knownfiles` requery driving list updates on the main thread — and want measuring rather than guessing, so they are not touched.
