### PR TITLE
fix(gui): stop left and right corrupting a flat list's name column

### DIFF
--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -39,6 +39,7 @@ const int kResortTimerId = wxID_HIGHEST + 1201;
 
 wxBEGIN_EVENT_TABLE(CMuleVirtualDataViewCtrl, CMuleDataViewCtrl)
 	EVT_TIMER(kResortTimerId, CMuleVirtualDataViewCtrl::OnResortTimer)
+	EVT_KEY_DOWN(CMuleVirtualDataViewCtrl::OnArrowKey)
 wxEND_EVENT_TABLE()
 
 /**
@@ -548,4 +549,34 @@ bool CMuleVirtualDataViewCtrl::IsInteracting() const
 		return true;
 	}
 	return wxGetMouseState().LeftIsDown();
+}
+
+void CMuleVirtualDataViewCtrl::OnArrowKey(wxKeyEvent &evt)
+{
+	const int key = evt.GetKeyCode();
+	if (key != WXK_LEFT && key != WXK_RIGHT) {
+		// Skip() so the base class still gets PageUp/PageDown/Home/End.
+		evt.Skip();
+		return;
+	}
+
+	// Swallowed. Left and right belong to the tree control: they expand and
+	// collapse, and a flat list has nothing to expand. Handed to the native
+	// control they do something worse than nothing here -- on macOS the name
+	// column repaints without each row's value being re-supplied, so every
+	// row draws the last row's text until something forces a full repaint.
+	//
+	// Scrolling sideways would be the useful alternative and is not
+	// available: the only portable lever is EnsureVisible(item, column),
+	// which needs to know which columns are off screen, and GetItemRect()
+	// reports a column's position in the full layout rather than in the
+	// viewport -- the same coordinates before and after a scroll. So the
+	// target cannot be worked out, and a first attempt behaved accordingly:
+	// right moved once and then stopped, left never fired at all because the
+	// x it compares against never goes negative. Doing it properly means
+	// reading the native scroll position per platform, which belongs in its
+	// own change rather than in a repaint fix.
+	//
+	// Deliberately not on CMuleDataViewCtrl: the search list is a real tree
+	// where these keys expand and collapse result variants.
 }

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -233,6 +233,10 @@ private:
 	void ScheduleResort();
 	void MaybeResortNow();
 	void OnResortTimer(wxTimerEvent &evt);
+	//! Swallows left/right in a flat list, which has no expand/collapse for
+	//! them to do and misrepaints when the native control handles them.
+	void OnArrowKey(wxKeyEvent &evt);
+
 	bool IsInteracting() const;
 
 	VirtualModel *m_virtualModel;


### PR DESCRIPTION
With a list focused, pressing left or right makes every row show the same name — the last row's, repeated — until something forces a full repaint.

## Cause of the trigger

Left and right belong to the tree control: they expand and collapse, and a flat list has nothing to expand. Handed to the native control in one, they do something worse than nothing — on macOS the name column repaints without each row's value being re-supplied, so every row draws the last row's text.

Only the name columns are affected, which fits: they are the only ones drawn by our own renderer rather than wx's.

The keys are now swallowed in `CMuleVirtualDataViewCtrl` — the flat lists: Downloads, Shared Files, Servers, Clients, Friends. Swallowed rather than skipped, since skipping hands them straight back to the control this exists to keep them away from. Every other key is skipped, so the base class goes on handling PageUp/PageDown/Home/End.

Deliberately **not** on `CMuleDataViewCtrl`: the search list is a real tree, with result variants under their parent, where these keys do their normal job and still should.

## Why not scroll sideways instead

That was the intended behaviour and it is not reachable with the API available, which is worth recording so the next person does not repeat it.

The only portable lever is `EnsureVisible(item, column)`, which requires knowing which columns are off screen. `GetItemRect()` cannot answer that: it reports a column's position within the whole layout, not within the viewport. Instrumented on a 14-column list, it returns identical coordinates before and after a scroll:

```
--- key=RIGHT viewport=1798 columns=14
    col 11: x=1729 w=130 right=1858
    -> target=11
    after EnsureVisible: col 11 x=1729 right=1858     <- unchanged
```

An implementation built on it behaved exactly as that predicts: right moved the view once and then never again, because the computed target was constant, and left never fired at all, because the `x` it compares against starts positive and only grows (`target=-1`, every press).

Doing it properly means reading the native scroll position per platform. That belongs in its own change rather than being folded into a repaint fix.

## What this does not fix

The trigger, not the defect.

Dragging the horizontal scrollbar across the same columns corrupts nothing, so the repaint path at fault is reachable only through these keys, and closing them closes it. If the symptom ever turns up by another route, the place to look is that the renderer is stateful: `CMuleIconTextRenderer` holds the current row's value between `SetValue()` and `Render()`, and one instance serves every row, so anything that renders without re-supplying values would paint the last value everywhere. That matches the symptom, but it is a hypothesis this PR has not confirmed.

## Verification

Built on macOS (monolithic + amulegui); clang-format and both clang-tidy tiers clean over the diff.

Checked by hand: the corruption is gone under held left/right, other keys and the search list's expand/collapse are unaffected.
