### PR TITLE
i18n: translate the log messages that can be, mark the rest (#866)

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -52,6 +52,7 @@ src/Logger.cpp
 src/MuleNotebook.cpp
 src/MuleTextCtrl.cpp
 src/MuleTrayIcon.cpp
+src/MuleUDPSocket.cpp
 src/muuli_wdr.cpp
 src/OScopeCtrl.cpp
 src/OtherFunctions.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -191,6 +191,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Collection file not found: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -594,6 +626,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1722,11 +1758,6 @@ msgstr ""
 #: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
-msgstr ""
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
 #: src/DownloadQueue.cpp
@@ -2924,6 +2955,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3157,6 +3193,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6138,6 +6184,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
@@ -6337,6 +6388,11 @@ msgstr ""
 
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
+msgstr ""
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
 msgstr ""
 
 #: src/ServerList.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:16+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -195,6 +195,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "إتصال بي : %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -605,6 +637,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1749,11 +1785,6 @@ msgstr ""
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2961,6 +2992,11 @@ msgstr "عوامل اﻻتصال الخارجي"
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3198,6 +3234,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6227,6 +6273,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "تعريف ملف"
@@ -6433,6 +6484,11 @@ msgstr ""
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "فشل في حفظ server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "فشل غير متوقع اثناء كتابة ملف %s : %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:17+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -206,6 +206,38 @@ msgstr "AVISU: Nun pues amestate a tí mesmu como una fonte pa un enllaz eD2k te
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Ficheru índiz non alcontráu: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Ensin ficheros que compartir en direutoriu: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Nun pue convertise l'enllaz magnet a eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Enllaz eD2k inválidu! FALLU: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -626,6 +658,10 @@ msgstr "Visita https://github.com/amule-org/amule/releases/latest pa comprobar s
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FALLU GRAVE: Nun pudo criase'l temporizador"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1767,11 +1803,6 @@ msgstr "Yá tienes esti ficheru '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Yá tas descargando el ficheru %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Nun pue convertise l'enllaz magnet a eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3015,6 +3046,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Conexón esterna: Falló handshake."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Descarga HTTP filu entamáu"
@@ -3257,6 +3293,16 @@ msgstr "Total DE: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total XU: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6344,6 +6390,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Fallu actualizando GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID Ficheru"
@@ -6550,6 +6601,11 @@ msgstr "Fallu al abrir '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "¡Fallu al guardar server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO error lleendo'l ficheru known.met: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -196,6 +196,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Връзката установена на: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -604,6 +636,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1744,11 +1780,6 @@ msgstr ""
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Вие вече опитвате да свалите файла %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2955,6 +2986,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3192,6 +3228,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6203,6 +6249,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
@@ -6408,6 +6459,11 @@ msgstr ""
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Грешка при записа на server.met!"
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr ""
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -190,6 +190,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Collection file not found: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -593,6 +625,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1721,11 +1757,6 @@ msgstr ""
 #: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
-msgstr ""
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
 #: src/DownloadQueue.cpp
@@ -2923,6 +2954,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3156,6 +3192,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6137,6 +6183,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
@@ -6336,6 +6387,11 @@ msgstr ""
 
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
+msgstr ""
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
 msgstr ""
 
 #: src/ServerList.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -206,6 +206,38 @@ msgstr "AVÍS: No us podeu afegir com a font per a un enllaç eD2k mentre teniu 
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "No s'ha trobat el fitxer d'índex: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "No s'ha trobat cap fitxer en el directori: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "No s'ha pogut convertir l'enllaç magnet a eD2k: %s+"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Enllaç eD2k invàlid! ERROR: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -626,6 +658,10 @@ msgstr "Visiteu https://github.com/amule-org/amule/releases/latest per a comprov
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR GREU: No s'ha pogut crear el temporitzador"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1764,11 +1800,6 @@ msgstr "Ja disposeu del fitxer '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ja esteu intentant baixar el fitxer %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "No s'ha pogut convertir l'enllaç magnet a eD2k: %s+"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3006,6 +3037,11 @@ msgstr "Connexió externa: Conformitat de connexió denegada."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "S'ha iniciat el fil Asio %d"
 
@@ -3247,6 +3283,16 @@ msgstr "Total BA: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total PU: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6317,6 +6363,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Error actualitzant GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Resum del fitxer"
@@ -6521,6 +6572,11 @@ msgstr "No s'ha pogut obrir '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "No s'ha pogut desar el server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Error d'E/S mentre es llegia el fitxer 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -209,6 +209,39 @@ msgstr "VAROVÁNÍ: Nemůžete přidat sebe jako zdroj pro eD2k odkaz, když má
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr "Oprávnění pro %s byla omezena pouze na vlastníka."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Index nenalezen: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Neplatný eD2k odkaz! CHYBA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -622,6 +655,10 @@ msgstr "Navštivte https://github.com/amule-org/amule/releases/latest  pro kontr
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITICKÁ CHYBA: Vytváření časovače selhalo"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1767,11 +1804,6 @@ msgstr "Soubor '%s' již máte"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Soubor %s se již pokoušíte stáhnout"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3002,6 +3034,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Heslo pro externí připojení."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synchronizační vlákno spuštěno."
@@ -3244,6 +3281,16 @@ msgstr "Celkem DL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Celkem UL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6319,6 +6366,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Selhala aktualizace GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID souboru"
@@ -6527,6 +6579,11 @@ msgstr "Nemohu otevřít '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Ukládání server.met selhalo!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "I/O chyba při čtení souboru known.met: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -196,6 +196,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Index fil ikke fundet: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -606,6 +638,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1752,11 +1788,6 @@ msgstr ""
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Du prøver allerede at downloade denne fil %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2969,6 +3000,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Ydre Forbindelses Parametre"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Synkroniserings tråd startet."
@@ -3209,6 +3245,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6245,6 +6291,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Fil ID"
@@ -6449,6 +6500,11 @@ msgstr ""
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Fejl ved gemning af server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Uventet fil fejl ved skrivning %s : %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -215,6 +215,38 @@ msgstr "WARNUNG: Man kann sich nicht als Quelle für einen eD2k-Verweis hinzufü
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Index-Datei nicht gefunden: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Kann Magnet-Verweis nicht in eD2k umwandeln: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Ungültiger eD2k-Link! Fehler: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -633,6 +665,10 @@ msgstr "Besuche https://github.com/amule-org/amule/releases/latest um zu sehen, 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "UNBEHEBBARER FEHLER: Es konnte kein Zeitgeber erstellt werden."
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1772,11 +1808,6 @@ msgstr "Die Datei '%s' ist bereits vorhanden"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Die Datei %s wird bereits heruntergeladen"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Kann Magnet-Verweis nicht in eD2k umwandeln: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3011,6 +3042,11 @@ msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-Thread %d gestartet"
 
@@ -3245,6 +3281,16 @@ msgstr "Gesamt-DL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Gesamt-UL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6313,6 +6359,11 @@ msgstr "Kad-Suche: weitere Ergebnisse von einem zusätzlichen Peer angefordert."
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Kad-Suche: kein Peer mehr verfügbar, um weitere Ergebnisse abzufragen (Limit erreicht oder noch keine Antworten)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Fehler beim Aktualisieren von %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Datei-ID"
@@ -6517,6 +6568,11 @@ msgstr "Konnte '%s' nicht öffnen"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Speichern der server.met fehlgeschlagen!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO-Fehler beim Lesen der 'server.met' Datei: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -206,6 +206,38 @@ msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Δεν μπορείτε να προσθέσ�
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Το αρχείο δεικτών δεν βρέθηκε (ψάχνω ψάχνω και τίποτα δεν βρίσκω)"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Δεν γίνεται η μετατροπή του μαγνητικού συνδέσμου σε σύνδεσμο eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Άκυρος σύνδεσμος eD2k! ΣΦΑΛΜΑ: %s"
 
 #: src/amule.cpp
 #, fuzzy
@@ -631,6 +663,10 @@ msgstr "Επισκεφτείτε το https://github.com/amule-org/amule/release
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ΜΟΙΡΑΙΟ ΣΦΑΛΜΑ: Αποτυχία δημιουργίας Χρονομέτρου"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1775,11 +1811,6 @@ msgstr "Το αρχείο '%s' υπάρχει ήδη"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ήδη προσπαθείτε να κατεβάσετε το αρχείο %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Δεν γίνεται η μετατροπή του μαγνητικού συνδέσμου σε σύνδεσμο eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3026,6 +3057,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Εξωτερική σύνδεση: Η πρόσβαση απορρίφθηκε"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Η αυτόματη ανανέωση ξεκίνησε"
@@ -3268,6 +3304,16 @@ msgstr "Συνολικό Κατέβασμα: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Συνολικό Ανέβασμα: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6356,6 +6402,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Τιμή ταυτότητας αρχείου"
@@ -6562,6 +6613,11 @@ msgstr "Αποτυχημένη προσπάθεια να ανοίξει '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Αποτυχία σβησίματος του server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Σφάλμα εισόδου εξόδου κατά την ανάγνωση του αρχείου known.met: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -191,6 +191,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Collection file not found: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -594,6 +626,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1722,11 +1758,6 @@ msgstr ""
 #: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
-msgstr ""
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
 #: src/DownloadQueue.cpp
@@ -2924,6 +2955,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3157,6 +3193,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6138,6 +6184,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
@@ -6337,6 +6388,11 @@ msgstr ""
 
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
+msgstr ""
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
 msgstr ""
 
 #: src/ServerList.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:24+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -217,6 +217,38 @@ msgstr "AVISO: no puede añadirse a sí mismo como fuente para un enlace eD2k te
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Fichero de índice no encontrado: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "No se han encontrado archivos para compartir en el directorio: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "No se puede convertir el enlace magnético a eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "¡Enlace eD2k inválido! ERROR: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -634,6 +666,10 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para comprobar
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERROR FATAL: no se ha podido crear el temporizador"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1775,11 +1811,6 @@ msgstr "Ya tiene el archivo '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ya está intentando descargar el archivo %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "No se puede convertir el enlace magnético a eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3012,6 +3043,11 @@ msgstr "Conexión externa: error al establecer la comunicación."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Hilo Asio %d iniciado"
 
@@ -3246,6 +3282,16 @@ msgstr "Total DES: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total SU: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6298,6 +6344,11 @@ msgstr "Búsqueda Kad: solicitados más resultados a otro par."
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Búsqueda Kad: no quedan pares a los que volver a pedir más resultados (límite alcanzado o aún sin respuestas)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Error actualizando %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID del archivo"
@@ -6500,6 +6551,11 @@ msgstr "Error al abrir '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "¡Error al guardar server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Error de E/S al leer 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -206,6 +206,38 @@ msgstr "HOIATUS: Sa ei saa ennast eD2k lingi jaoks allikana lisada ajal kui omad
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indeksfaili ei leidnud: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Kataloogis '%s' pole jagatavaid faile"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Ei suuda muuta magnet linki eD2k lingiks: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Vigane eD2k link! VIGA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -626,6 +658,10 @@ msgstr "Külasta https://github.com/amule-org/amule/releases/latest ja vaata ehk
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "Fataalne VIGA: Ei suutnud luua stopperit."
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1765,11 +1801,6 @@ msgstr "Fail '%s' on juba olemas"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Sa juba proovid '%s' faili tõmmata"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Ei suuda muuta magnet linki eD2k lingiks: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3006,6 +3037,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Väline Ühendus: Kätlemine ebaõnnestus."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automaatne värskendamine on käivitatud"
@@ -3248,6 +3284,16 @@ msgstr "Kokku AL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Kokku ÜL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6322,6 +6368,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "GeoIP.dat uuendamise viga"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FailiID"
@@ -6527,6 +6578,11 @@ msgstr "Ei suuda avada '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Ei saanud salvestada server.met faili!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO viga %s faili lugemisel: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -207,6 +207,38 @@ msgstr "KONTUZ: Ezin duzu zure burua ezarri eD2k lotura batean Id baxua duzunean
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Ez da index fitxategia aurkitu: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Ezin da lotura magnetikoa eD2k bihurtu: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Okerreko eD2k lotura! ERROREA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -627,6 +659,10 @@ msgstr "Bisitatu https://github.com/amule-org/amule/releases/latest gunea bertsi
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE KONPONEZINA: Huts kronometroa sortzean"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1766,11 +1802,6 @@ msgstr "Dagoeneko baduzu '%s' fitxategia"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Dagoeneko %s fitxategia deskargatzen ari zara"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Ezin da lotura magnetikoa eD2k bihurtu: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3007,6 +3038,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Kanpo Konexioa: Esku-emateak huts egin du."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP deskarga haria hasia"
@@ -3249,6 +3285,16 @@ msgstr "DE guztira: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "IG guztira: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6321,6 +6367,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Huts GeoIP.dat deskargatzean"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FitxategiID"
@@ -6525,6 +6576,11 @@ msgstr "Huts '%s' irekitzerakoan"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Huts server.met gordetzerakoan!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "SI errorea 'server.met' fitxategia irakurtzean: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -207,6 +207,38 @@ msgstr "VAROITUS: Et voi lisätä itseäsi lähteeksi eD2k-linkkiin kun sinulla 
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indeksitiedostoa ei löydetty: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Ei voitu kääntää magnet-linkkiä eD2k-linkiksi: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Virheellinen eD2k-linkki! VIRHE: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -627,6 +659,10 @@ msgstr "Vieraile nettisivulla https://github.com/amule-org/amule/releases/latest
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRIITTINEN VIRHE: Ajastimen luominen epäonnistui"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1766,11 +1802,6 @@ msgstr "Sinulla on jo tiedosto '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Lataat jo tiedostoa %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Ei voitu kääntää magnet-linkkiä eD2k-linkiksi: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3007,6 +3038,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Etäyhteys: Kättely epäonnistui"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "HTTP-lataussäie käynnistetty"
@@ -3249,6 +3285,16 @@ msgstr "Yht alas: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Yht ylös: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6321,6 +6367,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Virhe päivitettäessä GeoIP.dat-tiedostoa"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Tiedostotunniste"
@@ -6525,6 +6576,11 @@ msgstr "Kohteen '%s' avaaminen ei onnistunut"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Server.met:n tallennus epäonnistui!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO-virhe luettaessa tiedostoa 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:27+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -214,6 +214,38 @@ msgstr "AVERTISSEMENT : Vous ne pouvez pas vous ajouter vous-même en tant que 
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Fichier d'index non trouvé : "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Impossible de convertir le lien magnet en eD2k : %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Lien eD2k invalide ! ERREUR : %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -632,6 +664,10 @@ msgstr "Visitez https://github.com/amule-org/amule/releases/latest pour vérifie
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERREUR FATALE : Échec de la création du minuteur"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1773,11 +1809,6 @@ msgstr "Vous avez déjà le fichier '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Vous êtes déjà en train de télécharger le fichier %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Impossible de convertir le lien magnet en eD2k : %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3010,6 +3041,11 @@ msgstr "Connexion externe : Échange raté."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Processus ASIO %d démarré"
 
@@ -3244,6 +3280,16 @@ msgstr "Reçu au total : %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Émis au total : %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6292,6 +6338,11 @@ msgstr "Recherche Kad : résultats étendus demandés à un pair supplémentair
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Recherche Kad : plus aucun pair à recontacter pour plus de résultats (limite atteinte ou aucune réponse pour l'instant)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Erreur lors de la mise à jour de %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID du fichier"
@@ -6492,6 +6543,11 @@ msgstr "Échec de l'ouverture de '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Échec de l'enregistrement de server.met !"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Erreur d'E/S lors de la lecture de 'server.met' : "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:28+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -227,6 +227,38 @@ msgstr "AVISO: Non podes engadirte a ti mesmo como unha fonte para un enlace eD2
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Ficheiro do rexistro non atopado: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Non se puido converter a ligazón magnet a eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Ligazón eD2k inválida! ERRO: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -646,6 +678,10 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para obter act
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO GRAVE: Non se puido crear o temporizador"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1785,11 +1821,6 @@ msgstr "O ficheiro «%s» xa está descargado"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "O ficheiro %s xa se está descargando"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Non se puido converter a ligazón magnet a eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3024,6 +3055,11 @@ msgstr "Conexión externa: Fallou o saúdo."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Fío de E/S asíncrono %d iniciado"
 
@@ -3258,6 +3294,16 @@ msgstr "Total DE: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total EV: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6327,6 +6373,11 @@ msgstr "Busca de Kad: solicitóuselle ampliar a busca a un parceiro."
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Busca de Kad: non quedan parceiros sen preguntar por máis resultados (acadouse o límite, ou inda non hai respostas)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Fallou a actualización de %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "IDFicheiro"
@@ -6531,6 +6582,11 @@ msgstr "Non se puido abrir «%s»"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Non se puido gardar o ficheiro server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Ocorreu un erro de E/S ao ler o ficheiro «server.met»: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:29+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -201,6 +201,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "קובץ האינדקס לא נמצא"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -612,6 +644,10 @@ msgstr "בקר ב https://github.com/amule-org/amule/releases/latest כדי לב
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1754,11 +1790,6 @@ msgstr "כבר יש לך את הקובץ '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "אתה כבר מנסה להוריד את הקובץ %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2981,6 +3012,11 @@ msgid "External Connection: Handshake failed."
 msgstr "חיבור חיצוני נסגר."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "רענון אוטמטי התחיל"
@@ -3221,6 +3257,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6283,6 +6329,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "מ\"ז של קובץ"
@@ -6488,6 +6539,11 @@ msgstr "נכשל בפתיחת '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr ""
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "שגיאת קריאה/כתיבה תוך כדי הקובץ known.met: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -199,6 +199,39 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Uspostavljena veza sa: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -609,6 +642,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1759,11 +1796,6 @@ msgstr ""
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Vec pokusavate downloadovati fajl %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2978,6 +3010,11 @@ msgstr "Parametri za spoljasnju vezu"
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3218,6 +3255,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6268,6 +6315,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
@@ -6477,6 +6529,11 @@ msgstr ""
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Neuspjelo spasavanje server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Neocekivana fajl greska prilikom pisanja %s : %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -210,6 +210,37 @@ msgstr "FIGYELEM: Nem adhatod magad forrásként egy eD2k hivatkozáshoz amíg a
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Index fájl nem található: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "A magnet hivatkozás nem konvertálható eD2k-ra: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Érvénytelen eD2k hivatkozás! HIBA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -628,6 +659,10 @@ msgstr "Új verzióért látogasd meg a https://github.com/amule-org/amule/relea
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "VÉGZETES HIBA: Időzítő létrehozása sikertelen"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1761,11 +1796,6 @@ msgstr "Már megvan ez a fájl: '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Már próbálod letölteni a(z) '%s' fájlt."
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "A magnet hivatkozás nem konvertálható eD2k-ra: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2994,6 +3024,11 @@ msgstr "Külső kapcsolat: Kézfogás sikertelen."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asio szál %d elindítva"
 
@@ -3228,6 +3263,16 @@ msgstr "Összes letöltés: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Összes feltöltés: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6294,6 +6339,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Hiba %s frissítésekor"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Fájl ID"
@@ -6495,6 +6545,11 @@ msgstr "Nem sikerült megnyitni a '%s'-t"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "A server.met mentése sikertelen!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO hiba a 'server.met' fájl olvasása közben: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -216,6 +216,38 @@ msgstr "ATTENZIONE: non è possibile aggiungere te stesso come fonte di un link 
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr "Permessi di %s limitati al solo proprietario."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "File indice non trovato: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Impossibile scrivere il file di collezione '%s'."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Nessun file condivisibile trovato nella cartella: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Non posso convertire il magnet link in eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Collegamento eD2k non valido! ERRORE: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -634,6 +666,10 @@ msgstr "Visita https://github.com/amule-org/amule/releases/latest per controllar
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRORE FATALE: Creazione timer fallita"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1775,11 +1811,6 @@ msgstr "Hai già il file '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Stai già cercando di scaricare il file %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Non posso convertire il magnet link in eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3020,6 +3051,11 @@ msgstr "Connessione esterna: errore di negoziazione."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Thread %d asincrono avviato"
 
@@ -3254,6 +3290,16 @@ msgstr "DL totale: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "UL totale: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6281,6 +6327,11 @@ msgstr "Ricerca Kad: richiesti risultati più ampi a un altro peer."
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Ricerca Kad: nessun peer rimasto a cui richiedere altri risultati (limite raggiunto o nessuna risposta ancora ricevuta)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Errore durante l'aggiornamento di %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID File"
@@ -6481,6 +6532,11 @@ msgstr "Impossibile aprire '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Impossibile salvare il file server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Errore I/O durante la lettura del file 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -202,6 +202,37 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "インデックスファイルが見付かりませんでした： "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -625,6 +656,10 @@ msgstr "新しいバージョンの確認はhttps://github.com/amule-org/amule/r
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1765,11 +1800,6 @@ msgstr "あなたはすでにファイル'%s'を持っています"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3007,6 +3037,11 @@ msgid "External Connection: Handshake failed."
 msgstr "外接続用のパスワード。"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "同期化スレドを始めました。"
@@ -3248,6 +3283,16 @@ msgstr "DLの合計：%s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "ULの合計：%s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6315,6 +6360,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ファイルID"
@@ -6518,6 +6568,11 @@ msgstr "'%s'を開くことができませんでした"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "server.metを保存するのに失敗しました！"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "known.metファイル%sを読む時にIOエラーが発生しました"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -201,6 +201,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "인덱스 파일을 찾을 수 없음:"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -623,6 +655,10 @@ msgstr "https://github.com/amule-org/amule/releases/latest에 방문하셔서 �
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1773,11 +1809,6 @@ msgstr "이미 %s 파일을 가지고 있음"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "이미 %s 파일을 내려받으려고 하고있음"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3027,6 +3058,11 @@ msgid "External Connection: Handshake failed."
 msgstr "외부연결 암호"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "동기화 스레드가 시작되었습니다."
@@ -3268,6 +3304,16 @@ msgstr "전체 내려받기: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "전체 올려주기: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6348,6 +6394,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "파일아이디"
@@ -6554,6 +6605,11 @@ msgstr "'%s'을(를) 열지 못했습니다."
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "server.met을 저장하지 못함!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "known.met 파일을 읽는동안 입출력 오류: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:40+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -204,6 +204,39 @@ msgstr "DĖMESIO: jei jūsų ID yra žemas, negalite įdėti savęs prie eD2k nu
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indekso failas nerastas: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Nepavyko konvertuoti magnet nuorodos į eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Klaidinga eD2k nuoroda! KLAIDA: %s"
 
 #: src/amule.cpp
 #, fuzzy
@@ -630,6 +663,10 @@ msgstr "Aplankykite https://github.com/amule-org/amule/releases/latest ir pasiti
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRITINĖ KLAIDA: nepavyko sukurti laiko skaitliuko"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1780,11 +1817,6 @@ msgstr "Failas %s jau buvo atsiųstas"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Nepavyko konvertuoti magnet nuorodos į eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3038,6 +3070,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Išorinis ryšys: prieiga nesuteikta"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Automatinis atnaujinimas paleistas"
@@ -3280,6 +3317,16 @@ msgstr "Iš viso atsiųsta: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Iš viso išsiųsta: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6371,6 +6418,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Failo ID"
@@ -6580,6 +6632,11 @@ msgstr "Nepavyko atverti %s"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Nepavyko įrašyti server.met failo!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Nuskaitant known.met failą įvyko IO klaida: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -193,6 +193,39 @@ msgstr ""
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Dzēš datni: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Neizdevās iegūt lietotāja '%s' kopīgoto datņu sarakstu"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Nederīga eD2k saite! KĻŪDA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -600,6 +633,10 @@ msgstr "Apmeklējiet https://github.com/amule-org/amule/releases/latest vietni, 
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1735,11 +1772,6 @@ msgstr ""
 #: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
-msgstr ""
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
 #: src/DownloadQueue.cpp
@@ -2940,6 +2972,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3173,6 +3210,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6174,6 +6221,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Datnes ID"
@@ -6376,6 +6428,11 @@ msgstr ""
 
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
+msgstr ""
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
 msgstr ""
 
 #: src/ServerList.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:41+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -208,6 +208,38 @@ msgstr "WAARSCHUWING: U kunt uzelf niet toevoegen als bron voor een eD2k-link te
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indexbestand niet gevonden: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Geen deelbare bestanden gevonden in map: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Kan magnet-link niet omzetten naar eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Ongeldige eD2k-link! FOUT: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -628,6 +660,10 @@ msgstr "Bezoek https://github.com/amule-org/amule/releases/latest om te zien of 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATALE FOUT: Kon Timer niet aanmaken"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1767,11 +1803,6 @@ msgstr "U heeft het bestand '%s' al"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "U probeert het bestand %s al te downloaden"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Kan magnet-link niet omzetten naar eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3010,6 +3041,11 @@ msgstr "Externe verbinding: handshake mislukt."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asio-download thread %d gestart"
 
@@ -3252,6 +3288,16 @@ msgstr "Totaal gedownload: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totaal geupload: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6322,6 +6368,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Fout bij het updaten van GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Bestands-ID"
@@ -6526,6 +6577,11 @@ msgstr "Kon '%s' niet openen"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Kon server.met niet opslaan!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO- fout bij het lezen van 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -204,6 +204,38 @@ msgstr "ÅTVARING: Du kan ikkje leggje deg sjølv til som kjelde for ei eD2k len
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Registerfil ikkje funne: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Kan ikkje konvertere magnetlenkje til eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Ugangbar eD2k lenkje! FEIL: %s"
 
 #: src/amule.cpp
 #, fuzzy
@@ -629,6 +661,10 @@ msgstr "Vitje https://github.com/amule-org/amule/releases/latest for å sjekke o
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "FATAL FEIL: Greidde ikkje å lage tidtakar"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1773,11 +1809,6 @@ msgstr "Du har allereie fila: '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Du freistar allereie nedlasting av fila %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Kan ikkje konvertere magnetlenkje til eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3025,6 +3056,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Ekstern kopling: Tilgang nekta"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Autooppfrisking starta"
@@ -3267,6 +3303,16 @@ msgstr "Totalt NL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totalt OL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6349,6 +6395,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FilID"
@@ -6555,6 +6606,11 @@ msgstr "Greidde ikkje å opne '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Greidde ikkje å lagre server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO feil underlesing av known.met fila: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -208,6 +208,39 @@ msgstr "UWAGA: Nie możesz dodać samego siebie jako źródło linku ed2k, gdy m
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Nie znaleziono pliku indeksu: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Nie można skonwertować magnet linka do eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Nieprawidłowy link eD2k! BŁĄD: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -628,6 +661,10 @@ msgstr "Odwiedź https://github.com/amule-org/amule/releases/latest aby sprawdzi
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "KRYTYCZNY BŁĄD: Nie udało się utworzyć Timera"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1773,11 +1810,6 @@ msgstr "Masz już ten plik '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Starasz się już pobierać plik %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Nie można skonwertować magnet linka do eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3020,6 +3052,11 @@ msgid "External Connection: Handshake failed."
 msgstr "External Connection: Brak nawiązania"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rozpoczęte pobranie wątku HTTP"
@@ -3262,6 +3299,16 @@ msgstr "Razem DL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Razem UL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6353,6 +6400,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Błąd aktualizacji GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID pliku"
@@ -6561,6 +6613,11 @@ msgstr "Nie udało się otworzyć '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Nie udało się zapisać server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Błąd IO podczas odczytu pliku %s: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -215,6 +215,38 @@ msgstr "CUIDADO: Você não pode adicionar você mesmo como uma fonte para uma l
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr "Permissões restringidas em %s para o dono apenas."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Arquivo index não encontrado: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Falha ao gravar o arquivo de coleção '%s'."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Não pode converter ligação magnética para eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Ligação eD2k inválida! ERRO: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -630,6 +662,10 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para ver se h�
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Timer"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1771,11 +1807,6 @@ msgstr "Você já tem o arquivo '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ops! Você já está tentando baixar o arquivo %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Não pode converter ligação magnética para eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3016,6 +3047,11 @@ msgstr "Conexão Externa: Handshake falhou."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Iniciada a linha Asio %d"
 
@@ -3250,6 +3286,16 @@ msgstr "DL Total: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "UL Total: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6284,6 +6330,11 @@ msgstr "Busca Kad: pediu resultados mais amplos de mais um par."
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Busca Kad: nenhum par sobrou para pedir mais resultados novamente (capacidade atingida ou ainda sem respostas)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Erro ao atualizar %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID do arquivo"
@@ -6484,6 +6535,11 @@ msgstr "Falha ao abrir '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Falha ao salvar server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Erro de I/O ao ler arquivo 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -213,6 +213,38 @@ msgstr "AVISO: Não se pode adicionar a si próprio como fonte para um link eD2k
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Ficheiro de índice não encontrado: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Conversão de ligação magnet para eD2k não pode ser feita: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Ligação eD2k inválida! ERRO: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -633,6 +665,10 @@ msgstr "Visite https://github.com/amule-org/amule/releases/latest para verificar
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ERRO FATAL: Falha ao criar Temporizador"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1772,11 +1808,6 @@ msgstr "Já possui o ficheiro '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Já está a tentar transferir o ficheiro %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Conversão de ligação magnet para eD2k não pode ser feita: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3013,6 +3044,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Ligação Externa: Negociação inicial falhou."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Actualização automática iniciada"
@@ -3255,6 +3291,16 @@ msgstr "Total DL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total UL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6329,6 +6375,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Erro ao actualizar o GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID do Ficheiro"
@@ -6533,6 +6584,11 @@ msgstr "Erro ao abrir '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Falha ao gravar server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Erro de entrada/saída ao ler o ficheiro 'known.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -205,6 +205,39 @@ msgstr "ATENȚIE: Nu vă puteți adăuga ca sursă pentru o legătură eD2k cât
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Fișierul index nu a fost găsit:"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Nu se poate converti legătura magnet la eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Legătură eD2k nevalidă! EROARE: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -625,6 +658,10 @@ msgstr "Vizitați https://github.com/amule-org/amule/releases/latest pentru a ve
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "EROARE FATALĂ: A eșuat crearea temporizatorului"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1770,11 +1807,6 @@ msgstr "Deja aveți fișierul '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Deja încercați să descărcați fișierul %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Nu se poate converti legătura magnet la eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3016,6 +3048,11 @@ msgstr "Conexiune externă: A eșuat strângerea de mână."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Procesul Asio %d pornit"
 
@@ -3257,6 +3294,16 @@ msgstr "Total DE: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Total ÎN: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6336,6 +6383,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Eroare la actualizarea GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID fișier"
@@ -6543,6 +6595,11 @@ msgstr "A eșuat deschiderea '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "A eșuat salvarea server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Eroare IO la citirea 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -215,6 +215,39 @@ msgstr "ПРЕДУПРЕЖДЕНИЕ: Вы не можете добавить с
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr "Права доступа к %s ограничены только для владельца."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Индексный файл не найден: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Не удалось записать файл коллекции «%s»."
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Нет публикуемых файлов в директории: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Не удаётся преобразовать магнит-ссылку в eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Неверная ссылка eD2k! ОШИБКА: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -633,6 +666,10 @@ msgstr "Посетите https://github.com/amule-org/amule/releases/latest дл
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ФАТАЛЬНАЯ ОШИБКА: не удалось создать таймер"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1782,11 +1819,6 @@ msgstr "У вас уже есть файл '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Вы уже пытаетесь загрузить файл %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Не удаётся преобразовать магнит-ссылку в eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3035,6 +3067,11 @@ msgstr "Внешнее Соединение: авторизация неудач
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Поток Asio %d запущен"
 
@@ -3269,6 +3306,16 @@ msgstr "Всего скачано: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Всего отдано: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6324,6 +6371,11 @@ msgstr "Поиск Kad: запрошено расширение результа
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Поиск Kad: не осталось пиров для повторного запроса результатов (достигнут предел или ответов пока нет)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Ошибка обновления %s"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ИД файла"
@@ -6527,6 +6579,11 @@ msgstr "Невозможно открыть %s"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Не удалось сохранить server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Ошибка ввода/вывода при чтении файла known.met: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -207,6 +207,40 @@ msgstr "OPOZORILO: če imete nizek ID, sebe ne morete dodati kot vira za povezav
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indeksne datoteke ni mogoče najti: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Povezave magnet ni moč pretvoriti v eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Neveljavna povezava eD2k. NAPAKA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -630,6 +664,10 @@ msgstr "Obiščite https://github.com/amule-org/amule/releases/latest da preveri
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "USODNA NAPAKA: ustvaritev časomerilnika ni uspela"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1781,11 +1819,6 @@ msgstr "Datoteko »%s« že imate."
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Datoteko %s že poskušate prejemati"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Povezave magnet ni moč pretvoriti v eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3035,6 +3068,11 @@ msgstr "Zunanja povezava: rokovanje ni uspelo."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asinhrona nit %d se je začela"
 
@@ -3276,6 +3314,16 @@ msgstr "Skupno dol: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Skupno gor: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6369,6 +6417,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Napaka pri posodabljanju GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID datoteke"
@@ -6579,6 +6632,11 @@ msgstr "Ni bilo mogoče odpreti »%s«"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Ni bilo mogoče shraniti server.met."
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Vhodno/izhodna napaka med branjem »server.met«: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -202,6 +202,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indeksi i failit nuk u gjet:  "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -625,6 +657,10 @@ msgstr "Vizitoni https://github.com/amule-org/amule/releases/latest per te kontr
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1768,11 +1804,6 @@ msgstr "Ju e keni kete fail '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr ""
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3019,6 +3050,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Fjalekalimi per Lidhjet e Jashtme."
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Rifreskimi Automatik filloi"
@@ -3260,6 +3296,16 @@ msgstr "Totali i shkarkimit: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totali i ngarkimit: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6339,6 +6385,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FailiID"
@@ -6545,6 +6596,11 @@ msgstr "Deshtoi te hapi '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Deshtoi te shpetoje server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Gabim IO duke lexuar failin known.met: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -205,6 +205,38 @@ msgstr "VARNING: Du kan inte lägga till dig själv som källa för en eD2k-län
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Indexfil hittades inte: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Misslyckades med att hämta filer från användaren '%s'"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Inga delbara filer hittade i mappen: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Kan inte konvertera magnetlänk till eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Felaktig eD2k-länk! FEL: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -625,6 +657,10 @@ msgstr "Besök https://github.com/amule-org/amule/releases/latest för att se om
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ALLVARLIGT FEL: Kunde inte skapa Timer"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1764,11 +1800,6 @@ msgstr "Du har redan filen '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Du försöker redan hämta filen %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Kan inte konvertera magnetlänk till eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3006,6 +3037,11 @@ msgstr "Extern anslutning: Handskakning misslyckades."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asio tråd %d startad"
 
@@ -3247,6 +3283,16 @@ msgstr "Totalt DL: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Totalt UL: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6317,6 +6363,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Fel vid uppdatering av GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
@@ -6521,6 +6572,11 @@ msgstr "Misslyckades med att öppna '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Det gick inte att spara server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "IO fel vid läsning av 'server.met': "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -190,6 +190,38 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Collection file not found: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -593,6 +625,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1721,11 +1757,6 @@ msgstr ""
 #: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
-msgstr ""
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
 #: src/DownloadQueue.cpp
@@ -2923,6 +2954,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3156,6 +3192,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6137,6 +6183,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
@@ -6336,6 +6387,11 @@ msgstr ""
 
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
+msgstr ""
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
 msgstr ""
 
 #: src/ServerList.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -208,6 +208,38 @@ msgstr "UYARI: DüşükID olduğunuz sürece kendinizi bir kaynak olarak eD2k ba
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Fihristleme dosyası bulunamadı: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Magnet bağlantısı eD2k' ya çevrilemez: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Geçersiz eD2k bağlantısı! HATA: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -625,6 +657,10 @@ msgstr "Yeni sürüm denetimi için https://github.com/amule-org/amule/releases/
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ÖNEMLİ HATA: Zamanlayıcı oluşturulamadı"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1766,11 +1802,6 @@ msgstr "Zaten %s dosyası var."
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "%s dosyasını indirmeyi zaten deniyorsunuz"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Magnet bağlantısı eD2k' ya çevrilemez: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3003,6 +3034,11 @@ msgstr "Dış Bağlantı: Tanılama engellendi."
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asio iş parçacığı %d başladı"
 
@@ -3237,6 +3273,16 @@ msgstr "Toplam İND: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Toplam GÖN: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6285,6 +6331,11 @@ msgstr "Kad araması: bir eşten daha, daha geniş sonuçlar talep edildi."
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Kad araması: daha fazla sonucu tekrar talep edecek eş kalmadı (sınıra ulaşıldı veya henüz cevap alınamadı)."
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "%s unsurunun güncellemesinde hata oluştu"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Dosya Adresi"
@@ -6485,6 +6536,11 @@ msgstr "'%s' açma başarısız"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Server.met kaydetme işlemi başarısız!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "'server.met' dosyası okumada IO hatası: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -205,6 +205,39 @@ msgstr "ЗАСТЕРЕЖЕННЯ: ви не можете додати себе �
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "Файл індексу не знайдено: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "Неможливо отримати спільні файли користувача %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "Не знайдені спільні файли в теці: %s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "Неможливо перетворити magnet-посилання в eD2k-посилання: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "Невірне eD2k-посилання! ПОМИЛКА: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -625,6 +658,10 @@ msgstr "Відвідайте https://github.com/amule-org/amule/releases/latest,
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "ЖАХЛИВА ПОМИЛКА: не вдалося створити Timer"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1776,11 +1813,6 @@ msgstr "Ви вже маєте файл '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "Ви вже спробували звантажити файл %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "Неможливо перетворити magnet-посилання в eD2k-посилання: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3034,6 +3066,11 @@ msgid "External Connection: Handshake failed."
 msgstr "Зовнішнє з'єднання: в доступі відмовлено"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "Потік звантаження HTTP розпочатий"
@@ -3276,6 +3313,16 @@ msgstr "Всього звантажень: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "Всього вивантажень: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6375,6 +6422,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "Помилка оновлення GeoIP.dat"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID файлу"
@@ -6584,6 +6636,11 @@ msgstr "Не вдалося відкрити '%s'"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "Неможливо зберегти server.met!"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "Помилка введення-виведення під час читання файлу known.met: %s"
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -190,6 +190,37 @@ msgstr ""
 #: src/amuleAppCommon.cpp
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Collection file not found: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "No usable links in collection: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
 msgstr ""
 
 #: src/amule.cpp
@@ -593,6 +624,10 @@ msgstr ""
 
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
 msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
@@ -1721,11 +1756,6 @@ msgstr ""
 #: src/DownloadQueue.cpp
 #, c-format
 msgid "You are already trying to download the file %s"
-msgstr ""
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
 #: src/DownloadQueue.cpp
@@ -2923,6 +2953,11 @@ msgstr ""
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
@@ -3156,6 +3191,16 @@ msgstr ""
 #: src/MuleTrayIcon.cpp
 #, c-format
 msgid "Total UL: %s"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6137,6 +6182,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, c-format
+msgid "Error %u: %s\n"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr ""
@@ -6336,6 +6386,11 @@ msgstr ""
 
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
+msgstr ""
+
+#: src/ServerList.cpp
+#, c-format
+msgid "IO failure while writing 'server.met': %s"
 msgstr ""
 
 #: src/ServerList.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -212,6 +212,38 @@ msgstr "警告：在 Low ID 的情况下，你不能添加自己作为 ed2k 链�
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr "已将 %s 的权限限制为仅所有者。"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "索引文件未找到: "
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "写入链接集文件 '%s' 失败。"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "在目录中没有找到可以共享的文件：%s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "无法转换 magnet 链接为 eD2k：%s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "非法 eD2k 链接！错误: %s"
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -626,6 +658,10 @@ msgstr "访问 https://github.com/amule-org/amule/releases/latest 来检查 是�
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "致命错误：创建计时器失败"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1767,11 +1803,6 @@ msgstr "您已下载了文件 '%s'"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "您已经尝试下载文件 %s"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "无法转换 magnet 链接为 eD2k：%s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -3012,6 +3043,11 @@ msgstr "远程连接：握手失败。"
 
 #: src/LibSocketAsio.cpp
 #, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
+#, c-format
 msgid "Asio thread %d started"
 msgstr "Asio 线程 %d 已启动"
 
@@ -3246,6 +3282,16 @@ msgstr "总下载: %s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "总上传: %s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Paste eD2k or magnet links here"
@@ -6280,6 +6326,11 @@ msgstr "Kad 搜索：从又一个对等方请求了更广泛的结果。"
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr "Kad 搜索：没有剩余对等方可重新请求更多结果（已达上限或尚无响应）。"
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "更新 %s 出错"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "文件 ID"
@@ -6480,6 +6531,11 @@ msgstr "无法打开“%s”"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "无法保存 server.met！"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "读取“server.met”时发生 IO 错误: "
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-08 18:46+0200\n"
+"POT-Creation-Date: 2026-08-09 21:47+0200\n"
 "PO-Revision-Date: 2026-08-09 14:49+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -211,6 +211,37 @@ msgstr "警告：LowID 時不可以將自己加入 eD2k 連結來源。"
 #, c-format
 msgid "Restricted permissions on %s to owner-only."
 msgstr ""
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Collection file not found: %s"
+msgstr "找不到索引檔："
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid or empty collection file: %s"
+msgstr "無法從使用者 %s 取得分享檔案清單"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "No usable links in collection: %s"
+msgstr "目錄中找不到可分享的檔案：%s"
+
+#: src/amuleAppCommon.cpp
+#, c-format
+msgid "Skipped %u unusable link in collection: %s"
+msgid_plural "Skipped %u unusable links in collection: %s"
+msgstr[0] ""
+
+#: src/amuleAppCommon.cpp src/DownloadQueue.cpp
+#, c-format
+msgid "Cannot convert magnet link to eD2k: %s"
+msgstr "無法將 magnet 連結轉換為 eD2k: %s"
+
+#: src/amuleAppCommon.cpp
+#, fuzzy, c-format
+msgid "Invalid eD2k link \"%s\" - ERROR: %s"
+msgstr "無效的 eD2k 連結！錯誤：%s "
 
 #: src/amule.cpp
 msgid "Now, exiting main app..."
@@ -631,6 +662,10 @@ msgstr "請到 https://github.com/amule-org/amule/releases/latest 下載最新�
 #: src/amuleDlg.cpp
 msgid "FATAL ERROR: Failed to create Timer"
 msgstr "嚴重錯誤：無法建立計時器"
+
+#: src/amuleDlg.cpp
+msgid "Error! Unable to load Preferences"
+msgstr ""
 
 #: src/amuleDlg.cpp src/muuli_wdr.cpp
 msgid "Networks"
@@ -1764,11 +1799,6 @@ msgstr "您已經有檔案 %s"
 #, c-format
 msgid "You are already trying to download the file %s"
 msgstr "您已經在下載檔案 %s 了"
-
-#: src/DownloadQueue.cpp
-#, c-format
-msgid "Cannot convert magnet link to eD2k: %s"
-msgstr "無法將 magnet 連結轉換為 eD2k: %s"
 
 #: src/DownloadQueue.cpp
 #, c-format
@@ -2999,6 +3029,11 @@ msgid "External Connection: Handshake failed."
 msgstr "外部連線：訊號交換失敗"
 
 #: src/LibSocketAsio.cpp
+#, c-format
+msgid "Error creating UDP socket %s %d : %s"
+msgstr ""
+
+#: src/LibSocketAsio.cpp
 #, fuzzy, c-format
 msgid "Asio thread %d started"
 msgstr "已開始 HTTP 下載執行緒"
@@ -3241,6 +3276,16 @@ msgstr "總下載：%s"
 #, c-format
 msgid "Total UL: %s"
 msgstr "總上傳：%s"
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "Created %s at port %u"
+msgstr ""
+
+#: src/MuleUDPSocket.cpp
+#, c-format
+msgid "WARNING! %s: Packet to %s discarded due to error (%s) while sending."
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6304,6 +6349,11 @@ msgstr ""
 msgid "Kad search: no peer left to reask for more results (cap reached or no responses yet)."
 msgstr ""
 
+#: src/SearchList.cpp
+#, fuzzy, c-format
+msgid "Error %u: %s\n"
+msgstr "GeoIP.dat 更新錯誤"
+
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "檔案 ID"
@@ -6505,6 +6555,11 @@ msgstr "無法開啟 %s"
 #: src/ServerList.cpp
 msgid "Failed to save server.met!"
 msgstr "無法儲存 server.met ！"
+
+#: src/ServerList.cpp
+#, fuzzy, c-format
+msgid "IO failure while writing 'server.met': %s"
+msgstr "讀取 server.met 時發生 IO 錯誤："
 
 #: src/ServerList.cpp
 msgid "Invalid URL"

--- a/src/AsyncDNS.cpp
+++ b/src/AsyncDNS.cpp
@@ -59,7 +59,7 @@ wxThread::ExitCode CAsyncDNS::Entry()
 		event_data = m_socket;
 		break;
 	default:
-		AddLogLineN("WRONG TYPE ID ON ASYNC DNS SOLVING!!!");
+		AddLogLineN(LOG_DIAGNOSTIC("WRONG TYPE ID ON ASYNC DNS SOLVING!!!"));
 	}
 
 	if (event_id) {

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2483,7 +2483,7 @@ bool CUpDownClient::SendPacket(CPacket *packet, bool delpacket, bool controlpack
 		m_socket->SendPacket(packet, delpacket, controlpacket);
 		return true;
 	} else {
-		AddLogLineN("CAUGHT DEAD SOCKET IN SENDPACKET()");
+		AddLogLineN(LOG_DIAGNOSTIC("CAUGHT DEAD SOCKET IN SENDPACKET()"));
 		return false;
 	}
 }
@@ -2502,8 +2502,9 @@ float CUpDownClient::TickDownloadAndMeasure()
 		// freshly refilled budget.
 		m_socket->WakeIfPaused();
 	} else {
-		AddLogLineNS(
-			CFormat("CAUGHT DEAD SOCKET IN TICKDOWNLOADANDMEASURE() WITH SPEED %f") % kBpsClient);
+		AddLogLineNS(CFormat(LOG_DIAGNOSTIC(
+				     "CAUGHT DEAD SOCKET IN TICKDOWNLOADANDMEASURE() WITH SPEED %f")) %
+			     kBpsClient);
 	}
 
 	return kBpsClient;
@@ -2862,9 +2863,10 @@ void CUpDownClient::ProcessChatMessage(wxString message)
 							CPacket *packet = new CPacket(
 								fileAnswer, OP_EMULEPROT, OP_CHATCAPTCHAREQ);
 							theStats::AddUpOverheadOther(packet->GetPacketSize());
-							AddLogLineN(CFormat("sent Captcha %s (%d)") %
-								    m_strCaptchaChallenge %
-								    packet->GetPacketSize());
+							AddDebugLogLineN(logClient,
+								CFormat("sent Captcha %s (%d)") %
+									m_strCaptchaChallenge %
+									packet->GetPacketSize());
 							SafeSendPacket(packet);
 						} else {
 							wxFAIL;

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -1892,8 +1892,8 @@ private:
 					m_address.Service());
 			StartBackgroundRead();
 		} catch (const system_error &err) {
-			AddLogLineC(CFormat("Error creating UDP socket %s %d : %s") % m_address.IPAddress() %
-				    m_address.Service() % err.code().message());
+			AddLogLineC(CFormat(_("Error creating UDP socket %s %d : %s")) %
+				    m_address.IPAddress() % m_address.Service() % err.code().message());
 			m_socket = NULL;
 			m_OK = false;
 		}

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -397,6 +397,25 @@ public:
 };
 
 /**
+ * Marks a log string that is deliberately not wrapped in _().
+ *
+ * Both expand to the string unchanged, so neither reaches xgettext and neither
+ * costs anything at runtime; they exist so the reason is greppable and an
+ * untranslated literal is not mistaken for an oversight (issue #866).
+ *
+ * LOG_DIAGNOSTIC: an internal fault or trace whose value is being readable in
+ * a bug report someone pastes in. Translating it would make those reports
+ * harder to search, so it stays English on purpose.
+ *
+ * LOG_PRELOCALE: emitted before Localize_mule() has run, so no catalog is
+ * loaded and gettext would return the original text anyway. Wrapping one of
+ * these in _() would ship a string to translators that can never be shown
+ * translated. See the ordering note in CamuleApp::OnInit().
+ */
+#define LOG_DIAGNOSTIC(str) str
+#define LOG_PRELOCALE(str) str
+
+/**
  * These macros should be used when logging. The
  * AddLogLineM macro will simply call one of the
  * two CLogger::AddLogLine functions depending on

--- a/src/MuleUDPSocket.cpp
+++ b/src/MuleUDPSocket.cpp
@@ -73,7 +73,10 @@ void CMuleUDPSocket::CreateSocket()
 		AddDebugLogLineC(logMuleUDP, "Failed to create valid " + m_name);
 		DestroySocket();
 	} else {
-		AddLogLineN(wxString("Created ") << m_name << " at port " << m_addr.Service());
+		// One template rather than concatenation: translators need to be able to
+		// reorder the name and the port. m_name is a construction-time identifier
+		// ("Server UDP-Socket"), left untranslated on purpose.
+		AddLogLineN(CFormat(_("Created %s at port %u")) % m_name % m_addr.Service());
 	}
 }
 
@@ -153,10 +156,11 @@ void CMuleUDPSocket::OnReceive(int errorCode)
 		AddDebugLogLineN(logMuleUDP, m_name + ": Invalid Packet received");
 	} else if (!ip) {
 		// wxFAIL;
-		AddLogLineNS("Unknown ip receiving a UDP packet! Ignoring: '" + addr.IPAddress() + "'");
+		AddDebugLogLineN(logMuleUDP,
+			"Unknown ip receiving a UDP packet! Ignoring: '" + addr.IPAddress() + "'");
 	} else if (!port) {
 		// wxFAIL;
-		AddLogLineNS("Unknown port receiving a UDP packet! Ignoring");
+		AddDebugLogLineN(logMuleUDP, "Unknown port receiving a UDP packet! Ignoring");
 	} else if (theApp->clientlist->IsBannedClient(ip)) {
 		AddDebugLogLineN(logMuleUDP, m_name + ": Dropped packet from banned IP " + addr.IPAddress());
 	} else {
@@ -318,9 +322,9 @@ bool CMuleUDPSocket::SendTo(uint8_t *buffer, uint32_t length, uint32_t ip, uint1
 	} else if (uint32 error = m_socket->LastError()) {
 		// An error which we can't handle happened, so we drop
 		// the packet rather than risk entering an infinite loop.
-		AddLogLineN(("WARNING! " + m_name + ": Packet to ")
-			    << Uint32_16toStringIP_Port(ip, port) << " discarded due to error (" << error
-			    << ") while sending.");
+		AddLogLineN(
+			CFormat(_("WARNING! %s: Packet to %s discarded due to error (%s) while sending.")) %
+			m_name % Uint32_16toStringIP_Port(ip, port) % error);
 		sent = true;
 	} else {
 		AddDebugLogLineN(logMuleUDP,

--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -469,7 +469,8 @@ void COScopeCtrl::PlotHistory(unsigned cntPoints, bool bShiftGraph, bool bRefres
 		} catch (std::bad_alloc) {
 			// Failed memory allocation
 			AddLogLineC(
-				wxString("Error: COScopeCtrl::PlotHistory: Insuficient memory, cntPoints == ")
+				wxString(LOG_DIAGNOSTIC(
+					"Error: COScopeCtrl::PlotHistory: Insuficient memory, cntPoints == "))
 				<< cntPoints << ".");
 			for (i = 0; i < nTrends; ++i) {
 				delete[] apf[i];

--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -536,12 +536,13 @@ void CFileDataIO::WriteTag(const CTag &tag)
 			// TODO: Support more tag types
 			//  With the if above, this should NEVER happen.
 			AddLogLineNS(
-				CFormat("CFileDataIO::WriteTag: Unknown tag: type=0x%02X") % tag.GetType());
+				CFormat(LOG_DIAGNOSTIC("CFileDataIO::WriteTag: Unknown tag: type=0x%02X")) %
+				tag.GetType());
 			wxFAIL;
 			break;
 		}
 	} catch (...) {
-		AddLogLineNS("Exception in CDataIO:WriteTag");
+		AddLogLineNS(LOG_DIAGNOSTIC("Exception in CDataIO:WriteTag"));
 		throw;
 	}
 }

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -1386,7 +1386,7 @@ CSearchList::CMemFilePtr CSearchList::CreateSearchData(
 
 	if (_astrParserErrors.GetCount() > 0) {
 		for (unsigned int i = 0; i < _astrParserErrors.GetCount(); ++i) {
-			AddLogLineNS(CFormat("Error %u: %s\n") % i % _astrParserErrors[i]);
+			AddLogLineNS(CFormat(_("Error %u: %s\n")) % i % _astrParserErrors[i]);
 		}
 
 		return CMemFilePtr(nullptr);

--- a/src/ServerList.cpp
+++ b/src/ServerList.cpp
@@ -818,7 +818,7 @@ bool CServerList::SaveServerMet()
 		servermet.Close();
 
 	} catch (const CIOFailureException &e) {
-		AddLogLineC("IO failure while writing 'server.met': " + e.what());
+		AddLogLineC(CFormat(_("IO failure while writing 'server.met': %s")) % e.what());
 		return false;
 	}
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1071,8 +1071,8 @@ bool CamuleApp::OnInit()
 	// Normal level, not debug: these are the numbers the phase weighting
 	// above is meant to be tuned from, and a measurement that needs verbose
 	// logging turned on first is one nobody will report back.
-	AddLogLineN(CFormat("Startup phases: network %lld ms, %u part files %lld ms, shared scan "
-			    "%lld ms (estimate was %u)") %
+	AddLogLineN(CFormat(LOG_DIAGNOSTIC("Startup phases: network %lld ms, %u part files %lld ms, shared "
+					   "scan ") "%lld ms (estimate was %u)") %
 		    (networkDoneAt - splashPhaseStart).GetValue() % partFilesLoaded %
 		    (tempDoneAt - networkDoneAt).GetValue() % (sharedDoneAt - tempDoneAt).GetValue() %
 		    sharedEstimate);

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -620,16 +620,16 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 
 	if (theLogger.IsEnabledStdoutLog()) {
 		if (enable_daemon_fork) {
-			AddLogLineNS(
-				"Daemon will fork to background - log to stdout disabled"); // localization
-											    // not active yet
+			AddLogLineNS(LOG_PRELOCALE(
+				"Daemon will fork to background - log to stdout disabled")); // localization
+											     // not active yet
 			theLogger.SetEnabledStdoutLog(false);
 		} else {
-			AddLogLineNS("Logging to stdout enabled");
+			AddLogLineNS(LOG_PRELOCALE("Logging to stdout enabled"));
 		}
 	}
 
-	AddLogLineNS("Initialising " + FullMuleVersion);
+	AddLogLineNS(LOG_PRELOCALE("Initialising ") + FullMuleVersion);
 
 	// Ensure that "~/.aMule/" is accessible.
 	CPath outDir;
@@ -642,8 +642,8 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		wxRemoveFile(thePrefs::GetConfigDir() + m_configFile + ".backup");
 		wxRenameFile(thePrefs::GetConfigDir() + m_configFile,
 			thePrefs::GetConfigDir() + m_configFile + ".backup");
-		AddLogLineNS(CFormat("Your settings have been reset to default values.\nThe old config file "
-				     "has been saved as %s.backup\n") %
+		AddLogLineNS(CFormat(LOG_PRELOCALE("Your settings have been reset to default values.\nThe "
+						   "old config file ") "has been saved as %s.backup\n") %
 			     m_configFile);
 	}
 
@@ -692,21 +692,23 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 			}
 			ed2kFile.Write();
 		} else {
-			AddLogLineCS("Failed to open 'ED2KLinks', cannot add links.");
+			AddLogLineCS(LOG_PRELOCALE("Failed to open 'ED2KLinks', cannot add links."));
 		}
 	}
 
-	AddLogLineNS("Checking if there is an instance already running...");
+	AddLogLineNS(LOG_PRELOCALE("Checking if there is an instance already running..."));
 
 	m_singleInstance = new InstanceLock();
 	wxString lockfile = IsRemoteGui() ? "muleLockRGUI" : "muleLock";
 	InstanceLock::Result lockResult = m_singleInstance->Acquire(lockfile, thePrefs::GetConfigDir());
 	if (lockResult == InstanceLock::LOCK_HELD) {
-		AddLogLineCS(CFormat("There is an instance of %s already running") % m_appName);
-		AddLogLineNS(CFormat("(lock file: %s%s)") % thePrefs::GetConfigDir() % lockfile);
+		AddLogLineCS(
+			CFormat(LOG_PRELOCALE("There is an instance of %s already running")) % m_appName);
+		AddLogLineNS(
+			CFormat(LOG_PRELOCALE("(lock file: %s%s)")) % thePrefs::GetConfigDir() % lockfile);
 		if (linksPassed) {
-			AddLogLineNS(CFormat("passed %d %s to it, finished") % linksActuallyPassed %
-				     (linksPassed == 1 ? "link" : "links"));
+			AddLogLineNS(CFormat(LOG_PRELOCALE("passed %d %s to it, finished")) %
+				     linksActuallyPassed % (linksPassed == 1 ? "link" : "links"));
 			// Nothing was handed over, so don't pull the running
 			// instance to the front on account of a bad argument.
 			if (linksActuallyPassed == 0) {
@@ -729,18 +731,19 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 			ed2kFile.AddLine("RAISE_DIALOG");
 			ed2kFile.Write();
 
-			AddLogLineNS("Raising current running instance.");
+			AddLogLineNS(LOG_PRELOCALE("Raising current running instance."));
 		} else {
-			AddLogLineCS("Failed to open 'ED2KFile', cannot signal running instance.");
+			AddLogLineCS(
+				LOG_PRELOCALE("Failed to open 'ED2KFile', cannot signal running instance."));
 		}
 
 		return false;
 	} else if (lockResult == InstanceLock::LOCK_ERROR) {
-		AddLogLineCS(CFormat("Could not access lock file (%s%s); continuing without single-instance "
-				     "protection.") %
+		AddLogLineCS(CFormat(LOG_PRELOCALE("Could not access lock file (%s%s); continuing without "
+						   "single-instance ") "protection.") %
 			     thePrefs::GetConfigDir() % lockfile);
 	} else {
-		AddLogLineNS("No other instances are running.");
+		AddLogLineNS(LOG_PRELOCALE("No other instances are running."));
 	}
 
 #ifndef __WINDOWS__
@@ -804,7 +807,7 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	wxString amulewebPath;
 	if (cmdline.Found("use-amuleweb", &amulewebPath)) {
 		thePrefs::SetWSPath(amulewebPath);
-		AddLogLineNS(CFormat("Using amuleweb in '%s'.") % amulewebPath);
+		AddLogLineNS(CFormat(LOG_PRELOCALE("Using amuleweb in '%s'.")) % amulewebPath);
 	}
 #endif
 
@@ -872,13 +875,13 @@ CamuleAppCommon::CollectionExpansion CamuleAppCommon::ExpandPassedCollection(
 	if (!wxFile::Exists(path)) {
 		// The extension says collection, so a missing file is a real
 		// error rather than something to retry as a link.
-		AddLogLineCS(CFormat("Collection file not found: %s") % path);
+		AddLogLineCS(CFormat(_("Collection file not found: %s")) % path);
 		return kCollectionFailed;
 	}
 
 	CMuleCollection collection;
 	if (!collection.Open(path)) {
-		AddLogLineCS(CFormat("Invalid or empty collection file: %s") % path);
+		AddLogLineCS(CFormat(_("Invalid or empty collection file: %s")) % path);
 		return kCollectionFailed;
 	}
 
@@ -904,11 +907,14 @@ CamuleAppCommon::CollectionExpansion CamuleAppCommon::ExpandPassedCollection(
 	}
 
 	if (out.IsEmpty()) {
-		AddLogLineCS(CFormat("No usable links in collection: %s") % path);
+		AddLogLineCS(CFormat(_("No usable links in collection: %s")) % path);
 		return kCollectionFailed;
 	}
 	if (skipped > 0) {
-		AddLogLineCS(CFormat("Skipped %u unusable link(s) in collection: %s") % skipped % path);
+		AddLogLineCS(CFormat(wxPLURAL("Skipped %u unusable link in collection: %s",
+				     "Skipped %u unusable links in collection: %s",
+				     skipped)) %
+			     skipped % path);
 	}
 
 	return kCollectionExpanded;
@@ -925,7 +931,7 @@ bool CamuleAppCommon::CheckPassedLink(const wxString &in, wxString &out, int cat
 	if (link.compare(0, 7, "magnet:") == 0) {
 		link = CMagnetED2KConverter(link);
 		if (link.empty()) {
-			AddLogLineCS(CFormat("Cannot convert magnet link to eD2k: %s") % in);
+			AddLogLineCS(CFormat(_("Cannot convert magnet link to eD2k: %s")) % in);
 			return false;
 		}
 	}
@@ -938,7 +944,7 @@ bool CamuleAppCommon::CheckPassedLink(const wxString &in, wxString &out, int cat
 		}
 		return true;
 	} catch (const wxString &err) {
-		AddLogLineCS(CFormat("Invalid eD2k link \"%s\" - ERROR: %s") % link % err);
+		AddLogLineCS(CFormat(_("Invalid eD2k link \"%s\" - ERROR: %s")) % link % err);
 	}
 	return false;
 }

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -346,7 +346,7 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	bool override_size = ((dlg_size.x != DEFAULT_SIZE_X) || (dlg_size.y != DEFAULT_SIZE_Y));
 	if (!LoadGUIPrefs(override_where, override_size)) {
 		// Prefs not loaded for some reason, exit
-		AddLogLineC("Error! Unable to load Preferences");
+		AddLogLineC(_("Error! Unable to load Preferences"));
 		return;
 	}
 
@@ -737,7 +737,8 @@ void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 
 			// This shouldn't happen, but just in case
 			default:
-				AddLogLineC("Unknown button triggered CamuleApp::OnToolBarButton().");
+				AddDebugLogLineC(logStandard,
+					"Unknown button triggered CamuleApp::OnToolBarButton().");
 				break;
 			}
 		}
@@ -1790,11 +1791,11 @@ void CamuleDlg::Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon,
 		if (it != cat.end()) {
 			zip.OpenEntry(*it->second);
 			if (!new_image.LoadFile(zip, wxBITMAP_TYPE_PNG)) {
-				AddLogLineN("Warning: Error loading icon for " + iconName);
+				AddLogLineN(LOG_DIAGNOSTIC("Warning: Error loading icon for ") + iconName);
 				useSkins = false;
 			}
 		} else {
-			AddLogLineN("Warning: Can't load icon for " + iconName);
+			AddLogLineN(LOG_DIAGNOSTIC("Warning: Can't load icon for ") + iconName);
 			useSkins = false;
 		}
 	}
@@ -1826,7 +1827,8 @@ void CamuleDlg::Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon,
 				// condition. Fall back to a generic stock icon rather
 				// than shipping a bespoke raster twin of each toolbar
 				// asset just for an error path that can't happen.
-				AddLogLineN("Warning: Could not load built-in icon for " + iconName);
+				AddLogLineN(LOG_DIAGNOSTIC("Warning: Could not load built-in icon for ") +
+					    iconName);
 				art = wxArtProvider::GetBitmapBundle(
 					wxART_MISSING_IMAGE, wxART_TOOLBAR, wxSize(32, 32));
 			}

--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -196,7 +196,7 @@ static BOOL CtrlHandler(DWORD fdwCtrlType)
 	case CTRL_CLOSE_EVENT:
 	case CTRL_BREAK_EVENT:
 		// handle these
-		AddLogLineNS("Received break event, exit main loop");
+		AddDebugLogLineN(logStandard, "Received break event, exit main loop");
 		theApp->ExitMainLoop();
 		return TRUE;
 		break;


### PR DESCRIPTION
Closes #866.

Log output mixes languages: many lines are translated, many are not, and the untranslated ones never reach Weblate. Auditing every user-facing `AddLogLine*` call turns up **52 with a bare literal**, against 340 already going through gettext. They do not all want the same treatment.

## Twelve are genuine oversights — translated

The collection and link handlers in `amuleAppCommon.cpp` (reachable from the runtime file-open path, not only from startup), `MuleUDPSocket`'s socket-created and packet-discarded lines, `amuleDlg`'s preferences failure, `LibSocketAsio`'s UDP socket error, the search-expression parse error, and the `server.met` write failure.

Three built their message by concatenation and became a single `CFormat` template, since translators cannot reorder fragments; one became `wxPLURAL`.

## Fourteen cannot be translated — `LOG_PRELOCALE`

These run inside `InitCommon()`, which `OnInit()` calls at `:673` to establish the config dir and take the single-instance lock — before `CPreferences` exists at `:677`, and therefore before `Localize_mule()` at `:748` can read the language out of it. The ordering is already documented at `amule.cpp:606`.

This is most of what the reporter quoted: "Initialising aMule…", "Checking if there is an instance already running…", "No other instances are running." Wrapping them would ship strings to translators that can never appear translated.

Moving locale initialisation earlier does not work: locale needs the language from preferences, preferences need the config dir, and the config dir is established in `InitCommon` alongside the lock that stops two instances racing on it. Splitting it so preferences load before the lock is taken would trade a real concurrency guarantee for translated log lines — and the lines that would benefit are mostly the lock messages themselves.

## Ten stay English deliberately — `LOG_DIAGNOSTIC`

Internal faults whose worth is being greppable in a log someone pastes into a bug report: dead sockets, refcount leaks, an unknown tag type, icon-load failures. Translating those makes reports harder to search.

Both markers expand to the string unchanged, so nothing reaches xgettext and nothing costs anything at runtime. They exist so the reason is greppable and an untranslated literal is not read as an oversight.

## Five demoted to debug

Routine chatter using a user-facing macro — a captcha trace, two unknown-ip/port UDP lines, an unknown toolbar button, the daemon break event — now `AddDebugLogLine*` under `logClient`, `logMuleUDP` and `logStandard`.

## Also fixed

`src/MuleUDPSocket.cpp` was missing from `po/POTFILES.in`, so wrapping its strings extracted nothing at all. Added, and the regenerated pot was checked for each new string rather than the wrap being taken on trust.

## Testing

`amule`, `amulegui` and `amuled` build clean on macOS. clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors. Catalogs regenerated; verified the twelve new strings appear in `amule.pot` and that the marked ones do not.

Nothing here changes what a user sees in English — it changes which strings translators are given, and records why the rest are exempt.
