### PR TITLE
fix(core): accept eD2k links whose '|' delimiters are percent-encoded

### DIFF
--- a/src/ED2KLink.cpp
+++ b/src/ED2KLink.cpp
@@ -33,9 +33,10 @@
 
 #include <protocol/ed2k/Constants.h>
 
-#include "MemFile.h"          // Needed for CMemFile
-#include "NetworkFunctions.h" // Needed for Uint32toStringIP
-#include <common/Format.h>    // Needed for CFormat
+#include "MemFile.h"                // Needed for CMemFile
+#include "NetworkFunctions.h"       // Needed for Uint32toStringIP
+#include <common/Format.h>          // Needed for CFormat
+#include <common/StringFunctions.h> // Needed for UnescapeHTML, RestoreEncodedPipes
 
 CED2KLink::CED2KLink(LinkType type)
 : m_type(type)
@@ -50,6 +51,27 @@ CED2KLink::LinkType CED2KLink::GetKind() const
 }
 
 CED2KLink *CED2KLink::CreateLinkFromUrl(const wxString &link)
+{
+	try {
+		return ParseLink(link);
+	} catch (const wxString &) {
+		// Chromium blocks an ed2k:// URL that carries literal '|', so links
+		// are published, copied and pasted with the delimiters percent-
+		// encoded. Retry rather than decode up front: a link that parses as
+		// given is never touched, so a filename holding a real "%7C" -- which
+		// is how a '|' in a name is spelled -- cannot be split into extra
+		// fields by this. Every caller reaches the parser, so handling it
+		// here is what keeps the command line, the paste box, the browser
+		// handler and the EC clients agreeing.
+		const wxString restored = RestoreEncodedPipes(link);
+		if (restored == link) {
+			throw;
+		}
+		return ParseLink(restored);
+	}
+}
+
+CED2KLink *CED2KLink::ParseLink(const wxString &link)
 {
 	wxRegEx re_type("ed2k://\\|(file|server|serverlist)\\|.*/", wxRE_ICASE | wxRE_DEFAULT);
 	{

--- a/src/ED2KLink.h
+++ b/src/ED2KLink.h
@@ -42,6 +42,11 @@ public:
 		kInvalid
 	} LinkType;
 
+	/**
+	 * Parses a link, accepting percent-encoded '|' delimiters.
+	 *
+	 * Throws a wxString describing the problem if the link is not one.
+	 */
 	static CED2KLink *CreateLinkFromUrl(const wxString &link);
 
 	LinkType GetKind() const;
@@ -53,6 +58,9 @@ protected:
 	CED2KLink(LinkType type);
 
 private:
+	//! Parses a link exactly as given; CreateLinkFromUrl() drives the retry.
+	static CED2KLink *ParseLink(const wxString &link);
+
 	LinkType m_type;
 };
 

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -38,7 +38,8 @@
 
 #include <wx/tokenzr.h>
 
-#include <common/Format.h> // Needed for CFormat
+#include <common/Format.h>          // Needed for CFormat
+#include <common/StringFunctions.h> // Needed for RestoreEncodedPipes
 #include "OtherFunctions.h"
 #include "Constants.h"   // Needed for Priority Levels
 #include "DataToText.h"  // Needed for PriorityToStr
@@ -581,10 +582,9 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 			if (args.Find("|h=") > -1 && args.Find("|/|h=") == -1) {
 				args.Replace("|h=", "|/|h=");
 			}
-			// repair links where | is replaced with %7C (Firefox)
-			if (args.StartsWith("ed2k://%7C")) {
-				args.Replace("%7C", "|");
-			}
+			// The daemon restores these itself, but amulecmd is routinely
+			// pointed at an older one over EC, so repair before sending.
+			args = RestoreEncodedPipes(args);
 		}
 		request = new CECPacket(EC_OP_ADD_LINK);
 		request->AddTag(CECTag(EC_TAG_STRING, args));

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -916,11 +916,9 @@ CamuleAppCommon::CollectionExpansion CamuleAppCommon::ExpandPassedCollection(
 
 bool CamuleAppCommon::CheckPassedLink(const wxString &in, wxString &out, int cat)
 {
+	// Percent-encoded '|' delimiters are restored by CreateLinkFromUrl()
+	// below, which every other entry point reaches too.
 	wxString link(in);
-
-	// restore ASCII-encoded pipes
-	link.Replace("%7C", "|");
-	link.Replace("%7c", "|");
 
 	if (link.compare(0, 7, "magnet:") == 0) {
 		link = CMagnetED2KConverter(link);

--- a/src/libs/common/StringFunctions.cpp
+++ b/src/libs/common/StringFunctions.cpp
@@ -171,6 +171,14 @@ wxString UnescapeHTML(const wxString &str)
 	return result;
 }
 
+wxString RestoreEncodedPipes(const wxString &link)
+{
+	wxString restored(link);
+	restored.Replace("%7C", "|");
+	restored.Replace("%7c", "|");
+	return restored;
+}
+
 wxString validateURI(const wxString &url)
 {
 	wxURI uri(url);

--- a/src/libs/common/StringFunctions.h
+++ b/src/libs/common/StringFunctions.h
@@ -259,6 +259,20 @@ wxChar HexToDec(const wxString &hex);
 wxString UnescapeHTML(const wxString &str);
 
 /**
+ * Restores the '|' delimiters of an eD2k link that were percent-encoded.
+ *
+ * Chromium refuses to hand over an ed2k:// URL containing literal '|' at all
+ * (it navigates to about:blank#blocked), so sites publish the encoded spelling
+ * instead, and that is what ends up on the clipboard. Only the delimiters are
+ * touched: a filename keeps whatever escapes it arrived with, and
+ * CED2KFileLink runs UnescapeHTML() over it once the link tokenizes.
+ *
+ * @param link The link as the user supplied it.
+ * @return The same link with %7C / %7c restored to '|'.
+ */
+wxString RestoreEncodedPipes(const wxString &link);
+
+/**
  * Ensures that the url pass is valid by escaping various chars.
  */
 wxString validateURI(const wxString &url);

--- a/unittests/tests/StringFunctionsTest.cpp
+++ b/unittests/tests/StringFunctionsTest.cpp
@@ -206,3 +206,30 @@ TEST(StringFunctions, UnescapeHTMLPercentBeforeNonAscii)
 
 	ASSERT_EQUALS(name, UnescapeHTML(name));
 }
+
+// Issue #873: Chromium refuses to open an ed2k:// URL holding literal '|', so
+// links are published and copied with the delimiters percent-encoded, and
+// CED2KLink::CreateLinkFromUrl retries through this helper.
+TEST(StringFunctions, RestoreEncodedPipesHandlesBothCases)
+{
+	ASSERT_EQUALS(wxString("ed2k://|file|a.iso|1|H|/"),
+		RestoreEncodedPipes("ed2k://%7Cfile%7Ca.iso%7C1%7CH%7C/"));
+	ASSERT_EQUALS(wxString("ed2k://|file|a.iso|1|H|/"),
+		RestoreEncodedPipes("ed2k://%7cfile%7ca.iso%7c1%7cH%7c/"));
+}
+
+// A link that a mail client only half-encoded still has to come out whole.
+TEST(StringFunctions, RestoreEncodedPipesHandlesMixedSpellings)
+{
+	ASSERT_EQUALS(wxString("a|b|c"), RestoreEncodedPipes("a%7Cb|c"));
+}
+
+// Only the delimiters are its business: every other escape belongs to the
+// filename, which UnescapeHTML decodes later, and decoding it here would
+// double-decode a name containing a literal '%'.
+TEST(StringFunctions, RestoreEncodedPipesLeavesOtherEscapesAlone)
+{
+	ASSERT_EQUALS(wxString("a|b%20c%2F"), RestoreEncodedPipes("a%7Cb%20c%2F"));
+	ASSERT_EQUALS(wxString("nothing to do"), RestoreEncodedPipes("nothing to do"));
+	ASSERT_EQUALS(wxEmptyString, RestoreEncodedPipes(wxEmptyString));
+}


### PR DESCRIPTION
Closes #873.

Chromium refuses to hand over an `ed2k://` URL containing literal `|` — it navigates to `about:blank#blocked` — so sites publish the percent-encoded spelling instead, and that is what lands on the clipboard. Pasting one into the link box was rejected as *"Not a valid ed2k-URI"*.

aMule already repaired these in three separate places, none of which the paste box reaches:

| Entry point | Handling |
|---|---|
| Command line | `CheckPassedLink` replaced `%7C` / `%7c` |
| Browser / `ed2k://` handler | `wxURI::Unescape` on the whole URL |
| `amulecmd add` | replaced `%7C`, but only when the link *started* `ed2k://%7C` |
| **Paste box, and the EC clients** | **none** |

The EC gap means amulegui, amuleweb and amuleapi were affected too, not just the monolithic GUI.

The repair now lives in `CED2KLink::CreateLinkFromUrl` — which every one of those paths funnels through — behind a shared `RestoreEncodedPipes()` helper in `StringFunctions`.

It runs as a **retry, not as preprocessing**: a link that parses as given is never touched, so a filename holding a real `%7C` — which is how a `|` inside a name is spelled — cannot be split across fields. Decoding up front would silently fetch a different file.

The copy in `CheckPassedLink` goes away as redundant. amulecmd keeps its own call, since it is routinely pointed at an older daemon over EC where the repair has to happen client-side, and the protocol handler keeps `wxURI::Unescape`, which decodes a whole URL rather than just the delimiters.

## Testing

Verified against a local `amuled`, which normalises a command-line link through the changed path:

```
in:  ed2k://%7Cfile%7Cencoded-test.iso%7C1024%7CD41D…427E%7C/
out: ed2k://|file|encoded-test.iso|1024|D41D8CD98F00B204E9800998ECF8427E|/
```

and the safety case — `ed2k://|file|a%7Cb.iso|1024|…|/` parses on the first attempt with the name intact as one field, the retry never firing.

Three cases added to `StringFunctionsTest` covering the helper: both letter cases, mixed spellings, and other escapes left alone.

**Not covered by CI:** the retry in `CreateLinkFromUrl` itself. A standalone test target for the parser needs `SHAHashSet` → `CClientRef` → the client stack plus `CPreferences::s_configDir`, and past a few stubs it tests the stubs rather than aMule. The retry is verified by the manual runs above only.
