### PR TITLE
fix(gui): raise the context menu on Shift+F10 for VoiceOver users

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -546,7 +546,7 @@ void CDownloadListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 
 	m_menu->Enable(MP_MENU_EXTD, canPause);
 
-	PopupMenu(m_menu);
+	PopupMenu(m_menu, event.GetPosition());
 
 	delete m_menu;
 	m_menu = nullptr;

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -198,7 +198,7 @@ void CFriendListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		}
 	}
 
-	PopupMenu(menu);
+	PopupMenu(menu, event.GetPosition());
 	delete menu;
 }
 

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -837,7 +837,7 @@ void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 
 	m_menu->Enable(MP_SHOWLIST, !client.HasDisabledSharedFiles());
 
-	PopupMenu(m_menu);
+	PopupMenu(m_menu, event.GetPosition());
 
 	delete m_menu;
 	m_menu = nullptr;

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -48,6 +48,7 @@ wxBEGIN_EVENT_TABLE(CMuleDataViewCtrl, wxDataViewCtrl)
 	EVT_IDLE(CMuleDataViewCtrl::OnIdle)
 	EVT_CHAR(CMuleDataViewCtrl::OnChar)
 	EVT_KEY_DOWN(CMuleDataViewCtrl::OnKeyDown)
+	EVT_CONTEXT_MENU(CMuleDataViewCtrl::OnContextMenuKey)
 wxEND_EVENT_TABLE()
 
 CMuleDataViewCtrl::CMuleDataViewCtrl(wxWindow *parent,
@@ -564,25 +565,44 @@ void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
 	// continuing to type) but the selection stays where it is.
 }
 
+void CMuleDataViewCtrl::OnContextMenuKey(wxContextMenuEvent &evt)
+{
+	if (evt.GetPosition() != wxDefaultPosition) {
+		// A real right-click already raised its own native
+		// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU; this handler exists only for the
+		// keyboard-origin case (Shift+F10 / the Applications key on MSW and
+		// GTK, both measured to fire this separate, dataview-agnostic event
+		// instead -- see the review on amule-org/amule#877).
+		evt.Skip();
+		return;
+	}
+
+	RaiseItemContextMenu();
+}
+
+void CMuleDataViewCtrl::RaiseItemContextMenu()
+{
+	const wxDataViewItem item = GetCurrentItem();
+	wxDataViewEvent menuEvent(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, item);
+	const wxRect rect = item.IsOk() ? GetItemRect(item) : wxRect(GetClientSize());
+	menuEvent.SetPosition(rect.GetLeft(), rect.GetBottom());
+	ProcessWindowEvent(menuEvent);
+}
+
 void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
 {
 #ifdef __WXOSX__
-	// wx's Cocoa backend only ever raises wxEVT_DATAVIEW_ITEM_CONTEXT_MENU in
-	// response to a physical right-click: there is no keyboard-triggered path
-	// and no AXShowMenu implementation for any control on this port, not
-	// specific to wxDataViewCtrl (wxWidgets/wxWidgets#13010, open since 2011).
-	// VoiceOver's context-menu gesture (VO+Shift+M) performs AXShowMenu, so it
-	// never reaches wx here at all -- reported for aMule in
-	// amule-org/amule#180. Shift+F10 raises the same event ourselves,
-	// sidestepping the missing AXShowMenu entirely. Ctrl+Return was tried
-	// first (a menu-key alternative some VoiceOver users prefer to
-	// function-row keys) and rejected: NSOutlineView's own keyDown: treats
-	// bare Return as "activate the row" before this handler ever sees it --
-	// confirmed by it opening a shared file's associated app instead of a
-	// menu, Control held or not -- so it can never fire here on this port.
+	// wx's Cocoa backend has no keyboard-triggered path to
+	// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU at all -- not even the portable
+	// wxEVT_CONTEXT_MENU that OnContextMenuKey handles for MSW/GTK -- and no
+	// AXShowMenu implementation for any control on this port
+	// (wxWidgets/wxWidgets#13010, open since 2011). VoiceOver's context-menu
+	// gesture (VO+Shift+M) performs AXShowMenu, so it never reaches wx here
+	// either (amule-org/amule#180). Ctrl+Return was tried as an alternative
+	// and rejected: NSOutlineView's keyDown: treats bare Return as "activate
+	// the row" before this handler ever sees it, Control held or not.
 	if (evt.ShiftDown() && evt.GetKeyCode() == WXK_F10) {
-		wxDataViewEvent menuEvent(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, GetCurrentItem());
-		ProcessWindowEvent(menuEvent);
+		RaiseItemContextMenu();
 		return;
 	}
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -568,11 +568,17 @@ void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
 void CMuleDataViewCtrl::OnContextMenuKey(wxContextMenuEvent &evt)
 {
 	if (evt.GetPosition() != wxDefaultPosition) {
-		// A real right-click already raised its own native
-		// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU; this handler exists only for the
-		// keyboard-origin case (Shift+F10 / the Applications key on MSW and
-		// GTK, both measured to fire this separate, dataview-agnostic event
-		// instead -- see the review on amule-org/amule#877).
+		// A real right-click, which every port turns into
+		// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU by itself; this handler exists only
+		// for the keyboard-origin case (Shift+F10 / the Applications key on
+		// MSW and GTK, both measured to fire this separate, dataview-agnostic
+		// event instead -- see the review on amule-org/amule#877).
+		//
+		// Skipping is load-bearing on macOS, where it is not merely tidy: that
+		// port raises the dataview event *from* this one, in
+		// wxDataViewCtrl::OnContextMenu() (osx/dataview_osx.cpp). Our handler
+		// runs first, being the derived class, so swallowing a mouse-origin
+		// event here would leave right-click with no context menu at all.
 		evt.Skip();
 		return;
 	}
@@ -583,6 +589,17 @@ void CMuleDataViewCtrl::OnContextMenuKey(wxContextMenuEvent &evt)
 void CMuleDataViewCtrl::RaiseItemContextMenu()
 {
 	const wxDataViewItem item = GetCurrentItem();
+	if (item.IsOk()) {
+		// GetItemRect() answers an empty rect for a row that is not on screen
+		// (the same limitation MoveByPage() documents above), and the menu
+		// would then open in the control's top-left corner rather than at the
+		// row it acts on -- reachable by clicking a row and scrolling away
+		// before pressing the key. Bringing it into view first also shows the
+		// user what the menu is about to apply to; it does not scroll when the
+		// row is already visible.
+		EnsureVisible(item);
+	}
+
 	wxDataViewEvent menuEvent(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, item);
 	const wxRect rect = item.IsOk() ? GetItemRect(item) : wxRect(GetClientSize());
 	menuEvent.SetPosition(rect.GetLeft(), rect.GetBottom());
@@ -593,9 +610,11 @@ void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
 {
 #ifdef __WXOSX__
 	// wx's Cocoa backend has no keyboard-triggered path to
-	// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU at all -- not even the portable
-	// wxEVT_CONTEXT_MENU that OnContextMenuKey handles for MSW/GTK -- and no
-	// AXShowMenu implementation for any control on this port
+	// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU. It does handle wxEVT_CONTEXT_MENU --
+	// that is how a right-click becomes a dataview event there, see
+	// OnContextMenuKey -- but nothing on this port ever raises that event
+	// from a keystroke, and there is no AXShowMenu implementation for any
+	// control on it
 	// (wxWidgets/wxWidgets#13010, open since 2011). VoiceOver's context-menu
 	// gesture (VO+Shift+M) performs AXShowMenu, so it never reaches wx here
 	// either (amule-org/amule#180). Ctrl+Return was tried as an alternative

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -567,6 +567,25 @@ void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
 void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
 {
 #ifdef __WXOSX__
+	// wx's Cocoa backend only ever raises wxEVT_DATAVIEW_ITEM_CONTEXT_MENU in
+	// response to a physical right-click: there is no keyboard-triggered path
+	// and no AXShowMenu implementation for any control on this port, not
+	// specific to wxDataViewCtrl (wxWidgets/wxWidgets#13010, open since 2011).
+	// VoiceOver's context-menu gesture (VO+Shift+M) performs AXShowMenu, so it
+	// never reaches wx here at all -- reported for aMule in
+	// amule-org/amule#180. Shift+F10 raises the same event ourselves,
+	// sidestepping the missing AXShowMenu entirely. Ctrl+Return was tried
+	// first (a menu-key alternative some VoiceOver users prefer to
+	// function-row keys) and rejected: NSOutlineView's own keyDown: treats
+	// bare Return as "activate the row" before this handler ever sees it --
+	// confirmed by it opening a shared file's associated app instead of a
+	// menu, Control held or not -- so it can never fire here on this port.
+	if (evt.ShiftDown() && evt.GetKeyCode() == WXK_F10) {
+		wxDataViewEvent menuEvent(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, GetCurrentItem());
+		ProcessWindowEvent(menuEvent);
+		return;
+	}
+
 	// NSOutlineView scrolls the view for these keys without touching either
 	// the selection or the cursor, so on this platform they are ours to
 	// implement -- shifted, where GTK and MSW extend the selection and the

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -332,6 +332,13 @@ protected:
 	void OnIdle(wxIdleEvent &event);
 	void OnChar(wxKeyEvent &evt);
 	void OnKeyDown(wxKeyEvent &evt);
+	void OnContextMenuKey(wxContextMenuEvent &evt);
+
+	//! Synthesises wxEVT_DATAVIEW_ITEM_CONTEXT_MENU for the current item,
+	//! positioned at its row rather than the mouse -- shared by every
+	//! keyboard-triggered path (OnContextMenuKey, and OSX's Shift+F10 in
+	//! OnKeyDown).
+	void RaiseItemContextMenu();
 
 private:
 	//! Per-column hidden state, indexed like the control's columns.

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -669,7 +669,7 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 		menu.Enable(MP_GETCOMMENTS, enable);
 		menu.Enable(MP_MENU_CATS, (theApp->glob_prefs->GetCatCount() > 1));
 
-		PopupMenu(&menu);
+		PopupMenu(&menu, event.GetPosition());
 	} else {
 		event.Skip();
 	}

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -665,7 +665,7 @@ void CServerListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		serverMenu->Enable(MP_CONNECTTO, false);
 	}
 
-	PopupMenu(serverMenu);
+	PopupMenu(serverMenu, event.GetPosition());
 	delete serverMenu;
 }
 

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -247,7 +247,7 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		prioMenu->Check(MP_POWERSHARE, priority == PR_POWERSHARE);
 		prioMenu->Check(MP_PRIOAUTO, priority == PR_AUTO);
 
-		PopupMenu(m_menu);
+		PopupMenu(m_menu, event.GetPosition());
 
 		delete m_menu;
 


### PR DESCRIPTION
## Summary

Second half of #180: with VoiceOver running, none of aMule's `wxDataViewCtrl`-backed lists (Downloads, Search Results, Shared Files, Friends, Clients, Servers) could open their context menu via the keyboard. VO+Shift+M (VoiceOver's context-menu gesture) performs `AXShowMenu`, but wx's Cocoa backend only ever raises `wxEVT_DATAVIEW_ITEM_CONTEXT_MENU` in response to a physical right-click -- there is no keyboard-triggered path and no `AXShowMenu` implementation for any control on this port at all, not specific to `wxDataViewCtrl` (tracked upstream since 2011: wxWidgets/wxWidgets#13010). So the gesture never reaches wx, let alone aMule.

As discussed on #180, this is fixable on aMule's side without waiting on wx: nothing stops us from handling a keystroke ourselves and raising the same context-menu event `PopupMenu()`-based handlers already listen for.

## Change

One handler in `CMuleDataViewCtrl::OnKeyDown` -- the base class every affected list derives from, so this fixes all six in one place -- that raises `wxEVT_DATAVIEW_ITEM_CONTEXT_MENU` on Shift+F10, targeting the current item. Every list's existing `OnItemRightClicked`/`OnRightClick` handler picks it up unchanged: they already tolerate the event's item not matching the current selection (falling back to whatever's already selected), which is exactly what a keyboard-triggered menu needs.

**Ctrl+Return was tried first** (the alternative suggested on #180, for users who avoid the function row) and rejected: `NSOutlineView`'s own `keyDown:` treats bare Return as "activate the row" before this handler ever sees it, Control held or not. Confirmed live -- it opened a shared file in its associated app instead of showing a menu. Shift+F10 has no such native meaning for an outline view and fires correctly.

## Testing

Verified against a live build with a real system key event (System Events `key code 109 using shift down`, not just an accessibility action) sent to a selected row in Shared Files: the correct context menu opened with every expected item (screenshot taken during development). Ctrl+Return's rejection is from an equally live repro, not a guess.

Local clang-tidy CI replica (Tier-1 whole-tree + Tier-2 changed-lines vs. `upstream/master`): zero hits on this file; the Tier-1 hits that exist elsewhere are pre-existing, in `unittests/` files this change never touches.

Fixes the context-menu half of #180. The other half (custom-renderer cells reading as `<wxCustomRendererObject: ...>`) is a separate, already-filed upstream wx issue/PR (wxWidgets/wxWidgets#26808, wxWidgets/wxWidgets#26809).

## Test plan

- [x] Built locally against Homebrew wxwidgets, confirmed clean compile.
- [x] Live keyboard test: Shift+F10 on a selected Shared Files row opens the correct context menu.
- [x] Live keyboard test: Ctrl+Return does not (and cannot, on this port) -- confirmed and documented rather than left silently unhandled.
- [x] Local clang-tidy CI replica, Tier-1 + Tier-2, clean on the changed file.