### PR TITLE
perf(gui): don't re-sort a list nobody is looking at

### DIFF
--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -524,6 +524,22 @@ void CMuleVirtualDataViewCtrl::MaybeResortNow()
 		m_resortPending = false;
 		return;
 	}
+	// Nobody is looking at this list, so sorting it now buys nothing. The
+	// remote GUI keeps every list fed from the same poll whether or not its
+	// panel is on screen, so without this a single reply re-sorts the
+	// downloads, shared-files, sources and peers lists in full, once or twice
+	// a second, of which at most one is visible. Measured on a 1228-row
+	// shared list: 156 sorts in a 150-poll session, 143 of them while hidden.
+	//
+	// The work is deferred rather than dropped -- m_resortPending stays set,
+	// so the next update after the panel comes back sorts it. The poll that
+	// marks rows dirty runs continuously while connected, so that is within a
+	// poll interval of becoming visible, and a list only has a sort pending
+	// at all because something changed in it.
+	if (!IsShownOnScreen()) {
+		return;
+	}
+
 	// Hold off while interacting; the retry timer polls (only during
 	// interaction) until idle.
 	if (IsInteracting()) {


### PR DESCRIPTION
Found while measuring #867. Removes work that was never needed, though it is not the whole of that issue — see the end.

## What was happening

The remote GUI feeds every list from the same poll whether or not its panel is on screen. A list sorted on a column whose values move — speed, transferred, requests — marks a re-sort pending on each update, so a single reply re-sorts the downloads, shared-files, sources and peers lists in full, once or twice a second, of which at most one is visible.

Measured with a probe on a modest setup — 1228 shared files, 3 downloads — over a short session:

```
150 polls  ->  696 full sorts
CSharedFilePeersListCtrl  231
CSharedFilesCtrl          156     (143 of them while hidden)
CSourceListCtrl           151
CDownloadListCtrl         151
```

Each sort is a `std::sort` over every row plus a row-index rebuild and a selection round-trip. At 1228 rows that is ~1 ms a time; the cost grows with the list, so a user with thousands of files pays it several times a second for lists they are not looking at.

## The change

`MaybeResortNow()` returns early when the control is not on screen.

Deferred rather than dropped: `m_resortPending` stays set, so the next update after the panel comes back sorts it. The poll that marks rows dirty runs continuously while connected, so that is within a poll interval of becoming visible — and a list only has a sort pending because something in it changed.

## What this does not fix

Not the hiccups in #867.

The reporter's stutter follows the **visible** panel, and this changes nothing for a visible list. It is worth having on its own terms — several full sorts a second for nothing — but it should not be mistaken for the fix.

What the visible list actually costs is being measured separately. The probe used above deliberately did not time the repaint, only the notification and sort, so the paint side is still unmeasured; that gap is being closed before the reporter is asked to run anything.

## Verification

Built on macOS (monolithic + amulegui); clang-format and both clang-tidy tiers clean over the diff.

Checked by hand on a live remote core: lists sorted on a volatile column stay correctly ordered across panel switches, header-click sorting is unchanged, and selection and scroll position survive switching away and back.
