### PR TITLE
fix(ec): stop rounding doubles to 6 significant digits on the wire

### DIFF
--- a/src/libs/ec/cpp/ECTag.cpp
+++ b/src/libs/ec/cpp/ECTag.cpp
@@ -33,6 +33,9 @@
 #include "ECSpecialTags.h" // Needed for CValueMap
 #include "ECID.h"          // Needed for CECID
 
+#include <iomanip> // Needed for std::setprecision
+#include <limits>  // Needed for std::numeric_limits
+
 /**********************************************************
  *							  *
  *	CECTag class					  *
@@ -263,7 +266,12 @@ CECTag::CECTag(ec_tagname_t name, double data)
 : m_tagName(name)
 {
 	std::ostringstream double_str;
-	double_str << data;
+	// Default stream precision is 6 significant digits, which switches to
+	// scientific notation past 1e6 and quantises the value: a statsgraph
+	// timestamp (seconds of uptime) lands on a 10-second grid once the
+	// daemon has been up ~11.6 days, and 100 seconds past ~115 days.
+	// max_digits10 is the shortest precision that round-trips exactly.
+	double_str << std::setprecision(std::numeric_limits<double>::max_digits10) << data;
 	std::string double_string = double_str.str();
 	const char *double_chr = double_string.c_str();
 	m_dataLen = (ec_taglen_t)strlen(double_chr) + 1;


### PR DESCRIPTION
`CECTag`'s double constructor serialises through a default `ostringstream` (`ECTag.cpp:265`), whose precision is 6 *significant* digits — so the absolute error grows with magnitude. That is harmless for the small values most double tags carry (transfer rates, ratios, `dl_up_modifier`), but the statsgraph timestamp is seconds of uptime (`Statistics.cpp:413`, `GetUptimeMillis() / 1000.0`). Past 1e6 the stream switches to scientific notation and the value lands on a grid:

| daemon uptime | on the wire | resolution |
|---|---|---|
| 1 hour | `3600.5` | exact |
| 1 day | `86400.5` | exact |
| **11.6 days** | `1e+06` | **10 s** |
| 30 days | `2.592e+06` | 10 s |
| 115 days | `1e+07` | 100 s |

## Why that breaks the graph

The statistics graph is a delta protocol: the client stores its newest point's timestamp and sends it back as `EC_TAG_STATSGRAPH_LAST`, and the core returns every point newer than it.

The marker itself never drifts — it is recomputed from the true newest sample on every poll, so it always lands within half a grid step of reality. The damage is that the marker is *stuck on the grid while real time keeps moving*. At 12 days of uptime the grid is 10 s, so `1036800.5` and `1036801.5` and everything up to `1036809.5` all serialise to `1036800`: the marker does not move for ten real seconds, while the client keeps polling once a second.

| poll | true newest | marker sent | points returned |
|---|---|---|---|
| 1 | 1036800.5 | 1036800 | 1 |
| 2 | 1036801.5 | 1036800 | 2 |
| 3 | 1036802.5 | 1036800 | 3 |
| … | | | |
| 10 | 1036809.5 | 1036800 | 10 |

That is 55 points delivered for 10 seconds of data. `CStatGraphRem::HandlePacket` has no per-point timestamps to check against — it shifts `numPoints` samples in, assuming they are `sStep` apart — so the graph scrolls several times too fast, replaying seconds it already drew.

In the upper half of each grid cell the rounding goes the other way: the marker lands *ahead* of the newest sample, the core finds nothing newer, and the client gets `EC_OP_FAILED "No points for graph."` until real time catches up.

So past ~11.6 days of uptime the graph alternates between racing with duplicated data and stalling — continuously, not as a one-off glitch. Past ~115 days the grid is 100 s and, with the request width capped at 32 points, the client receives 32 duplicated points on essentially every poll.

Nothing outside the statistics graph is affected: the other double tags carry magnitudes where 6 digits is ample.

## The fix

`max_digits10` (17) is the shortest precision that round-trips a double exactly:

```
12 days  (uptime 1036800.5s)
  before:     1.0368e+06   error -0.5s
  after :      1036800.5   error +0s
115 days (uptime 10000000.5s)
  before:          1e+07   error -0.5s
  after :     10000000.5   error +0s
```

## Compatibility

The tag stays a length-prefixed NUL-terminated string, so the longer text is wire-compatible in both directions — `GetDoubleData()` parses it with `istringstream >> data` unchanged, and an older peer reading a newer value (or the reverse) is unaffected.

## Testing

Full unit suite passes (34/34) on macOS. The failure mode only appears past ~11 days of daemon uptime, which is why it has gone unnoticed. The behaviour above is derived from the protocol rather than observed on a long-uptime daemon.
