### PR TITLE
fix(gui): keep a pixel between a chunk bar and the rows around it

### DIFF
--- a/src/MuleBarRenderer.cpp
+++ b/src/MuleBarRenderer.cpp
@@ -99,7 +99,7 @@ bool CMuleBarRenderer::Render(wxRect cell, wxDC *dc, int WXUNUSED(state))
 	if (!bFlat) {
 		wxDCPenChanger pen(*dc, *wxBLACK_PEN);
 		wxDCBrushChanger brush(*dc, *wxTRANSPARENT_BRUSH);
-		dc->DrawRectangle(cell);
+		dc->DrawRectangle(BorderRectForBar(cell));
 	}
 	return true;
 }

--- a/src/MuleBarRenderer.h
+++ b/src/MuleBarRenderer.h
@@ -150,14 +150,38 @@ protected:
 	 * into this same rect, not the raw cell, or it will not line up with the
 	 * bar underneath it.
 	 */
+	/**
+	 * The area a bar may paint in, one pixel clear of the row above and below.
+	 *
+	 * Pre-port every caller inset the rect it handed the bar by a pixel top and
+	 * bottom before drawing (CSharedFilesCtrl::OnDrawItem and its equivalents),
+	 * and the 3D border went on that inset rect, not on the cell. Only the
+	 * inner `!bFlat` step survived the port into this class; while GetSize()
+	 * reported the text height the clamp in WXCallRender() happened to supply
+	 * the missing gap, so nothing showed until the bar started filling its cell
+	 * (issue #880). Without it, flat bars in adjacent rows touch and read as one
+	 * block, and 3D borders double up into a single thick line.
+	 */
 	static wxRect InsetForBar(wxRect cell, bool bFlat)
 	{
+		cell.y++;
+		cell.height -= 2;
 		if (!bFlat) {
+			// Round bar has a black border; the bar sits a pixel inside it.
 			cell.x++;
 			cell.y++;
 			cell.width -= 2;
 			cell.height -= 2;
 		}
+		return cell;
+	}
+
+	//! The rect the 3D border is stroked on: the cell less the separating
+	//! pixel, so the border does not sit where the gap belongs.
+	static wxRect BorderRectForBar(wxRect cell)
+	{
+		cell.y++;
+		cell.height -= 2;
 		return cell;
 	}
 


### PR DESCRIPTION
Closes #880.

With the 3D-depth slider at fully flat, bars in adjacent rows touch and read as one solid block. It shows in every list carrying a bar, not just Downloads.

## Where the gap went

Pre-port each caller inset the rect it handed the bar by a pixel top and bottom — `CSharedFilesCtrl::OnDrawItem` built it as `(columnRect.y + 1, columnRect.height - 2)` before calling `DrawAvailabilityBar` — and the 3D border was stroked on that inset rect rather than on the column:

```cpp
if (!bFlat) { dc->SetPen(*wxBLACK_PEN); dc->DrawRectangle(rect); }   // rect is already inset
```

Only the inner `!bFlat` step moved into `CMuleBarRenderer`. The outer one belonged to the caller and was dropped when the cell rect took over in #842.

Nothing showed at the time, because `GetSize()` reported the text height and `WXCallRender()` clamps the rect it hands `Render()` to that height — which happened to leave the same gap. #849 stopped reporting a height, to fix bars being painted short on GTK, and the bar now fills its cell exactly. So this is a regression from #849, surfacing a gap missing since #842; #848 only made it visible in Downloads.

## What changes

The inset is restored for both modes and the border is stroked on it.

Flat rows regain their separator. 3D rows also stop sharing a border line with their neighbours, which is what the pre-port build looked like — a doubled black line reads as a deliberate divider, so that half went unreported. A 3D bar loses two pixels of height as a result, which is a visible change at default row heights and is deliberate.

Applying the outer inset only when flat would fix the report and leave 3D untouched, but it would keep the port diverging from what it replaced for no reason beyond avoiding a visible diff.

## Testing

macOS Debug, flat and 3D at several slider positions, across Downloads, Shared Files and a download's Sources. clang-format 18 and Tier-2 clang-tidy clean on the diff with 0 compiler errors.
