### PR TITLE
fix(gui): skip row-change notifications for rows that aren't on screen

### DIFF
--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -173,6 +173,28 @@ long CMuleVirtualDataViewCtrl::RowOfData(wxUIntPtr data) const
 	return (it == m_rowOf.end()) ? -1 : it->second;
 }
 
+bool CMuleVirtualDataViewCtrl::GetVisibleRowRange(long &firstRow, long &lastRow) const
+{
+	const wxDataViewItem top = GetTopItem();
+	const int perPage = GetCountPerPage();
+	if (!top.IsOk() || perPage <= 0) {
+		return false;
+	}
+
+	firstRow = static_cast<long>(m_virtualModel->GetRow(top));
+	lastRow = firstRow + perPage - 1;
+	return true;
+}
+
+bool CMuleVirtualDataViewCtrl::IsItemDataSelected(wxUIntPtr data) const
+{
+	const long row = RowOfData(data);
+	if (row < 0) {
+		return false;
+	}
+	return IsSelected(m_virtualModel->GetItem(static_cast<unsigned>(row)));
+}
+
 wxUIntPtr CMuleVirtualDataViewCtrl::ItemAt(long row) const
 {
 	if (row < 0 || static_cast<size_t>(row) >= m_items.size()) {
@@ -369,7 +391,39 @@ void CMuleVirtualDataViewCtrl::RefreshItemData(wxUIntPtr data)
 	if (row < 0) {
 		return;
 	}
-	m_virtualModel->RowChanged(static_cast<unsigned>(row));
+
+	// Only rows the user can actually see are worth telling the control
+	// about. Values are pulled per cell as they are drawn, so a row that is
+	// off screen -- or in a list on a panel that isn't showing -- renders
+	// current data the moment it is scrolled or switched into view, with no
+	// notification needed. wxDataViewCtrl reaches the same conclusion, but
+	// only at the very end of wxDataViewMainWindow::DoItemChanged(): before
+	// it intersects the row against the client rect it invalidates every
+	// column's cached best width (a clear + resize of a per-column vector)
+	// and constructs and dispatches a wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
+	// which no aMule handler is listening for. Measured on a reporter's
+	// 11,000-row download list, that unconditional prologue cost ~20us per
+	// row and ~300ms of every one-second poll -- and it was charged for the
+	// list on all four panels he wasn't looking at as well as the one he
+	// was (issue #867).
+	//
+	// The pre-wxDataViewCtrl lists did not have this problem because the
+	// vendored generic wxListCtrl ordered it the other way round:
+	// wxListMainWindow::RefreshLine() tested the visible range first and
+	// returned, so an off-screen row cost two integer comparisons. This
+	// restores that ordering.
+	//
+	// Skipping the notification for a row that really is visible would
+	// leave a stale cell on screen, so both unknowns resolve towards
+	// refreshing: a backend that cannot report its viewport, and the
+	// partially visible row below the last fully visible one.
+	long firstRow = 0;
+	long lastRow = 0;
+	const bool offScreen = !IsShownOnScreen() || (GetVisibleRowRange(firstRow, lastRow) &&
+							     (row < firstRow || row > lastRow + 1));
+	if (!offScreen) {
+		m_virtualModel->RowChanged(static_cast<unsigned>(row));
+	}
 
 	// The value that just changed may be the one the list is sorted by, in
 	// which case the row has to move. Scheduled rather than done here: an
@@ -436,13 +490,10 @@ void CMuleVirtualDataViewCtrl::SortList()
 	// to be right.
 	if (currentData != 0) {
 		const long row = RowOfData(currentData);
-		const wxDataViewItem top = GetTopItem();
-		const int perPage = GetCountPerPage();
-		if (row >= 0 && top.IsOk() && perPage > 0) {
-			const long topRow = static_cast<long>(m_virtualModel->GetRow(top));
-			if (row >= topRow && row < topRow + perPage) {
-				SetCurrentItem(m_virtualModel->GetItem(static_cast<unsigned>(row)));
-			}
+		long firstRow = 0;
+		long lastRow = 0;
+		if (row >= 0 && GetVisibleRowRange(firstRow, lastRow) && row >= firstRow && row <= lastRow) {
+			SetCurrentItem(m_virtualModel->GetItem(static_cast<unsigned>(row)));
 		}
 	}
 }

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -102,6 +102,28 @@ public:
 
 	bool HasItemData(wxUIntPtr data) const { return m_rowOf.count(data) != 0; }
 	long RowOfData(wxUIntPtr data) const;
+	/**
+	 * The rows the control currently has on screen, as the inclusive range
+	 * [firstRow, lastRow]. lastRow is the last *fully* visible row, so a
+	 * caller that must not miss a drawn pixel has to allow for one more
+	 * below it.
+	 *
+	 * Returns false when the backend cannot report its viewport -- the
+	 * wxDataViewCtrl base answers GetTopItem()/GetCountPerPage() with
+	 * "don't know" and only the ports override them. The range is then
+	 * meaningless and the caller has to fall back to whatever is safe for
+	 * it. Which way that falls is not symmetric: treating a visible row as
+	 * off screen leaves a stale cell in front of the user, whereas treating
+	 * an off-screen row as visible only costs the work it saved.
+	 */
+	bool GetVisibleRowRange(long &firstRow, long &lastRow) const;
+	/**
+	 * Whether this item is part of the selection. Answers the one question
+	 * without materialising the whole selection the way
+	 * GetSelectedItemData() has to -- worth the separate entry point on the
+	 * per-item update paths, which ask it once per changed row.
+	 */
+	bool IsItemDataSelected(wxUIntPtr data) const;
 	wxUIntPtr ItemAt(long row) const;
 	long ItemDataCount() const { return static_cast<long>(m_items.size()); }
 

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -25,8 +25,6 @@
 
 #include "SharedFilesCtrl.h" // Interface declarations
 
-#include <algorithm> // Needed for std::find
-
 #include <wx/file.h>    // Needed for wxFile
 #include <wx/filedlg.h> // Needed for wxFileDialog
 
@@ -978,8 +976,7 @@ void CSharedFilesCtrl::UpdateItem(CKnownFile *toupdate)
 	// throttled+idle-gated re-sort.
 	RefreshItemData(data);
 
-	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
-	if (std::find(selected.begin(), selected.end(), data) != selected.end()) {
+	if (IsItemDataSelected(data)) {
 		theApp->amuledlg->m_sharedfileswnd->SelectionUpdated();
 	}
 }


### PR DESCRIPTION
`CMuleVirtualDataViewCtrl::RefreshItemData()` told the control about every updated row unconditionally. Values are pulled per cell as they are drawn, so a row that is off screen — or in a list on a panel that isn't showing — already renders current data the moment it is scrolled or switched into view. The notification buys nothing.

wxDataViewCtrl reaches that conclusion too, but only at the very end of `wxDataViewMainWindow::DoItemChanged()`. Before it intersects the row against the client rect it invalidates every column's cached best width and dispatches a `wxEVT_DATAVIEW_ITEM_VALUE_CHANGED` that no aMule handler listens for. Neither is skippable from outside, so the only lever is not to call it.

This is a regression from the wxDataViewCtrl port. The vendored generic `wxListCtrl` that `CMuleVirtualListCtrl` drove ordered it the other way round — `wxListMainWindow::RefreshLine()` tested the visible range first and returned, so an off-screen row cost two integer comparisons. This restores that ordering.

Measured on a reporter's 11,000-row download list against a remote daemon (#867): ~20 µs per row, ~300 ms out of every one-second poll, charged for the download list on all four panels he was not looking at as well as the one he was.

The gate is on the base class, so all six virtual lists get it. Both unknowns resolve towards refreshing, since skipping a genuinely visible row would leave a stale cell in front of the user: a backend that cannot report its viewport, and the partially visible row below the last fully visible one. `SortList()`'s open-coded copy of the same visible-range test now shares the helper.

`CSharedFilesCtrl::UpdateItem()` also asked whether the updated row was selected by materialising the entire selection, once per changed file — O(n²) with the whole list selected. `IsItemDataSelected()` answers it directly.

## Testing

Built clean on macOS. Verified with a temporary probe against a remote core that a visible list issues ~one screenful of notifications per poll and a list on a hidden panel issues zero, while the model keeps updating underneath.
