### PR TITLE
fix(core): only mark a partfile EC-dirty when something exported changed

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1503,10 +1503,57 @@ uint32 CPartFile::Process(uint8 m_icounter)
 	// Partfiles have ~20 EC-exported fields that change frequently and
 	// independently (status, speed, transfer counters, source counts, gap
 	// list, hashed-part count, …). Per-field hooks have diminishing
-	// returns when the file is actively transferring anyway, so use a
-	// coarse mark here — Process() runs once per second per partfile and
-	// the file genuinely has new state every tick during active download.
-	MarkECChanged();
+	// returns when the file is actively transferring anyway, so the mark
+	// here stays coarse — but it is not unconditional. "Process() ran"
+	// is not the same as "this file has new state": a queued download with
+	// no sources ticks once a second and every exported value comes back
+	// identical, and marking it anyway made Get_EC_Response_GetUpdate's
+	// change test pass for every non-paused download, every poll. With
+	// 11,000 of them that is the whole download list re-encoded and
+	// re-sent once a second, and the same again on the client applying it
+	// (issue #867).
+	//
+	// Everything else in CEC_PartFile_Tag is event-driven and marks itself
+	// where it changes (SetStatus, SetCategory, SetDownPriority, the gap
+	// and corruption paths, SetHashingProgress, …). This covers what only
+	// Process() can move.
+	//
+	// GetDlActiveTime() is deliberately absent. It is wall-clock derived --
+	// m_nDlActiveTime plus the time since m_tActivated, and every
+	// PS_READY/PS_EMPTY file is activated the moment the client connects --
+	// so it advances every second whether or not the download is doing
+	// anything, and including it here would answer "changed" always and
+	// leave this test doing nothing. The cost is that an idle download's
+	// active time reaches a remote GUI only when something real about the
+	// file changes; it is read in one place, the File Details dialog, and a
+	// file that is actually transferring changes something every tick
+	// anyway.
+	const std::array<uint64, 12> ecTickState = { GetStatus(),
+		GetSourceCount(),
+		GetNotCurrentSourcesCount(),
+		GetTransferingSrcCount(),
+		GetSrcA4AFCount(),
+		GetTransferred(),
+		GetCompletedSize(),
+		// Quantised exactly as the tag sends it, so a speed wobble too
+		// small to change the wire value doesn't count as a change.
+		(uint64)(GetKBpsDown() * 1024),
+		GetAvailablePartCount(),
+		m_nCompleteSourcesCount,
+		// The last two are already implied by the ones above -- a block
+		// arriving moves GetTransferred(), and availability reaching
+		// complete moves GetAvailablePartCount() on the same pass. They
+		// are listed anyway because that is a coupling, not a guarantee:
+		// neither stamp marks EC-dirty of its own accord
+		// (UpdateAvailablePartCount only calls MarkMetDirty), so relying
+		// on the neighbour would leave the field to go stale the day
+		// either one moves.
+		(uint64)lastseencomplete,
+		(uint64)GetLastChangeDatetime() };
+	if (ecTickState != m_ecTickState) {
+		m_ecTickState = ecTickState;
+		MarkECChanged();
+	}
 
 	uint16 old_trans;
 	uint64 dwCurTick = ::GetTickCount64();

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -29,6 +29,7 @@
 #include "KnownFile.h"     // Needed for CKnownFile
 #include "FileAutoClose.h" // Needed for CFileAutoClose
 #include "FileArea.h"      // Needed for CFileArea (PartFileBufferedData)
+#include <array>           // Needed for std::array (m_ecTickState)
 #include <atomic>          // Needed for std::atomic (m_iWrites)
 #include <mutex>           // Needed for std::mutex (m_hpartfileMutex)
 
@@ -516,6 +517,17 @@ private:
 	//   * FlushBuffer Phase 2's PB_READY synchronous fallback around
 	//     item->area.FlushAt(...)
 	std::mutex m_hpartfileMutex;
+
+	/**
+	 * The EC-exported values Process() can move in a single tick, as of the
+	 * last tick that moved any of them. Lets the per-tick mark tell a file
+	 * that actually did something from one that merely got a second older --
+	 * see the comment on the comparison in Process().
+	 *
+	 * Ordered to match the capture there; the values only exist to be
+	 * compared, so a plain array avoids naming ten fields twice.
+	 */
+	std::array<uint64, 12> m_ecTickState{};
 
 	uint8 m_category;
 	uint32 m_nDlActiveTime;


### PR DESCRIPTION
`CPartFile::Process()` called `MarkECChanged()` unconditionally. "`Process()` ran" is not the same as "this file has new state": a queued download with no sources ticks once a second and every exported value comes back identical. Marking it anyway made `Get_EC_Response_GetUpdate`'s change test pass for every non-paused download on every poll, so the incremental protocol — which downloads share with shared files, one loop, same skip test — never skipped a single one.

On a reporter's 11,000-download queue that is the whole list re-encoded and re-sent once a second, and the same again on the client applying it: ~11,081 tags and ~300 ms of main-thread time per poll (#867).

`Process()` now captures the exported values it can move and marks only when one of them differs from the previous tick. Speed is quantised with the tag's own expression so a wobble too small to change the wire value doesn't count.

## Why the CValueMap wasn't already suppressing these

`GetDlActiveTime()` is wall-clock derived — `m_nDlActiveTime` plus the time since `m_tActivated` — and `CDownloadQueue::OnConnectionState()` activates every `PS_READY`/`PS_EMPTY` file the moment the client connects. So it advances every second whether or not the download is doing anything, and one ticking field keeps the whole tag non-empty no matter how well the valuemap works on the other thirty.

It is therefore excluded from the captured set: including it would answer "changed" always and leave the test doing nothing. The cost is that an idle download's active time reaches a remote GUI only when something real about the file changes. It is read in one place, the File Details dialog, and a file that is actually transferring changes something every tick anyway.

## Coverage of the rest of the tag

Everything else in `CEC_PartFile_Tag` is event-driven and marks itself where it changes. Verified rather than assumed, for: priority (`SetDownPriority`), category, pause/stop/insufficient (all three mark), complete-sources Lo/Hi/aggregate (`UpdatePartsInfo`), queued count (`AddUploadingClient`/`RemoveUploadingClient`), upload speed and uploading count (`SetUploadState` on the transitions, plus `AddTransferred` on every uploaded chunk), the request/accept/transfer statistics, last upload, hashing progress, and the corruption/compression/ICH counters.

`lastseencomplete` and `m_lastDateChanged` are in the captured set even though each is already implied by a neighbour — a block arriving moves `GetTransferred()`, and availability reaching complete moves `GetAvailablePartCount()` on the same pass. Neither marks EC-dirty of its own accord (`UpdateAvailablePartCount` only calls `MarkMetDirty`), so leaving them to the coupling would let the field go stale the day either neighbour moves.

## Testing

Builds clean on macOS. Verified at runtime with a temporary probe in `Process()` counting, per second, how many of the files it processed were marked -- which under the old code is by definition all of them.

Two local daemons on separate ports, LAN filtering off, one sharing a 40 MB file and one downloading it from the other:

| state | processed / window | marked |
|---|---|---|
| first tick (state captured) | 5 | 1 |
| queued, no sources, 81 consecutive windows | 4 | **0** |
| actively transferring | 4 | **4** |

So an idle download stops being re-sent entirely, and an active one still marks on every tick, which is what keeps a remote GUI live while a file is downloading. Pausing was also confirmed to stop `Process()` being called at all, per its existing `PS_READY`/`PS_EMPTY` gate.
