### PR TITLE
fix(gui): keep the free-space separator out of the low-space warning

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -1171,6 +1171,10 @@ void CDownloadListCtrl::UpdateFreeSpace()
 		if (!m_freeSpaceLabel) {
 			return;
 		}
+		// Its own label so the "|" is not recoloured with the figure;
+		// resolved alongside it and equally long-lived.
+		m_freeSpaceSepLabel =
+			CastByName("downloadsFreeSpaceSep", theApp->amuledlg->m_transferwnd, wxStaticText);
 	}
 
 	const sint64 freeSpace = theStats::GetTempFreeSpace();
@@ -1200,7 +1204,7 @@ void CDownloadListCtrl::UpdateFreeSpace()
 
 	const bool warn = (freeSpace != FREE_SPACE_UNKNOWN) && (static_cast<uint64>(freeSpace) < remaining);
 	// Continues the "Total queue size:" label to its left.
-	CamuleDlg::SetFreeSpaceLabel(m_freeSpaceLabel, freeSpace, warn, " | ");
+	CamuleDlg::SetFreeSpaceLabel(m_freeSpaceLabel, freeSpace, warn, m_freeSpaceSepLabel);
 }
 
 // File_checked_for_headers

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -335,6 +335,7 @@ private:
 	//! The "Free space:" label, resolved by name on first use. Lives in the
 	//! sources pane, so it cannot be reached through GetParent().
 	wxStaticText *m_freeSpaceLabel = nullptr;
+	wxStaticText *m_freeSpaceSepLabel = nullptr;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -612,7 +612,25 @@ void CamuleDlg::UpdateFreeSpaceLabels()
 	}
 }
 
-void CamuleDlg::SetFreeSpaceLabel(wxStaticText *label, sint64 freeSpace, bool warn, const wxString &separator)
+namespace
+{
+/**
+ * SetLabel() repaints even when the text is unchanged, and this runs once a
+ * second for the life of the session. Answers whether the layout has to be
+ * redone, so a caller touching two labels relayouts once.
+ */
+bool SetLabelIfChanged(wxStaticText *label, const wxString &text)
+{
+	if (!label || label->GetLabel() == text) {
+		return false;
+	}
+	label->SetLabel(text);
+	return true;
+}
+} // namespace
+
+void CamuleDlg::SetFreeSpaceLabel(
+	wxStaticText *label, sint64 freeSpace, bool warn, wxStaticText *separatorLabel)
 {
 	if (!label) {
 		return;
@@ -623,26 +641,42 @@ void CamuleDlg::SetFreeSpaceLabel(wxStaticText *label, sint64 freeSpace, bool wa
 	// or its mount (commonly a NAS for the temp or incoming directory) is
 	// unreachable. Printing "0 bytes" there would read as a full disk.
 	if (freeSpace == FREE_SPACE_UNKNOWN) {
-		if (!label->GetLabel().IsEmpty()) {
-			label->SetLabel(wxEmptyString);
+		// The separator exists only to join this figure to the field
+		// before it, so it goes when the figure does -- otherwise the
+		// queue size is left trailing a bare "|". Hidden rather than
+		// emptied: its padding is sizer border, which an empty label
+		// would still reserve.
+		bool relayout = SetLabelIfChanged(label, wxEmptyString);
+		if (separatorLabel && separatorLabel->IsShown()) {
+			separatorLabel->Show(false);
+			relayout = true;
+		}
+		if (relayout) {
 			label->GetParent()->Layout();
 		}
 		return;
 	}
 
-	// The separator is layout, not language: it stays out of the catalog so
-	// translators are given the figure alone.
-	const wxString text = separator + wxString(CFormat(_("Free space: %s")) % CastItoXBytes(freeSpace));
 	const wxColour colour = warn ? *wxRED : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
-
-	// Both guarded: SetLabel() on an unchanged string still triggers a
-	// repaint, and this runs once a second for the life of the session.
 	if (label->GetForegroundColour() != colour) {
 		label->SetForegroundColour(colour);
 		label->Refresh();
 	}
-	if (label->GetLabel() != text) {
-		label->SetLabel(text);
+
+	// The separator sits in its own label and is never recoloured: a
+	// wxStaticText colours all or nothing, so a separator sharing this label
+	// turned red along with the figure whenever the warning fired. It is
+	// layout, not language, so it stays out of the catalog either way and
+	// translators are given the figure alone -- and the gaps around it are
+	// sizer border, so the bar carries no whitespace of its own.
+	bool relayout = SetLabelIfChanged(separatorLabel, "|");
+	if (separatorLabel && !separatorLabel->IsShown()) {
+		separatorLabel->Show(true);
+		relayout = true;
+	}
+	relayout =
+		SetLabelIfChanged(label, CFormat(_("Free space: %s")) % CastItoXBytes(freeSpace)) || relayout;
+	if (relayout) {
 		label->GetParent()->Layout();
 	}
 }

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -230,8 +230,18 @@ public:
 	 */
 	void UpdateFreeSpaceLabels();
 
+	/**
+	 * Writes a free-space figure into @a label, red when @a warn.
+	 *
+	 * @a separatorLabel is the "|" joining this figure to the field before
+	 * it, in a label of its own because a wxStaticText colours all or
+	 * nothing -- kept here rather than at the call sites so it is set and
+	 * cleared with the figure it belongs to, and never left trailing the
+	 * field before it when there is nothing to show. Panels that show the
+	 * figure on its own pass nothing.
+	 */
 	static void SetFreeSpaceLabel(
-		wxStaticText *label, sint64 freeSpace, bool warn, const wxString &separator = wxEmptyString);
+		wxStaticText *label, sint64 freeSpace, bool warn, wxStaticText *separatorLabel = nullptr);
 
 	/**
 	 * Brings the main window back from every state that hides it.

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -463,12 +463,29 @@ wxSizer *transferBottomPane( wxWindow *parent, bool call_fit, bool set_sizer )
     item5b->SetName( "downloadsTotalSize" );
     item5a->Add( item5b, wxSizerFlags().CenterVertical() );
 
+    // The "|" joining the two figures, in a label of its own for the same
+    // reason the figure has one: a wxStaticText colours all or nothing, so a
+    // separator sharing the label below would turn red along with the figure
+    // whenever the warning fires. Shown and hidden by SetFreeSpaceLabel()
+    // together with that figure, never recoloured.
+    //
+    // The gaps around it are sizer border, not spaces in the text: a static
+    // text is sized to its text extent, which ignores trailing whitespace, so
+    // a " | " label loses the space on one side and -- right-aligned inside a
+    // box sized for three glyphs -- doubles it on the other.
+    wxStaticText *item5c = new wxStaticText( parent, -1, wxEmptyString );
+    item5c->SetName( "downloadsFreeSpaceSep" );
+    // Starts hidden: the labels either side start empty, and a shown separator
+    // would reserve its border before there is anything to separate.
+    item5c->Show( false );
+    item5a->Add( item5c, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 4) );
+
     // Separate label rather than more text in the one above: it turns red on
     // its own when the free space no longer covers what is left to download,
     // and a wxStaticText colours all or nothing.
-    wxStaticText *item5c = new wxStaticText( parent, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
-    item5c->SetName( "downloadsFreeSpace" );
-    item5a->Add( item5c, wxSizerFlags().CenterVertical() );
+    wxStaticText *item5d = new wxStaticText( parent, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
+    item5d->SetName( "downloadsFreeSpace" );
+    item5a->Add( item5d, wxSizerFlags().CenterVertical() );
 
     item1->Add( item5a, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
 


### PR DESCRIPTION
Follow-up to #757, from ghysler's testing of the merged feature: the `|` joining the queue size to the free-space figure turned red along with the figure when free space stopped covering what is left to download, so the separator read as part of the warning.

The figure already had a label of its own, precisely because a `wxStaticText` colours all or nothing — the separator was just prepended to that label's text, so it inherited the colour. It now has its own label, set and hidden by `SetFreeSpaceLabel()` together with the figure it joins. Keeping that in one place matters: the separator has to vanish whenever the figure does, or the queue size is left trailing a bare `|`. Appending it to the queue-size label would have been fewer lines, but `SetTotalSize()` runs on its own path and knows nothing about free space, so every future condition that blanks the figure would become something two call sites must agree about.

The gaps around it are sizer border, not spaces in the text. A static text is sized to its text extent, which ignores trailing whitespace, so a `" | "` label loses the space on one side; right-aligned in a box sized for three glyphs, it doubles it on the other. That is what the first attempt rendered — two spaces before the bar and none after. It is also hidden rather than emptied when there is no figure, since an empty label still reserves its border, and created hidden because both neighbouring labels start empty.

Downloads only — Shared Files shows the figure on its own and passes no separator.

## Test plan

- [x] macOS: normal build plus a throwaway forced-warn build, confirming only the figure reddens and the gap is even on both sides
- [x] Linux and Windows: same check
- [x] clang-format v18 whole-file clean; Tier-1 and Tier-2 clang-tidy clean, 0 compiler errors
- [x] Both binaries: monolithic reads its own `CFreeSpaceThread`, amulegui gets the figures over `EC_TAG_STATS_TEMP_FREE_SPACE`, so the "no figure" path is worth seeing on each
