### PR TITLE
fix(gui): don't reuse ECIDs across a daemon restart

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -919,6 +919,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -955,6 +959,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:16+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -938,6 +938,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -977,6 +981,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:17+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -956,6 +956,10 @@ msgid "Reconnected to the remote core."
 msgstr "Coneutáu a la rede."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Fallu de conexón. Nun ye dable coneutar a %s:%d\n"
@@ -995,6 +999,11 @@ msgstr "Enllaz non válidu o yá ta na llista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo direutoriu '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -935,6 +935,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -972,6 +976,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -918,6 +918,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -954,6 +958,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -954,6 +954,10 @@ msgid "Reconnected to the remote core."
 msgstr "Connecta a la xarxa."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Connexió fallida. No ha estat possible connectar-se a %s:%d\n"
@@ -993,6 +997,11 @@ msgstr "L'enllaç és invàlid o ja és present a la llista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantindrà el directori '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -952,6 +952,10 @@ msgid "Reconnected to the remote core."
 msgstr "Připojit se k síti."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -990,6 +994,11 @@ msgstr "Neplatný odkaz, nebo je již v seznamu."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -941,6 +941,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -980,6 +984,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -963,6 +963,10 @@ msgid "Reconnected to the remote core."
 msgstr "Mit Netzwerk verbinden."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Verbindung fehlgeschlagen. Konnte nicht zu %s:%d verbinden\n"
@@ -1002,6 +1006,11 @@ msgstr "Ungültiger Verweis oder schon auf der Liste"
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nutze weiter das Verzeichnis '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -965,6 +965,10 @@ msgid "Reconnected to the remote core."
 msgstr "Σύνδεση στο δίκτυο."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -1003,6 +1007,11 @@ msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -919,6 +919,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -955,6 +959,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:24+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -969,6 +969,10 @@ msgid "Reconnected to the remote core."
 msgstr "Reconectado al core remoto."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Intento de reconexión %d: conectando a %s:%d"
@@ -1006,6 +1010,11 @@ msgstr "El enlace no es válido o ya está en la lista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantiene el directorio '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -955,6 +955,10 @@ msgid "Reconnected to the remote core."
 msgstr "Ühendu võrguga."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Ühendus ebaõnnestus. Ei suuda määratud ühenduda %s:%d\n"
@@ -994,6 +998,11 @@ msgstr "Vigane link või on juba loetelus."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' kataloogi."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -956,6 +956,10 @@ msgid "Reconnected to the remote core."
 msgstr "Sarera konektatu."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Konexioak huts egin du. Ezin da %s-ra konektatu:%d\n"
@@ -995,6 +999,11 @@ msgstr "Lotura baliogabea edo zerrendan dagoeneko."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa mantenduko da."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -956,6 +956,10 @@ msgid "Reconnected to the remote core."
 msgstr "Yhdistä verkkoon."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Yhdistäminen epäonnistui. Ei saatu yhteyttä %s:%d\n"
@@ -995,6 +999,11 @@ msgstr "Virheellinen linkki tai se on jo listalla."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:27+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -967,6 +967,10 @@ msgid "Reconnected to the remote core."
 msgstr "La connexion au noyau distant a été rétablie."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tentative de reconnexion %d : connexion à %s:%d"
@@ -1004,6 +1008,11 @@ msgstr "Lien invalide ou déjà dans la liste."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on garde le répertoire '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:28+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -976,6 +976,10 @@ msgid "Reconnected to the remote core."
 msgstr "Conectar á rede."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Fallou a conexión. Non se puido conectar a %s:%d\n"
@@ -1015,6 +1019,11 @@ msgstr "Ligazón inválida ou xa presente na lista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantendo o directorio «%s»."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:29+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -946,6 +946,10 @@ msgid "Reconnected to the remote core."
 msgstr "התחבר לרשת."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -984,6 +988,11 @@ msgstr "קישור לא תקף או שכבר נמצא ברשימה."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -944,6 +944,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -982,6 +986,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -957,6 +957,10 @@ msgid "Reconnected to the remote core."
 msgstr "Kapcsolódás a hálózathoz."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Kapcsolat sikertelen. Kapcsolat felvétel %s:%d-el nem lehetséges\n"
@@ -996,6 +1000,11 @@ msgstr "Érvénytelen hivatkozás, vagy már rajta van a listán."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a '%s' könyvtár megtartva."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -969,6 +969,10 @@ msgid "Reconnected to the remote core."
 msgstr "Riconnesso al core remoto."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tentativo di riconnessione %d: connessione a %s:%d"
@@ -1006,6 +1010,11 @@ msgstr "Collegamento non valido o già nella lista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mantenuta la directory '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -960,6 +960,10 @@ msgid "Reconnected to the remote core."
 msgstr "ネットワークへ接続します。"
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -998,6 +1002,11 @@ msgstr "不正なリンク、またはリンクがすでにリストに入って
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -964,6 +964,10 @@ msgid "Reconnected to the remote core."
 msgstr "통신망에 연결합니다."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -1002,6 +1006,11 @@ msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:40+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -965,6 +965,10 @@ msgid "Reconnected to the remote core."
 msgstr "Prisijungti prie tinklo."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -1003,6 +1007,11 @@ msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -932,6 +932,10 @@ msgid "Reconnected to the remote core."
 msgstr "Pieslēgties tīklam."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Jau %d. mēģinājums atjaunot savienojumu: pieslēdzas %s:%d"
@@ -969,6 +973,11 @@ msgstr "Nederīga saite vai jau ir sarakstā."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nevar izveidot '%s' mapi '%s' kategorijai, turpinam izmantot '%s' mapi."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:41+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -956,6 +956,10 @@ msgid "Reconnected to the remote core."
 msgstr "Verbind met het netwerk."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Verbinding mislukt. Kon niet verbinden met %s:%d\n"
@@ -995,6 +999,11 @@ msgstr "Ongeldige link of al op de lijst."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -963,6 +963,10 @@ msgid "Reconnected to the remote core."
 msgstr "Kople til nettverket."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -1001,6 +1005,11 @@ msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -958,6 +958,10 @@ msgid "Reconnected to the remote core."
 msgstr "Połącz z siecią."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Połączenie nie powiodło się. Nie można połączyć się z %s:%d\n"
@@ -997,6 +1001,11 @@ msgstr "Nieprawidłowy lub znajdujący się już na liście link."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nadal katalog '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -965,6 +965,10 @@ msgid "Reconnected to the remote core."
 msgstr "Reconectado ao núcleo remoto."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tentativa de reconexão %d: conectando-se a %s:%d"
@@ -1002,6 +1006,11 @@ msgstr "Link inválido ou já está na lista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretório '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -962,6 +962,10 @@ msgid "Reconnected to the remote core."
 msgstr "Religar à rede."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "A ligação falhou. Não é possível ligar a %s:%d\n"
@@ -1001,6 +1005,11 @@ msgstr "Ligação inválida ou já na lista."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Não é possível criar o directório '%s' para a categoria '%s', a manter directório '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -955,6 +955,10 @@ msgid "Reconnected to the remote core."
 msgstr "Conectare la rețea."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Conectare eșuată. Nu se poate conecta la %s:%d\n"
@@ -994,6 +998,11 @@ msgstr "Legătură nevalidă sau care este deja în listă."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează directorul '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -969,6 +969,10 @@ msgid "Reconnected to the remote core."
 msgstr "Подключение к удалённому ядру восстановлено."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Попытка переподключения %d: подключение к %s:%d"
@@ -1006,6 +1010,11 @@ msgstr "Ссылка неверна или уже в списке."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Не удается создать директорию '%s' для категории '%s', оставляем директорию '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -960,6 +960,10 @@ msgid "Reconnected to the remote core."
 msgstr "Poveži se z omrežjem."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Povezava ni uspela. Ni se moč povezati z %s: %d\n"
@@ -999,6 +1003,11 @@ msgstr "Neveljavna povezava oz. je že na seznamu."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »%s«."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -960,6 +960,10 @@ msgid "Reconnected to the remote core."
 msgstr "Lidhu me rrjetin."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -998,6 +1002,11 @@ msgstr "Link i pavlere ose qe eshte ne liste."
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -954,6 +954,10 @@ msgid "Reconnected to the remote core."
 msgstr "Anslut till nätverket."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Anslutning misslyckades. Kan inte ansluta till %s:%d\n"
@@ -993,6 +997,11 @@ msgstr "Felaktig länk eller redan i listan."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -918,6 +918,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -954,6 +958,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -960,6 +960,10 @@ msgid "Reconnected to the remote core."
 msgstr "Uzaktaki çekirdeğe tekrar bağlanıldı."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "Tekrar bağlanma teşebbüsü %d: %s:%d unsuruna bağlanılıyor"
@@ -997,6 +1001,11 @@ msgstr "Geçersiz bağlantı veya zaten listede mevcut."
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanılıyor."
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -956,6 +956,10 @@ msgid "Reconnected to the remote core."
 msgstr "З'єднання з мережею."
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "З'єдання невдале. Неможливо з'єднатися з %s:%d\n"
@@ -994,6 +998,11 @@ msgstr "Недопустиме посилання або вже в перелі�
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -917,6 +917,10 @@ msgid "Reconnected to the remote core."
 msgstr ""
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr ""
@@ -953,6 +957,11 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -961,6 +961,10 @@ msgid "Reconnected to the remote core."
 msgstr "已重新连接到远程核心。"
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "重新连接尝试 %d：正在连接到 %s:%d"
@@ -998,6 +1002,11 @@ msgstr "非法链接或已经存在列表中。"
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目录。"
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-09 21:47+0200\n"
+"POT-Creation-Date: 2026-08-10 19:30+0200\n"
 "PO-Revision-Date: 2026-08-09 14:49+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -959,6 +959,10 @@ msgid "Reconnected to the remote core."
 msgstr "連線到網路。"
 
 #: src/amule-remote-gui.cpp
+msgid "The remote core was restarted; reloading."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
 #, fuzzy, c-format
 msgid "Reconnect attempt %d: connecting to %s:%d"
 msgstr "無法連線到 %s:%d\n"
@@ -998,6 +1002,11 @@ msgstr "無效連結或已在清單中。"
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
+msgstr ""
 
 #: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
 #: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -642,6 +642,17 @@ private:
 	std::set<uint32> m_sentWithDetailIdsPart;
 };
 
+namespace
+{
+//! Identifies this daemon process to EC clients (EC_TAG_SESSION_ID). Random
+//! rather than a counter or a pid so it cannot repeat across a restart.
+uint64 GetEcSessionId()
+{
+	static const uint64 s_sessionId = GetRandomUint64();
+	return s_sessionId;
+}
+} // namespace
+
 CECServerSocket::CECServerSocket(ECNotifier *notifier)
 : CECMuleSocket(true)
 , m_conn_state(CONN_INIT)
@@ -1404,6 +1415,19 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				if (m_my_flags & EC_FLAG_LARGE_TAG_COUNT) {
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
 				}
+				// Identifies this daemon *process*. ECIDs come from a
+				// counter that restarts with the process (CECID), so
+				// after a daemon restart the same numbers are handed
+				// out again, in whatever order files load this time --
+				// and a client that kept its objects across the
+				// reconnect would pair them up by number and quietly
+				// describe one file with another's data. A client that
+				// sees a different value here knows its ECIDs mean
+				// nothing any more and starts over. Old clients ignore
+				// the tag; new clients that don't see it (old daemon)
+				// fall back to starting over on every reconnect, which
+				// is correct if wasteful.
+				response->AddTag(CECTag(EC_TAG_SESSION_ID, GetEcSessionId()));
 				if (m_partialUpdateActive) {
 					// Confirm partial-update mode so the client switches
 					// off its bulk "missing == deleted" fallback and

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1105,7 +1105,13 @@ void CamuleRemoteGuiApp::Startup()
 	// first connection reached. Stays 0 against a daemon that doesn't send
 	// EC_TAG_SESSION_ID, which makes every later reconnect take the
 	// start-over path.
-	m_ecSessionId = m_connect ? m_connect->GetServerSessionId() : 0;
+	//
+	// Not null-guarded, deliberately: Startup() only runs on a successful
+	// connect and the lines below dereference m_connect unconditionally, so
+	// a guard here would protect nothing while claiming the pointer is
+	// optional -- which is also how the static analyser reads it, and it
+	// then reports the dereference below as reachable with null.
+	m_ecSessionId = m_connect->GetServerSessionId();
 
 	dialog->Destroy();
 	dialog = NULL;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2090,18 +2090,26 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 		const int arrived = file->m_partStatus.Size();
 		const int parts = file->GetPartCount();
 		const int copied = std::min(arrived, parts);
-		if (arrived != parts) {
+		if (arrived != parts && !m_loggedPartStatusMismatch) {
 			// Says the tag and the object disagree about which file this
 			// is. The reconnect path is supposed to make that impossible
 			// by discarding everything keyed by ECID when the daemon
 			// changes underneath us, so this firing means that went
-			// wrong -- worth a line, because clamping the copy leaves no
-			// other trace and the rest of this update is applying the
-			// same mismatched tag to the same object.
-			AddDebugLogLineN(logEC,
-				CFormat(wxT("EC: part-status length %d does not match part count %d for "
-					    "file ID %u (%s)")) %
-					arrived % parts % file->ECID() % file->GetFileName().GetPrintable());
+			// wrong. Critical rather than debug: clamping the copy leaves
+			// no other trace, the rest of this update goes on applying the
+			// same mismatched tag to the same object, and what the user
+			// ends up looking at is a row describing the wrong file --
+			// which they can act on, and would otherwise have no reason to
+			// suspect.
+			//
+			// Once per session, not once per file: if the ECID space has
+			// gone bad it has gone bad for everything, and this sits in a
+			// loop that runs over the whole library on every poll.
+			m_loggedPartStatusMismatch = true;
+			AddLogLineC(CFormat(_("The remote core sent inconsistent data for \"%s\" "
+					      "(part status %d, expected %d). The file list may be "
+					      "showing the wrong information; reconnect to clear it.")) %
+				    file->GetFileName().GetPrintable() % arrived % parts);
 		}
 		for (int i = 0; i < copied; ++i) {
 			file->m_AvailPartFrequency[i] = data[i];
@@ -2249,6 +2257,8 @@ void CKnownFilesRem::ResetForNewDaemonSession()
 	// Nothing left to reconcile against, so the one-shot absence-prune has
 	// no work and must not fire on a list it would find empty anyway.
 	m_reconnectReconcile = false;
+	// New session, new chance to complain if the ECIDs go bad again.
+	m_loggedPartStatusMismatch = false;
 }
 
 void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2090,6 +2090,19 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 		const int arrived = file->m_partStatus.Size();
 		const int parts = file->GetPartCount();
 		const int copied = std::min(arrived, parts);
+		if (arrived != parts) {
+			// Says the tag and the object disagree about which file this
+			// is. The reconnect path is supposed to make that impossible
+			// by discarding everything keyed by ECID when the daemon
+			// changes underneath us, so this firing means that went
+			// wrong -- worth a line, because clamping the copy leaves no
+			// other trace and the rest of this update is applying the
+			// same mismatched tag to the same object.
+			AddDebugLogLineN(logEC,
+				CFormat(wxT("EC: part-status length %d does not match part count %d for "
+					    "file ID %u (%s)")) %
+					arrived % parts % file->ECID() % file->GetFileName().GetPrintable());
+		}
 		for (int i = 0; i < copied; ++i) {
 			file->m_AvailPartFrequency[i] = data[i];
 		}

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -22,6 +22,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
+#include <algorithm> // Needed for std::min
+
 #include <wx/ipc.h>
 #include <wx/cmdline.h>  // Needed for wxCmdLineParser
 #include <wx/config.h>   // Do_not_auto_remove (win32)
@@ -911,11 +913,43 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 
 	if (result == wxID_OK) {
 		AddLogLineCS(_("Reconnected to the remote core."));
-		// The next full poll reconciles every list against the fresh server
-		// snapshot in place (update / add / prune) — no wipe, so scroll and
-		// selection survive. Arm the one-shot prune for the file lists and
-		// resume polling.
-		if (knownfiles) {
+
+		// Everything we hold is keyed by ECID, and an ECID only means
+		// something within one daemon process: CECID hands them out from a
+		// counter that restarts with the process, so a restarted daemon
+		// reissues the same numbers in whatever order it loads files this
+		// time. Reconciling in place across that pairs our objects with
+		// whatever now happens to share their number.
+		//
+		// EC_TAG_SESSION_ID says which process we're talking to. Same value
+		// means the socket dropped but the daemon lived (a sleeping laptop,
+		// a dead tunnel), so the in-place reconcile below is right and keeps
+		// scroll and selection. Anything else -- a different value, or none
+		// at all because the daemon predates the tag -- means we cannot
+		// trust a single ID we hold, and starting over is the only correct
+		// answer even though it costs the user their scroll position.
+		const uint64 sessionId = m_connect ? m_connect->GetServerSessionId() : 0;
+		const bool sameSession = sessionId != 0 && sessionId == m_ecSessionId;
+		m_ecSessionId = sessionId;
+
+		if (!sameSession) {
+			AddLogLineNS(_("The remote core was restarted; reloading."));
+			if (knownfiles) {
+				knownfiles->ResetForNewDaemonSession();
+			}
+			if (clientlist) {
+				clientlist->ResetForNewSession();
+			}
+			if (serverlist) {
+				serverlist->ResetForNewSession();
+			}
+			if (friendlist) {
+				friendlist->ResetForNewSession();
+			}
+		} else if (knownfiles) {
+			// Same daemon: the next full poll reconciles every list against
+			// the fresh snapshot in place (update / add / prune) — no wipe,
+			// so scroll and selection survive.
 			knownfiles->ArmReconnectReconcile();
 		}
 		if (poll_timer) {
@@ -1067,6 +1101,11 @@ void CamuleRemoteGuiApp::Startup()
 	m_ecHost = dialog->Host();
 	m_ecPort = dialog->Port();
 	m_ecPass = dialog->PassHash();
+	// Baseline for the reconnect comparison: which daemon process this
+	// first connection reached. Stays 0 against a daemon that doesn't send
+	// EC_TAG_SESSION_ID, which makes every later reconnect take the
+	// start-over path.
+	m_ecSessionId = m_connect ? m_connect->GetServerSessionId() : 0;
 
 	dialog->Destroy();
 	dialog = NULL;
@@ -2034,8 +2073,28 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 	if (parttag) {
 		const uint8 *data =
 			file->m_partStatus.Decode((uint8 *)parttag->GetTagData(), parttag->GetTagDataLen());
-		for (int i = 0; i < file->GetPartCount(); ++i) {
+		// The two bounds come from different places and are not guaranteed to
+		// agree: the buffer is as long as the decoder made it from what the
+		// wire carried, while GetPartCount() is this object's own, derived
+		// from the size it currently believes the file to be. They match for
+		// as long as an ECID keeps meaning the same file -- which a daemon
+		// restart ends, because CECID hands IDs out from a counter that starts
+		// again with the process while amulegui deliberately keeps its objects
+		// across a reconnect. An ID that comes back naming a different file
+		// then pairs a short buffer with a long part count, and this loop
+		// reads off the end of the heap allocation.
+		//
+		// Copy what actually arrived and clear the rest, rather than trusting
+		// either bound alone: leaving the tail would show the previous file's
+		// availability under the new one's name.
+		const int arrived = file->m_partStatus.Size();
+		const int parts = file->GetPartCount();
+		const int copied = std::min(arrived, parts);
+		for (int i = 0; i < copied; ++i) {
 			file->m_AvailPartFrequency[i] = data[i];
+		}
+		for (int i = copied; i < parts; ++i) {
+			file->m_AvailPartFrequency[i] = 0;
 		}
 	}
 	wxString fileName;
@@ -2164,6 +2223,19 @@ void CKnownFilesRem::ArmReconnectReconcile()
 			static_cast<CPartFile *>(file)->m_PartFileEncoderData.ResetDecoder();
 		}
 	}
+}
+
+void CKnownFilesRem::ResetForNewDaemonSession()
+{
+	CRemoteContainer<CKnownFile, uint32, CEC_SharedFile_Tag>::ResetForNewSession();
+
+	// Back to the state a cold boot starts in: the next reply is a full
+	// library snapshot and gets the batched ShowFileList() treatment, not
+	// the per-item show-and-sort that a steady-state poll uses.
+	m_initialUpdate = true;
+	// Nothing left to reconcile against, so the one-shot absence-prune has
+	// no work and must not fire on a list it would find empty anyway.
+	m_reconnectReconcile = false;
 }
 
 void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -623,6 +623,11 @@ class CKnownFilesRem : public CRemoteContainer<CKnownFile, uint32, CEC_SharedFil
 	// a single prune-by-absence against that snapshot, then clears this.
 	bool m_reconnectReconcile = false;
 
+	// One-shot for the part-status length mismatch warning: the check sits
+	// in a per-file loop that covers the whole library on every poll, and
+	// the condition it reports is library-wide when it happens at all.
+	bool m_loggedPartStatusMismatch = false;
+
 public:
 	CKnownFilesRem(CRemoteConnect *conn);
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -248,6 +248,28 @@ public:
 		m_item_count = 0;
 	}
 
+	/**
+	 * Drops every item, one at a time through the normal removal path.
+	 *
+	 * Not Flush(): that empties the indices and leaks the objects, and
+	 * anything else still holding a raw pointer to one of them never hears
+	 * about it. RemoveItem() -> DeleteItem() is the path that tears a live
+	 * item down properly -- the destroy broadcast that makes clients and
+	 * list controls drop their references, removal from the views, then the
+	 * delete -- so this pays that per item rather than inventing a second,
+	 * quieter teardown.
+	 *
+	 * For use when everything keyed by ECID has stopped meaning anything,
+	 * which is what a reconnect to a restarted daemon amounts to.
+	 */
+	void ResetForNewSession()
+	{
+		for (iterator it = begin(); it != end();) {
+			iterator it2 = it++;
+			RemoveItem(it2);
+		}
+	}
+
 	//
 	// Flush & reload
 	//
@@ -610,6 +632,14 @@ public:
 	// and reset every reused file's differential decoders (see the .cpp).
 	void ArmReconnectReconcile();
 
+	/**
+	 * Throw away every file and start again from the next poll, for a
+	 * reconnect where the ECIDs we hold have stopped meaning anything.
+	 * Re-arms the cold-boot path so the repopulate goes through
+	 * ShowFileList()'s batching rather than one sort per inserted row.
+	 */
+	void ResetForNewDaemonSession();
+
 	uint16 requested;
 	uint32 transferred;
 	uint16 accepted;
@@ -940,6 +970,11 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 	wxString m_ecHost;
 	int m_ecPort = 0;
 	wxString m_ecPass;
+	// EC_TAG_SESSION_ID of the daemon process we last connected to, so a
+	// reconnect can tell "the socket dropped" from "the daemon restarted".
+	// 0 until the first successful connect, and against a daemon too old to
+	// send it -- either way the reconnect path treats it as "can't tell".
+	uint64 m_ecSessionId = 0;
 	void BeginReconnect();
 	void AttemptReconnect();
 	void ScheduleNextReconnect();

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -217,6 +217,7 @@ EC_TAG_AEAD_CLIENT_PUBKEY                 0x0021
 EC_TAG_AEAD_SERVER_PUBKEY                 0x0022
 EC_TAG_AEAD_CLIENT_CONFIRM                0x0023
 EC_TAG_AEAD_SERVER_CONFIRM                0x0024
+EC_TAG_SESSION_ID                         0x0025
 
 
 EC_TAG_CLIENT_NAME                        0x0100

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -204,6 +204,7 @@ m_req_fifo_thr(20)
 , m_aeadNegotiated(false)
 , m_preferNoZlib(false)
 , m_forceZlib(false)
+, m_serverSessionId(0)
 , m_serverPartialUpdate(false)
 , m_serverPartialSearch(false)
 , m_canMultiSearch(false)
@@ -753,6 +754,12 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			// tags for unchanged files (#713).
 			if (reply->GetTagByName(EC_TAG_CAN_PARTIAL_UPDATE)) {
 				m_serverPartialUpdate = true;
+			}
+			// Which daemon process we're talking to. Stays 0 against a
+			// daemon that doesn't send it, which the reconnect path
+			// reads as "can't tell" and handles the safe way.
+			if (const CECTag *sessionTag = reply->GetTagByName(EC_TAG_SESSION_ID)) {
+				m_serverSessionId = sessionTag->GetInt();
 			}
 			if (reply->GetTagByName(EC_TAG_CAN_PARTIAL_SEARCH)) {
 				m_serverPartialSearch = true;

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -197,6 +197,14 @@ private:
 	// Set via SetForceZlib() from the caller's config/CLI plumbing.
 	bool m_forceZlib;
 
+	// The daemon process this connection is talking to (EC_TAG_SESSION_ID
+	// from AUTH_OK), or 0 against a daemon too old to send it. ECIDs are
+	// only meaningful within one such session -- CECID hands them out from
+	// a counter that restarts with the process -- so a reconnect that comes
+	// back with a different value (or with 0, where we cannot tell) has to
+	// discard everything keyed by ECID rather than reconcile against it.
+	uint64 m_serverSessionId;
+
 	// Set when the server echoed `EC_TAG_CAN_PARTIAL_UPDATE` in AUTH_OK,
 	// confirming it speaks the partial-update INC_UPDATE protocol: skip
 	// the bulk "anything missing == deleted" loop and instead delete only
@@ -305,6 +313,8 @@ public:
 	void SetCanChat(bool can) noexcept { m_canChat = can; }
 
 	bool ServerSupportsPartialUpdate() const { return m_serverPartialUpdate; }
+	//! See m_serverSessionId. 0 means the daemon didn't tell us.
+	uint64 GetServerSessionId() const { return m_serverSessionId; }
 	bool ServerSupportsPartialSearch() const { return m_serverPartialSearch; }
 
 	bool ServerSupportsMultiSearch() const { return m_serverMultiSearch; }


### PR DESCRIPTION
An ECID only means something within one daemon process. `CECID` hands them out from a counter that restarts with the process, so a restarted amuled reissues the same numbers, in whatever order it loads files that time. amulegui deliberately keeps its objects across a reconnect so scroll and selection survive (#444), and reconciles the fresh snapshot against them by ECID — which after a restart pairs each object with whatever now happens to share its number. The row survives and is quietly overwritten with a different file's name, size and statistics, and if the class no longer matches it also ends up in the wrong list.

It can also crash. `CKnownFilesRem::ProcessItemUpdate` copies the part-status array using two bounds from different places: the buffer is as long as the decoder made it from what arrived, while `GetPartCount()` is the object's own, derived from the size it currently believes the file to be. They agree for as long as an ECID keeps meaning the same file. Paired with a file of a different size the loop reads off the end of the heap allocation, which fits the `0xc0000005` in #884.

## What changes

The daemon identifies its process in AUTH_OK via a new `EC_TAG_SESSION_ID`, and a reconnect compares it:

- **Same value** — the socket dropped but the daemon lived (a sleeping laptop, a dead tunnel). In-place reconcile as today; scroll and selection still survive.
- **Different, or absent** because the daemon predates the tag — nothing keyed by ECID can be trusted. Every such container is dropped and repopulated from the next poll. That fallback is what makes this work against daemons already deployed.

Teardown goes through `RemoteContainer::ResetForNewSession()`, which drops items one at a time through the existing `RemoveItem`/`DeleteItem` path rather than clearing indices: that path fires the destroy broadcast that makes clients and list controls drop their raw pointers (#748, #755), removes the rows from the views, then deletes. `CKnownFilesRem` also re-arms the cold-boot path so the repopulate is batched through `ShowFileList()` instead of sorting once per inserted row (#414).

The part-status copy is bounded and its tail cleared regardless — two bounds from different sources shouldn't be assumed to agree — and a mismatch now logs at critical level, once per session, naming the file. Silent clamping would leave a row describing the wrong file with nothing pointing at why.

## Testing

Both branches exercised against a local daemon with a populated library:

| scenario | session id | branch taken | result |
|---|---|---|---|
| daemon restarted | changes | reset | no crash, both lists repopulate correctly, selection lost (expected) |
| socket dropped via a TCP relay, daemon untouched | unchanged | in-place reconcile | reconnects, **selection preserved** |
| daemon without the tag | `0` | reset | connects normally; backward compatible |

Verified separately that the id is stable across repeated connects to one process and differs after every restart. Tier-2 clang-tidy clean on the changed lines; po catalogs regenerated for the two new strings.
