### PR TITLE
fix(gui): log assertions from amulegui the way the other apps do

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -316,6 +316,17 @@ void CamuleRemoteGuiApp::OnFatalException()
 }
 #endif
 
+void CamuleRemoteGuiApp::OnAssertFailure(
+	const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg)
+{
+	// Unlike CamuleApp there is no app-state gate here: the remote GUI has
+	// no equivalent of IsRunning(), and its window is either up or the
+	// assert came from a thread that cannot show a dialog anyway.
+	if (ReportAssertFailure(file, line, func, cond, msg, wxThread::IsMain())) {
+		wxApp::OnAssertFailure(file, line, func, cond, msg);
+	}
+}
+
 void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 {
 	static int request_step = 0;

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -972,6 +972,19 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 	void OnFatalException();
 #endif
 
+	// Likewise for assertions, which until now amulegui alone dropped: the
+	// wxWidgets dialog was the only record, so anything that aborted before
+	// it could be read left nothing behind, and remotelogfile showed a clean
+	// session. Compiled unconditionally for the reason CamuleApp's copy is:
+	// distro wx packages keep wxDEBUG_LEVEL=1, so release builds assert too.
+	//
+	// No `override` keyword, deliberately: nothing else in this class carries
+	// one, and -Werror=inconsistent-missing-override then demands it on all
+	// eight of the others. Worth a sweep of its own rather than dragging one
+	// into this change.
+	void OnAssertFailure(
+		const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg);
+
 #ifdef __WXMAC__
 	// Restore the main window when the user clicks the Dock icon while no
 	// window is visible. Mirrors CamuleGuiApp; both hand off to

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1850,34 +1850,12 @@ void CamuleApp::SetOSFiles(const wxString &new_path)
 void CamuleApp::OnAssertFailure(
 	const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg)
 {
-	wxString errmsg =
-		CFormat("Assertion failed: %s:%s:%d: Assertion '%s' failed. %s\nBacktrace follows:\n%s\n") %
-		file % func % line % cond % (msg ? wxString(msg) : wxString()) %
-		get_backtrace(2); // Skip the function-calls directly related to the assert call.
-	theLogger.EmergencyLog(errmsg, false);
-
-	// --disable-fatal: skip the wxApp dialog and abort directly so a
-	// supervisor (systemd, watchdog script) sees a non-zero exit and
-	// can restart aMule. The errmsg above is already on stderr and in
-	// the log; nothing useful would be lost by skipping the dialog.
-	if (m_disableFatal) {
-		raise(SIGABRT);
-		return; // unreachable
-	}
-
-	if (wxThread::IsMain() && IsRunning()) {
+	// The log copy, the backtrace and --disable-fatal are the same for every
+	// app and live in CamuleAppCommon; only the base to fall through to is
+	// ours. IsRunning() gates the dialog because wxWidgets cannot show one
+	// before the app is up or once it is tearing down.
+	if (ReportAssertFailure(file, line, func, cond, msg, wxThread::IsMain() && IsRunning())) {
 		AMULE_APP_BASE::OnAssertFailure(file, line, func, cond, msg);
-	} else {
-#ifdef _MSC_VER
-		wxString s = CFormat("%s in %s") % cond % func;
-		if (msg) {
-			s << " : " << msg;
-		}
-		_wassert(s.wc_str(), file, line);
-#else
-		// Abort, allows gdb to catch the assertion
-		raise(SIGABRT);
-#endif
 	}
 }
 

--- a/src/amule.h
+++ b/src/amule.h
@@ -199,6 +199,31 @@ protected:
 	wxString m_PidFile;
 
 	bool InitCommon(int argc, wxChar **argv);
+
+	/**
+	 * Logs an assertion, with a backtrace, and applies --disable-fatal.
+	 *
+	 * Every app wants this identically -- the log copy is often the only
+	 * record that survives, since the wxWidgets dialog dies with the
+	 * process if nobody presses Continue -- but only the app itself knows
+	 * which wxWidgets base to hand the assert on to afterwards, so the
+	 * decision is returned rather than acted on here.
+	 *
+	 * @param dialogUsable whether wxWidgets can still put its assert dialog
+	 *        on screen: false off the main thread, and false for an app
+	 *        that is not running yet or is already tearing down.
+	 * @return true when the caller should call its base OnAssertFailure().
+	 *         Does not return at all when --disable-fatal is set, or when
+	 *         the dialog is unusable: both abort so a supervisor sees a
+	 *         non-zero exit and a debugger catches the assert in place.
+	 */
+	bool ReportAssertFailure(const wxChar *file,
+		int line,
+		const wxChar *func,
+		const wxChar *cond,
+		const wxChar *msg,
+		bool dialogUsable);
+
 	void RefreshSingleInstanceChecker();
 	// Drop the single-instance lock (and unlink its file). OnExit() calls
 	// std::_Exit() to dodge the wxWebSession teardown crash, which bypasses

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -27,6 +27,8 @@
 // but preprocessor-dependent (using theApp, thePrefs), so it is compiled separately for each app.
 //
 
+#include <signal.h> // Needed for raise(), SIGABRT
+
 #include <wx/wx.h>
 #include <wx/cmdline.h>  // Needed for wxCmdLineParser
 #include <wx/evtloop.h>  // Needed for wxEventLoopBase
@@ -55,8 +57,9 @@
 #include "GuiEvents.h"              // Needed for Notify_*
 #include "KnownFile.h"
 #include "Logger.h"
-#include "MagnetURI.h"      // Needed for CMagnetURI
-#include "MuleCollection.h" // Needed for expanding .emulecollection arguments
+#include "MagnetURI.h"        // Needed for CMagnetURI
+#include "MuleCollection.h"   // Needed for expanding .emulecollection arguments
+#include <common/MuleDebug.h> // Needed for get_backtrace
 #include "Preferences.h"
 #include "ScopedPtr.h"
 #include "MuleVersion.h" // Needed for GetMuleVersion()
@@ -64,6 +67,45 @@
 #ifndef CLIENT_GUI
 #include "DownloadQueue.h"
 #endif
+
+bool CamuleAppCommon::ReportAssertFailure(const wxChar *file,
+	int line,
+	const wxChar *func,
+	const wxChar *cond,
+	const wxChar *msg,
+	bool dialogUsable)
+{
+	wxString errmsg =
+		CFormat("Assertion failed: %s:%s:%d: Assertion '%s' failed. %s\nBacktrace follows:\n%s\n") %
+		file % func % line % cond % (msg ? wxString(msg) : wxString()) %
+		get_backtrace(2); // Skip the function-calls directly related to the assert call.
+	theLogger.EmergencyLog(errmsg, false);
+
+	// --disable-fatal: skip the wxApp dialog and abort directly so a
+	// supervisor (systemd, watchdog script) sees a non-zero exit and
+	// can restart aMule. The errmsg above is already on stderr and in
+	// the log; nothing useful would be lost by skipping the dialog.
+	if (m_disableFatal) {
+		raise(SIGABRT);
+		return false; // unreachable
+	}
+
+	if (!dialogUsable) {
+#ifdef _MSC_VER
+		wxString s = CFormat("%s in %s") % cond % func;
+		if (msg) {
+			s << " : " << msg;
+		}
+		_wassert(s.wc_str(), file, line);
+#else
+		// Abort, allows gdb to catch the assertion
+		raise(SIGABRT);
+#endif
+		return false; // unreachable
+	}
+
+	return true;
+}
 
 CamuleAppCommon::CamuleAppCommon()
 {


### PR DESCRIPTION
amulegui was the one app that dropped assertions on the floor. `CamuleApp` overrides `OnAssertFailure()` to write the assert plus a backtrace through `EmergencyLog` before wxWidgets shows its dialog; `CamuleRemoteGuiApp` never had that override, so the dialog was the only record. Anything that aborted before it could be read — or was simply left unanswered, which terminates the process — left `remotelogfile` showing a clean session.

That is not hypothetical: it is what made the follow-up on #884 hard to act on. A reconnect assertion was reported with "nothing relevant in remotelogfile", and the log genuinely ended mid-session with no trace, because amulegui never wrote one.

The log copy, the backtrace and the `--disable-fatal` short circuit are identical for every app, so they move into `CamuleAppCommon::ReportAssertFailure()`, which both apps already inherit. What differs stays at the call site: which wxWidgets base to hand the assert on to, and whether the dialog can be shown at all — `CamuleApp` gates that on `IsRunning()`, which the remote GUI has no equivalent of. The override itself cannot move into the mixin, since `CamuleAppCommon` is not a `wxApp` and so cannot override its virtual.

## Test plan

- [x] macOS: monolithic, amuled and amulegui all build clean
- [x] Verified by calling the handler directly in a throwaway build, since no build here can raise a real assertion — Homebrew's `wx-config` reports `-DwxDEBUG_LEVEL=0`, so `wxASSERT` compiles out on macOS regardless of build type. The assertion reaches `remotelogfile` with the same `!` severity marker `DoLine` uses
- [x] clang-format v18 whole-file clean; Tier-2 clang-tidy clean, 0 compiler errors
- [x] Windows debug build: confirm a real assertion is captured with a populated backtrace

## Noted, deliberately not changed

`CaMuleExternalConnector::OnAssertFailure()` is a third copy, serving amulecmd, amuleweb and amuleapi. It is weaker than the other two — wrapped in `#ifdef __WXDEBUG__`, gated on `#if !wxUSE_STACKWALKER` so it logs nothing at all when the stack walker is available, and writing to stderr rather than to a log file. It does not inherit `CamuleAppCommon`, so folding it in is a larger change than this one.

`CamuleRemoteGuiApp` carries no `override` keywords at all, so adding one trips `-Werror=inconsistent-missing-override` on the other eight members. The new declaration therefore omits it, with a comment saying why; a sweep of that class would be worth doing on its own.
