### PR TITLE
fix(gui): use a virtual list model so the lists stop asserting on Windows

### DIFF
--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -49,7 +49,21 @@ wxEND_EVENT_TABLE()
  * question by indexing into the owner's m_items. Nothing here is virtual for
  * subclasses to touch -- they see the wxUIntPtr-based hooks instead.
  */
-class CMuleVirtualDataViewCtrl::VirtualModel : public wxDataViewIndexListModel
+// wxDataViewVirtualListModel, not wxDataViewIndexListModel: despite the name,
+// only the former is virtual in the generic backend (MSW). An index-list model
+// gets a real wxDataViewTreeNode per row hanging off a root branch, and each
+// branch caches the sort order it was last sorted under. Marking our columns
+// sortable to get the header caret sets the window's sort order without wx
+// ever sorting anything -- the list owns its own order -- so the branch cache
+// and the window disagree, and the next RowChanged() trips
+// "m_branchData->sortOrder == window->GetSortOrder()" in PutChildInSortOrder()
+// (datavgen.cpp, present in 3.2 and 3.3 alike). A virtual list model has no
+// tree nodes at all, so the code that asserts is never reached.
+//
+// On macOS this is a no-op: wx typedefs wxDataViewVirtualListModel to
+// wxDataViewIndexListModel there ("better than nothing", dataview.h), which is
+// also why the assert has only ever been seen on Windows.
+class CMuleVirtualDataViewCtrl::VirtualModel : public wxDataViewVirtualListModel
 {
 public:
 	explicit VirtualModel(CMuleVirtualDataViewCtrl *owner)

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -38,7 +38,7 @@
  *
  * The wxDataViewCtrl counterpart of CMuleVirtualListCtrl, and virtual in the
  * same sense: the control materialises nothing per row. Rows are addressed by
- * index through a wxDataViewIndexListModel, and cell text is pulled from the
+ * index through a wxDataViewVirtualListModel, and cell text is pulled from the
  * subclass on demand for the cells actually drawn.
  *
  * Two consequences are worth knowing before deriving from this.
@@ -130,7 +130,7 @@ public:
 	/**
 	 * Resolves a wxDataViewItem from an event (e.g. an activation or
 	 * context-menu event) back to its row, through the
-	 * wxDataViewIndexListModel AssociateVirtualModel() installed.
+	 * wxDataViewVirtualListModel AssociateVirtualModel() installed.
 	 *
 	 * A wxDataViewItem's ID *is* the row number for this model, but that
 	 * detail is model-internal; going through GetRow() rather than casting


### PR DESCRIPTION
Every list built on `CMuleVirtualDataViewCtrl` trips a wxWidgets assertion on Windows as soon as one of its rows is updated:

```
datavgen.cpp:PutChildInSortOrder: assertion
'm_branchData->sortOrder == window->GetSortOrder()' failed
```

Reported on #884 after testing a debug build. Reproduced by connecting to an ED2k server — which updates a row in the server list — and confirmed from the backtrace, which reaches the assert through `wxDataViewIndexListModel::RowChanged()`.

Despite the name, `wxDataViewIndexListModel` is **not** virtual in the generic backend that MSW uses: every row gets a real `wxDataViewTreeNode` under a root branch, and each branch caches the sort order it was last sorted under. This control marks its columns sortable purely so the header caret appears, while the list sorts `m_items` itself and never asks wx to reorder anything — as the class comment already says, the list owns the order. So the window's sort order says one thing, the branch's cache says another, and the first `RowChanged()` afterwards notices.

`wxDataViewVirtualListModel` has no tree nodes at all, so the asserting code is unreachable rather than merely kept in agreement, and rows stop costing a node each. It predates our wx 3.2 floor and carries the same API for everything this model uses (`GetRow`, `GetItem`, `RowInserted`, `RowDeleted`, `RowsDeleted`, `RowChanged`, `Reset`). On macOS it changes nothing at all — wx typedefs it to `wxDataViewIndexListModel` there, which is also why this was only ever seen on Windows.

## Test plan

- [x] Windows (wx 3.3, generic backend, debug amulegui): the reproduction no longer asserts
- [x] Linux (wx **3.2.9**, GTK): builds clean on the floor version; lists populate, sort, and hold selection with no regressions. GTK takes a different path for virtual models, so this was the real risk — it cannot reproduce the assert itself, since only MSW uses the generic backend
- [x] macOS: builds clean; unaffected by construction
- [x] clang-format v18 whole-file clean; Tier-2 clang-tidy clean, 0 compiler errors

Worth noting the scope: this was not specific to the server list. Any row update in Downloads, Shared Files, Servers or the client lists would do it, which is why a plain server connect was enough to trigger it.
