### PR TITLE
fix(server): don't mark servers dead when the fault is at our end, and back off between sweeps

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6256,11 +6256,11 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+msgid "Failed to connect to all servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6264,6 +6264,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6299,13 +6306,6 @@ msgstr ""
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] ""
-msgstr[1] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:16+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6349,11 +6349,12 @@ msgstr ""
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "فشل في اﻹتصال باي خادم في القائمة القيام بمحاولة اخرى"
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "فشل في اﻹتصال باي خادم في القائمة القيام بمحاولة اخرى"
 
 #: src/ServerConnect.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:16+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6357,6 +6357,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "فشل في اﻹتصال باي خادم في القائمة القيام بمحاولة اخرى"
 
 #: src/ServerConnect.cpp
+#, fuzzy, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "اﻹتصال الذاتي بالخادم سيعيد المحاولة بعد %d ثانية"
+msgstr[1] "اﻹتصال الذاتي بالخادم سيعيد المحاولة بعد %d ثانية"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6392,13 +6399,6 @@ msgstr "%s (%s:%i) يظهر انه ﻻ يعمل"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, fuzzy, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "اﻹتصال الذاتي بالخادم سيعيد المحاولة بعد %d ثانية"
-msgstr[1] "اﻹتصال الذاتي بالخادم سيعيد المحاولة بعد %d ثانية"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:17+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6467,11 +6467,12 @@ msgstr "Fallu al coneutar a tolos sirvidores ofuscaos llistaos. Tentándolo de n
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Fallu al coneutar a tolos sirvidores."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Fallu al coneutar a tolos sirvidores."
 
 #: src/ServerConnect.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:17+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6475,6 +6475,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Fallu al coneutar a tolos sirvidores."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Reintentaráse la conexón automática al sirvidor en %d segundu"
+msgstr[1] "Reintentaráse la conexón automática al sirvidor en %d segundos"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Protocolu eD2k deshabilitáu nes preferencies, nun se coneuta."
 
@@ -6510,13 +6517,6 @@ msgstr "%s (%s:%i) paez tar cayíu."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) paez tar enllenu."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Reintentaráse la conexón automática al sirvidor en %d segundu"
-msgstr[1] "Reintentaráse la conexón automática al sirvidor en %d segundos"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6325,11 +6325,12 @@ msgstr ""
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Грешка при свързване към всички сървъри в списъка - започвам отначало."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Грешка при свързване към всички сървъри в списъка - започвам отначало."
 
 #: src/ServerConnect.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6333,6 +6333,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Грешка при свързване към всички сървъри в списъка - започвам отначало."
 
 #: src/ServerConnect.cpp
+#, fuzzy, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "На всеки %d секунди ще бъде правен автоматичен опит за свързване"
+msgstr[1] "На всеки %d секунди ще бъде правен автоматичен опит за свързване"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6368,13 +6375,6 @@ msgstr "%s (%s:%i) изглежда не отговаря"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, fuzzy, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "На всеки %d секунди ще бъде правен автоматичен опит за свързване"
-msgstr[1] "На всеки %d секунди ще бъде правен автоматичен опит за свързване"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6255,11 +6255,11 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+msgid "Failed to connect to all servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6263,6 +6263,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6298,13 +6305,6 @@ msgstr ""
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] ""
-msgstr[1] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6439,11 +6439,12 @@ msgstr "No s'ha pogut connectar amb els servidors ofuscats de la llista. Intenta
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "No s'ha pogut connectar amb cap servidor de la llista. Intentant-ho de nou."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "No s'ha pogut connectar amb cap servidor de la llista. Intentant-ho de nou."
 
 #: src/ServerConnect.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6447,6 +6447,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "No s'ha pogut connectar amb cap servidor de la llista. Intentant-ho de nou."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Es reintentarà la connexió al servidor en %d segon"
+msgstr[1] "Es reintentarà la connexió al servidor en %d segons"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "La xarxa eD2k és inhabilitada a les preferències, no es connectarà."
 
@@ -6482,13 +6489,6 @@ msgstr "%s (%s:%i) sembla estar aturat."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) sembla estar ple."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Es reintentarà la connexió al servidor en %d segon"
-msgstr[1] "Es reintentarà la connexió al servidor en %d segons"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6450,6 +6450,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Selhalo připojení ke všem serverům na seznamu. Zkouším znovu."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Síť eD2k je zakázána v nastavení, nepřipojuji se."
 
@@ -6485,14 +6493,6 @@ msgstr "%s (%s:%i) se zdá být mrtvý."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) se zdá být plný."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6442,11 +6442,12 @@ msgstr "Selhalo připojení ke všem serverům s obfuskací. Zkouším to znovu 
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Selhalo připojení ke všem serverům na seznamu. Zkouším znovu."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Selhalo připojení ke všem serverům na seznamu. Zkouším znovu."
 
 #: src/ServerConnect.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6373,6 +6373,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, fuzzy, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatisk forbindelse til server vil prøve igen om %d sekunder"
+msgstr[1] "Automatisk forbindelse til server vil prøve igen om %d sekunder"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6408,13 +6415,6 @@ msgstr "%s (%s:%i) ser ud til at være død"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, fuzzy, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatisk forbindelse til server vil prøve igen om %d sekunder"
-msgstr[1] "Automatisk forbindelse til server vil prøve igen om %d sekunder"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6365,12 +6365,14 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
-msgstr ""
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
+msgstr "Fejl ved hentning af node listen"
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
-msgstr ""
+#, fuzzy
+msgid "Failed to connect to all servers listed."
+msgstr "Fejl ved hentning af node listen"
 
 #: src/ServerConnect.cpp
 #, fuzzy, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6443,6 +6443,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Fehler beim Verbinden zu allen Servern in der Liste. Ein neuer Durchgang wird gestartet."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatische Verbindungsherstellung zum Server wird in %d Sekunde wiederholt"
+msgstr[1] "Automatische Verbindungsherstellung zum Server wird in %d Sekunden wiederholt"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k-Netzwerk ist in den Einstellungen deaktiviert - verbinde nicht."
 
@@ -6478,13 +6485,6 @@ msgstr "%s (%s:%i) scheint tot zu sein."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) scheint voll zu sein."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatische Verbindungsherstellung zum Server wird in %d Sekunde wiederholt"
-msgstr[1] "Automatische Verbindungsherstellung zum Server wird in %d Sekunden wiederholt"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6435,11 +6435,12 @@ msgstr "Verbindung zu allen gelisteten verschleierten Servern misslungen. Versuc
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Fehler beim Verbinden zu allen Servern in der Liste. Ein neuer Durchgang wird gestartet."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Fehler beim Verbinden zu allen Servern in der Liste. Ein neuer Durchgang wird gestartet."
 
 #: src/ServerConnect.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6479,11 +6479,12 @@ msgstr "Αποτυχία σύνδεσης σε όλους τους συσκοτ�
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Αποτυχία σύνδεσης σε όλους τους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Αποτυχία σύνδεσης σε όλους τους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα."
 
 #: src/ServerConnect.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6487,6 +6487,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Αποτυχία σύνδεσης σε όλους τους διακομιστές της λίστας. Θα γίνει άλλο ένα πέρασμα."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Αυτόματη σύνδεση στον διακομιστή θα επιχειρηθεί ξανά σε %d δευτερόλεπτο"
+msgstr[1] "Αυτόματη σύνδεση στον διακομιστή θα επιχειρηθεί ξανά σε %d δευτερόλεπτα"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Το δίκτυο eD2k απενεργοποιήθηκε στις επιλογές, δεν γίνεται σύνδεση."
 
@@ -6522,13 +6529,6 @@ msgstr "%s (%s:%i) φαίνεται να είναι νεκρό"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) φαίνεται να είναι γεμάτο."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Αυτόματη σύνδεση στον διακομιστή θα επιχειρηθεί ξανά σε %d δευτερόλεπτο"
-msgstr[1] "Αυτόματη σύνδεση στον διακομιστή θα επιχειρηθεί ξανά σε %d δευτερόλεπτα"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6264,6 +6264,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6299,13 +6306,6 @@ msgstr ""
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] ""
-msgstr[1] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6256,11 +6256,11 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+msgid "Failed to connect to all servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:24+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6418,11 +6418,12 @@ msgstr "Error al conectar a todos los servidores ofuscados listados. Se va a dar
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Error al conectar a todos los servidores. Se va a dar otra pasada."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Error al conectar a todos los servidores. Se va a dar otra pasada."
 
 #: src/ServerConnect.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:24+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6426,6 +6426,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Error al conectar a todos los servidores. Se va a dar otra pasada."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Se reintentará la conexión automática al servidor en %d segundo"
+msgstr[1] "Se reintentará la conexión automática al servidor en %d segundos"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Protocolo eD2k deshabilitado en las preferencias, no se hace la conexión."
 
@@ -6461,13 +6468,6 @@ msgstr "%s (%s:%i) parece estar caído."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar lleno."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Se reintentará la conexión automática al servidor en %d segundo"
-msgstr[1] "Se reintentará la conexión automática al servidor en %d segundos"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6452,6 +6452,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Proovin %d sekundi pärast serveriga uuesti automaatselt ühenduda."
+msgstr[1] "Proovin %d sekundi pärast uuesti serveriga automaatselt ühenduda."
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k on seadetes väljalülitatud, ei ühendu"
 
@@ -6487,13 +6494,6 @@ msgstr "%s (%s:%i) on vist surnud."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) on vist täis."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Proovin %d sekundi pärast serveriga uuesti automaatselt ühenduda."
-msgstr[1] "Proovin %d sekundi pärast uuesti serveriga automaatselt ühenduda."
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6444,11 +6444,12 @@ msgstr "Kõigi näidatud hämatud serveritega ühenduse loomine ebaõnnestus. L�
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Serveritega ühenduse loomine ebaõnnestus. Lähen uuele katsele."
 
 #: src/ServerConnect.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6443,11 +6443,12 @@ msgstr "Huts zerrendaturiko nahasitako zerbitzarietara konektatzean. Nahaste gab
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Huts zerrendako zerbitzari guztietara konektatzen saiatzerakoan. Berriz hasiko nahiz."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Huts zerrendako zerbitzari guztietara konektatzen saiatzerakoan. Berriz hasiko nahiz."
 
 #: src/ServerConnect.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6451,6 +6451,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Huts zerrendako zerbitzari guztietara konektatzen saiatzerakoan. Berriz hasiko nahiz."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Zerbitzariarekiko konexio automatikoa berriz saiatuko da segundo %d-etan"
+msgstr[1] "Zerbitzariarekiko konexio automatikoa berriz saiatuko da %d segundotan"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k sarea hobespenetan ezgaiturik, ez da konektatuko."
 
@@ -6486,13 +6493,6 @@ msgstr "%s (%s:%i) hilik dagoela dirudi."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) beterik dagoela dirudi."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Zerbitzariarekiko konexio automatikoa berriz saiatuko da segundo %d-etan"
-msgstr[1] "Zerbitzariarekiko konexio automatikoa berriz saiatuko da %d segundotan"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6443,11 +6443,12 @@ msgstr "Kätketyt yhteysyritykset palvelimille epäonnistuivat. Yritetään uude
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Yhdistäminen kaikkiin listattuihin palvelimiin epäonnistui. Aloitetaan uusi kierros."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Yhdistäminen kaikkiin listattuihin palvelimiin epäonnistui. Aloitetaan uusi kierros."
 
 #: src/ServerConnect.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6451,6 +6451,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Yhdistäminen kaikkiin listattuihin palvelimiin epäonnistui. Aloitetaan uusi kierros."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automaattinen uudelleenyhdistäminen palvelimelle %d sekunnin päästä"
+msgstr[1] "Automaattinen uudelleenyhdistäminen palvelimelle %d sekunnin päästä"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k-verkko kytketty pois päältä asetuksista, ei yhdistetä."
 
@@ -6486,13 +6493,6 @@ msgstr "%s (%s:%i) näyttää kuolleelta."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) on ilmeisesti täysi."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automaattinen uudelleenyhdistäminen palvelimelle %d sekunnin päästä"
-msgstr[1] "Automaattinen uudelleenyhdistäminen palvelimelle %d sekunnin päästä"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:27+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6410,11 +6410,13 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr "Échec de la connexion aux serveurs brouillés listés. Nouvel essai sans brouillage."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
 msgstr "Échec de la connexion à tous les serveurs statiques listés. Nouvel essai."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Échec de la connexion aux serveurs listés. Nouvel essai."
 
 #: src/ServerConnect.cpp

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:27+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6418,6 +6418,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Échec de la connexion aux serveurs listés. Nouvel essai."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Nouvelle tentative de connexion automatique au serveur dans %d seconde"
+msgstr[1] "Nouvelle tentative de connexion automatique au serveur dans %d secondes"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Le réseau e2Dk est désactivé dans les préférences, pas de connexion."
 
@@ -6453,13 +6460,6 @@ msgstr "%s (%s:%i) semble être indisponible."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s : %i) semble être plein."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Nouvelle tentative de connexion automatique au serveur dans %d seconde"
-msgstr[1] "Nouvelle tentative de connexion automatique au serveur dans %d secondes"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:28+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6449,11 +6449,12 @@ msgstr "Non se puido conectar a todos os servidores ofuscados listados. Tentánd
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Erro ao conectar a todos os servidores. Tentándoo de novo."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Erro ao conectar a todos os servidores. Tentándoo de novo."
 
 #: src/ServerConnect.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:28+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6457,6 +6457,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Erro ao conectar a todos os servidores. Tentándoo de novo."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Tentarase conectar automaticamente ao servidor en %d segundo"
+msgstr[1] "Tentarase conectar automaticamente ao servidor en %d segundos"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Protocolo eD2k inhabilitado nos axustes, non se conectou."
 
@@ -6492,13 +6499,6 @@ msgstr "%s (%s:%i) parece estar caído."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar cheo."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Tentarase conectar automaticamente ao servidor en %d segundo"
-msgstr[1] "Tentarase conectar automaticamente ao servidor en %d segundos"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:29+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6405,11 +6405,12 @@ msgstr "החיבור לשרתים המבלבלים שברשימה כשל, מבצ
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "ההתחברות לכל השרתים הרשומים כשלה, מבצע מעבר נוסף."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "ההתחברות לכל השרתים הרשומים כשלה, מבצע מעבר נוסף."
 
 #: src/ServerConnect.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:29+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6413,6 +6413,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "ההתחברות לכל השרתים הרשומים כשלה, מבצע מעבר נוסף."
 
 #: src/ServerConnect.cpp
+#, fuzzy, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "התחברות אוטומטית לשרת ינוסה שוב תוך %d שניות"
+msgstr[1] "התחברות אוטומטית לשרת ינוסה שוב תוך %d שניות"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6448,13 +6455,6 @@ msgstr "נראה כאלו ש %s·(%s:%i) מת."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "נראה כאלו ש %s·(%s:%i) מלא."
-
-#: src/ServerConnect.cpp
-#, fuzzy, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "התחברות אוטומטית לשרת ינוסה שוב תוך %d שניות"
-msgstr[1] "התחברות אוטומטית לשרת ינוסה שוב תוך %d שניות"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6391,11 +6391,12 @@ msgstr ""
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Neuspjesno spajanje sa svim serverima u list. Pocinje iznova."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Neuspjesno spajanje sa svim serverima u list. Pocinje iznova."
 
 #: src/ServerConnect.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6399,6 +6399,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Neuspjesno spajanje sa svim serverima u list. Pocinje iznova."
 
 #: src/ServerConnect.cpp
+#, fuzzy, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatsko spajanje sa serverom ce ponovo poceti za %d sekundi"
+msgstr[1] "Automatsko spajanje sa serverom ce ponovo poceti za %d sekundi"
+msgstr[2] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6434,14 +6442,6 @@ msgstr "%s (%s:%i) je mrtav"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, fuzzy, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatsko spajanje sa serverom ce ponovo poceti za %d sekundi"
-msgstr[1] "Automatsko spajanje sa serverom ce ponovo poceti za %d sekundi"
-msgstr[2] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6423,6 +6423,12 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Az összes felsorolt kiszolgálóval történő kapcsolatfelvétel sikertelen. Újra próbálkozom."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatikus kapcsolódás a kiszolgálóhoz %d másodperc múlva"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Az eD2k hálózat le van tiltva a beállításokban, nem kapcsolódom."
 
@@ -6458,12 +6464,6 @@ msgstr "A %s (%s:%i) halottnak tűnik."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "A %s (%s:%i) úgy látszik megtelt."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatikus kapcsolódás a kiszolgálóhoz %d másodperc múlva"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6415,11 +6415,12 @@ msgstr "Az összes felsorolt zavart kiszolgálóval sikertelen a kapcsolatfelvé
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Az összes felsorolt kiszolgálóval történő kapcsolatfelvétel sikertelen. Újra próbálkozom."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Az összes felsorolt kiszolgálóval történő kapcsolatfelvétel sikertelen. Újra próbálkozom."
 
 #: src/ServerConnect.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6399,11 +6399,13 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr "Impossibile collegarsi ai server con offuscamento di protocollo. Ci riprovo senza offuscamento."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
 msgstr "Impossibile connettersi a tutti i server statici in lista. Procedo con un altro tentativo."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Impossibile connettersi a tutti i server in lista. Procedo con un altro tentativo."
 
 #: src/ServerConnect.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6407,6 +6407,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Impossibile connettersi a tutti i server in lista. Procedo con un altro tentativo."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Riconnessione automatica al server tra %d secondo"
+msgstr[1] "Riconnessione automatica al server tra %d secondi"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rete eD2k disabilitata nelle preferenze, connessione impossibile."
 
@@ -6442,13 +6449,6 @@ msgstr "%s (%s:%i) sembra non essere attivo."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) sembra essere pieno."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Riconnessione automatica al server tra %d secondo"
-msgstr[1] "Riconnessione automatica al server tra %d secondi"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6445,6 +6445,12 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "リストされたすべてのサーバへの接続に失敗しました。もう一度試行します。"
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "自動的なサーバへの接続は、あと%d秒で再試行します"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6480,12 +6486,6 @@ msgstr "%s（%s：%i）は応答しないようです。"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s（%s：%i）は一杯のようです。"
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "自動的なサーバへの接続は、あと%d秒で再試行します"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6437,11 +6437,12 @@ msgstr "難読化されたすべてのサーバへの接続に失敗しました
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "リストされたすべてのサーバへの接続に失敗しました。もう一度試行します。"
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "リストされたすべてのサーバへの接続に失敗しました。もう一度試行します。"
 
 #: src/ServerConnect.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6471,11 +6471,12 @@ msgstr "난독화된 서버들로의 연결이 모두 실패했습니다. 난독
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "모든 서버 목록에 접속하지 못했습니다. 다른 서버를 만드세요."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "모든 서버 목록에 접속하지 못했습니다. 다른 서버를 만드세요."
 
 #: src/ServerConnect.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6479,6 +6479,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "모든 서버 목록에 접속하지 못했습니다. 다른 서버를 만드세요."
 
 #: src/ServerConnect.cpp
+#, fuzzy, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "%d 초후에 서버로 자동 접속을 재시도"
+msgstr[1] "%d 초후에 서버로 자동 접속을 재시도"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6514,13 +6521,6 @@ msgstr "%s(%s:%i)가 죽은것 같습니다."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s(%s:%i)가 가득찬것 같습니다."
-
-#: src/ServerConnect.cpp
-#, fuzzy, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "%d 초후에 서버로 자동 접속을 재시도"
-msgstr[1] "%d 초후에 서버로 자동 접속을 재시도"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:40+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6503,6 +6503,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Nepavyko prisijungti nei prie vieno iš serverių sąraše. Bandoma dar kartą."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Po %d sekundės bus bandoma prisijungti prie serverio automatiškai"
+msgstr[1] "Po %d sekundžių bus bandoma prisijungti prie serverio automatiškai"
+msgstr[2] "Po %d sekundžių bus bandoma prisijungti prie serverio automatiškai"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k tinklas išjungtas parinktyse, nebus jungiamasi."
 
@@ -6538,14 +6546,6 @@ msgstr "%s (%s:%i) neatsako, galbūt išjungtas."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) pilnas."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Po %d sekundės bus bandoma prisijungti prie serverio automatiškai"
-msgstr[1] "Po %d sekundžių bus bandoma prisijungti prie serverio automatiškai"
-msgstr[2] "Po %d sekundžių bus bandoma prisijungti prie serverio automatiškai"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:40+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6495,11 +6495,12 @@ msgstr "Nepavyko prisijungti nei prie vieno iš slepiamų serverių sąraše. Ba
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Nepavyko prisijungti nei prie vieno iš serverių sąraše. Bandoma dar kartą."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Nepavyko prisijungti nei prie vieno iš serverių sąraše. Bandoma dar kartą."
 
 #: src/ServerConnect.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6293,11 +6293,11 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+msgid "Failed to connect to all servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6301,6 +6301,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundēm"
+msgstr[1] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundes"
+msgstr[2] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundēm"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k tīkls ir atspējots iestatījumos, nepieslēdzas tīklam."
 
@@ -6336,14 +6344,6 @@ msgstr "Šķiet, ka %s (%s:%i) miris."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "Šķiet, ka %s (%s:%i) pilns."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundēm"
-msgstr[1] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundes"
-msgstr[2] "Automātiskā pieslēgšanās serverim tiks veikta pēc %d sekundēm"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:41+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6452,6 +6452,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Kon niet verbinden met een server in de lijst. Nogmaals proberen."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatische verbinding naar server zal in %d seconde opnieuw proberen"
+msgstr[1] "Automatische verbinding naar server zal in %d seconden opnieuw proberen"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2K-netwerk is uitgeschakeld in voorkeuren, wordt niet mee verbonden."
 
@@ -6487,13 +6494,6 @@ msgstr "%s (%s:%i) lijkt dood te zijn."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) lijkt vol te zijn."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatische verbinding naar server zal in %d seconde opnieuw proberen"
-msgstr[1] "Automatische verbinding naar server zal in %d seconden opnieuw proberen"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:41+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6444,11 +6444,12 @@ msgstr "Kon niet verbinden met een geobfusceerde server. Nogmaals proberen zonde
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Kon niet verbinden met een server in de lijst. Nogmaals proberen."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Kon niet verbinden met een server in de lijst. Nogmaals proberen."
 
 #: src/ServerConnect.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6472,11 +6472,12 @@ msgstr "Greidde ikkje å kople til alle tåkelagde tenarar i lista. Freistar ein
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Greidde ikkje å kople til alle tenarane i lista. Freistar ein gong til."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Greidde ikkje å kople til alle tenarane i lista. Freistar ein gong til."
 
 #: src/ServerConnect.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6480,6 +6480,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Greidde ikkje å kople til alle tenarane i lista. Freistar ein gong til."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatisk tenaroppkopling freistar på nytt om %d sekund"
+msgstr[1] "Automatisk tenaroppkopling freistar på nytt om %d sekund"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k nettverket deaktivert i innstillingar, koplar ikkje til"
 
@@ -6515,13 +6522,6 @@ msgstr "%s·(%s:%i) ser ut til å vere daud."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s·(%s:%i) ser ut til å vere full."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatisk tenaroppkopling freistar på nytt om %d sekund"
-msgstr[1] "Automatisk tenaroppkopling freistar på nytt om %d sekund"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6476,11 +6476,12 @@ msgstr "Nie udało się połączyć do wszystkich zamaskowanych serwerów na li�
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Nie udało się połączyć do serwerów z listy. Kolejne podejście."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Nie udało się połączyć do serwerów z listy. Kolejne podejście."
 
 #: src/ServerConnect.cpp

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6484,6 +6484,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Nie udało się połączyć do serwerów z listy. Kolejne podejście."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatyczne łączenie do serwera nastąpi za %d sekundę"
+msgstr[1] "Automatyczne łączenie do serwera nastąpi za %d sekundy"
+msgstr[2] "Automatyczne łączenie do serwera nastąpi za %d sekund"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Sieć eD2K wyłączona w preferencjach, nie łączę."
 
@@ -6519,14 +6527,6 @@ msgstr "%s (%s:%i) wygląda na wyłączony."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) wygląda na pełny."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatyczne łączenie do serwera nastąpi za %d sekundę"
-msgstr[1] "Automatyczne łączenie do serwera nastąpi za %d sekundy"
-msgstr[2] "Automatyczne łączenie do serwera nastąpi za %d sekund"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6402,11 +6402,13 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr "Falha ao conectar em todos servidores obscurecidos listados. Tentando de novo sem ofuscação."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
 msgstr "Falha ao conectar em todos os servidores estáticos listados. Tentando novamente."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Falha ao conectar em todos os servidores listados. Tentando novamente."
 
 #: src/ServerConnect.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6410,6 +6410,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Falha ao conectar em todos os servidores listados. Tentando novamente."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Conexão automática com o servidor irá se repetir em %d segundo"
+msgstr[1] "Conexão automática com o servidor irá se repetir em %d segundos"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rede eD2k desabilitada nas preferências, não conectado."
 
@@ -6445,13 +6452,6 @@ msgstr "%s (%s:%i) parece estar desativado."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar cheio."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Conexão automática com o servidor irá se repetir em %d segundo"
-msgstr[1] "Conexão automática com o servidor irá se repetir em %d segundos"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6451,11 +6451,12 @@ msgstr "Ligação a servidores ofuscados falhou. A tentar de novo, sem ofuscaç�
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Falha ao ligar a todos os servidores listados. A tentar novamente."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Falha ao ligar a todos os servidores listados. A tentar novamente."
 
 #: src/ServerConnect.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6459,6 +6459,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Falha ao ligar a todos os servidores listados. A tentar novamente."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Ligação automática ao servidor irá repetir-se em %d segundo"
+msgstr[1] "Ligação automática ao servidor irá repetir-se em %d segundos"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rede eD2K desactivada nas preferências, a ligação não vai ser feita."
 
@@ -6494,13 +6501,6 @@ msgstr "%s (%s:%i) parece estar morto."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) parece estar cheio."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Ligação automática ao servidor irá repetir-se em %d segundo"
-msgstr[1] "Ligação automática ao servidor irá repetir-se em %d segundos"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6459,11 +6459,12 @@ msgstr "A eșuat conectarea la toate serverele disimulate listate. Se execută u
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "A eșuat conectarea la toate serverele listate. Se execută un alt pas."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "A eșuat conectarea la toate serverele listate. Se execută un alt pas."
 
 #: src/ServerConnect.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6467,6 +6467,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "A eșuat conectarea la toate serverele listate. Se execută un alt pas."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Se va reîncerca conectarea automată la server în %d secundă"
+msgstr[1] "Se va reîncerca conectarea automată la server în %d secunde"
+msgstr[2] "Se va reîncerca conectarea automată la server în %d de secunde"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Rețeaua eD2k este dezactivată în preferințe, nu se conectează."
 
@@ -6502,14 +6510,6 @@ msgstr "%s (%s:%i) par să fie moarte."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) par să fie pline."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Se va reîncerca conectarea automată la server în %d secundă"
-msgstr[1] "Se va reîncerca conectarea automată la server în %d secunde"
-msgstr[2] "Se va reîncerca conectarea automată la server în %d de secunde"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6443,11 +6443,13 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr "Не удалось соединиться ни с одним замаскированным сервером в списке. Повторная попытка, но без маскировки."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
 msgstr "Не удалось подключиться ко всем перечисленным постоянным серверам. Повторная попытка."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Не удалось подключиться ни к одному серверу из списка. Повторная попытка."
 
 #: src/ServerConnect.cpp

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6451,6 +6451,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Не удалось подключиться ни к одному серверу из списка. Повторная попытка."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Автоматическое соединение с сервером будет предпринято через %d секунду"
+msgstr[1] "Автоматическое соединение с сервером будет предпринято через %d секунды"
+msgstr[2] "Автоматическое соединение с сервером будет предпринято через %d секунд"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Сеть eD2k отключена в настройках, не соединяется."
 
@@ -6486,14 +6494,6 @@ msgstr "%s (%s:%i) вероятно умер."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) вероятно заполнен."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Автоматическое соединение с сервером будет предпринято через %d секунду"
-msgstr[1] "Автоматическое соединение с сервером будет предпринято через %d секунды"
-msgstr[2] "Автоматическое соединение с сервером будет предпринято через %d секунд"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6493,11 +6493,12 @@ msgstr "Ni bilo mogoče vzpostaviti maskirane povezave na strežnike na seznamu.
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Ni se bilo mogoče povezati na katerega koli izmed strežnikov na seznamu. Ponoven poskus."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Ni se bilo mogoče povezati na katerega koli izmed strežnikov na seznamu. Ponoven poskus."
 
 #: src/ServerConnect.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6501,6 +6501,15 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Ni se bilo mogoče povezati na katerega koli izmed strežnikov na seznamu. Ponoven poskus."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekund"
+msgstr[1] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekundo"
+msgstr[2] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekundi"
+msgstr[3] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekunde"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "Omrežje eD2k je onemogočeno v nastavitvah, brez povezovanja."
 
@@ -6536,15 +6545,6 @@ msgstr "%s (%s:%i) je nedosegljiv."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) je poln."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekund"
-msgstr[1] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekundo"
-msgstr[2] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekundi"
-msgstr[3] "Samodejen poskus povezovanja na strežnik se bo ponovil čez %d sekunde"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6470,6 +6470,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "E pamundur te lidhem tek serverat qe jane ne liste. Po provoj perseri."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Rilidhje automatike tek serveri do te behet ne %d sekonde"
+msgstr[1] "Rilidhje automatike tek serveri do te behet ne %d sekonda"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6505,13 +6512,6 @@ msgstr "%s (%s:%i) duket sikur nuk ka shenja jete."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) duket sikur eshte plote."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Rilidhje automatike tek serveri do te behet ne %d sekonde"
-msgstr[1] "Rilidhje automatike tek serveri do te behet ne %d sekonda"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6462,11 +6462,12 @@ msgstr "E pamundur te lidhet tek lista e serverave me protokollin e turbullimit.
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "E pamundur te lidhem tek serverat qe jane ne liste. Po provoj perseri."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "E pamundur te lidhem tek serverat qe jane ne liste. Po provoj perseri."
 
 #: src/ServerConnect.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6439,11 +6439,12 @@ msgstr "Det gick inte att ansluta till några fördunkliade servrar i listan. G�
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Misslyckades med att ansluta till alla listade servrar. Gör ett nytt försök."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Misslyckades med att ansluta till alla listade servrar. Gör ett nytt försök."
 
 #: src/ServerConnect.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6447,6 +6447,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Misslyckades med att ansluta till alla listade servrar. Gör ett nytt försök."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Automatisk anslutning till servern testas igen om %d sekund"
+msgstr[1] "Automatisk anslutning till servern testas igen om %d sekunder"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k-nätverket inaktiverad i inställnigarna, ansluter inte."
 
@@ -6482,13 +6489,6 @@ msgstr "%s (%s:%i) verkar vara död."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) verkar vara full."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Automatisk anslutning till servern testas igen om %d sekund"
-msgstr[1] "Automatisk anslutning till servern testas igen om %d sekunder"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6263,6 +6263,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6298,13 +6305,6 @@ msgstr ""
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] ""
-msgstr[1] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6255,11 +6255,11 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+msgid "Failed to connect to all servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6403,11 +6403,13 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr "Listelenen gizlenmiş bağlantılı tüm sunuculara bağlanma başarısız. Gizlenmiş bağlantı olmadan geçiş yapılacak."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
 msgstr "Listelenen statik sunucuların hiç birine bağlanılamadı. Başka bir geçiş yapılıyor."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Listelenen sunucuların hiç birine bağlanılamadı. Başka bir geçiş yapılıyor."
 
 #: src/ServerConnect.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6411,6 +6411,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Listelenen sunucuların hiç birine bağlanılamadı. Başka bir geçiş yapılıyor."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Sunucuya otomatik bağlanma %d saniye içinde tekrar denenecek"
+msgstr[1] "Sunucuya otomatik bağlanma %d saniye içinde tekrar denenecek"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k ağı ayarlarda devre dışı bırakılmış, bağlanılmıyor."
 
@@ -6446,13 +6453,6 @@ msgstr "%s (%s:%i) görünüşe göre ölü."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) görünüşe göre dolu."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Sunucuya otomatik bağlanma %d saniye içinde tekrar denenecek"
-msgstr[1] "Sunucuya otomatik bağlanma %d saniye içinde tekrar denenecek"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6499,11 +6499,12 @@ msgstr "Не вдалося з'єднатися з усіма перелічен
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "Не вдалося з'єднатися з усіма переліченими серверами. Робиться ще одна спроба."
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "Не вдалося з'єднатися з усіма переліченими серверами. Робиться ще одна спроба."
 
 #: src/ServerConnect.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6507,6 +6507,14 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "Не вдалося з'єднатися з усіма переліченими серверами. Робиться ще одна спроба."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "Автоматичне з'єднання з сервером повториться через %d секунду"
+msgstr[1] "Автоматичне з'єднання з сервером повториться через %d секунди"
+msgstr[2] "Автоматичне з'єднання з сервером повториться через %d секунд"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k вимкнена в налаштуваннях, не з'єднується."
 
@@ -6542,14 +6550,6 @@ msgstr "%s (%s:%i) здається мертвий."
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) здається заповнений."
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "Автоматичне з'єднання з сервером повториться через %d секунду"
-msgstr[1] "Автоматичне з'єднання з сервером повториться через %d секунди"
-msgstr[2] "Автоматичне з'єднання з сервером повториться через %d секунд"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6262,6 +6262,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr ""
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr ""
 
@@ -6297,13 +6304,6 @@ msgstr ""
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr ""
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] ""
-msgstr[1] ""
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6254,11 +6254,11 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+msgid "Failed to connect to all servers listed."
 msgstr ""
 
 #: src/ServerConnect.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6406,6 +6406,13 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "无法连接列表中的所有服务器. 开始新的一轮尝试."
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "服务器自动连接会在 %d 秒后重新尝试"
+msgstr[1] "服务器自动连接会在 %d 秒后重新尝试"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "首选项中已禁用eD2k网络，将不会连接。"
 
@@ -6441,13 +6448,6 @@ msgstr "%s（%s：%i）可能已当机"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s（%s：%i）可能已没有空位"
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "服务器自动连接会在 %d 秒后重新尝试"
-msgstr[1] "服务器自动连接会在 %d 秒后重新尝试"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6398,11 +6398,13 @@ msgid "Failed to connect to all obfuscated servers listed. Making another pass w
 msgstr "无法连接至列出的全部模糊协议服务器，尝试不使用模糊协议。"
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all static servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all static servers listed."
 msgstr "无法连接列出的所有静态服务器。开始新的一轮尝试。"
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "无法连接列表中的所有服务器. 开始新的一轮尝试."
 
 #: src/ServerConnect.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:23+0200\n"
+"POT-Creation-Date: 2026-08-10 23:55+0200\n"
 "PO-Revision-Date: 2026-08-09 14:49+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6425,11 +6425,12 @@ msgstr "無法與清單中的模糊伺服器連線，嘗試不使用模糊協定
 
 #: src/ServerConnect.cpp
 #, fuzzy
-msgid "Failed to connect to all static servers listed. Making another pass."
+msgid "Failed to connect to all static servers listed."
 msgstr "無法與清單中的模糊伺服器連線，開始下一輪嘗試。"
 
 #: src/ServerConnect.cpp
-msgid "Failed to connect to all servers listed. Making another pass."
+#, fuzzy
+msgid "Failed to connect to all servers listed."
 msgstr "無法與清單中的模糊伺服器連線，開始下一輪嘗試。"
 
 #: src/ServerConnect.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 21:41+0200\n"
+"POT-Creation-Date: 2026-08-10 23:23+0200\n"
 "PO-Revision-Date: 2026-08-09 14:49+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6433,6 +6433,12 @@ msgid "Failed to connect to all servers listed. Making another pass."
 msgstr "無法與清單中的模糊伺服器連線，開始下一輪嘗試。"
 
 #: src/ServerConnect.cpp
+#, c-format
+msgid "Automatic connection to server will retry in %d second"
+msgid_plural "Automatic connection to server will retry in %d seconds"
+msgstr[0] "在 %d 秒後自動連線到伺服器"
+
+#: src/ServerConnect.cpp
 msgid "eD2k network disabled on preferences, not connecting."
 msgstr "eD2k 網路已在偏好設定中被停用了，未連線。"
 
@@ -6468,12 +6474,6 @@ msgstr "%s (%s:%i) 可能已當機。"
 #, c-format
 msgid "%s (%s:%i) appears to be full."
 msgstr "%s (%s:%i) 可能已客滿。"
-
-#: src/ServerConnect.cpp
-#, c-format
-msgid "Automatic connection to server will retry in %d second"
-msgid_plural "Automatic connection to server will retry in %d seconds"
-msgstr[0] "在 %d 秒後自動連線到伺服器"
 
 #: src/ServerConnect.cpp
 #, c-format

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -87,12 +87,12 @@ void CServerConnect::TryAnotherConnectionrequest()
 					ConnectToAnyServer(false, true);
 					m_recurseTryAnotherConnectionrequest = false;
 				} else {
-					AddLogLineC(
-						staticOnly
-							? _("Failed to connect to all static servers listed. "
-							    "Making another pass.")
-							: _("Failed to connect to all servers listed. Making "
-							    "another pass."));
+					// No "making another pass" here any more: the next one is
+					// the timer's, below.
+					AddLogLineC(staticOnly
+							    ? _("Failed to connect to all static servers "
+								"listed.")
+							    : _("Failed to connect to all servers listed."));
 					// Wait before starting over instead of restarting the sweep
 					// here. Every server having failed says nothing about when
 					// one will answer, and with the link down they all fail the
@@ -104,7 +104,7 @@ void CServerConnect::TryAnotherConnectionrequest()
 					// before. StopConnectionTry() first: it stops the timer, so
 					// arming it earlier would be undone.
 					StopConnectionTry();
-					if (thePrefs::Reconnect() && !m_idRetryTimer.IsRunning()) {
+					if (thePrefs::Reconnect()) {
 						AddLogLineN(
 							CFormat(wxPLURAL(
 								"Automatic connection to server will retry "
@@ -141,6 +141,9 @@ void CServerConnect::ConnectToAnyServer(bool prioSort, bool bNoCrypt)
 	connecting = true;
 	singleconnecting = false;
 	m_bTryObfuscated = thePrefs::IsServerCryptLayerTCPRequested() && !bNoCrypt;
+	// Each sweep judges DNS on its own evidence: whether the link was up
+	// during the last one says nothing about now.
+	m_hostnameResolvedThisSweep = false;
 
 	// Barry - Only auto-connect to static server option
 	if (thePrefs::AutoConnectStaticOnly()) {
@@ -538,6 +541,7 @@ CServerConnect::CServerConnect(CServerList *in_serverlist, amuleIPV4Address &add
 	singleconnecting = false;
 	m_recurseTryAnotherConnectionrequest = false;
 	m_bTryObfuscated = thePrefs::IsServerCryptLayerTCPRequested();
+	m_hostnameResolvedThisSweep = false;
 
 	// initialize socket for udp packets
 	if (thePrefs::GetNetworkED2K()) {

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -141,9 +141,6 @@ void CServerConnect::ConnectToAnyServer(bool prioSort, bool bNoCrypt)
 	connecting = true;
 	singleconnecting = false;
 	m_bTryObfuscated = thePrefs::IsServerCryptLayerTCPRequested() && !bNoCrypt;
-	// Each sweep judges DNS on its own evidence: whether the link was up
-	// during the last one says nothing about now.
-	m_hostnameResolvedThisSweep = false;
 
 	// Barry - Only auto-connect to static server option
 	if (thePrefs::AutoConnectStaticOnly()) {
@@ -206,6 +203,11 @@ void CServerConnect::StopConnectionTry()
 	connectionattemps.clear();
 	connecting = false;
 	singleconnecting = false;
+	// Every sweep ends here, so this is where the DNS evidence expires. Outside
+	// a sweep there is nothing to have proved the resolver works, and a manual
+	// connect judged on a sweep that ran while the link was up would blame a
+	// name that cannot resolve now -- three of those delete the server.
+	m_hostnameResolvedThisSweep = false;
 
 	if (m_idRetryTimer.IsRunning()) {
 		m_idRetryTimer.Stop();

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -67,7 +67,6 @@ void CServerConnect::TryAnotherConnectionrequest()
 
 		if (!next_server) {
 			if (connectionattemps.empty()) {
-				m_recurseTryAnotherConnectionrequest = true;
 				// In static-only mode only static servers were attempted, so say
 				// so rather than implying the whole list failed.
 				const bool staticOnly = thePrefs::AutoConnectStaticOnly();
@@ -80,9 +79,13 @@ void CServerConnect::TryAnotherConnectionrequest()
 							    : _("Failed to connect to all obfuscated servers "
 								"listed. "
 								"Making another pass without obfuscation."));
-					// try all servers on the non-obfuscated port next
+					// try all servers on the non-obfuscated port next. Bounded:
+					// one extra pass with different parameters, after which the
+					// wrap-around below takes over.
+					m_recurseTryAnotherConnectionrequest = true;
 					m_bTryObfuscated = false;
 					ConnectToAnyServer(false, true);
+					m_recurseTryAnotherConnectionrequest = false;
 				} else {
 					AddLogLineC(
 						staticOnly
@@ -90,9 +93,29 @@ void CServerConnect::TryAnotherConnectionrequest()
 							    "Making another pass.")
 							: _("Failed to connect to all servers listed. Making "
 							    "another pass."));
-					ConnectToAnyServer(false);
+					// Wait before starting over instead of restarting the sweep
+					// here. Every server having failed says nothing about when
+					// one will answer, and with the link down they all fail the
+					// moment they are tried -- so the immediate restart this
+					// replaces meant a full pass per second, for as long as the
+					// outage lasted. The same timer the CS_FATALERROR path uses,
+					// so a caller that switched auto-reconnect off now gets what
+					// it asked for here too; it never consulted the setting
+					// before. StopConnectionTry() first: it stops the timer, so
+					// arming it earlier would be undone.
+					StopConnectionTry();
+					if (thePrefs::Reconnect() && !m_idRetryTimer.IsRunning()) {
+						AddLogLineN(
+							CFormat(wxPLURAL(
+								"Automatic connection to server will retry "
+								"in %d second",
+								"Automatic connection to server will retry "
+								"in %d seconds",
+								CS_RETRYCONNECTTIME)) %
+							CS_RETRYCONNECTTIME);
+						m_idRetryTimer.Start(1000 * CS_RETRYCONNECTTIME);
+					}
 				}
-				m_recurseTryAnotherConnectionrequest = false;
 			}
 			return;
 		}

--- a/src/ServerConnect.h
+++ b/src/ServerConnect.h
@@ -107,6 +107,21 @@ public:
 	bool AwaitingTestFromIP(uint32 ip);
 	bool IsConnectedObfuscated() const;
 
+	//! Records that a server's hostname resolved during the current sweep.
+	void NoteHostnameResolved() { m_hostnameResolvedThisSweep = true; }
+
+	/**
+	 * Whether DNS has answered for anything since this sweep began.
+	 *
+	 * A server whose hostname does not resolve is the commonest way an eD2k
+	 * server dies, and pruning it is the point of "remove dead servers" -- but
+	 * with the link down nothing resolves, and blaming the whole list for that
+	 * is what emptied it (issue #887). One server failing to resolve while
+	 * others answered is the case that says something about that server, and
+	 * this is what separates the two.
+	 */
+	bool HostnameResolvedThisSweep() const { return m_hostnameResolvedThisSweep; }
+
 	/**
 	 * Called when a socket has been DNS resolved.
 	 *
@@ -125,6 +140,8 @@ private:
 	int8 max_simcons;
 	bool m_bTryObfuscated;
 	bool m_recurseTryAnotherConnectionrequest;
+	//! See HostnameResolvedThisSweep(); reset as each sweep starts.
+	bool m_hostnameResolvedThisSweep;
 	CServerSocket *connectedsocket;
 	CServerList *used_list;
 	CServerUDPSocket *serverudpsocket;

--- a/src/ServerConnect.h
+++ b/src/ServerConnect.h
@@ -111,7 +111,7 @@ public:
 	void NoteHostnameResolved() { m_hostnameResolvedThisSweep = true; }
 
 	/**
-	 * Whether DNS has answered for anything since this sweep began.
+	 * Whether a resolver has answered since the current sweep began.
 	 *
 	 * A server whose hostname does not resolve is the commonest way an eD2k
 	 * server dies, and pruning it is the point of "remove dead servers" -- but
@@ -119,6 +119,11 @@ public:
 	 * is what emptied it (issue #887). One server failing to resolve while
 	 * others answered is the case that says something about that server, and
 	 * this is what separates the two.
+	 *
+	 * Only a lookup that actually ran counts: most of server.met carries an
+	 * address already, and going straight to connect proves nothing about the
+	 * resolver. Cleared by StopConnectionTry(), which every sweep ends at, so
+	 * a connect made outside one is never judged on an earlier sweep's link.
 	 */
 	bool HostnameResolvedThisSweep() const { return m_hostnameResolvedThisSweep; }
 

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -99,15 +99,41 @@ void CServerSocket::OnConnect(int nErrorCode)
 		SetConnectionState(CS_WAITFORLOGIN);
 		break;
 
-	case boost::system::errc::address_in_use:
-	case boost::system::errc::address_not_available:
-	case boost::system::errc::bad_address:
+	// Only what the server itself answered counts against it, because
+	// CS_SERVERDEAD is what raises its failed count -- and a server whose
+	// count passes the "remove dead servers" threshold is deleted from the
+	// list for good. It refused the connection, or it accepted the SYN and
+	// then said nothing: either is evidence about that server.
 	case boost::system::errc::connection_refused:
-	case boost::system::errc::host_unreachable:
-	case boost::system::errc::invalid_argument:
 	case boost::system::errc::timed_out:
 		m_bIsDeleting = true;
 		SetConnectionState(CS_SERVERDEAD);
+		serverconnect->DestroySocket(this);
+		return;
+
+	// Not the server's doing, so it keeps its failed count -- but the sweep
+	// carries on to the next candidate, which is what separates these from
+	// the CS_FATALERROR default below. "No route to this host" is what every
+	// server in the list answers within seconds once the link is down, and
+	// the whole list used to accrue failures that way and then be deleted the
+	// moment connectivity returned, since RemoveDeadServers() only runs after
+	// a connection succeeds. The rest are local socket faults (address in use
+	// or not available, a bad address, an invalid argument) that were never
+	// about the server either.
+	//
+	// Deliberately not CS_FATALERROR: that one calls StopConnectionTry() and
+	// waits CS_RETRYCONNECTTIME before trying anything else, which is right
+	// when the whole network is gone (errc::network_unreachable and friends
+	// still land there, via default) but wrong for one unreachable host --
+	// a single stale entry would otherwise stall the sweep for 30 seconds
+	// instead of aMule moving on to the next server.
+	case boost::system::errc::address_in_use:
+	case boost::system::errc::address_not_available:
+	case boost::system::errc::bad_address:
+	case boost::system::errc::host_unreachable:
+	case boost::system::errc::invalid_argument:
+		m_bIsDeleting = true;
+		SetConnectionState(CS_ERROR);
 		serverconnect->DestroySocket(this);
 		return;
 

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -111,15 +111,24 @@ void CServerSocket::OnConnect(int nErrorCode)
 		serverconnect->DestroySocket(this);
 		return;
 
-	// Not the server's doing, so it keeps its failed count -- but the sweep
-	// carries on to the next candidate, which is what separates these from
-	// the CS_FATALERROR default below. "No route to this host" is what every
-	// server in the list answers within seconds once the link is down, and
-	// the whole list used to accrue failures that way and then be deleted the
-	// moment connectivity returned, since RemoveDeadServers() only runs after
-	// a connection succeeds. The rest are local socket faults (address in use
-	// or not available, a bad address, an invalid argument) that were never
-	// about the server either.
+	// Not counted against the server, but the sweep still carries on to the
+	// next candidate -- which is what separates these from the CS_FATALERROR
+	// default below.
+	//
+	// host_unreachable is the one that matters and the one that is ambiguous:
+	// a router can report it by ICMP for a remote host that genuinely no
+	// longer routes, so it is not purely a fault at our end. It is classified
+	// here anyway because of how it fails when it is ours: with the link down
+	// every server in the list answers that way within milliseconds, so the
+	// whole list used to accrue failures and then be deleted the moment
+	// connectivity returned -- RemoveDeadServers() only runs after a
+	// connection succeeds. A server that has genuinely stopped routing still
+	// gets counted, through the timeouts and the UDP pings that reach it by
+	// other paths; the cost of the wrong call the other way is the list.
+	//
+	// The rest are unambiguous local socket faults -- an address in use or not
+	// available, a bad address, an invalid argument -- and were never about
+	// the server at all.
 	//
 	// Deliberately not CS_FATALERROR: that one calls StopConnectionTry() and
 	// waits CS_RETRYCONNECTTIME before trying anything else, which is right
@@ -751,6 +760,11 @@ void CServerSocket::OnHostnameResolved(uint32 ip)
 
 	m_IsSolving = false;
 	if (ip) {
+		// DNS answered, so a *different* server failing to resolve during this
+		// sweep is about that server rather than about our link -- see
+		// CServerConnect::HostnameResolvedThisSweep().
+		serverconnect->NoteHostnameResolved();
+
 		if (theApp->ipfilter->IsFiltered(ip, true)) {
 			AddLogLineC(CFormat(_("Server IP %s (%s) is filtered.  Not connecting.")) %
 				    Uint32toStringIP(ip) % cur_server->GetAddress());
@@ -785,7 +799,25 @@ void CServerSocket::OnHostnameResolved(uint32 ip)
 	} else {
 		AddLogLineC(CFormat(_("Could not solve dns for server %s: Unable to connect!")) %
 			    cur_server->GetAddress());
-		OnConnect(boost::system::errc::host_unreachable);
+
+		// Decided here rather than by handing OnConnect() a synthesised
+		// host_unreachable, which is what this used to do: a name that does not
+		// resolve is not a socket error, and the two want opposite answers.
+		//
+		// An unresolvable hostname is the commonest way an eD2k server actually
+		// dies, so this is the main thing "remove dead servers" prunes on, and
+		// it has to keep working. But with the link down nothing resolves, and
+		// counting that against every server in turn is what emptied the list
+		// (issue #887). Blame it only once DNS has answered for something else
+		// this sweep -- then the failure is about this server, not about us.
+		//
+		// The first server in a sweep therefore cannot be blamed, since nothing
+		// has resolved yet; a genuinely dead entry is caught on a later sweep
+		// instead. Erring that way costs a delay, while erring the other way
+		// costs the server list.
+		m_bIsDeleting = true;
+		SetConnectionState(serverconnect->HostnameResolvedThisSweep() ? CS_SERVERDEAD : CS_ERROR);
+		serverconnect->DestroySocket(this);
 	}
 }
 uint32 CServerSocket::GetServerIP() const

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -122,9 +122,10 @@ void CServerSocket::OnConnect(int nErrorCode)
 	// every server in the list answers that way within milliseconds, so the
 	// whole list used to accrue failures and then be deleted the moment
 	// connectivity returned -- RemoveDeadServers() only runs after a
-	// connection succeeds. A server that has genuinely stopped routing still
-	// gets counted, through the timeouts and the UDP pings that reach it by
-	// other paths; the cost of the wrong call the other way is the list.
+	// connection succeeds. A server that has genuinely stopped routing is
+	// still counted by the UDP status pings, which run while connected to
+	// some other server and have their own AddFailedCount(); it is no longer
+	// counted here, and the cost of the wrong call the other way is the list.
 	//
 	// The rest are unambiguous local socket faults -- an address in use or not
 	// available, a bad address, an invalid argument -- and were never about
@@ -758,12 +759,20 @@ void CServerSocket::SendPacket(CPacket *packet, bool delpacket, bool controlpack
 void CServerSocket::OnHostnameResolved(uint32 ip)
 {
 
+	// ConnectToServer() calls straight in here with the address it already had
+	// whenever no lookup was needed, which is most of server.met -- and that
+	// path succeeds just as well with the link down. Only a resolver that
+	// actually answered is evidence about DNS, so record what got us here
+	// before the flag is cleared.
+	const bool didLookup = m_IsSolving;
 	m_IsSolving = false;
 	if (ip) {
-		// DNS answered, so a *different* server failing to resolve during this
-		// sweep is about that server rather than about our link -- see
-		// CServerConnect::HostnameResolvedThisSweep().
-		serverconnect->NoteHostnameResolved();
+		if (didLookup) {
+			// DNS answered, so a *different* server failing to resolve during
+			// this sweep is about that server rather than about our link --
+			// see CServerConnect::HostnameResolvedThisSweep().
+			serverconnect->NoteHostnameResolved();
+		}
 
 		if (theApp->ipfilter->IsFiltered(ip, true)) {
 			AddLogLineC(CFormat(_("Server IP %s (%s) is filtered.  Not connecting.")) %


### PR DESCRIPTION
Reported in #887: with the internet connection down, aMule sweeps the whole server list several times a second, marks every server dead, and (with "remove dead servers" on, the default) empties the list.

## Servers were blamed for failures at our end

`CS_SERVERDEAD` is the only state that raises a server's failed count, and a server past the threshold is deleted for good. Five error codes were reaching it that are not the server's answer: `host_unreachable`, `address_in_use`, `address_not_available`, `bad_address`, `invalid_argument`.

`host_unreachable` is the one that mattered, and it is genuinely ambiguous: a router also reports it by ICMP for a remote host that no longer routes, so it is not purely a fault at our end. It is reclassified anyway because of how it fails when it is ours. With the link down every server answers that way in milliseconds, so each sweep costs the whole list a failure. Nothing is visible while it happens, because `RemoveDeadServers()` only runs after a connection succeeds, which is why the list appears to be wiped by the reconnect rather than by the outage. A server that has genuinely stopped routing is still counted by the UDP status pings, which increment on send and reset only on reply (`ServerList.cpp:351`); it is no longer counted over TCP, and the cost of the wrong call in the other direction is the whole list.

These now report `CS_ERROR`: not counted against the server, but the sweep still moves straight to the next candidate. Deliberately not `CS_FATALERROR`, which stops the sweep and waits. That is right when the whole network is gone (`network_unreachable` and friends still land there) and wrong for one unreachable host.

`connection_refused` and `timed_out` are unchanged.

## A hostname that will not resolve is judged on its own evidence

`OnHostnameResolved()` reported a name it could not resolve by synthesising `host_unreachable`, so the reclassification above would have silently changed DNS handling too. Since an unresolvable hostname is the commonest way an eD2k server actually dies, that would have left "remove dead servers" pruning on `connection_refused` and `timed_out` alone.

DNS is now decided where it happens rather than routed through `OnConnect()`, and it still counts against the server, but only when a lookup that actually ran has answered during the same sweep. Most of `server.met` carries an address already and goes straight to connect, which proves nothing about the resolver and succeeds just as well with the link down, so those entries are not evidence. The condition is therefore that some *other* hostname-based server resolved during the sweep.

What that means in practice:

- Several dyndns entries in the list: one failing while the others resolve is blamed, as before.
- A single dyndns entry among static-IP servers, which is the common shape: nothing else ever runs a lookup, so that entry is never blamed through DNS on any sweep. It is still pruned, by the UDP status pings described above, which increment on send, reset only on reply, and remove at the threshold.
- Nothing resolving at all, which is the outage case: no server is blamed, which is the point.

So DNS-based pruning now needs at least two name-resolving servers in the list. Below that the UDP path carries it. The failure this trades away is the one that emptied the list.

## The sweep never paused

`TryAnotherConnectionrequest()` called `ConnectToAnyServer()` straight back when a pass failed, resetting the cursor and starting over with nothing bounding it. A failed connect returns immediately rather than waiting on a SYN timeout, so that is a full pass every second or so.

The wrap-around now goes through the retry timer the `CS_FATALERROR` path already uses: stop, and come back in `CS_RETRYCONNECTTIME` (30 s). The obfuscated to plaintext fallback stays immediate, being one bounded extra pass.

Two consequences worth stating outright:

- **This path now honours `thePrefs::Reconnect()`**, which it never consulted. With auto-reconnect off, a failed sweep now stops for good rather than looping. That is correct, but a user relying on the old unbounded sweep will experience it as *"aMule stopped reconnecting after the update"*.
- **"Making another pass." had become false**, sitting directly above a line announcing a 30-second wait, and it is the line a user watches during exactly the outage this fixes. The clause is dropped from the two variants that no longer make an immediate pass; the two obfuscation variants still do and keep theirs. Both come back fuzzy rather than untranslated, so the old text is pre-filled for translators.

## Not included

The connectivity checker proposed in #887. The error codes already carry the information locally, so a probe would add a third-party dependency, a host that eventually rots, and false negatives wherever ICMP or port 4661 is blocked.

## Testing

Reproduced headlessly on an Ubuntu ARM64 VM by adding `ip route add unreachable 203.0.113.0/24`, so the kernel returns a genuine `EHOSTUNREACH` for a list of five servers in that range. Baseline is `b64d3840c`, 75 s of observation each, identical config.

| | baseline | patched |
|---|---|---|
| servers marked dead | 155 | **0** |
| sweeps exhausted | 63 | 6 |
| retry timer armed | 0 | 3 |
| interval between sweeps | ~1 s | **30 s** |

Patched sweep timestamps: `00:17:58`, `00:17:59`, `00:18:29`, `00:18:30`, `00:19:00`, `00:19:01`. The pairs one second apart are the obfuscated and plaintext passes; the 30 s gaps are the timer.

Happy path re-checked separately with real servers and no route interference: the patched daemon downloads the list, connects, and holds the connection as before.

Not exercised at runtime: the DNS branch. Adding a dyndns server needs a hand-written `server.met` tag record, since `ed2k://|server|...` links take an IP only. That path is covered by reading and by review, not by a test.

macOS build clean; clang-format 18 and both clang-tidy tiers clean. POT msgid count is 1970 either side, two strings replaced by two.
