### PR TITLE
Rework the statistics and Kad graphs: renderer, hover readout, and history depth

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2729,6 +2729,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr ""
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3669,18 +3681,6 @@ msgid "Download-Speed"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:16+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2764,6 +2764,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "الحالي"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "معدل العمل"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "معدل الجلسة"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3717,18 +3729,6 @@ msgid "Download-Speed"
 msgstr "سرعة-التحميل"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "الحالي"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "معدل العمل"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "معدل الجلسة"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "سرعة-الرفع"
 
@@ -3736,7 +3736,7 @@ msgstr "سرعة-الرفع"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "تحميل نشط"
 
@@ -3744,7 +3744,7 @@ msgstr "تحميل نشط"
 msgid "Active connections (1:1)"
 msgstr "إتصال نشط (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "رفع نشط"
 
@@ -4352,7 +4352,7 @@ msgstr "معدل رفع الحالي"
 msgid "Upload session average"
 msgstr "معدل رفع الجلسة"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "اتصال نشط"
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:17+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2818,6 +2818,18 @@ msgstr "Fallu al renomar el nuevu ficheru GeoIP.dat, albortando actualización."
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Actual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Media d'execución"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Media de la sesión"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3782,18 +3794,6 @@ msgid "Download-Speed"
 msgstr "Velocidá de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Actual"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Media d'execución"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Media de la sesión"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidá de xuba"
 
@@ -3801,7 +3801,7 @@ msgstr "Velocidá de xuba"
 msgid "Connections"
 msgstr "Conexones"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Descargues actives"
 
@@ -3809,7 +3809,7 @@ msgstr "Descargues actives"
 msgid "Active connections (1:1)"
 msgstr "Conexones actives (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Xubes actives"
 
@@ -4423,7 +4423,7 @@ msgstr "Promediu Xuba/tiempu"
 msgid "Upload session average"
 msgstr "Promediu xuba/sesión"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Conexones actives"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2759,6 +2759,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Текущ"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr ""
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3709,18 +3721,6 @@ msgid "Download-Speed"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Текущ"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
@@ -3728,7 +3728,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr ""
 
@@ -3736,7 +3736,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr ""
 
@@ -4345,7 +4345,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2728,6 +2728,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr ""
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3668,18 +3680,6 @@ msgid "Download-Speed"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2808,6 +2808,18 @@ msgstr "Fallada al canviar de nom el nou fitxer %s, actualització interrompuda.
 msgid "IP filter is ready"
 msgstr "El filtre d'IP està llest"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Actual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Mitjana total"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Mitjana de la sessió"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3771,18 +3783,6 @@ msgid "Download-Speed"
 msgstr "Velocitat de baixada"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Actual"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Mitjana total"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Mitjana de la sessió"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocitat de pujada"
 
@@ -3790,7 +3790,7 @@ msgstr "Velocitat de pujada"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Baixades actives"
 
@@ -3798,7 +3798,7 @@ msgstr "Baixades actives"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Pujades actives"
 
@@ -4411,7 +4411,7 @@ msgstr "Mitjana de pujada total"
 msgid "Upload session average"
 msgstr "Mitjana de pujada de la sessió"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Connexions actives"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:20+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2801,6 +2801,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr "IP filtr je připraven"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Průměr sezení"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3767,18 +3779,6 @@ msgid "Download-Speed"
 msgstr "Rychlost stahování"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Průměr sezení"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Rychlost odesílání"
 
@@ -3786,7 +3786,7 @@ msgstr "Rychlost odesílání"
 msgid "Connections"
 msgstr "Připojení"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktivní stahování"
 
@@ -3794,7 +3794,7 @@ msgstr "Aktivní stahování"
 msgid "Active connections (1:1)"
 msgstr "Aktivní připojení (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktivní odesílání"
 
@@ -4407,7 +4407,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktivní připojení"
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2770,6 +2770,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Nuværende"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Nuværende Gennemsnit"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Sessions Gennemsnit"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3730,18 +3742,6 @@ msgid "Download-Speed"
 msgstr "Download-Hastighed"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Nuværende"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Nuværende Gennemsnit"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Sessions Gennemsnit"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Upload-Hastighed"
 
@@ -3749,7 +3749,7 @@ msgstr "Upload-Hastighed"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3757,7 +3757,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Forbindelser (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktive Forbindelser"
 

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2813,6 +2813,18 @@ msgstr "Das Umbenennen der neuen %s-Datei ist fehlgeschlagen, breche Aktualisier
 msgid "IP filter is ready"
 msgstr "IP-Filter ist bereit"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Aktuell"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "gleitender Mittelwert"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Sitzungsdurchschnitt"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3769,18 +3781,6 @@ msgid "Download-Speed"
 msgstr "Download-Geschwindigkeit"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Aktuell"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "gleitender Mittelwert"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Sitzungsdurchschnitt"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Upload-Geschwindigkeit"
 
@@ -3788,7 +3788,7 @@ msgstr "Upload-Geschwindigkeit"
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktive Downloads"
 
@@ -3796,7 +3796,7 @@ msgstr "Aktive Downloads"
 msgid "Active connections (1:1)"
 msgstr "Aktive Verbindungen (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktive Uploads"
 
@@ -4410,7 +4410,7 @@ msgstr "Upload: Durchschnitt"
 msgid "Upload session average"
 msgstr "Upload: Sitzungsdurchschnitt"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktive Verbindungen"
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:23+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2827,6 +2827,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Τρέχων"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Μέσο τρεξίματος"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Μέσο περιόδου"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3793,18 +3805,6 @@ msgid "Download-Speed"
 msgstr "Ταχύτητα κατεβάσματος"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Τρέχων"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Μέσο τρεξίματος"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Μέσο περιόδου"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Ταχύτητα ανεβάσματος"
 
@@ -3812,7 +3812,7 @@ msgstr "Ταχύτητα ανεβάσματος"
 msgid "Connections"
 msgstr "Συνδέσεις"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Ενεργά κατεβάσματα"
 
@@ -3820,7 +3820,7 @@ msgstr "Ενεργά κατεβάσματα"
 msgid "Active connections (1:1)"
 msgstr "Ενεργές συνδέσεις (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Ενεργά ανεβάσματα"
 
@@ -4434,7 +4434,7 @@ msgstr "Μέσο τρέξιμο ανεβάσματος"
 msgid "Upload session average"
 msgstr "Μέσο συνεδρίας ανεβάσματος"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Ενεργές συνδέσεις"
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2729,6 +2729,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr ""
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3669,18 +3681,6 @@ msgid "Download-Speed"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:24+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2816,6 +2816,18 @@ msgstr "Error al renombrar el nuevo archivo %s, actualización cancelada."
 msgid "IP filter is ready"
 msgstr "El filtro de IP está listo"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Actual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Media de ejecución"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Media de la sesión"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3762,18 +3774,6 @@ msgid "Download-Speed"
 msgstr "Velocidad de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Actual"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Media de ejecución"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Media de la sesión"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidad de subida"
 
@@ -3781,7 +3781,7 @@ msgstr "Velocidad de subida"
 msgid "Connections"
 msgstr "Conexiones"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3789,7 +3789,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexiones activas (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Subidas activas"
 
@@ -4400,7 +4400,7 @@ msgstr "Promedio de subida en ejecución"
 msgid "Upload session average"
 msgstr "Promedio de subida en la sesión"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Conexiones activas"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2809,6 +2809,18 @@ msgstr "Faili %s ümbernimetamine ebaõnnestus, katkestan uuendamise."
 msgid "IP filter is ready"
 msgstr "IP filter on lähtestatud"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Hetkel"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Hetke keskmine"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Seansi keskmine"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3772,18 +3784,6 @@ msgid "Download-Speed"
 msgstr "Tõmbamise kiirus"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Hetkel"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Hetke keskmine"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Seansi keskmine"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Saatmise kiirus"
 
@@ -3791,7 +3791,7 @@ msgstr "Saatmise kiirus"
 msgid "Connections"
 msgstr "Ühendused"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktiivsed tõmbamised"
 
@@ -3799,7 +3799,7 @@ msgstr "Aktiivsed tõmbamised"
 msgid "Active connections (1:1)"
 msgstr "Aktiivseid ühendusi (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktiivsed saatmised"
 
@@ -4412,7 +4412,7 @@ msgstr "Hetke saatmise keskmine"
 msgid "Upload session average"
 msgstr "Seansi keskmine saatmine"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktiivseid ühendusi"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2810,6 +2810,18 @@ msgstr "Huts %s fitxategi berria berrizendatzean, eguneraketa baztertzen."
 msgid "IP filter is ready"
 msgstr "IP iragazkia presta dago"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Unekoa"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Funtzionamendu bataz bestekoa"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "saio batez bestekoa"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3773,18 +3785,6 @@ msgid "Download-Speed"
 msgstr "Deskarga abiadura"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Unekoa"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Funtzionamendu bataz bestekoa"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "saio batez bestekoa"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Igoera abiadura"
 
@@ -3792,7 +3792,7 @@ msgstr "Igoera abiadura"
 msgid "Connections"
 msgstr "Konexioak"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Deskarga aktiboak"
 
@@ -3800,7 +3800,7 @@ msgstr "Deskarga aktiboak"
 msgid "Active connections (1:1)"
 msgstr "konexio aktiboak (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Igoera aktiboak"
 
@@ -4413,7 +4413,7 @@ msgstr "Martxan igoerak bataz bestean"
 msgid "Upload session average"
 msgstr "Saioaren bataz besteko igoerak"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Konexio aktiboak"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:26+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2810,6 +2810,18 @@ msgstr "Uuden tiedoston %s uudelleennimeäminen epäonnistui, keskeytän päivit
 msgid "IP filter is ready"
 msgstr "IP-suodatin on valmiina"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Nykyinen"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Yhtäjaksoinen keskiarvo"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Session keskiarvo"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3773,18 +3785,6 @@ msgid "Download-Speed"
 msgstr "Latausnopeus"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Nykyinen"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Yhtäjaksoinen keskiarvo"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Session keskiarvo"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Lähetysnopeus"
 
@@ -3792,7 +3792,7 @@ msgstr "Lähetysnopeus"
 msgid "Connections"
 msgstr "Yhteydet"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktiiviset lataukset"
 
@@ -3800,7 +3800,7 @@ msgstr "Aktiiviset lataukset"
 msgid "Active connections (1:1)"
 msgstr "Aktiiviset yhteydet (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktiiviset lähetykset"
 
@@ -4413,7 +4413,7 @@ msgstr "Lähetyksen yhtäjaksoinen keskiarvo"
 msgid "Upload session average"
 msgstr "Lähetyksen keskiarvo sessiossa"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktiiviset yhteydet"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:27+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2814,6 +2814,18 @@ msgstr "Impossible de renommer le nouveau fichier %s, abandon de la mise à jour
 msgid "IP filter is ready"
 msgstr "IP filter est prêt"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Actuelle"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Moyenne totale"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Moyenne de la session"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3760,18 +3772,6 @@ msgid "Download-Speed"
 msgstr "Vitesse de réception"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Actuelle"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Moyenne totale"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Moyenne de la session"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Vitesse d'émission"
 
@@ -3779,7 +3779,7 @@ msgstr "Vitesse d'émission"
 msgid "Connections"
 msgstr "Connexions"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Téléchargements actifs"
 
@@ -3787,7 +3787,7 @@ msgstr "Téléchargements actifs"
 msgid "Active connections (1:1)"
 msgstr "Connexions actives (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Envois actifs"
 
@@ -4398,7 +4398,7 @@ msgstr "Envoi moyen total"
 msgid "Upload session average"
 msgstr "Envoi moyen sur la session"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Connexions actives"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:28+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2826,6 +2826,18 @@ msgstr "Non se lle puido cambiar o nome ao ficheiro %s, cancelando actualizació
 msgid "IP filter is ready"
 msgstr "O filtro de IP está listo"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Actual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Media de execución"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Media de sesión"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3782,18 +3794,6 @@ msgid "Download-Speed"
 msgstr "Velocidade de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Actual"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Media de execución"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Media de sesión"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidade de envío"
 
@@ -3801,7 +3801,7 @@ msgstr "Velocidade de envío"
 msgid "Connections"
 msgstr "Conexións"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Descargas activas"
 
@@ -3809,7 +3809,7 @@ msgstr "Descargas activas"
 msgid "Active connections (1:1)"
 msgstr "Conexións activas (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Envíos activos"
 
@@ -4423,7 +4423,7 @@ msgstr "Media de subida en execución"
 msgid "Upload session average"
 msgstr "Media de subida na sesión"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Conexións activas"
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:29+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2782,6 +2782,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "נוכחיים"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "ממוצע רץ"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "ממוצע ההרצה הנוכחית"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3744,18 +3756,6 @@ msgid "Download-Speed"
 msgstr "מהירות הורדה"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "נוכחיים"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "ממוצע רץ"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "ממוצע ההרצה הנוכחית"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "מהירות-העלאה"
 
@@ -3763,7 +3763,7 @@ msgstr "מהירות-העלאה"
 msgid "Connections"
 msgstr "חיבורים"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "הורדות פעילות"
 
@@ -3771,7 +3771,7 @@ msgstr "הורדות פעילות"
 msgid "Active connections (1:1)"
 msgstr "חיבורים פעילים (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "העלאות פעילים"
 
@@ -4380,7 +4380,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2779,6 +2779,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Trenutno"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Prosjek rada"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Prosjek misije"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3739,18 +3751,6 @@ msgid "Download-Speed"
 msgstr "Brzina downloada"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Trenutno"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Prosjek rada"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Prosjek misije"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Brzina uploada"
 
@@ -3758,7 +3758,7 @@ msgstr "Brzina uploada"
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktivni downloadovi"
 
@@ -3766,7 +3766,7 @@ msgstr "Aktivni downloadovi"
 msgid "Active connections (1:1)"
 msgstr "Aktivne veze (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktivni uploadovi"
 
@@ -4375,7 +4375,7 @@ msgstr "Prosjek tekuceg uploada"
 msgid "Upload session average"
 msgstr "Prosjek uploada misije"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktivne veze"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2798,6 +2798,18 @@ msgstr "Új %s fájl átnevezése sikertelen, frissítés megszakítása."
 msgid "IP filter is ready"
 msgstr "IP szűrő készen áll"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Aktuális"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Futásátlag"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Munkafolyamatok átlaga"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3751,18 +3763,6 @@ msgid "Download-Speed"
 msgstr "Letöltési sebesség"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Aktuális"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Futásátlag"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Munkafolyamatok átlaga"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Feltöltési sebesség"
 
@@ -3770,7 +3770,7 @@ msgstr "Feltöltési sebesség"
 msgid "Connections"
 msgstr "Kapcsolatok"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktív letöltések"
 
@@ -3778,7 +3778,7 @@ msgstr "Aktív letöltések"
 msgid "Active connections (1:1)"
 msgstr "Aktív kapcsolatok (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktív feltöltések"
 
@@ -4392,7 +4392,7 @@ msgstr "Feltöltési futás átlaga"
 msgid "Upload session average"
 msgstr "Feltöltési folyamatok átlaga"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktív kapcsolatok"
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:37+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2825,6 +2825,18 @@ msgstr "Impossibile rinominare il nuovo file %s, interruzione aggiornamento."
 msgid "IP filter is ready"
 msgstr "Filtro IP pronto"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Corrente"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Media attuale"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Media sessione"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3767,18 +3779,6 @@ msgid "Download-Speed"
 msgstr "Velocità download"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Corrente"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Media attuale"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Media sessione"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocità upload"
 
@@ -3786,7 +3786,7 @@ msgstr "Velocità upload"
 msgid "Connections"
 msgstr "Connessioni"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Download attivi"
 
@@ -3794,7 +3794,7 @@ msgstr "Download attivi"
 msgid "Active connections (1:1)"
 msgstr "Connessioni attive (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Upload attivi"
 
@@ -4402,7 +4402,7 @@ msgstr "Media upload in corso"
 msgid "Upload session average"
 msgstr "Media sessione di upload"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Connessioni attive"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2810,6 +2810,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "現在"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "移動平均"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "セッション平均"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3770,18 +3782,6 @@ msgid "Download-Speed"
 msgstr "ダウンロード速度："
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "現在"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "移動平均"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "セッション平均"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "アップロード速度"
 
@@ -3789,7 +3789,7 @@ msgstr "アップロード速度"
 msgid "Connections"
 msgstr "接続数"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "アクティブなダウンロード数"
 
@@ -3797,7 +3797,7 @@ msgstr "アクティブなダウンロード数"
 msgid "Active connections (1:1)"
 msgstr "アクティブな接続（1:1）"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "アクティブなアップロード数"
 
@@ -4409,7 +4409,7 @@ msgstr "アップロード移動平均"
 msgid "Upload session average"
 msgstr "アップロードセッション平均"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "アクティブ接続数"
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2828,6 +2828,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "현재"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "동작중 평균"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "세션 평균"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3791,18 +3803,6 @@ msgid "Download-Speed"
 msgstr "내려받기 속도"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "현재"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "동작중 평균"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "세션 평균"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "올려주기 속도"
 
@@ -3810,7 +3810,7 @@ msgstr "올려주기 속도"
 msgid "Connections"
 msgstr "연결"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "활성화된 내려받기"
 
@@ -3818,7 +3818,7 @@ msgstr "활성화된 내려받기"
 msgid "Active connections (1:1)"
 msgstr "활성화된 연결 (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "활성화된 올려주기"
 
@@ -4430,7 +4430,7 @@ msgstr "올려주기 운용 평균"
 msgid "Upload session average"
 msgstr "올려주기 세션 평균"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "활성화된 연결"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:40+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2837,6 +2837,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Dabartinė sparta"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Dabartinis vidurkis"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Seanso vidurkis"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3804,18 +3816,6 @@ msgid "Download-Speed"
 msgstr "Atsiuntimo sparta"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Dabartinė sparta"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Dabartinis vidurkis"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Seanso vidurkis"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Išsiuntimo sparta"
 
@@ -3823,7 +3823,7 @@ msgstr "Išsiuntimo sparta"
 msgid "Connections"
 msgstr "Ryšiai"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktyvūs atsiuntimai"
 
@@ -3831,7 +3831,7 @@ msgstr "Aktyvūs atsiuntimai"
 msgid "Active connections (1:1)"
 msgstr "Aktyvūs ryšiai (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktyvūs išsiuntimai"
 
@@ -4443,7 +4443,7 @@ msgstr "Dabartinis išsiuntimo vidurkis"
 msgid "Upload session average"
 msgstr "Seanso išsiuntimo vidurkis"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktyvūs ryšiai"
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2745,6 +2745,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Pašreizējais"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Visu laiku vidējais"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Sesijas vidējais"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3691,18 +3703,6 @@ msgid "Download-Speed"
 msgstr "Lejupielādes ātrums"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Pašreizējais"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Visu laiku vidējais"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Sesijas vidējais"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Augšupielādes ātrums"
 
@@ -3710,7 +3710,7 @@ msgstr "Augšupielādes ātrums"
 msgid "Connections"
 msgstr "Savienojumi"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktīvas lejupielādes"
 
@@ -3718,7 +3718,7 @@ msgstr "Aktīvas lejupielādes"
 msgid "Active connections (1:1)"
 msgstr "Aktīvi savienojumi (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktīvas augšupielādes"
 
@@ -4326,7 +4326,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktīvi savienojumi"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:41+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2812,6 +2812,18 @@ msgstr "Kon nieuw bestand %s niet hernoemen, update wordt gestopt."
 msgid "IP filter is ready"
 msgstr "IP-filter is klaar"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Huidige"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Lopende gemiddelde"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Sessie gemiddelde"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3776,18 +3788,6 @@ msgid "Download-Speed"
 msgstr "Downloadsnelheid"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Huidige"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Lopende gemiddelde"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Sessie gemiddelde"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Uploadsnelheid"
 
@@ -3795,7 +3795,7 @@ msgstr "Uploadsnelheid"
 msgid "Connections"
 msgstr "Verbindingen"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Actieve downloads"
 
@@ -3803,7 +3803,7 @@ msgstr "Actieve downloads"
 msgid "Active connections (1:1)"
 msgstr "Actieve verbinding (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Actieve uploads"
 
@@ -4416,7 +4416,7 @@ msgstr "Lopend gemiddelde upload"
 msgid "Upload session average"
 msgstr "Sessie gemiddelde upload"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Actieve verbindingen"
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:42+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2826,6 +2826,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Novérande"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Køyregjennomsnitt"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Gjennomsnitt økt"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3790,18 +3802,6 @@ msgid "Download-Speed"
 msgstr "Nedlastingsfart"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Novérande"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Køyregjennomsnitt"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Gjennomsnitt økt"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Opplastingsfart"
 
@@ -3809,7 +3809,7 @@ msgstr "Opplastingsfart"
 msgid "Connections"
 msgstr "Koplingar"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktive nedlastingar"
 
@@ -3817,7 +3817,7 @@ msgstr "Aktive nedlastingar"
 msgid "Active connections (1:1)"
 msgstr "Aktive koplingar (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktive opplastingar"
 
@@ -4429,7 +4429,7 @@ msgstr "Gjennomsnittleg køyrande opplasting"
 msgid "Upload session average"
 msgstr "Gjennomsnittleg økt opplasting"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktive koplingar"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2821,6 +2821,18 @@ msgstr "Nie można załadować danych kraju dla '%s'."
 msgid "IP filter is ready"
 msgstr "Filtr IP jest gotowy"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Aktualna"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Bieżąca średnia"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Średnia sesji"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3787,18 +3799,6 @@ msgid "Download-Speed"
 msgstr "Prędkość pobierania"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Aktualna"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Bieżąca średnia"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Średnia sesji"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Prędkość wysyłania"
 
@@ -3806,7 +3806,7 @@ msgstr "Prędkość wysyłania"
 msgid "Connections"
 msgstr "Połączenie"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktywne pobierania"
 
@@ -3814,7 +3814,7 @@ msgstr "Aktywne pobierania"
 msgid "Active connections (1:1)"
 msgstr "Aktywnych połączeń (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktywne wysyłania"
 
@@ -4427,7 +4427,7 @@ msgstr "Bieżąca średnia wysyłania"
 msgid "Upload session average"
 msgstr "Średnia wysyłania sesji"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktywnych połączeń"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:43+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2821,6 +2821,18 @@ msgstr "Falha ao renomear novo arquivo %s, abortando atualização."
 msgid "IP filter is ready"
 msgstr "Filtro IP está pronto"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Atual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Média de execução"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Média da sessão"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3763,18 +3775,6 @@ msgid "Download-Speed"
 msgstr "Download (Velocidade)"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Atual"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Média de execução"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Média da sessão"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Upload (velocidade)"
 
@@ -3782,7 +3782,7 @@ msgstr "Upload (velocidade)"
 msgid "Connections"
 msgstr "Conexões"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Downloads ativos"
 
@@ -3790,7 +3790,7 @@ msgstr "Downloads ativos"
 msgid "Active connections (1:1)"
 msgstr "Conexões ativas (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Uploads ativos"
 
@@ -4400,7 +4400,7 @@ msgstr "Média dos Uploads ativos"
 msgid "Upload session average"
 msgstr "Média dos Uploads da sessão"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Conexões ativas"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2816,6 +2816,18 @@ msgstr "Falhou ao mudar o nome ao novo ficheiro %s, a cancelar actualização."
 msgid "IP filter is ready"
 msgstr "O filtro de IPs está pronto"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Actual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Média actual"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Média da sessão"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3779,18 +3791,6 @@ msgid "Download-Speed"
 msgstr "Velocidade de Download"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Actual"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Média actual"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Média da sessão"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Velocidade de Upload"
 
@@ -3798,7 +3798,7 @@ msgstr "Velocidade de Upload"
 msgid "Connections"
 msgstr "Ligações"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Downloads activos"
 
@@ -3806,7 +3806,7 @@ msgstr "Downloads activos"
 msgid "Active connections (1:1)"
 msgstr "Ligações activas (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Uploads activos"
 
@@ -4419,7 +4419,7 @@ msgstr "Média actual de upload"
 msgid "Upload session average"
 msgstr "Média de upload da sessão"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Ligações activas"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:44+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2816,6 +2816,18 @@ msgstr "A eșuat redenumirea fișierului nou %s , se abandonează actualizarea."
 msgid "IP filter is ready"
 msgstr "Filtrul IP este gata"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Curentul"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Medie rulare"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Medie sesiune"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3782,18 +3794,6 @@ msgid "Download-Speed"
 msgstr "Viteză-descărcare"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Curentul"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Medie rulare"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Medie sesiune"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Viteză-încărcare"
 
@@ -3801,7 +3801,7 @@ msgstr "Viteză-încărcare"
 msgid "Connections"
 msgstr "Conexiuni"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Descărcări active"
 
@@ -3809,7 +3809,7 @@ msgstr "Descărcări active"
 msgid "Active connections (1:1)"
 msgstr "Conexiuni active (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Încărcări active"
 
@@ -4422,7 +4422,7 @@ msgstr "Medie rulare încărcare"
 msgid "Upload session average"
 msgstr "Medie încărcare pe sesiune"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Conexiuni active"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:45+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2837,6 +2837,18 @@ msgstr "Не удалось переименовать новый файл %s, �
 msgid "IP filter is ready"
 msgstr "IP-фильтр готов"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Текущая"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Средняя за всё время"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Средняя за сеанс"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3789,18 +3801,6 @@ msgid "Download-Speed"
 msgstr "Скорость скачивания"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Текущая"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Средняя за всё время"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Средняя за сеанс"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Скорость отдачи"
 
@@ -3808,7 +3808,7 @@ msgstr "Скорость отдачи"
 msgid "Connections"
 msgstr "Соединения"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Активные скачивания"
 
@@ -3816,7 +3816,7 @@ msgstr "Активные скачивания"
 msgid "Active connections (1:1)"
 msgstr "Активные соединения (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Активные отдачи"
 
@@ -4425,7 +4425,7 @@ msgstr "Средняя общая отдача"
 msgid "Upload session average"
 msgstr "Средняя отдача за сеанс"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Активные соединения"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2833,6 +2833,18 @@ msgstr "Preimenovanje nove datoteke %s ni uspelo, posodobitev preklicana."
 msgid "IP filter is ready"
 msgstr "Filter IP je pripravljen"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Trenutno"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Trenutno povprečje"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Povprečje seje"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3802,18 +3814,6 @@ msgid "Download-Speed"
 msgstr "Hitrost prejemanja"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Trenutno"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Trenutno povprečje"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Povprečje seje"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Hitrost pošiljanja"
 
@@ -3821,7 +3821,7 @@ msgstr "Hitrost pošiljanja"
 msgid "Connections"
 msgstr "Povezave"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Dejavna prejemanja"
 
@@ -3829,7 +3829,7 @@ msgstr "Dejavna prejemanja"
 msgid "Active connections (1:1)"
 msgstr "Dejavne povezave (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Dejavna pošiljanja"
 
@@ -4443,7 +4443,7 @@ msgstr "Povprečje pošiljanja"
 msgid "Upload session average"
 msgstr "Povprečje seje za pošiljanje"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Dejavne povezave"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:46+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2820,6 +2820,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Aktualisht"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Mesatarja e Punes"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Mesatarja e Sesionit"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3783,18 +3795,6 @@ msgid "Download-Speed"
 msgstr "Shpejtesia-Shkarkimit"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Aktualisht"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Mesatarja e Punes"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Mesatarja e Sesionit"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Shpejtesia-Ngarkimit"
 
@@ -3802,7 +3802,7 @@ msgstr "Shpejtesia-Ngarkimit"
 msgid "Connections"
 msgstr "Lidhjet"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Shkarkime Aktive"
 
@@ -3810,7 +3810,7 @@ msgstr "Shkarkime Aktive"
 msgid "Active connections (1:1)"
 msgstr "Lidhje Aktive (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Ngarkime Aktive"
 
@@ -4422,7 +4422,7 @@ msgstr "Mesatarja e ngarkimit ne punim"
 msgid "Upload session average"
 msgstr "Mesatarja e sesionit te ngarkimeve"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Lidhjet aktive"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2808,6 +2808,18 @@ msgstr "Det gick inte att byta namn på ny %s fil, avbryter uppdateringen."
 msgid "IP filter is ready"
 msgstr "IP-filter är redo"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Aktuell"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Löpande medelvärde"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Sessionens genomsnittliga"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3771,18 +3783,6 @@ msgid "Download-Speed"
 msgstr "Nedladdningshastighet"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Aktuell"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Löpande medelvärde"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Sessionens genomsnittliga"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Uppladdningshastighet"
 
@@ -3790,7 +3790,7 @@ msgstr "Uppladdningshastighet"
 msgid "Connections"
 msgstr "Anslutningar"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktiva hämtningar"
 
@@ -3798,7 +3798,7 @@ msgstr "Aktiva hämtningar"
 msgid "Active connections (1:1)"
 msgstr "Aktiva anslutningar (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktiva uppladdningar"
 
@@ -4411,7 +4411,7 @@ msgstr "Hämtningar nu, medelvärde"
 msgid "Upload session average"
 msgstr "Uppladdningsession, genomsnittlig"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktiva anslutningar"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:50+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2728,6 +2728,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr ""
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3668,18 +3680,6 @@ msgid "Download-Speed"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr ""
 
@@ -3695,7 +3695,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:47+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2807,6 +2807,18 @@ msgstr "Yeni %s dosyası yeniden adlandırılamadı. Güncelleme iptal edildi."
 msgid "IP filter is ready"
 msgstr "IP süzgeci hazır"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Şimdiki"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Çalışma ortalaması"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Oturum ortalaması"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3753,18 +3765,6 @@ msgid "Download-Speed"
 msgstr "İndirme Hızı"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Şimdiki"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Çalışma ortalaması"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Oturum ortalaması"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Gönderim Hızı"
 
@@ -3772,7 +3772,7 @@ msgstr "Gönderim Hızı"
 msgid "Connections"
 msgstr "Bağlantılar"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Aktif İndirmeler"
 
@@ -3780,7 +3780,7 @@ msgstr "Aktif İndirmeler"
 msgid "Active connections (1:1)"
 msgstr "Aktif Bağlantılar (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Aktif Göndermeler"
 
@@ -4391,7 +4391,7 @@ msgstr "Gönderme çalışma Ortalaması"
 msgid "Upload session average"
 msgstr "Gönderme oturum ortalaması"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Aktif bağlantılar"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2832,6 +2832,18 @@ msgstr "Неможливо змінити назву нового файлу Geo
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "Поточна"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "Середня"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "Середня за сесію"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3802,18 +3814,6 @@ msgid "Download-Speed"
 msgstr "Швидкість звантаження"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "Поточна"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "Середня"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "Середня за сесію"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "Швидкість вивантаження"
 
@@ -3821,7 +3821,7 @@ msgstr "Швидкість вивантаження"
 msgid "Connections"
 msgstr "З'єднання"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "Чинні звантаження"
 
@@ -3829,7 +3829,7 @@ msgstr "Чинні звантаження"
 msgid "Active connections (1:1)"
 msgstr "Чинні з'єднання (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "Чинні вивантаження"
 
@@ -4443,7 +4443,7 @@ msgstr "Вивантаження середні за роботу"
 msgid "Upload session average"
 msgstr "Вивантаження середні за сесію"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "Чинні з'єднання"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2727,6 +2727,18 @@ msgstr ""
 msgid "IP filter is ready"
 msgstr ""
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr ""
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr ""
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3667,18 +3679,6 @@ msgid "Download-Speed"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr ""
 
@@ -3686,7 +3686,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr ""
 
@@ -3694,7 +3694,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr ""
 
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:48+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2817,6 +2817,18 @@ msgstr "重名命新的%s文件失败，放弃更新。"
 msgid "IP filter is ready"
 msgstr "IP过滤器已准备好"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "当前"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "动态平均值"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "本次运行平均值"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3759,18 +3771,6 @@ msgid "Download-Speed"
 msgstr "下载速度"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "当前"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "动态平均值"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "本次运行平均值"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "上传速度"
 
@@ -3778,7 +3778,7 @@ msgstr "上传速度"
 msgid "Connections"
 msgstr "连接"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "活跃下载"
 
@@ -3786,7 +3786,7 @@ msgstr "活跃下载"
 msgid "Active connections (1:1)"
 msgstr "活跃连接 (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "活跃上传"
 
@@ -4396,7 +4396,7 @@ msgstr "动态平均上传"
 msgid "Upload session average"
 msgstr "本次运行平均上传"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "活跃连接"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-10 23:55+0200\n"
+"POT-Creation-Date: 2026-08-11 12:27+0200\n"
 "PO-Revision-Date: 2026-08-09 14:49+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2804,6 +2804,18 @@ msgstr "無法重新命名新的 %s 檔案，停止更新。"
 msgid "IP filter is ready"
 msgstr "IP 過濾表已備妥"
 
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Current"
+msgstr "目前"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Running average"
+msgstr "執行中平均值"
+
+#: src/KadDlg.cpp src/muuli_wdr.cpp src/StatisticsDlg.cpp
+msgid "Session average"
+msgstr "本次平均值"
+
 #: src/KadDlg.cpp
 #, c-format
 msgid "Nodes (%u)"
@@ -3764,18 +3776,6 @@ msgid "Download-Speed"
 msgstr "下載速度"
 
 #: src/muuli_wdr.cpp
-msgid "Current"
-msgstr "目前"
-
-#: src/muuli_wdr.cpp
-msgid "Running average"
-msgstr "執行中平均值"
-
-#: src/muuli_wdr.cpp
-msgid "Session average"
-msgstr "本次平均值"
-
-#: src/muuli_wdr.cpp
 msgid "Upload-Speed"
 msgstr "上傳速度"
 
@@ -3783,7 +3783,7 @@ msgstr "上傳速度"
 msgid "Connections"
 msgstr "連線"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active downloads"
 msgstr "目前下載數"
 
@@ -3791,7 +3791,7 @@ msgstr "目前下載數"
 msgid "Active connections (1:1)"
 msgstr "目前連線數 (1:1)"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active uploads"
 msgstr "目前上傳數"
 
@@ -4404,7 +4404,7 @@ msgstr "執行中平均上傳"
 msgid "Upload session average"
 msgstr "本次平均上傳"
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/StatisticsDlg.cpp
 msgid "Active connections"
 msgstr "目前連線數"
 

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -3312,6 +3312,12 @@ static CECPacket *GetStatsGraphs(const CECPacket *request)
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_UL, sessionUl));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_KAD, sessionKad));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_TIMESPAN, sessionTimespan));
+			// How deep we can actually answer at the requested scale, so
+			// the client can cap its next request instead of guessing.
+			// Over-asking gets a record repeated rather than an error,
+			// and without timestamps on the wire the client cannot see it.
+			response->AddTag(
+				CECTag(EC_TAG_STATSGRAPH_DEPTH, (uint16)CStatistics::GetPointsPerRange()));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_LAST, dTimestamp));
 		} else {
 			response = new CECPacket(EC_OP_FAILED);

--- a/src/KadDlg.cpp
+++ b/src/KadDlg.cpp
@@ -101,43 +101,37 @@ void CKadDlg::SetUpdatePeriod(int step)
 
 void CKadDlg::SetGraphColors()
 {
-	static const char aTrend[] = { 2, 1, 0 };
-	static const int aRes[] = { IDC_C0, IDC_C0_3, IDC_C0_2 };
+	// Same shape as the download graph on the statistics panel -- three
+	// trends, the same three legend swatches -- driven by the Kad graph's
+	// own preference colours.
+	static const CStatisticsDlg::GraphColorSlot aSlot[] = { { 12, 2, IDC_C0, wxTRANSLATE("Current") },
+		{ 13, 1, IDC_C0_3, wxTRANSLATE("Running average") },
+		{ 14, 0, IDC_C0_2, wxTRANSLATE("Session average") } };
 
-	m_kad_scope->SetBackgroundColor(CStatisticsDlg::getColors(0));
-	m_kad_scope->SetGridColor(CStatisticsDlg::getColors(1));
-
-	for (size_t i = 0; i < 3; ++i) {
-		m_kad_scope->SetPlotColor(CStatisticsDlg::getColors(12 + i), aTrend[i]);
-
-		CColorFrameCtrl *ctrl = CastChild(aRes[i], CColorFrameCtrl);
-		ctrl->SetBackgroundBrushColour(CMuleColour(CStatisticsDlg::getColors(12 + i)));
-		ctrl->SetFrameBrushColour(*wxBLACK);
+	CStatisticsDlg::ApplyGraphFrameColors(m_kad_scope);
+	for (const CStatisticsDlg::GraphColorSlot &slot : aSlot) {
+		CStatisticsDlg::ApplyGraphSlot(this, m_kad_scope, slot);
 	}
 }
 
 void CKadDlg::UpdateGraph(const GraphUpdateInfo &update)
 {
-	std::vector<float *> v(3);
-	v[0] = const_cast<float *>(&update.kadnodes[0]);
-	v[1] = const_cast<float *>(&update.kadnodes[1]);
-	v[2] = const_cast<float *>(&update.kadnodes[2]);
-	const std::vector<float *> &apfKad(v);
-	unsigned nodeCount = static_cast<unsigned>(update.kadnodes[2]);
-
+	// A hidden panel needs no update: the graph redraws from the statistics
+	// history and catches up by itself the next time it is painted.
 	if (!IsShownOnScreen()) {
-		m_kad_scope->DelayPoints();
-	} else {
-		// Check the current node-count to see if we should increase the graph height
-		if (m_kad_scope->GetUpperLimit() < update.kadnodes[2]) {
-			// Grow the limit by 50 sized increments. The integer ceiling-to-50 is
-			// intentional; a whole number is what we want for the axis range.
-			// NOLINTNEXTLINE(bugprone-integer-division)
-			m_kad_scope->SetRanges(0.0, ((nodeCount + 49) / 50) * 50);
-		}
-
-		m_kad_scope->AppendPoints(update.timestamp, apfKad);
+		return;
 	}
+
+	// Check the current node-count to see if we should increase the graph height
+	if (m_kad_scope->GetUpperLimit() < update.kadnodes[2]) {
+		const unsigned nodeCount = static_cast<unsigned>(update.kadnodes[2]);
+		// Grow the limit by 50 sized increments. The integer ceiling-to-50 is
+		// intentional; a whole number is what we want for the axis range.
+		// NOLINTNEXTLINE(bugprone-integer-division)
+		m_kad_scope->SetRanges(0.0, (float)(((nodeCount + 49) / 50) * 50));
+	}
+
+	m_kad_scope->AppendPoints(update.timestamp);
 }
 
 void CKadDlg::UpdateNodeCount(unsigned nodeCount)

--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -23,16 +23,19 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
+#include <algorithm>
 #include <cmath>
-#include <wx/dcmemory.h>
-#include <wx/dcclient.h>
+#include <memory>
 #include <wx/dcbuffer.h>
+#include <wx/dcclient.h>
+#include <wx/geometry.h> // Needed for wxPoint2DDouble
+#if wxUSE_GRAPHICS_CONTEXT
+#include <wx/graphics.h>
+#endif
 
 #include <common/Format.h>
 
 #include "amule.h"          // Needed for theApp
-#include "amuleDlg.h"       // Needed for CamuleDlg
-#include "Logger.h"         // Needed for AddLogLineM
 #include "OScopeCtrl.h"     // Interface declarations
 #include "OtherFunctions.h" // Needed for CastSecondsToHM
 #include "Statistics.h"
@@ -40,8 +43,35 @@
 wxBEGIN_EVENT_TABLE(COScopeCtrl, wxControl)
 	EVT_PAINT(COScopeCtrl::OnPaint)
 	EVT_SIZE(COScopeCtrl::OnSize)
+	EVT_MOTION(COScopeCtrl::OnMouseMove)
+	EVT_LEAVE_WINDOW(COScopeCtrl::OnMouseLeave)
 wxEND_EVENT_TABLE()
 
+namespace
+{
+// CStatistics::GetHistory always writes three arrays, whatever the caller
+// asked to plot, so the buffers handed to it are never shorter than this.
+const unsigned kHistoryTrends = 3;
+
+// Trend whose area is shaded. GetHistory puts the instantaneous value in
+// the third array, which is the spiky curve the shading reads well under;
+// the other two are averages that would shade as near-solid blocks.
+const unsigned kShadedTrend = 2;
+
+// Alpha of the shading where it meets its curve. It fades to nothing at
+// the bottom of the plot.
+const unsigned char kShadeAlpha = 0x48;
+
+// Ink for text drawn over the graph background, which the user chooses.
+wxColour ContrastInk(const wxColour &bg)
+{
+	const double luma = 0.299 * bg.Red() + 0.587 * bg.Green() + 0.114 * bg.Blue();
+	return luma < 128.0 ? wxColour(0xF0, 0xF0, 0xF0) : wxColour(0x20, 0x20, 0x20);
+}
+
+// G.Hayduk: the first 15 trends have predefined colours, further ones are
+// drawn in white unless SetPlotColor is called. In practice every graph in
+// the GUI overrides all of its colours from the preferences during Init().
 const wxColour crPreset[16] = { wxColour(0xFF, 0x00, 0x00),
 	wxColour(0xFF, 0xC0, 0xC0),
 	wxColour(0xFF, 0xFF, 0x00),
@@ -58,484 +88,533 @@ const wxColour crPreset[16] = { wxColour(0xFF, 0x00, 0x00),
 	wxColour(0xA0, 0x00, 0xA0),
 	wxColour(0xFF, 0xFF, 0xFF),
 	wxColour(0x80, 0x80, 0x80) };
+} // namespace
 
 COScopeCtrl::COScopeCtrl(int cntTrends, int nDecimals, StatsGraphType type, wxWindow *parent)
 : wxControl(parent, -1, wxDefaultPosition, wxDefaultSize)
-, timerRedraw(this)
+, graph_type(type)
+, m_trends(std::max<unsigned>((unsigned)cntTrends, 1))
+, m_nYGrids(5)
+, m_nShiftPixels(1)
+, m_nYDecimals((unsigned)nDecimals)
+, m_bgColour(0, 0, 0)       // see also SetBackgroundColor
+, m_gridColour(0, 255, 255) // see also SetGridColor
+, m_bStopped(false)
+, m_sLastTimestamp(0.0)
+, m_sLastPeriod(1.0)
+, m_ptHover(wxDefaultPosition)
 {
-	// since plotting is based on a LineTo for each new point
-	// we need a starting point (i.e. a "previous" point)
-	// use 0.0 as the default first point.
-	// these are public member variables, and can be changed outside
-	// (after construction).
-
-	// G.Hayduk: NTrends is the number of trends that will be drawn on
-	// the plot. First 15 plots have predefined colors, but others will
-	// be drawn with white, unless you call SetPlotColor
-	nTrends = cntTrends;
-	pdsTrends = new PlotData_t[nTrends];
-
-	PlotData_t *ppds = pdsTrends;
-	for (unsigned i = 0; i < nTrends; ++i, ++ppds) {
-		ppds->crPlot = (i < 15 ? crPreset[i] : *wxWHITE);
-		ppds->penPlot = *(wxThePenList->FindOrCreatePen(ppds->crPlot, 1, wxPENSTYLE_SOLID));
-		ppds->fPrev = ppds->fLowerLimit = ppds->fUpperLimit = 0.0;
+	for (unsigned i = 0; i < m_trends.size(); ++i) {
+		m_trends[i].crPlot = (i < 15 ? crPreset[i] : *wxWHITE);
+		m_trends[i].fLowerLimit = m_trends[i].fUpperLimit = 0.0;
 	}
 
-	bRecreateGraph = bRecreateGrid = bRecreateAll = bStopped = false;
-	m_onPaint = false;
-	nDelayedPoints = 0;
-	sLastTimestamp = 0.0;
-	sLastPeriod = 1.0;
-	nShiftPixels = 1;
-	nYDecimals = nDecimals;
-	m_bgColour = wxColour(0, 0, 0);       // see also SetBackgroundColor
-	m_gridColour = wxColour(0, 255, 255); // see also SetGridColor
-	brushBack = *wxBLACK_BRUSH;
+	SetCursor(wxCursor(wxCURSOR_CROSS));
 
-	strXUnits = "X"; // can also be set with SetXUnits
-	strYUnits = "Y"; // can also be set with SetYUnits
+	m_strYUnits = "Y"; // can also be set with SetYUnits
 
-	nXGrids = 6;
-	nYGrids = 5;
-
-	graph_type = type;
-
-	// Connect the timer (dynamically, so the Controls don't have to share a common timer id)
-	Connect(timerRedraw.GetId(), wxEVT_TIMER, (wxObjectEventFunction)&COScopeCtrl::OnTimer);
-	// Don't draw background (avoid ugly flickering on wxMSW on resize)
-	SetBackgroundStyle(wxBG_STYLE_CUSTOM);
-
-	// Ensure that various size-constraints are calculated (via OnSize).
-	SetClientSize(GetClientSize());
-}
-
-COScopeCtrl::~COScopeCtrl()
-{
-	delete[] pdsTrends;
+	// Everything inside the client area is painted by OnPaint.
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 void COScopeCtrl::SetRange(float fLower, float fUpper, unsigned iTrend)
 {
-	PlotData_t *ppds = pdsTrends + iTrend;
-	if ((ppds->fLowerLimit == fLower) && (ppds->fUpperLimit == fUpper))
+	if (iTrend >= m_trends.size()) {
 		return;
-	ppds->fLowerLimit = fLower;
-	ppds->fUpperLimit = fUpper;
-	ppds->fVertScale = (float)m_rectPlot.GetHeight() / (fUpper - fLower);
-	ppds->yPrev = GetPlotY(ppds->fPrev, ppds);
-
-	if (iTrend == 0) {
-		InvalidateCtrl();
-	} else {
-		InvalidateGraph();
 	}
+	PlotData_t &trend = m_trends[iTrend];
+	if (trend.fLowerLimit == fLower && trend.fUpperLimit == fUpper) {
+		return;
+	}
+	trend.fLowerLimit = fLower;
+	trend.fUpperLimit = fUpper;
+	Refresh(false);
 }
 
 void COScopeCtrl::SetRanges(float fLower, float fUpper)
 {
-	for (unsigned iTrend = 0; iTrend < nTrends; ++iTrend) {
+	for (unsigned iTrend = 0; iTrend < m_trends.size(); ++iTrend) {
 		SetRange(fLower, fUpper, iTrend);
 	}
 }
 
 void COScopeCtrl::SetYUnits(const wxString &strUnits, const wxString &strMin, const wxString &strMax)
 {
-	strYUnits = strUnits;
-	strYMin = strMin;
-	strYMax = strMax;
-	InvalidateGrid();
+	m_strYUnits = strUnits;
+	m_strYMin = strMin;
+	m_strYMax = strMax;
+	Refresh(false);
 }
 
 void COScopeCtrl::SetGridColor(const wxColour &cr)
 {
-
 	if (cr == m_gridColour) {
 		return;
 	}
-
 	m_gridColour = cr;
-	InvalidateGrid();
+	Refresh(false);
 }
 
 void COScopeCtrl::SetPlotColor(const wxColour &cr, unsigned iTrend)
 {
-	PlotData_t *ppds = pdsTrends + iTrend;
-	if (ppds->crPlot == cr)
+	if (iTrend >= m_trends.size() || m_trends[iTrend].crPlot == cr) {
 		return;
-	ppds->crPlot = cr;
-	ppds->penPlot = *(wxThePenList->FindOrCreatePen(ppds->crPlot, 1, wxPENSTYLE_SOLID));
-	InvalidateGraph();
+	}
+	m_trends[iTrend].crPlot = cr;
+	Refresh(false);
+}
+
+void COScopeCtrl::SetTrendLabel(const wxString &label, unsigned iTrend)
+{
+	if (iTrend >= m_trends.size()) {
+		return;
+	}
+	m_trends[iTrend].strLabel = label;
 }
 
 void COScopeCtrl::SetBackgroundColor(const wxColour &cr)
 {
-
-	if (m_bgColour == cr) {
+	if (cr == m_bgColour) {
 		return;
 	}
-
 	m_bgColour = cr;
-	brushBack = *(wxTheBrushList->FindOrCreateBrush(cr, wxBRUSHSTYLE_SOLID));
-	InvalidateCtrl();
-}
-
-void COScopeCtrl::RecreateGrid()
-{
-	// There is a lot of drawing going on here - particularly in terms of
-	// drawing the grid.  Don't panic, this is all being drawn (only once)
-	// to a bitmap.  The result is then BitBlt'd to the control whenever needed.
-	bRecreateGrid = false;
-	if (m_rectClient.GetWidth() == 0 || m_rectClient.GetHeight() == 0) {
-		return;
-	}
-
-	wxMemoryDC dcGrid(m_bmapGrid);
-
-	wxPen solidPen = *(wxThePenList->FindOrCreatePen(m_gridColour, 1, wxPENSTYLE_SOLID));
-	wxString strTemp;
-
-	// fill the grid background
-	dcGrid.SetBrush(brushBack);
-	dcGrid.SetPen(*wxTRANSPARENT_PEN);
-	dcGrid.DrawRectangle(m_rectClient);
-
-	// adjust the plot rectangle dimensions
-	// assume 6 pixels per character (this may need to be adjusted)
-	m_rectPlot.x = m_rectClient.GetLeft() + 6 * 7 + 4;
-	// draw the plot rectangle
-	dcGrid.SetPen(solidPen);
-	dcGrid.DrawRectangle(
-		m_rectPlot.x - 1, m_rectPlot.y - 1, m_rectPlot.GetWidth() + 2, m_rectPlot.GetHeight() + 2);
-	dcGrid.SetPen(wxNullPen);
-
-	// create some fonts (horizontal and vertical)
-	wxFont axisFont(10, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
-	dcGrid.SetFont(axisFont);
-
-	// y max
-	dcGrid.SetTextForeground(m_gridColour);
-	if (strYMax.IsEmpty()) {
-		strTemp = wxString::Format("%.*f", nYDecimals, pdsTrends[0].fUpperLimit);
-	} else {
-		strTemp = strYMax;
-	}
-	wxCoord sizX, sizY;
-	dcGrid.GetTextExtent(strTemp, &sizX, &sizY);
-	dcGrid.DrawText(strTemp, m_rectPlot.GetLeft() - 4 - sizX, m_rectPlot.GetTop() - 7);
-	// y min
-	if (strYMin.IsEmpty()) {
-		strTemp = wxString::Format("%.*f", nYDecimals, pdsTrends[0].fLowerLimit);
-	} else {
-		strTemp = strYMin;
-	}
-	dcGrid.GetTextExtent(strTemp, &sizX, &sizY);
-	dcGrid.DrawText(strTemp, m_rectPlot.GetLeft() - 4 - sizX, m_rectPlot.GetBottom());
-
-	// x units
-	strTemp = CastSecondsToHM((m_rectPlot.GetWidth() / nShiftPixels) * (int)floor(sLastPeriod + 0.5));
-	// floor(x + 0.5) is a way of doing round(x) that works with gcc < 3 ...
-	if (bStopped) {
-		strXUnits = CFormat(_("Disabled [%s]")) % strTemp;
-	} else {
-		strXUnits = strTemp;
-	}
-
-	dcGrid.GetTextExtent(strXUnits, &sizX, &sizY);
-	dcGrid.DrawText(strXUnits,
-		(m_rectPlot.GetLeft() + m_rectPlot.GetRight()) / 2 - sizX / 2,
-		m_rectPlot.GetBottom() + 4);
-
-	// y units
-	if (!strYUnits.IsEmpty()) {
-		dcGrid.GetTextExtent(strYUnits, &sizX, &sizY);
-		dcGrid.DrawText(strYUnits,
-			m_rectPlot.GetLeft() - 4 - sizX,
-			(m_rectPlot.GetTop() + m_rectPlot.GetBottom()) / 2 - sizY / 2);
-	}
-	// no more drawing to this bitmap is needed until the setting are changed
-
-	if (bRecreateGraph) {
-		RecreateGraph(false);
-	}
-
-	// finally, force the plot area to redraw
 	Refresh(false);
 }
 
-void COScopeCtrl::AppendPoints(double sTimestamp, const std::vector<float *> &apf)
+void COScopeCtrl::AppendPoints(double sTimestamp)
 {
-	sLastTimestamp = sTimestamp;
-
-	if (nDelayedPoints) {
-		// Ensures that delayed points get added before the new point.
-		// We do this by simply drawing the history up to and including
-		// the new point.
-		int n = std::min(m_rectPlot.GetWidth(), nDelayedPoints + 1);
-		nDelayedPoints = 0;
-		PlotHistory(n, true, false);
-	} else {
-		ShiftGraph(1);
-		DrawPoints(apf, 1);
-	}
-
+	// The sample itself is already in CStatistics' history by the time we
+	// get here, and the next paint reads it back from there, so there is
+	// nothing to accumulate -- just ask for that paint.
+	m_sLastTimestamp = sTimestamp;
 	Refresh(false);
-}
-
-void COScopeCtrl::OnPaint(wxPaintEvent &WXUNUSED(evt))
-{
-	m_onPaint = true;
-
-	// no real plotting work is performed here unless we are coming out of a hidden state;
-	// normally, just putting the existing bitmaps on the client to avoid flicker,
-	// establish a memory dc and then BitBlt it to the client
-	wxBufferedPaintDC dc(this);
-
-	if (bRecreateAll) {
-		return;
-	}
-
-	if (bRecreateGrid) {
-		RecreateGrid(); // this will also recreate the graph if that flag is set
-	} else if (bRecreateGraph) {
-		RecreateGraph(true);
-	}
-
-	if (nDelayedPoints) { // we've just come out of hiding, so catch up
-		int n = std::min(m_rectPlot.GetWidth(), nDelayedPoints);
-		nDelayedPoints = 0;          // (this is more efficient than plotting in the
-		PlotHistory(n, true, false); // background because the bitmap is shifted only
-	} // once for all delayed points together)
-
-	// We have assured that we have a valid and resized if needed
-	// wxDc and bitmap. Proceed to blit.
-	dc.DrawBitmap(m_bmapGrid, 0, 0, false);
-
-	// Overwrites the plot section of the image
-	dc.DrawBitmap(m_bmapPlot, m_rectPlot.x, m_rectPlot.y, false);
-
-	// draw the dotted lines.
-	// This is done last because wxMAC doesn't support the wxOR logical
-	// operation, preventing us from simply blitting the plot on top of
-	// the grid bitmap.
-
-	dc.SetPen(*(wxThePenList->FindOrCreatePen(m_gridColour, 1, wxPENSTYLE_LONG_DASH)));
-	for (unsigned j = 1; j < (nYGrids + 1); ++j) {
-		unsigned GridPos = (m_rectPlot.GetHeight()) * j / (nYGrids + 1) + m_rectPlot.GetTop();
-
-		dc.DrawLine(m_rectPlot.GetLeft(), GridPos, m_rectPlot.GetRight(), GridPos);
-	}
-}
-
-void COScopeCtrl::OnSize(wxSizeEvent &WXUNUSED(evt))
-{
-	// This gets called repeatedly as the user resizes the app;
-	// we use the timer mechanism through InvalidateCtrl to avoid unnecessary redrawing
-	// NOTE: OnSize automatically gets called during the setup of the control
-	if (GetClientRect() == m_rectClient) {
-		return;
-	}
-
-	m_rectClient = GetClientRect();
-	if (m_rectClient.GetWidth() < 1 || m_rectClient.GetHeight() < 1) {
-		return;
-	}
-
-	// the "left" coordinate and "width" will be modified in
-	// InvalidateCtrl to be based on the y axis scaling
-	m_rectPlot.SetLeft(20);
-	m_rectPlot.SetTop(10);
-	m_rectPlot.SetRight(std::max<int>(m_rectPlot.GetLeft() + 1, m_rectClient.GetRight() - 40));
-	m_rectPlot.SetBottom(std::max<int>(m_rectPlot.GetTop() + 1, m_rectClient.GetBottom() - 25));
-
-	PlotData_t *ppds = pdsTrends;
-	for (unsigned iTrend = 0; iTrend < nTrends; ++iTrend, ++ppds) {
-		ppds->fVertScale = (float)m_rectPlot.GetHeight() / (ppds->fUpperLimit - ppds->fLowerLimit);
-		ppds->yPrev = GetPlotY(ppds->fPrev, ppds);
-	}
-
-	if (!m_bmapGrid.IsOk() || (m_rectClient != wxSize(m_bmapGrid.GetWidth(), m_bmapGrid.GetHeight()))) {
-		m_bmapGrid.Create(m_rectClient.GetWidth(), m_rectClient.GetHeight());
-	}
-	if (!m_bmapPlot.IsOk() || (m_rectPlot != wxSize(m_bmapPlot.GetWidth(), m_bmapPlot.GetHeight()))) {
-		m_bmapPlot.Create(m_rectPlot.GetWidth(), m_rectPlot.GetHeight());
-	}
-
-	InvalidateCtrl();
-}
-
-void COScopeCtrl::ShiftGraph(unsigned cntPoints)
-{
-	wxMemoryDC dcPlot(m_bmapPlot);
-
-	unsigned cntPixelOffset = cntPoints * nShiftPixels;
-	if (cntPixelOffset >= (unsigned)m_rectPlot.GetWidth()) {
-		cntPixelOffset = m_rectPlot.GetWidth();
-	} else {
-		dcPlot.Blit(0,
-			0,
-			m_rectPlot.GetWidth(),
-			m_rectPlot.GetHeight(),
-			&dcPlot,
-			cntPixelOffset,
-			0); // scroll graph to the left
-	}
-
-	// clear a rectangle over the right side of plot prior to adding the new points
-	dcPlot.SetPen(*wxTRANSPARENT_PEN);
-	dcPlot.SetBrush(brushBack); // fill with background color
-	dcPlot.DrawRectangle(
-		m_rectPlot.GetWidth() - cntPixelOffset, 0, cntPixelOffset, m_rectPlot.GetHeight());
-}
-
-unsigned COScopeCtrl::GetPlotY(float fPlot, PlotData_t *ppds)
-{
-	if (fPlot <= ppds->fLowerLimit) {
-		return m_rectPlot.GetBottom();
-	} else if (fPlot >= ppds->fUpperLimit) {
-		return m_rectPlot.GetTop() + 1;
-	} else {
-		return m_rectPlot.GetBottom() - (unsigned)((fPlot - ppds->fLowerLimit) * ppds->fVertScale);
-	}
-}
-
-void COScopeCtrl::DrawPoints(const std::vector<float *> &apf, unsigned cntPoints)
-{
-	// this appends a new set of data points to a graph; all of the plotting is
-	// directed to the memory based bitmap associated with dcPlot
-	// the will subsequently be BitBlt'd to the client in OnPaint
-	// draw the next line segment
-	unsigned y, yPrev;
-	unsigned cntPixelOffset =
-		std::min((unsigned)(m_rectPlot.GetWidth() - 1), (cntPoints - 1) * nShiftPixels);
-	PlotData_t *ppds = pdsTrends;
-
-	wxMemoryDC dcPlot(m_bmapPlot);
-
-	for (unsigned iTrend = 0; iTrend < nTrends; ++iTrend, ++ppds) {
-		const float *pf = apf[iTrend] + cntPoints - 1;
-		yPrev = ppds->yPrev;
-		dcPlot.SetPen(ppds->penPlot);
-
-		for (int x = m_rectPlot.GetRight() - cntPixelOffset; x <= m_rectPlot.GetRight();
-			x += nShiftPixels) {
-			y = GetPlotY(*pf--, ppds);
-
-			// Map onto the smaller bitmap
-			dcPlot.DrawLine(x - nShiftPixels - m_rectPlot.GetX(),
-				yPrev - m_rectPlot.GetY(),
-				x - m_rectPlot.GetX(),
-				y - m_rectPlot.GetY());
-
-			yPrev = y;
-		}
-		ppds->fPrev = *(pf + 1);
-		ppds->yPrev = yPrev;
-	}
-}
-
-void COScopeCtrl::PlotHistory(unsigned cntPoints, bool bShiftGraph, bool bRefresh)
-{
-	wxASSERT(graph_type != GRAPH_INVALID);
-
-	if (graph_type != GRAPH_INVALID) {
-		unsigned i;
-		unsigned cntFilled;
-		std::vector<float *> apf(nTrends);
-		try {
-			for (i = 0; i < nTrends; ++i) {
-				apf[i] = new float[cntPoints];
-			}
-			double sFinal = (bStopped ? sLastTimestamp : -1.0);
-			cntFilled = theApp->m_statistics->GetHistory(
-				cntPoints, sLastPeriod, sFinal, apf, graph_type);
-			if (cntFilled > 1 || (bShiftGraph && cntFilled != 0)) {
-				if (bShiftGraph) { // delayed points - we have an fPrev
-					ShiftGraph(cntFilled);
-				} else { // fresh graph, we need to preset fPrev, yPrev
-					PlotData_t *ppds = pdsTrends;
-					for (i = 0; i < nTrends; ++i, ++ppds)
-						ppds->yPrev = GetPlotY(
-							ppds->fPrev = *(apf[i] + cntFilled - 1), ppds);
-					cntFilled--;
-				}
-				DrawPoints(apf, cntFilled);
-				if (bRefresh)
-					Refresh(false);
-			}
-			for (i = 0; i < nTrends; ++i) {
-				delete[] apf[i];
-			}
-		} catch (std::bad_alloc) {
-			// Failed memory allocation
-			AddLogLineC(
-				wxString(LOG_DIAGNOSTIC(
-					"Error: COScopeCtrl::PlotHistory: Insuficient memory, cntPoints == "))
-				<< cntPoints << ".");
-			for (i = 0; i < nTrends; ++i) {
-				delete[] apf[i];
-			}
-		}
-	} else {
-		// No history (yet) for Kad.
-	}
-}
-
-void COScopeCtrl::RecreateGraph(bool bRefresh)
-{
-	bRecreateGraph = false;
-	nDelayedPoints = 0;
-
-	wxMemoryDC dcPlot(m_bmapPlot);
-	dcPlot.SetBackground(brushBack);
-	dcPlot.Clear();
-
-	PlotHistory(m_rectPlot.GetWidth(), false, bRefresh);
 }
 
 void COScopeCtrl::Reset(double sNewPeriod)
 {
-	bool bStoppedPrev = bStopped;
-	bStopped = false;
-	if (sLastPeriod != sNewPeriod || bStoppedPrev) {
-		sLastPeriod = sNewPeriod;
-		InvalidateCtrl();
+	const bool bWasStopped = m_bStopped;
+	m_bStopped = false;
+	if (m_sLastPeriod != sNewPeriod || bWasStopped) {
+		m_sLastPeriod = sNewPeriod;
+		Refresh(false);
 	}
 }
 
 void COScopeCtrl::Stop()
 {
-	bStopped = true;
-	bRecreateGraph = false;
-	RecreateGrid();
+	m_bStopped = true;
+	Refresh(false);
 }
 
-void COScopeCtrl::InvalidateCtrl(bool bInvalidateGraph, bool bInvalidateGrid)
+wxString COScopeCtrl::GetYMaxLabel() const
 {
-	bRecreateGraph |= bInvalidateGraph;
-	bRecreateGrid |= bInvalidateGrid;
-	// To prevent startup problems don't start timer logic until
-	// a native OnPaint event has been generated.
-	if (m_onPaint) {
-		bRecreateAll |= bInvalidateGraph && bInvalidateGrid;
-		timerRedraw.Start(100, true); // One-shot timer
+	if (!m_strYMax.IsEmpty()) {
+		return m_strYMax;
 	}
+	return wxString::Format("%.*f", (int)m_nYDecimals, m_trends[0].fUpperLimit);
 }
 
-void COScopeCtrl::OnTimer(wxTimerEvent &WXUNUSED(evt))
-/*	The timer is used to consolidate redrawing of the graphs:  when the user resizes
-	the application, we get multiple calls to OnSize.  If he changes several parameters
-	in the Preferences, we get several individual SetXYZ calls.  If we were to try to
-	recreate the graphs for each such event, performance would be sluggish, but with
-	the timer, each event (if they come in quick succession) simply restarts the timer
-	until there is a little pause and OnTimer actually gets called and does its work.
-*/
+wxString COScopeCtrl::GetYMinLabel() const
 {
-	if (!theApp->amuledlg || !theApp->amuledlg->SafeState()) {
+	if (!m_strYMin.IsEmpty()) {
+		return m_strYMin;
+	}
+	return wxString::Format("%.*f", (int)m_nYDecimals, m_trends[0].fLowerLimit);
+}
+
+wxString COScopeCtrl::GetXUnitsLabel(const wxRect &rectPlot) const
+{
+	// floor(x + 0.5) rounds the period to whole seconds.
+	const uint32 sSpan =
+		(uint32)(rectPlot.GetWidth() / m_nShiftPixels) * (uint32)std::floor(m_sLastPeriod + 0.5);
+	const wxString strSpan = CastSecondsToHM(sSpan);
+
+	if (m_bStopped) {
+		return CFormat(_("Disabled [%s]")) % strSpan;
+	}
+	return strSpan;
+}
+
+wxRect COScopeCtrl::ComputePlotRect(wxDC &dc) const
+{
+	const wxRect rectClient = GetClientRect();
+	const int pad = FromDIP(4);
+	const int lineHeight = dc.GetCharHeight();
+
+	// The left gutter has to hold whichever of the three y axis labels is
+	// widest. The old code assumed 6 pixels per character and reserved room
+	// for seven of them, which was too much at small values and too little
+	// once the axis went into five digits.
+	int gutter = std::max(dc.GetTextExtent(GetYMaxLabel()).x, dc.GetTextExtent(GetYMinLabel()).x);
+	if (!m_strYUnits.IsEmpty()) {
+		gutter = std::max(gutter, dc.GetTextExtent(m_strYUnits).x);
+	}
+
+	wxRect rectPlot;
+	rectPlot.x = rectClient.GetLeft() + gutter + 2 * pad;
+	rectPlot.y = rectClient.GetTop() + lineHeight / 2 + pad;
+	rectPlot.SetRight(rectClient.GetRight() - 2 * pad);
+	rectPlot.SetBottom(rectClient.GetBottom() - lineHeight - 2 * pad);
+	return rectPlot;
+}
+
+void COScopeCtrl::DrawGrid(wxDC &dc, const wxRect &rectPlot)
+{
+	const int pad = FromDIP(4);
+
+	// Frame, just outside the plot area so it never overlaps a curve.
+	wxRect rectFrame = rectPlot;
+	rectFrame.Inflate(1, 1);
+	dc.SetPen(wxPen(m_gridColour, 1));
+	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+	dc.DrawRectangle(rectFrame);
+
+	// Horizontal rules. Kept on the plain wxDC rather than the graphics
+	// context on purpose: these are axis-aligned hairlines and stay crisp
+	// only if they are not anti-aliased.
+	dc.SetPen(wxPen(m_gridColour, 1, wxPENSTYLE_LONG_DASH));
+	for (unsigned j = 1; j <= m_nYGrids; ++j) {
+		const int y = rectPlot.GetTop() + (int)((unsigned)rectPlot.GetHeight() * j / (m_nYGrids + 1));
+		dc.DrawLine(rectPlot.GetLeft(), y, rectPlot.GetRight(), y);
+	}
+
+	dc.SetTextForeground(m_gridColour);
+
+	wxString label = GetYMaxLabel();
+	wxSize extent = dc.GetTextExtent(label);
+	dc.DrawText(label, rectPlot.GetLeft() - pad - extent.x, rectPlot.GetTop() - extent.y / 2);
+
+	label = GetYMinLabel();
+	extent = dc.GetTextExtent(label);
+	dc.DrawText(label, rectPlot.GetLeft() - pad - extent.x, rectPlot.GetBottom() - extent.y / 2);
+
+	if (!m_strYUnits.IsEmpty()) {
+		extent = dc.GetTextExtent(m_strYUnits);
+		dc.DrawText(m_strYUnits,
+			rectPlot.GetLeft() - pad - extent.x,
+			(rectPlot.GetTop() + rectPlot.GetBottom() - extent.y) / 2);
+	}
+
+	label = GetXUnitsLabel(rectPlot);
+	extent = dc.GetTextExtent(label);
+	dc.DrawText(
+		label, (rectPlot.GetLeft() + rectPlot.GetRight() - extent.x) / 2, rectPlot.GetBottom() + pad);
+}
+
+void COScopeCtrl::DrawCurves(wxDC &dc, wxGraphicsContext *gc, const wxRect &rectPlot)
+{
+	// A paint can reach us before the application has finished starting up.
+	if (theApp == nullptr || theApp->m_statistics == nullptr) {
 		return;
 	}
-	bRecreateAll = false;
-	Refresh();
+
+	const unsigned cntPoints = (unsigned)rectPlot.GetWidth() / m_nShiftPixels + 1;
+	const unsigned cntTrends = std::max<unsigned>((unsigned)m_trends.size(), kHistoryTrends);
+
+	std::vector<std::vector<float>> samples(cntTrends, std::vector<float>(cntPoints, 0.0f));
+	std::vector<float *> apf(cntTrends);
+	for (unsigned i = 0; i < cntTrends; ++i) {
+		apf[i] = samples[i].data();
+	}
+
+	// A stopped graph keeps showing the window that ended with the last
+	// sample it saw instead of sliding towards the present.
+	const double sFinal = m_bStopped ? m_sLastTimestamp : -1.0;
+	const unsigned cntFilled =
+		theApp->m_statistics->GetHistory(cntPoints, m_sLastPeriod, sFinal, apf, graph_type);
+	if (cntFilled < 2) {
+		return;
+	}
+
+	// GetHistory returns the samples newest first, so index 0 is the point
+	// at the right hand edge and the curve is walked leftwards from there.
+	const double lineWidth = FromDIP(3) / 2.0;
+	auto xAt = [&](unsigned i) { return rectPlot.GetRight() - (double)i * m_nShiftPixels; };
+
+#if wxUSE_GRAPHICS_CONTEXT
+	if (gc) {
+		gc->SetAntialiasMode(wxANTIALIAS_DEFAULT);
+		gc->Clip(rectPlot.x, rectPlot.y, rectPlot.GetWidth(), rectPlot.GetHeight());
+
+		// Shading first, so every curve stays legible on top of it.
+		if (IsShaded()) {
+			wxGraphicsPath area = gc->CreatePath();
+			area.MoveToPoint(xAt(0), rectPlot.GetBottom());
+			for (unsigned i = 0; i < cntFilled; ++i) {
+				area.AddLineToPoint(xAt(i),
+					GetPlotY(samples[kShadedTrend][i], m_trends[kShadedTrend], rectPlot));
+			}
+			area.AddLineToPoint(xAt(cntFilled - 1), rectPlot.GetBottom());
+			area.CloseSubpath();
+
+			// Anchor the gradient to the curve's own peak, not to the top
+			// of the plot. Anchoring it to the plot would tie the shading's
+			// opacity to how much of the y range the graph happens to be
+			// using: the Kad graph grows its range to fit, so its curve
+			// rides near the top and shades fine, but a transfer rate well
+			// under the configured maximum sits low in the plot, where a
+			// plot-anchored gradient has already faded to nothing.
+			double yPeak = rectPlot.GetBottom();
+			for (unsigned i = 0; i < cntFilled; ++i) {
+				yPeak = std::min(yPeak,
+					GetPlotY(samples[kShadedTrend][i], m_trends[kShadedTrend], rectPlot));
+			}
+
+			const wxColour &cr = m_trends[kShadedTrend].crPlot;
+			if (yPeak < rectPlot.GetBottom() - 1.0) {
+				gc->SetBrush(gc->CreateLinearGradientBrush(0.0,
+					yPeak,
+					0.0,
+					rectPlot.GetBottom(),
+					wxColour(cr.Red(), cr.Green(), cr.Blue(), kShadeAlpha),
+					wxColour(cr.Red(), cr.Green(), cr.Blue(), wxALPHA_TRANSPARENT)));
+			} else {
+				// Curve flat on the baseline: nothing to grade over.
+				gc->SetBrush(wxBrush(wxColour(cr.Red(), cr.Green(), cr.Blue(), kShadeAlpha)));
+			}
+			gc->SetPen(*wxTRANSPARENT_PEN);
+			gc->FillPath(area);
+		}
+
+		for (unsigned iTrend = 0; iTrend < m_trends.size(); ++iTrend) {
+			wxGraphicsPath path = gc->CreatePath();
+			path.MoveToPoint(xAt(0), GetPlotY(samples[iTrend][0], m_trends[iTrend], rectPlot));
+			for (unsigned i = 1; i < cntFilled; ++i) {
+				path.AddLineToPoint(
+					xAt(i), GetPlotY(samples[iTrend][i], m_trends[iTrend], rectPlot));
+			}
+
+			gc->SetPen(gc->CreatePen(wxGraphicsPenInfo(m_trends[iTrend].crPlot, lineWidth)
+							 .Join(wxJOIN_ROUND)
+							 .Cap(wxCAP_ROUND)));
+			gc->StrokePath(path);
+		}
+
+		gc->ResetClip();
+		DrawHover(gc, rectPlot, samples, cntFilled);
+		return;
+	}
+#else
+	(void)gc;
+#endif
+
+	// Fallback for a wxWidgets built without a graphics context: aliased
+	// hairlines, i.e. what the graphs looked like before this renderer.
+	dc.SetClippingRegion(rectPlot);
+	std::vector<wxPoint> points(cntFilled);
+	for (unsigned iTrend = 0; iTrend < m_trends.size(); ++iTrend) {
+		for (unsigned i = 0; i < cntFilled; ++i) {
+			points[i] = wxPoint(
+				(int)xAt(i), (int)GetPlotY(samples[iTrend][i], m_trends[iTrend], rectPlot));
+		}
+		dc.SetPen(wxPen(m_trends[iTrend].crPlot, 1));
+		dc.DrawLines((int)cntFilled, points.data());
+	}
+	dc.DestroyClippingRegion();
+}
+
+bool COScopeCtrl::IsShaded() const
+{
+	if (kShadedTrend >= m_trends.size()) {
+		return false;
+	}
+
+	// On the rate graphs and the Kad graph the three trends are three
+	// views of one quantity -- its current value, its running average and
+	// its session average -- so shading the current one states that
+	// quantity's magnitude. The connections graph instead plots three
+	// unrelated counts (active uploads, connections, active downloads);
+	// there is no primary among them to shade, and singling one out would
+	// only be invisible today because the counts sit low against the
+	// axis range.
+	return graph_type != GRAPH_CONN;
+}
+
+double COScopeCtrl::GetPlotY(float value, const PlotData_t &trend, const wxRect &rectPlot) const
+{
+	// Half a pen width of headroom keeps a curve pinned to the top or the
+	// bottom of the range from painting over the frame.
+	const double halfPen = FromDIP(3) / 4.0;
+	const double yTop = rectPlot.GetTop() + halfPen;
+	const double yBottom = rectPlot.GetBottom() - halfPen;
+
+	const float fSpan = trend.fUpperLimit - trend.fLowerLimit;
+	if (fSpan <= 0.0f) {
+		return yBottom;
+	}
+
+	const double fraction = (value - trend.fLowerLimit) / fSpan;
+	return std::min(std::max(rectPlot.GetBottom() - fraction * rectPlot.GetHeight(), yTop), yBottom);
+}
+
+void COScopeCtrl::OnPaint(wxPaintEvent &WXUNUSED(evt))
+{
+	wxAutoBufferedPaintDC dc(this);
+
+	dc.SetBackground(wxBrush(m_bgColour));
+	dc.Clear();
+
+	// Axis labels are conventionally a step below the UI font.
+	dc.SetFont(GetFont().Smaller());
+
+	const wxRect rectPlot = ComputePlotRect(dc);
+	if (rectPlot.GetWidth() < 2 || rectPlot.GetHeight() < 2) {
+		return;
+	}
+
+	// Everything drawn straight onto the wxDC has to be done before the
+	// graphics context is created from it: the two share one surface and
+	// only the most recently created of them may write to it.
+	DrawGrid(dc, rectPlot);
+
+#if wxUSE_GRAPHICS_CONTEXT
+	// Created here rather than inside DrawCurves because wxGraphicsContext
+	// has no overload taking the wxDC base class, and this is the last
+	// place that still knows which kind of paint DC we are holding.
+	std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
+	DrawCurves(dc, gc.get(), rectPlot);
+#else
+	DrawCurves(dc, nullptr, rectPlot);
+#endif
+}
+
+void COScopeCtrl::DrawHover(wxGraphicsContext *gc,
+	const wxRect &rectPlot,
+	const std::vector<std::vector<float>> &samples,
+	unsigned cntFilled)
+{
+#if wxUSE_GRAPHICS_CONTEXT
+	if (m_ptHover == wxDefaultPosition || !rectPlot.Contains(m_ptHover)) {
+		return;
+	}
+
+	// Snap to the sample under the cursor. One sample is m_nShiftPixels
+	// wide, so this is the pixel the cursor is on in all current graphs.
+	unsigned iSample = (unsigned)((rectPlot.GetRight() - m_ptHover.x + (int)m_nShiftPixels / 2) /
+				      (int)m_nShiftPixels);
+	if (iSample >= cntFilled) {
+		return;
+	}
+
+	const wxColour ink = ContrastInk(m_bgColour);
+	const double x = rectPlot.GetRight() - (double)iSample * m_nShiftPixels;
+	const double markerRadius = FromDIP(4) / 2.0 + 1.0;
+
+	// Crosshair.
+	gc->SetPen(gc->CreatePen(wxGraphicsPenInfo(wxColour(ink.Red(), ink.Green(), ink.Blue(), 0x60), 1.0)));
+	wxGraphicsPath crosshair = gc->CreatePath();
+	crosshair.MoveToPoint(x, rectPlot.GetTop());
+	crosshair.AddLineToPoint(x, rectPlot.GetBottom());
+	gc->StrokePath(crosshair);
+
+	// One marker per trend, ringed in the background colour so markers
+	// that land on top of each other stay separable.
+	for (unsigned iTrend = 0; iTrend < m_trends.size(); ++iTrend) {
+		const double y = GetPlotY(samples[iTrend][iSample], m_trends[iTrend], rectPlot);
+		gc->SetPen(gc->CreatePen(wxGraphicsPenInfo(m_bgColour, 2.0)));
+		gc->SetBrush(wxBrush(m_trends[iTrend].crPlot));
+		gc->DrawEllipse(x - markerRadius, y - markerRadius, markerRadius * 2, markerRadius * 2);
+	}
+
+	// Readout. The header is how far back in time this sample is, in the
+	// same units the x axis label under the graph uses. Deliberately not
+	// the word "Current" for the newest sample: one of the trends is
+	// already called that.
+	const uint32 sAgo = (uint32)iSample * (uint32)std::floor(m_sLastPeriod + 0.5);
+	const wxString strHeader = CFormat("-%s") % CastSecondsToHM(sAgo);
+
+	std::vector<wxString> aLabel, aValue;
+	for (unsigned iTrend = 0; iTrend < m_trends.size(); ++iTrend) {
+		aLabel.push_back(m_trends[iTrend].strLabel);
+		wxString strValue = wxString::Format("%.*f", (int)m_nYDecimals, samples[iTrend][iSample]);
+		if (!m_strYUnits.IsEmpty()) {
+			strValue << " " << m_strYUnits;
+		}
+		aValue.push_back(strValue);
+	}
+
+	const wxFont font = GetFont();
+	gc->SetFont(font, ink);
+
+	double wLabel = 0.0, wValue = 0.0, lineHeight = 0.0, w = 0.0, h = 0.0, d = 0.0, e = 0.0;
+	gc->GetTextExtent(strHeader, &w, &h, &d, &e);
+	lineHeight = h;
+	double wHeader = w;
+	for (unsigned i = 0; i < aLabel.size(); ++i) {
+		gc->GetTextExtent(aLabel[i], &w, &h, &d, &e);
+		wLabel = std::max(wLabel, w);
+		lineHeight = std::max(lineHeight, h);
+		gc->GetTextExtent(aValue[i], &w, &h, &d, &e);
+		wValue = std::max(wValue, w);
+	}
+
+	const double pad = FromDIP(6);
+	const double gap = FromDIP(12);
+	const double dot = FromDIP(6);
+	const double boxW = std::max(wHeader, dot + pad / 2 + wLabel + gap + wValue) + 2 * pad;
+	const double cntLines = (double)(aLabel.size() + 1);
+	const double boxH = cntLines * lineHeight + cntLines * 2.0 + 2 * pad;
+
+	// Prefer the right of the crosshair, flip when that would overflow.
+	double boxX = x + gap;
+	if (boxX + boxW > rectPlot.GetRight()) {
+		boxX = x - gap - boxW;
+	}
+	boxX = std::max(boxX, (double)rectPlot.GetLeft());
+	double boxY = std::min(
+		std::max(m_ptHover.y - boxH / 2, (double)rectPlot.GetTop()), rectPlot.GetBottom() - boxH);
+
+	gc->SetBrush(wxBrush(wxColour(m_bgColour.Red(), m_bgColour.Green(), m_bgColour.Blue(), 0xE6)));
+	gc->SetPen(gc->CreatePen(wxGraphicsPenInfo(wxColour(ink.Red(), ink.Green(), ink.Blue(), 0x50), 1.0)));
+	gc->DrawRoundedRectangle(boxX, boxY, boxW, boxH, FromDIP(4));
+
+	double textY = boxY + pad;
+	gc->DrawText(strHeader, boxX + pad, textY);
+	textY += lineHeight + 2.0;
+
+	for (unsigned i = 0; i < aLabel.size(); ++i) {
+		gc->SetBrush(wxBrush(m_trends[i].crPlot));
+		gc->SetPen(*wxTRANSPARENT_PEN);
+		gc->DrawEllipse(boxX + pad, textY + (lineHeight - dot) / 2, dot, dot);
+
+		gc->DrawText(aLabel[i], boxX + pad + dot + pad / 2, textY);
+		gc->GetTextExtent(aValue[i], &w, &h, &d, &e);
+		gc->DrawText(aValue[i], boxX + boxW - pad - w, textY);
+		textY += lineHeight + 2.0;
+	}
+#else
+	(void)gc;
+	(void)rectPlot;
+	(void)samples;
+	(void)cntFilled;
+#endif
+}
+
+void COScopeCtrl::OnMouseMove(wxMouseEvent &evt)
+{
+	const wxPoint pt = evt.GetPosition();
+	if (pt != m_ptHover) {
+		m_ptHover = pt;
+		Refresh(false);
+	}
+	evt.Skip();
+}
+
+void COScopeCtrl::OnMouseLeave(wxMouseEvent &evt)
+{
+	if (m_ptHover != wxDefaultPosition) {
+		m_ptHover = wxDefaultPosition;
+		Refresh(false);
+	}
+	evt.Skip();
+}
+
+void COScopeCtrl::OnSize(wxSizeEvent &WXUNUSED(evt))
+{
+	// The plot is laid out from the client size on every paint, so a resize
+	// only has to invalidate the whole control -- a partial repaint would
+	// leave the old axis labels behind.
+	Refresh(false);
 }
 
 // File_checked_for_headers

--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -413,6 +413,27 @@ void COScopeCtrl::DrawCurves(wxDC &dc, wxGraphicsContext *gc, const wxRect &rect
 	dc.DestroyClippingRegion();
 }
 
+wxString COScopeCtrl::FormatValue(float value) const
+{
+	// The rate graphs hand their readout to CastItoSpeed so it picks the
+	// unit, the way every other speed in the GUI is shown -- a hover on a
+	// fast download reads "2.13 MB/s" rather than "2179.4 kB/s". It wants
+	// bytes per second; the graphs plot kB/s.
+	//
+	// Keyed on the graph rather than on m_strYUnits because those units
+	// are _("kB/s"), i.e. translated: comparing against the literal would
+	// quietly stop matching in every locale but English.
+	if (graph_type == GRAPH_DOWN || graph_type == GRAPH_UP) {
+		return CastItoSpeed((uint32)(value * 1024.0f));
+	}
+
+	wxString formatted = wxString::Format("%.*f", (int)m_nYDecimals, value);
+	if (!m_strYUnits.IsEmpty()) {
+		formatted << " " << m_strYUnits;
+	}
+	return formatted;
+}
+
 bool COScopeCtrl::IsShaded() const
 {
 	if (kShadedTrend >= m_trends.size()) {
@@ -526,11 +547,7 @@ void COScopeCtrl::DrawHover(wxGraphicsContext *gc,
 	std::vector<wxString> aLabel, aValue;
 	for (unsigned iTrend = 0; iTrend < m_trends.size(); ++iTrend) {
 		aLabel.push_back(m_trends[iTrend].strLabel);
-		wxString strValue = wxString::Format("%.*f", (int)m_nYDecimals, samples[iTrend][iSample]);
-		if (!m_strYUnits.IsEmpty()) {
-			strValue << " " << m_strYUnits;
-		}
-		aValue.push_back(strValue);
+		aValue.push_back(FormatValue(samples[iTrend][iSample]));
 	}
 
 	const wxFont font = GetFont();

--- a/src/OScopeCtrl.h
+++ b/src/OScopeCtrl.h
@@ -117,6 +117,8 @@ private:
 	double GetPlotY(float value, const PlotData_t &trend, const wxRect &rectPlot) const;
 	// Whether this graph shades the area under its instantaneous trend.
 	bool IsShaded() const;
+	// One sample as the hover readout shows it, scaled and given its unit.
+	wxString FormatValue(float value) const;
 
 	std::vector<PlotData_t> m_trends;
 	unsigned m_nYGrids;

--- a/src/OScopeCtrl.h
+++ b/src/OScopeCtrl.h
@@ -26,31 +26,36 @@
 #ifndef OSCOPECTRL_H
 #define OSCOPECTRL_H
 
-#ifndef NULL
-#define NULL 0
-#endif
-
 #include <vector>
 #include <wx/control.h> // Needed for wxControl
-#include <wx/timer.h>   // Needed for wxTimer
-#include <wx/pen.h>
-#include <wx/bitmap.h>
 #include <wx/colour.h>
 
 #include "Constants.h" // Needed for StatsGraphType
 
-class wxMemoryDC;
+class wxDC;
+// Only ever held as a pointer here, so this stays valid in a wxWidgets
+// built without wxUSE_GRAPHICS_CONTEXT, where the class does not exist.
+class wxGraphicsContext;
 
 /////////////////////////////////////////////////////////////////////////////
 // COScopeCtrl window
+//
+// A scrolling line graph for the Statistics and Networks->Kad panels. All
+// four graphs in the GUI are instances of this control, so anything changed
+// here applies to every one of them.
+//
+// The control keeps no copy of the plotted samples: every paint asks
+// CStatistics::GetHistory for as many points as the plot area is wide and
+// redraws the whole curve. That is what lets the curves be drawn through a
+// wxGraphicsContext (anti-aliased, resolution independent) -- the previous
+// incremental design scrolled a cached bitmap sideways and appended one
+// segment per sample, which cannot carry anti-aliased content without
+// smearing it, and pinned the graph to the logical, non-HiDPI resolution.
 
 class COScopeCtrl : public wxControl
 {
-	friend class CStatisticsDlg;
-
 public:
-	COScopeCtrl(int NTrends, int nDecimals, StatsGraphType type, wxWindow *parent = NULL);
-	~COScopeCtrl();
+	COScopeCtrl(int NTrends, int nDecimals, StatsGraphType type, wxWindow *parent = nullptr);
 
 	void SetRange(float dLower, float dUpper, unsigned iTrend = 0);
 	void SetRanges(float dLower, float dUpper);
@@ -58,68 +63,79 @@ public:
 	void SetBackgroundColor(const wxColour &color);
 	void SetGridColor(const wxColour &color);
 	void SetPlotColor(const wxColour &color, unsigned iTrend = 0);
-	float GetUpperLimit() { return pdsTrends[0].fUpperLimit; }
-	void Reset(double sNewPeriod);
+	// Name shown for this trend in the hover tooltip, i.e. the same text
+	// the legend beside the graph carries.
+	void SetTrendLabel(const wxString &label, unsigned iTrend = 0);
+	float GetUpperLimit() const { return m_trends[0].fUpperLimit; }
+
+	// Freeze the graph at the last sample (statistics update delay set to 0).
 	void Stop();
-	void RecreateGraph(bool bRefresh = true);
-	void RecreateGrid();
-	void AppendPoints(double sTimestamp, const std::vector<float *> &apf);
-	void DelayPoints() { nDelayedPoints++; }
+	// Resume, and adopt a new seconds-per-sample period.
+	void Reset(double sNewPeriod);
+	// A new sample has been recorded: it is already in the history, so this
+	// only has to ask for a repaint.
+	void AppendPoints(double sTimestamp);
+	// Repaint after something that changes the shape of the curve without
+	// adding a sample, e.g. a new running-average window.
+	void InvalidateGraph() { Refresh(false); }
 
 	StatsGraphType graph_type;
 
-public:
-	unsigned nTrends;
-	unsigned nXGrids;
-	unsigned nYGrids;
-	unsigned nShiftPixels; // amount to shift with each new point
-	unsigned nYDecimals;
+private:
+	struct PlotData_t
+	{
+		wxColour crPlot;
+		wxString strLabel;
+		float fLowerLimit;
+		float fUpperLimit;
+	};
 
-	wxString strXUnits;
-	wxString strYUnits, strYMin, strYMax;
+	void OnPaint(wxPaintEvent &evt);
+	void OnSize(wxSizeEvent &evt);
+	void OnMouseMove(wxMouseEvent &evt);
+	void OnMouseLeave(wxMouseEvent &evt);
+
+	// Splits the client area into the plot rectangle and the label gutters,
+	// measuring the axis labels rather than assuming a character width.
+	wxRect ComputePlotRect(wxDC &dc) const;
+	void DrawGrid(wxDC &dc, const wxRect &rectPlot);
+	// gc is created by the caller, which is where the concrete paint DC
+	// type is still known; it is null if this wxWidgets has no graphics
+	// context, and the curves then fall back to plain wxDC polylines.
+	void DrawCurves(wxDC &dc, wxGraphicsContext *gc, const wxRect &rectPlot);
+	// Crosshair, per-trend markers and the value readout at the hovered
+	// sample. samples is what DrawCurves has just plotted.
+	void DrawHover(wxGraphicsContext *gc,
+		const wxRect &rectPlot,
+		const std::vector<std::vector<float>> &samples,
+		unsigned cntFilled);
+	// Formats the y axis labels; empty strings fall back to the trend range.
+	wxString GetYMaxLabel() const;
+	wxString GetYMinLabel() const;
+	wxString GetXUnitsLabel(const wxRect &rectPlot) const;
+	// y for one sample, clamped into the plot area with room for the pen.
+	double GetPlotY(float value, const PlotData_t &trend, const wxRect &rectPlot) const;
+	// Whether this graph shades the area under its instantaneous trend.
+	bool IsShaded() const;
+
+	std::vector<PlotData_t> m_trends;
+	unsigned m_nYGrids;
+	unsigned m_nShiftPixels; // horizontal distance between two samples
+	unsigned m_nYDecimals;
+
+	wxString m_strYUnits, m_strYMin, m_strYMax;
 	wxColour m_bgColour;
 	wxColour m_gridColour;
 
-	typedef struct PlotDataStruct
-	{
-		wxColour crPlot; // data plot color
-		wxPen penPlot;
-		unsigned yPrev;
-		float fPrev;
-		float fLowerLimit; // lower bounds
-		float fUpperLimit; // upper bounds
-		float fVertScale;
-	} PlotData_t;
+	bool m_bStopped;
+	double m_sLastTimestamp;
+	double m_sLastPeriod;
 
-protected:
+	// Cursor position while it is over the control, wxDefaultPosition
+	// otherwise. Drives the hover readout.
+	wxPoint m_ptHover;
+
 	wxDECLARE_EVENT_TABLE();
-	PlotData_t *pdsTrends;
-
-	wxRect m_rectClient;
-	wxRect m_rectPlot;
-	wxBrush brushBack;
-	wxBitmap m_bmapGrid;
-	wxBitmap m_bmapPlot;
-
-	void InvalidateGraph() { InvalidateCtrl(true, false); }
-	void InvalidateGrid() { InvalidateCtrl(false, true); }
-
-private:
-	bool bRecreateGrid, bRecreateGraph, bRecreateAll, bStopped;
-	int nDelayedPoints;
-	double sLastTimestamp;
-	double sLastPeriod;
-	wxTimer timerRedraw;
-	bool m_onPaint;
-
-	void OnTimer(wxTimerEvent &evt);
-	void OnPaint(wxPaintEvent &evt);
-	void OnSize(wxSizeEvent &evt);
-	void ShiftGraph(unsigned cntPoints);
-	void PlotHistory(unsigned cntPoints, bool bShiftGraph, bool bRefresh);
-	void DrawPoints(const std::vector<float *> &apf, unsigned cntPoints);
-	unsigned GetPlotY(float fPlot, PlotData_t *ppds);
-	void InvalidateCtrl(bool bInvalidateGraph = true, bool bInvalidateGrid = true);
 };
 
 #endif // OSCOPECTRL_H

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -1189,9 +1189,10 @@ bool PrefsUnifiedDlg::TransferFromWindow()
 			CStatisticsDlg::acrStat[i] = thePrefs::s_colors[i];
 			theApp->amuledlg->m_statisticswnd->ApplyStatsColor(i);
 		}
-
-		theApp->amuledlg->m_kademliawnd->SetGraphColors();
 	}
+	// The Kad graph re-reads all of its colours in one go, so it only needs
+	// telling once, after the loop above has updated acrStat.
+	theApp->amuledlg->m_kademliawnd->SetGraphColors();
 
 #ifdef __DEBUG__
 	// Get debugging toggles

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -1258,23 +1258,26 @@ CStatistics::~CStatistics()
 	delete s_statTree;
 }
 
-void CStatistics::AddHistoryRecord(const HR &hr)
+void CStatistics::AddHistoryRecord(const HR &hr, double minSpacing)
 {
-	// Drop anything not newer than what the ring already ends with.
+	// Keep only what the graphs will actually plot: one record every
+	// minSpacing seconds, that being the seconds-per-point they draw at.
 	//
+	// Two things otherwise fill the ring with points no axis asks for.
 	// GetHistoryForGui appends a record before testing whether it is one
-	// the caller already has, so every poll comes back carrying at least
-	// the newest record again, and a poll that finds one new second of
-	// data returns that second plus one older point as well. Drawing is
-	// indifferent -- GetHistory skips same-timestamp records -- but
-	// kHistoryCap counts records rather than distinct samples, so each
-	// duplicate evicts a real one and the graphs reach about half as far
-	// back as the cap suggests.
+	// the caller already has, so every poll returns at least the newest
+	// record again; and the daemon's newest record advances one second per
+	// poll whatever spacing was requested, so a graph drawing at 3 s was
+	// storing three records for every point it could show. Drawing never
+	// noticed -- GetHistory just skips what it does not need -- but
+	// kHistoryCap bounds the ring in records, so both effects cost real
+	// history: measured against a live daemon the graphs opened with 28
+	// minutes behind them and decayed toward 15.
 	//
 	// Safe against a daemon restart resetting its uptime clock: Startup()
 	// builds a new CStatistics (and a new CStatGraphRem) per connection,
 	// so timestamps only ever move forward within one ring's lifetime.
-	if (!listHR.empty() && hr.sTimestamp <= listHR.back().sTimestamp) {
+	if (!listHR.empty() && hr.sTimestamp < listHR.back().sTimestamp + minSpacing) {
 		return;
 	}
 

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -432,6 +432,14 @@ unsigned CStatistics::GetHistory(        // Assemble arrays of sample points for
 		return (0);
 	}
 
+	// CLIENT_GUI builds start with an empty list -- unlike the monolithic
+	// constructor, which pre-allocates every record up front -- and the
+	// rbegin() below is dereferenced before the rend() test, so a paint
+	// arriving before the first graph reply would read an invalid iterator.
+	if (listHR.empty()) {
+		return (0);
+	}
+
 	float *pf1 = ppf[0];
 	float *pf2 = ppf[1];
 	float *pf3 = ppf[2];
@@ -1252,6 +1260,24 @@ CStatistics::~CStatistics()
 
 void CStatistics::AddHistoryRecord(const HR &hr)
 {
+	// Drop anything not newer than what the ring already ends with.
+	//
+	// GetHistoryForGui appends a record before testing whether it is one
+	// the caller already has, so every poll comes back carrying at least
+	// the newest record again, and a poll that finds one new second of
+	// data returns that second plus one older point as well. Drawing is
+	// indifferent -- GetHistory skips same-timestamp records -- but
+	// kHistoryCap counts records rather than distinct samples, so each
+	// duplicate evicts a real one and the graphs reach about half as far
+	// back as the cap suggests.
+	//
+	// Safe against a daemon restart resetting its uptime clock: Startup()
+	// builds a new CStatistics (and a new CStatGraphRem) per connection,
+	// so timestamps only ever move forward within one ring's lifetime.
+	if (!listHR.empty() && hr.sTimestamp <= listHR.back().sTimestamp) {
+		return;
+	}
+
 	listHR.push_back(hr);
 	while (listHR.size() > kHistoryCap) {
 		listHR.pop_front();

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -716,7 +716,13 @@ public:
 	// RecordHistory() does the equivalent push from local counters).
 	// Appends one HR record to listHR and caps the ring at
 	// kHistoryCap so memory stays bounded across long sessions.
-	void AddHistoryRecord(const HR &hr);
+	// minSpacing is the seconds-per-point the graphs are drawing at, and
+	// records closer together than that are dropped: keeping finer data
+	// than is ever plotted just spends the ring on points no axis asks for.
+	void AddHistoryRecord(const HR &hr, double minSpacing);
+	// Drops everything. Used when the sample spacing changes, which
+	// invalidates the resolution the stored points were kept at.
+	void ClearHistory() { listHR.clear(); }
 	// Records, not seconds: they are spaced at whatever scale CStatGraphRem
 	// asked the daemon for, which is the "Update delay" preference. So this
 	// is ~30 min at a 1 s delay and proportionally longer above that.

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -723,10 +723,15 @@ public:
 	// Drops everything. Used when the sample spacing changes, which
 	// invalidates the resolution the stored points were kept at.
 	void ClearHistory() { listHR.clear(); }
-	// Records, not seconds: they are spaced at whatever scale CStatGraphRem
-	// asked the daemon for, which is the "Update delay" preference. So this
-	// is ~30 min at a 1 s delay and proportionally longer above that.
-	static const size_t kHistoryCap = 1800;
+	// Records, not seconds. One is kept per plotted point, so the useful
+	// way to read this is as a plot width: a graph draws one point per
+	// pixel, and cannot show more than this many however wide its window
+	// is. The span that covers depends on the "Update delay" preference
+	// the points were fetched at -- 3 h at a 1 s delay, a day at 8 s --
+	// but the pixel bound is the same either way, which is what matters
+	// because the Kad graph spans the whole window. At 64 bytes a record
+	// the whole ring is about 225 KB.
+	static const size_t kHistoryCap = 3600;
 
 	static uint64 GetUptimeMillis();
 	static uint64 GetUptimeSeconds();

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -508,6 +508,23 @@ public:
 
 	void SetAverageMinutes(uint8 minutes) { average_minutes = minutes; }
 
+	// Records held per resolution range. The list is nHistRanges of these,
+	// each range at twice the spacing of the one before, so this sets both
+	// how far back the graphs can reach and how much of that reach is at
+	// fine resolution: at a 3 s update delay the two finest ranges are the
+	// ones a graph can plot from, giving 3 x this many seconds of history.
+	//
+	// Was (1280 / 2) - 80 = 560, once derived from a GUI width. That put
+	// the finest usable reach at 28 minutes, which a remote GUI could
+	// exhaust in a window barely wider than half a screen. At 64 bytes a
+	// record the whole list costs 7 x this x 64 bytes -- 787 KB here,
+	// against 245 KB at the old value.
+	//
+	// Public because it is reported to remote GUIs over EC: a client that
+	// asked for more points than a range holds would be answered with the
+	// same record repeated, and would have no way to tell.
+	static int GetPointsPerRange() { return 1800; }
+
 private:
 	std::list<HR> listHR;
 	typedef std::list<HR>::iterator listPOS;
@@ -521,11 +538,6 @@ private:
 		double sStep,
 		const std::vector<float *> &ppf,
 		StatsGraphType which_graph);
-
-	int GetPointsPerRange()
-	{
-		return (1280 / 2) - 80; // This used to be a calc. based on GUI width
-	}
 
 	/* Graphs-related vars */
 

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -717,7 +717,10 @@ public:
 	// Appends one HR record to listHR and caps the ring at
 	// kHistoryCap so memory stays bounded across long sessions.
 	void AddHistoryRecord(const HR &hr);
-	static const size_t kHistoryCap = 1800; // ~30 min @ 1 Hz
+	// Records, not seconds: they are spaced at whatever scale CStatGraphRem
+	// asked the daemon for, which is the "Update delay" preference. So this
+	// is ~30 min at a 1 s delay and proportionally longer above that.
+	static const size_t kHistoryCap = 1800;
 
 	static uint64 GetUptimeMillis();
 	static uint64 GetUptimeSeconds();

--- a/src/StatisticsDlg.cpp
+++ b/src/StatisticsDlg.cpp
@@ -116,80 +116,63 @@ wxColour CStatisticsDlg::acrStat[cntStatColors] = { wxColour(0, 0, 64),
 	wxColour(0, 210, 0),
 	wxColour(0, 128, 0) };
 
+void CStatisticsDlg::ApplyGraphFrameColors(COScopeCtrl *scope)
+{
+	scope->SetBackgroundColor(getColors(kGraphBackgroundColor));
+	scope->SetGridColor(getColors(kGraphGridColor));
+}
+
+void CStatisticsDlg::ApplyGraphSlot(wxWindow *panel, COScopeCtrl *scope, const GraphColorSlot &slot)
+{
+	const wxColour &cr = getColors(slot.colorIndex);
+	scope->SetPlotColor(cr, slot.iTrend);
+	scope->SetTrendLabel(wxGetTranslation(slot.label), slot.iTrend);
+
+	CColorFrameCtrl *swatch = dynamic_cast<CColorFrameCtrl *>(panel->FindWindow(slot.swatchId));
+	if (swatch == nullptr) {
+		throw wxString(
+			CFormat("CStatisticsDlg::ApplyGraphSlot: control missing (%d)\n") % slot.swatchId);
+	}
+	swatch->SetBackgroundBrushColour(cr);
+	swatch->SetFrameBrushColour(*wxBLACK);
+}
+
 void CStatisticsDlg::ApplyStatsColor(int index)
 {
-	static char aTrend[] = { 0, 0, 2, 1, 0, 2, 1, 0, 1, 2, 0 };
-	static int aRes[] = {
-		0, 0, IDC_C0, IDC_C0_3, IDC_C0_2, IDC_C1, IDC_C1_3, IDC_C1_2, IDC_S0, IDC_S3, IDC_S1
-	};
-	// clang-format off
-	static COScopeCtrl** apscope[] = { NULL, NULL, &pscopeDL,&pscopeDL,&pscopeDL, &pscopeUL,&pscopeUL,&pscopeUL, &pscopeConn,&pscopeConn,&pscopeConn };
-	// clang-format on
+	// Colours 2..10 drive one trend each of the three graphs on this panel,
+	// three per graph. Colour 11 is the systray speed bar and 12..14 belong
+	// to the Kad graph; both are applied by their own owners.
+	static const GraphColorSlot aSlot[] = { { 2, 2, IDC_C0, wxTRANSLATE("Current") },
+		{ 3, 1, IDC_C0_3, wxTRANSLATE("Running average") },
+		{ 4, 0, IDC_C0_2, wxTRANSLATE("Session average") },
+		{ 5, 2, IDC_C1, wxTRANSLATE("Current") },
+		{ 6, 1, IDC_C1_3, wxTRANSLATE("Running average") },
+		{ 7, 0, IDC_C1_2, wxTRANSLATE("Session average") },
+		{ 8, 1, IDC_S0, wxTRANSLATE("Active connections") },
+		{ 9, 2, IDC_S3, wxTRANSLATE("Active downloads") },
+		{ 10, 0, IDC_S1, wxTRANSLATE("Active uploads") } };
 
-	const wxColour &cr = acrStat[index];
-
-	int iRes = aRes[index];
-	int iTrend = (unsigned char)aTrend[index];
-	COScopeCtrl **ppscope = apscope[index];
-	CColorFrameCtrl *ctrl;
-	switch (index) {
-	case 0:
-		pscopeDL->SetBackgroundColor(cr);
-		pscopeUL->SetBackgroundColor(cr);
-		pscopeConn->SetBackgroundColor(cr);
-		break;
-	case 1:
-		pscopeDL->SetGridColor(cr);
-		pscopeUL->SetGridColor(cr);
-		pscopeConn->SetGridColor(cr);
-		break;
-	case 2:
-	case 3:
-	case 4:
-	case 5:
-	case 6:
-	case 7:
-	case 8:
-	case 9:
-	case 10:
-		(*ppscope)->SetPlotColor(cr, iTrend);
-		if ((ctrl = CastChild(iRes, CColorFrameCtrl)) == NULL) {
-			throw wxString(
-				CFormat("CStatisticsDlg::ApplyStatsColor: control missing (%d)\n") % iRes);
-		}
-		ctrl->SetBackgroundBrushColour(cr);
-		ctrl->SetFrameBrushColour(*wxBLACK);
-		break;
-	default:
-		break; // ignore unknown index, like SysTray speedbar color
+	if (index == kGraphBackgroundColor || index == kGraphGridColor) {
+		ApplyGraphFrameColors(pscopeDL);
+		ApplyGraphFrameColors(pscopeUL);
+		ApplyGraphFrameColors(pscopeConn);
+		return;
 	}
+
+	if (index < 2 || index > 10) {
+		return; // not one of this panel's graph colours
+	}
+
+	COScopeCtrl *scope = (index <= 4) ? pscopeDL : ((index <= 7) ? pscopeUL : pscopeConn);
+	ApplyGraphSlot(this, scope, aSlot[index - 2]);
 }
 
 void CStatisticsDlg::UpdateStatGraphs(const uint32 peakconnections, const GraphUpdateInfo &update)
 {
 
-	std::vector<float *> v1(3);
-	v1[0] = const_cast<float *>(&update.downloads[0]);
-	v1[1] = const_cast<float *>(&update.downloads[1]);
-	v1[2] = const_cast<float *>(&update.downloads[2]);
-	const std::vector<float *> &apfDown(v1);
-	std::vector<float *> v2(3);
-	v2[0] = const_cast<float *>(&update.uploads[0]);
-	v2[1] = const_cast<float *>(&update.uploads[1]);
-	v2[2] = const_cast<float *>(&update.uploads[2]);
-	const std::vector<float *> &apfUp(v2);
-	std::vector<float *> v3(3);
-	v3[0] = const_cast<float *>(&update.connections[0]);
-	v3[1] = const_cast<float *>(&update.connections[1]);
-	v3[2] = const_cast<float *>(&update.connections[2]);
-	const std::vector<float *> &apfConn(v3);
-
-	if (!IsShownOnScreen()) {
-		pscopeDL->DelayPoints();
-		pscopeUL->DelayPoints();
-		pscopeConn->DelayPoints();
-	}
-
+	// The sample itself reaches the graphs through the statistics history,
+	// which already holds it by the time we get here; update only carries
+	// what this panel needs for its own labels and ranges.
 	static unsigned nScalePrev = 1;
 	unsigned nScale = (unsigned)std::ceil((float)peakconnections / pscopeConn->GetUpperLimit());
 	if (nScale != nScalePrev) {
@@ -206,9 +189,9 @@ void CStatisticsDlg::UpdateStatGraphs(const uint32 peakconnections, const GraphU
 		return;
 	}
 
-	pscopeDL->AppendPoints(update.timestamp, apfDown);
-	pscopeUL->AppendPoints(update.timestamp, apfUp);
-	pscopeConn->AppendPoints(update.timestamp, apfConn);
+	pscopeDL->AppendPoints(update.timestamp);
+	pscopeUL->AppendPoints(update.timestamp);
+	pscopeConn->AppendPoints(update.timestamp);
 }
 
 void CStatisticsDlg::SetUpdatePeriod(int step)

--- a/src/StatisticsDlg.h
+++ b/src/StatisticsDlg.h
@@ -67,6 +67,32 @@ public:
 	void ApplyStatsColor(int index);
 	void RebuildStatTreeRemote(const CECTag *);
 	static const wxColour &getColors(unsigned num);
+
+	// Colour indexes shared by every graph in the GUI.
+	enum
+	{
+		kGraphBackgroundColor = 0,
+		kGraphGridColor = 1
+	};
+
+	// One trend's colour wiring: which preference colour drives it and
+	// which legend swatch shows the same colour beside the graph. CKadDlg
+	// describes its graph with these too, so both panels colour their
+	// graphs through the code below rather than each rolling its own.
+	struct GraphColorSlot
+	{
+		unsigned colorIndex; // index into getColors()
+		unsigned iTrend;     // trend within the graph
+		int swatchId;        // CColorFrameCtrl showing the same colour
+		// wxTRANSLATE'd copy of the legend text beside the swatch; the
+		// graph shows it in its hover readout.
+		const char *label;
+	};
+
+	// Background and grid are the same two colours for every graph.
+	static void ApplyGraphFrameColors(COScopeCtrl *scope);
+	// panel is the window holding slot.swatchId.
+	static void ApplyGraphSlot(wxWindow *panel, COScopeCtrl *scope, const GraphColorSlot &slot);
 	COScopeCtrl *GetDLScope() { return pscopeDL; };
 	COScopeCtrl *GetConnScope() { return pscopeConn; };
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -4088,7 +4088,17 @@ void CStatGraphRem::DoRequery()
 	// however far back the user had asked to see. Monolithic amule has no
 	// equivalent step because it reads the same history directly.
 	const uint16 nScale = std::max<uint16>(thePrefs::GetTrafficOMeterInterval(), 1);
-	m_sScale = (double)nScale;
+	if ((double)nScale != m_sScale) {
+		// The ring keeps one record per requested interval, so what is in
+		// it is only meaningful at the scale it was fetched at: replotting
+		// 8 s records on a 3 s axis would place them at the wrong times.
+		// Drop it and let it refill at the new resolution. Deliberately
+		// without resetting m_lastTimestamp -- asking for a fresh backfill
+		// here would race the reply still in the air from the previous
+		// scale, whose points would then be timestamped with this one.
+		theApp->m_statistics->ClearHistory();
+		m_sScale = (double)nScale;
+	}
 	request.AddTag(CECTag(EC_TAG_STATSGRAPH_SCALE, nScale));
 	// Upper bound on points per reply. In the steady state the daemon
 	// only sends what is newer than the timestamp above, i.e. one point
@@ -4275,7 +4285,7 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 			/* cntConnections */ (uint16)conn,
 			/* kadNodesCur    */ (uint16)kad,
 			/* kadNodesTotal  */ (uint64)aKadTotal[i] };
-		theApp->m_statistics->AddHistoryRecord(hr);
+		theApp->m_statistics->AddHistoryRecord(hr, m_sScale);
 
 		if (theApp->amuledlg) {
 			theApp->amuledlg->m_statisticswnd->UpdateStatGraphs(m_peakConnections, update);

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -4074,8 +4074,9 @@ void CStatGraphRem::DoRequery()
 {
 	CECPacket request(EC_OP_GET_STATSGRAPHS, EC_DETAIL_FULL);
 	// Send back the most recent timestamp we've seen; daemon-side
-	// CStatistics::GetHistoryForWeb uses it as the lower bound so the
+	// CStatistics::GetHistoryForGui uses it as the lower bound so the
 	// response only carries points the GUI hasn't drawn yet.
+	// (GetHistoryForWeb is amuleweb's near-identical twin, not this path.)
 	request.AddTag(CECTag(EC_TAG_STATSGRAPH_LAST, m_lastTimestamp));
 	// Seconds between points. This has to be the same step the graphs are
 	// going to plot at -- COScopeCtrl gets it from the "Update delay"

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -4062,6 +4062,14 @@ void CStatTreeRem::HandlePacket(const CECPacket *p)
 	}
 }
 
+namespace
+{
+// See the comment in DoRequery: the daemon's newest history range holds
+// this many records at 1 s spacing.
+const uint16 kMaxHistoryPoints = 560;
+
+} // namespace
+
 void CStatGraphRem::DoRequery()
 {
 	CECPacket request(EC_OP_GET_STATSGRAPHS, EC_DETAIL_FULL);
@@ -4069,14 +4077,34 @@ void CStatGraphRem::DoRequery()
 	// CStatistics::GetHistoryForWeb uses it as the lower bound so the
 	// response only carries points the GUI hasn't drawn yet.
 	request.AddTag(CECTag(EC_TAG_STATSGRAPH_LAST, m_lastTimestamp));
-	// 1 s between points — matches monolithic amule's
-	// CamuleDlg::OnCoreTimer graph cadence, and lines up with the
-	// 1 s history-record granularity the daemon itself stores.
-	request.AddTag(CECTag(EC_TAG_STATSGRAPH_SCALE, (uint16)1));
-	// Generous upper bound: 32 points = ~32 s of backlog per poll,
-	// so a brief stall / reconnect catches up in one round-trip
-	// instead of needing dozens.
-	request.AddTag(CECTag(EC_TAG_STATSGRAPH_WIDTH, (uint16)32));
+	// Seconds between points. This has to be the same step the graphs are
+	// going to plot at -- COScopeCtrl gets it from the "Update delay"
+	// preference via CStatisticsDlg::SetUpdatePeriod, and asks
+	// CStatistics::GetHistory for points that far apart. Requesting a
+	// fixed 1 s here (which is what this used to do) meant amulegui
+	// honoured the preference when drawing and ignored it when fetching,
+	// so the graphs only ever had the daemon's 1-second range behind them
+	// however far back the user had asked to see. Monolithic amule has no
+	// equivalent step because it reads the same history directly.
+	const uint16 nScale = std::max<uint16>(thePrefs::GetTrafficOMeterInterval(), 1);
+	m_sScale = (double)nScale;
+	request.AddTag(CECTag(EC_TAG_STATSGRAPH_SCALE, nScale));
+	// Upper bound on points per reply. In the steady state the daemon
+	// only sends what is newer than the timestamp above, i.e. one point
+	// per poll, so this bites in exactly two cases: the first poll after
+	// connecting, where m_lastTimestamp is still 0 and the daemon serves
+	// its whole history, and catching up after a stall or a reconnect.
+	// Both then arrive in a single round-trip and the graphs open with
+	// history behind them instead of filling in over the next minutes.
+	//
+	// The value is the depth of the daemon's 1-second history range:
+	// CStatistics allocates GetPointsPerRange() records per range and
+	// keeps only the newest range at 1 s spacing (the ones behind it go
+	// to 2 s, 4 s, ...). Asking for more would return records that are
+	// not 1 s apart while HandlePacket reconstructs their timestamps
+	// assuming they are, which stretches the left of the plot rather
+	// than showing more of the past.
+	request.AddTag(CECTag(EC_TAG_STATSGRAPH_WIDTH, (uint16)kMaxHistoryPoints));
 	m_conn->SendRequest(this, &request);
 }
 
@@ -4129,14 +4157,43 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 	const float sessionUl = sessionTs > 0.0 ? (float)(sessionUlB / sessionTs) : 0.0f;
 	const float sessionKad = sessionTs > 0.0 ? (float)(sessionKadN / sessionTs) : 0.0f;
 
-	// Running-average window: mirror CPreciseRateCounter's
-	// count_average=true behaviour with a deque of per-second samples
-	// sized to GetStatsAverageMinutes() minutes (the same preference
-	// monolithic amule's CStatistics::OnStatsChange uses). The
-	// daemon-side counter's per-tick state isn't on the wire, so this
-	// is recomputed locally from the per-point rates we already unpack.
-	const size_t winCap = (size_t)thePrefs::GetStatsAverageMinutes() * 60;
-	const size_t cap = winCap ? winCap : 1;
+	// Cumulative session counters for each point in the reply.
+	//
+	// ComputeAverages derives the session-average trend as
+	// kBytesReceived / sTimestamp, so it needs the cumulative figure as
+	// it stood at each point, but the daemon only sends the latest one.
+	// Storing that latest figure against every point (which is what this
+	// used to do) is close enough over the handful of points a steady
+	// poll returns, and turns the trend into a flat line at today's
+	// value over the several hundred a backfill returns.
+	//
+	// So walk it backwards instead: the newest point takes the daemon's
+	// own figure, and each earlier point subtracts the per-point rate
+	// that this same reply already carries. Only the session-average
+	// trend depends on this -- the current-rate trend is the daemon's
+	// per-point value verbatim, and the running average is rebuilt from
+	// those same per-point values.
+	std::vector<double> aKBytesDl(numPoints, 0.0);
+	std::vector<double> aKBytesUl(numPoints, 0.0);
+	std::vector<double> aKadTotal(numPoints, 0.0);
+	{
+		double kDl = (double)sessionDlB;
+		double kUl = (double)sessionUlB;
+		double kKad = (double)sessionKadN;
+		for (size_t j = numPoints; j-- > 0;) {
+			aKBytesDl[j] = std::max(kDl, 0.0);
+			aKBytesUl[j] = std::max(kUl, 0.0);
+			aKadTotal[j] = std::max(kKad, 0.0);
+
+			uint32 dl, ul, kad;
+			memcpy(&dl, raw + j * 16 + 0, 4);
+			memcpy(&ul, raw + j * 16 + 4, 4);
+			memcpy(&kad, raw + j * 16 + 12, 4);
+			kDl -= (ENDIAN_NTOHL(dl) / 1024.0) * m_sScale;
+			kUl -= (ENDIAN_NTOHL(ul) / 1024.0) * m_sScale;
+			kKad -= (double)ENDIAN_NTOHL(kad) * m_sScale;
+		}
+	}
 
 	for (size_t i = 0; i < numPoints; i++) {
 		uint32 dl, ul, conn, kad;
@@ -4161,40 +4218,27 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 		const float ul_kbps = ul / 1024.0f;
 		const float kad_cnt = (float)kad;
 
-		m_winDl.push_back(dl_kbps);
-		m_winUp.push_back(ul_kbps);
-		m_winKad.push_back(kad_cnt);
-		while (m_winDl.size() > cap)
-			m_winDl.pop_front();
-		while (m_winUp.size() > cap)
-			m_winUp.pop_front();
-		while (m_winKad.size() > cap)
-			m_winKad.pop_front();
-
-		double sumDl = 0.0, sumUp = 0.0, sumKad = 0.0;
-		for (float v : m_winDl)
-			sumDl += v;
-		for (float v : m_winUp)
-			sumUp += v;
-		for (float v : m_winKad)
-			sumKad += v;
-		const float runDl = m_winDl.empty() ? 0.0f : (float)(sumDl / m_winDl.size());
-		const float runUp = m_winUp.empty() ? 0.0f : (float)(sumUp / m_winUp.size());
-		const float runKad = m_winKad.empty() ? 0.0f : (float)(sumKad / m_winKad.size());
-
 		GraphUpdateInfo update;
 		update.timestamp = m_lastTimestamp;
 		// Slot layout matches CStatistics::GetPointsForUpdate:
 		//   downloads/uploads/kadnodes — [0] session avg, [1] running avg, [2] current.
 		//   connections — [0] cntUploads, [1] cntConnections, [2] cntDownloads.
+		// Only timestamp and kadnodes[2] are read now that the graphs draw
+		// from the history rather than from the point handed to them; the
+		// rest is filled to keep the struct's contract with the monolithic
+		// producer. In particular the running-average slots are left at
+		// their per-point value: the trend the graphs actually plot is
+		// rebuilt by CStatistics::ComputeAverages, which sizes its window
+		// from the sample step and so stays right whatever scale we asked
+		// the daemon for.
 		update.downloads[0] = sessionDl;
-		update.downloads[1] = runDl;
+		update.downloads[1] = dl_kbps;
 		update.downloads[2] = dl_kbps;
 		update.uploads[0] = sessionUl;
-		update.uploads[1] = runUp;
+		update.uploads[1] = ul_kbps;
 		update.uploads[2] = ul_kbps;
 		update.kadnodes[0] = sessionKad;
-		update.kadnodes[1] = runKad;
+		update.kadnodes[1] = kad_cnt;
 		update.kadnodes[2] = kad_cnt;
 		update.connections[0] = (float)cntUp;
 		update.connections[1] = (float)conn;
@@ -4203,27 +4247,26 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 		if (conn > m_peakConnections) {
 			m_peakConnections = conn;
 		}
-		if (theApp->amuledlg) {
-			theApp->amuledlg->m_statisticswnd->UpdateStatGraphs(m_peakConnections, update);
-			theApp->amuledlg->m_kademliawnd->UpdateGraph(update);
-		}
 
 		// Mirror the decoded point into the client-side history ring
-		// so COScopeCtrl::PlotHistory (now shared with monolithic) can
-		// replay across tab switches and auto-rescale wipes without
-		// another daemon round-trip. Field mapping mirrors
-		// CStatistics::GetPointsForUpdate so the same GetHistory +
-		// ComputeAverages code paths read it back correctly:
+		// so COScopeCtrl (which draws straight from the history, and is
+		// shared with monolithic) can replay across tab switches and
+		// auto-rescale wipes without another daemon round-trip. This has
+		// to happen before the graphs are told about the sample, which is
+		// also the order the monolithic build sees: there,
+		// CStatistics::GetPointsForUpdate reads the record back out of
+		// the history to build update. Field mapping mirrors
+		// GetPointsForUpdate so the same GetHistory + ComputeAverages
+		// code paths read it back correctly:
 		//   kBytes{Received,Sent} / kadNodesTotal are stored as
 		//   (session rate * timestamp) so ComputeAverages's
 		//   "kValueRun / sTimestamp" recovers the session-avg trend.
 		// Per-point timestamps are reconstructed from the batch by
 		// stepping back from m_lastTimestamp at 1 s spacing (matches
 		// the scale we request in DoRequery).
-		const double sStep = 1.0;
-		const double pointTs = m_lastTimestamp - (double)(numPoints - 1 - i) * sStep;
-		HR hr = { /* kBytesSent     */ (double)sessionUl * pointTs,
-			/* kBytesReceived */ (double)sessionDl * pointTs,
+		const double pointTs = m_lastTimestamp - (double)(numPoints - 1 - i) * m_sScale;
+		HR hr = { /* kBytesSent     */ aKBytesUl[i],
+			/* kBytesReceived */ aKBytesDl[i],
 			/* kBpsUpCur      */ ul_kbps,
 			/* kBpsDownCur    */ dl_kbps,
 			/* sTimestamp     */ pointTs,
@@ -4231,8 +4274,13 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 			/* cntUploads     */ (uint16)cntUp,
 			/* cntConnections */ (uint16)conn,
 			/* kadNodesCur    */ (uint16)kad,
-			/* kadNodesTotal  */ (uint64)((double)sessionKad * pointTs) };
+			/* kadNodesTotal  */ (uint64)aKadTotal[i] };
 		theApp->m_statistics->AddHistoryRecord(hr);
+
+		if (theApp->amuledlg) {
+			theApp->amuledlg->m_statisticswnd->UpdateStatGraphs(m_peakConnections, update);
+			theApp->amuledlg->m_kademliawnd->UpdateGraph(update);
+		}
 	}
 }
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -4123,9 +4123,8 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 	m_lastTimestamp = tsTag->GetDoubleData();
 
 	// EC_TAG_STATSGRAPH_DATA carries N x (dl_Bps, ul_Bps, conn, kadCur)
-	// uint32 4-tuples in network byte order. Points are sStep seconds
-	// apart (we request 1 s in DoRequery, matching monolithic amule's
-	// CamuleDlg::OnCoreTimer graph cadence).
+	// uint32 4-tuples in network byte order. Points are m_sScale seconds
+	// apart, that being the scale DoRequery asked this reply for.
 	const uint8_t *raw = (const uint8_t *)dataTag->GetTagData();
 	size_t dataLen = dataTag->GetTagDataLen();
 	size_t numPoints = dataLen / (4 * sizeof(uint32));

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -4065,8 +4065,15 @@ void CStatTreeRem::HandlePacket(const CECPacket *p)
 namespace
 {
 // See the comment in DoRequery: the daemon's newest history range holds
-// this many records at 1 s spacing.
-const uint16 kMaxHistoryPoints = 560;
+// this many records at its finest spacing, so this is how much it can
+// serve before the answers stop lining up with the scale we asked for.
+// Tracks CStatistics::GetPointsPerRange() and has to be raised with it.
+//
+// Against an older daemon, whose ranges are shallower, a request this
+// deep runs off the end of the resolution it was asked for and the far
+// left of the first backfill is drawn time-compressed. It corrects
+// itself as live points replace the backfilled ones.
+const uint16 kMaxHistoryPoints = 1800;
 
 } // namespace
 
@@ -4115,7 +4122,7 @@ void CStatGraphRem::DoRequery()
 	// not 1 s apart while HandlePacket reconstructs their timestamps
 	// assuming they are, which stretches the left of the plot rather
 	// than showing more of the past.
-	request.AddTag(CECTag(EC_TAG_STATSGRAPH_WIDTH, (uint16)kMaxHistoryPoints));
+	request.AddTag(CECTag(EC_TAG_STATSGRAPH_WIDTH, std::min(kMaxHistoryPoints, m_nDaemonDepth)));
 	m_conn->SendRequest(this, &request);
 }
 
@@ -4132,6 +4139,24 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 		return;
 	}
 	m_lastTimestamp = tsTag->GetDoubleData();
+
+	// How many points this daemon can answer with before it starts
+	// repeating a record. Absent from daemons predating the tag, which is
+	// exactly the case the conservative default covers. Learning that it
+	// can serve more than we asked for is worth a one-off refetch: the
+	// ring only accepts points newer than what it holds, so the deeper
+	// history would never arrive otherwise.
+	const CECTag *depthTag = p->GetTagByName(EC_TAG_STATSGRAPH_DEPTH);
+	if (depthTag) {
+		const uint16 nDepth = std::max<uint16>((uint16)depthTag->GetInt(), 1);
+		if (nDepth > m_nDaemonDepth) {
+			m_nDaemonDepth = nDepth;
+			theApp->m_statistics->ClearHistory();
+			m_lastTimestamp = 0.0;
+			return;
+		}
+		m_nDaemonDepth = nDepth;
+	}
 
 	// EC_TAG_STATSGRAPH_DATA carries N x (dl_Bps, ul_Bps, conn, kadCur)
 	// uint32 4-tuples in network byte order. Points are m_sScale seconds

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -25,7 +25,6 @@
 #ifndef AMULE_REMOTE_GUI_H
 #define AMULE_REMOTE_GUI_H
 
-#include <deque>                  // std::deque for CStatGraphRem rolling-average windows
 #include <functional>             // std::function for the CSharedFilesRem
 				  // Reload(yieldCb) shim — matches the daemon-side
 				  // signature added in PrefsUnifiedDlg's commit path.
@@ -891,17 +890,12 @@ class CStatGraphRem : public CECPacketHandlerBase
 	// Last timestamp the daemon reported; sent back on the next request
 	// so the response only carries points the GUI hasn't seen yet.
 	double m_lastTimestamp;
-
-	// Per-metric sliding window of recent samples — feeds the
-	// "Running average" line on each COScopeCtrl. Mirrors monolithic
-	// amule's CPreciseRateCounter with count_average=true: simple
-	// mean of the last N one-second samples, where N is
-	// GetStatsAverageMinutes()*60. Session average is pulled from
-	// EC_TAG_STATSGRAPH_SESSION_* (set by the daemon) so no local
-	// integral is needed.
-	std::deque<float> m_winDl;
-	std::deque<float> m_winUp;
-	std::deque<float> m_winKad;
+	// Seconds between points, as asked for by the request this reply
+	// answers. Timestamps are not on the wire, so HandlePacket steps back
+	// from m_lastTimestamp at this spacing to place the points; keeping
+	// the value the request used means a preference change mid-flight
+	// cannot mislabel the reply already in the air.
+	double m_sScale;
 
 public:
 	// Peak connection count seen so far. CLIENT_GUI doesn't get the
@@ -913,6 +907,7 @@ public:
 	CStatGraphRem(CRemoteConnect *conn)
 	: m_conn(conn)
 	, m_lastTimestamp(0.0)
+	, m_sScale(1.0)
 	, m_peakConnections(0)
 	{
 	}

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -896,6 +896,12 @@ class CStatGraphRem : public CECPacketHandlerBase
 	// the value the request used means a preference change mid-flight
 	// cannot mislabel the reply already in the air.
 	double m_sScale;
+	// Points this daemon says it can answer with per resolution range,
+	// from EC_TAG_STATSGRAPH_DEPTH. Starts at what daemons predating that
+	// tag were built with, since their silence is indistinguishable from
+	// having that much -- asking for more would get records repeated, and
+	// with no timestamps on the wire they would be drawn as real samples.
+	uint16 m_nDaemonDepth;
 
 public:
 	// Peak connection count seen so far. CLIENT_GUI doesn't get the
@@ -908,6 +914,7 @@ public:
 	: m_conn(conn)
 	, m_lastTimestamp(0.0)
 	, m_sScale(1.0)
+	, m_nDaemonDepth(560)
 	, m_peakConnections(0)
 	{
 	}

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -600,6 +600,13 @@ EC_TAG_SELECT_PREFS                       0x1000
 ## EC_TAG_STAT_NODE_VALUE; the English display string stays alongside it
 ## (EC_VALUE_STRING) so GUI/legacy consumers are unaffected.
 		EC_TAG_STAT_VALUE_ENUM                    0x1B13
+## Records the daemon holds per resolution range, i.e. how many points
+## it can answer with before it starts repeating a record because the
+## requested spacing is finer than the one it stored. Timestamps are not
+## on the wire, so a client that over-asks cannot tell the repeats apart
+## and would draw them as distinct samples on a wrong time axis. Absent
+## from daemons predating this tag; assume the 560 they were built with.
+		EC_TAG_STATSGRAPH_DEPTH                   0x1B14
 
 	EC_TAG_PREFS_SECURITY                     0x1C00
 		EC_TAG_SECURITY_CAN_SEE_SHARES            0x1C01


### PR DESCRIPTION
The graphs on the Statistics and Networks → Kad panels were still drawn the way they were in 2002, and on a remote GUI they were also nearly empty. This rewrites the renderer, adds a hover readout, and fixes the history behind them — which turned out to be several separate faults, only one of which was visible before this work put history on screen where a user could see it disappear.

All four graphs are instances of the same control, so everything here applies to each of them.

## The renderer

`COScopeCtrl` scrolled a cached bitmap sideways and appended one line segment per sample. That was cheap, but it pinned the graphs to aliased hairlines at the logical, non-HiDPI resolution: anti-aliased content cannot be blitted sideways without smearing its edge pixels, and the cached bitmaps were created at logical size, so a HiDPI display upscaled them.

wxWidgets ships no chart widget and 3.2/3.3 add none, so there was nothing to switch to. What it does have — and what aMule was not using anywhere — is `wxGraphicsContext`, anti-aliased vector drawing backed by Core Graphics, Cairo or Direct2D/GDI+ depending on platform.

The control now keeps no copy of the plotted samples. Every paint asks `CStatistics::GetHistory` for as many points as the plot is wide and redraws the whole curve, which is the path a resize already took, so the data side needed nothing new. That removes `ShiftGraph`, `DrawPoints`, `PlotHistory`, `RecreateGrid`, `RecreateGraph`, both cached bitmaps, the coalescing timer, the four `bRecreate*` flags and the delayed-point counter.

Two deliberate splits: only the data curves go through the graphics context, because the grid and axis labels are axis-aligned hairlines that stay crisper unsmoothed; and the context is created in `OnPaint` rather than in `DrawCurves`, because `wxGraphicsContext::Create` has no overload for the `wxDC` base class and the concrete paint-DC type has to still be in scope. A `wxDC` polyline fallback sits behind `#if wxUSE_GRAPHICS_CONTEXT` for a wx built without it.

With the bitmaps gone the graphs are HiDPI-correct, and the left gutter is measured from the axis labels instead of assuming six pixels per character for seven of them — too wide at small values, too narrow past five digits.

`AppendPoints` no longer takes the sample: it is already in the history by the time the graphs hear about it, so both callers stop building a `std::vector<float *>` of `const_cast`s, and `DelayPoints` goes with the incremental path it fed.

## Shading, hover and the readout

The area under the instantaneous trend is shaded with a vertical gradient in the trend's own colour, anchored to the curve's peak rather than the top of the plot — otherwise the shading's opacity depends on how much of the y range the graph happens to use, and a transfer rate well under the configured maximum sits low in the plot where a plot-anchored gradient has already faded out. The connections graph is deliberately unshaded: its three trends are unrelated counts, unlike the rate and Kad graphs where the three are current / running-average / session-average views of one quantity.

Hovering gives a crosshair at the nearest sample, a marker per trend ringed in the background colour so overlapping markers stay separable, and a readout naming each trend with its value. Speeds go through `CastItoSpeed`, so a fast transfer reads `2.13 MB/s` rather than `2179.4 kB/s`. Trend names reuse the strings the legend already carries, so the catalogs gain no messages.

## Shared colour wiring

`CStatisticsDlg::ApplyGraphFrameColors` and `ApplyGraphSlot` are now the single implementation of pointing a graph and its legend swatch at a preference colour; `CKadDlg` described the same thing separately. `PrefsUnifiedDlg` was calling `SetGraphColors()` once per colour rather than once.

## amulegui: history that reaches as far as the window

Four separate faults, each in its own commit.

**The update delay was honoured when drawing and ignored when fetching.** `COScopeCtrl` asks `GetHistory` for points as far apart as the *Update delay* preference, but `DoRequery` always requested a scale of 1 s. However far back the user asked to see, only the daemon's 1-second range was ever behind the plot. It now requests the scale it will plot at, and remembers it for the reply so a preference change in flight cannot mislabel the batch answering it.

**The reply cap was 32 points.** Since the request carries the newest timestamp the GUI holds, the daemon only sends what is newer, so the cap only bit on the first poll after connecting — where that timestamp is 0 and the daemon would serve its whole history — and when catching up after a stall. Both now arrive in one round-trip, so the panel opens with history behind it rather than filling in over the following minutes.

**Duplicates were evicting real history.** `GetHistoryForGui` appends a record before testing whether the caller already has it, so every poll returns at least the newest record again. Drawing never noticed, because `GetHistory` skips records sharing a timestamp — but `kHistoryCap` bounds the ring in records, not distinct samples, so each duplicate evicted a real one. Measured against a live daemon, the graphs opened with 28 minutes behind them and decayed to 15.

**The ring stored finer data than any axis asked for.** The daemon's newest record advances one second per poll whatever spacing was requested, so a graph drawing at a 3 s delay kept three records per plotted point. It now keeps one record per plotted interval, which makes the ring's bound a plot width rather than a duration — and 3600 of them, since the Kad graph spans the whole window and 1800 was reachable by a maximized one.

Per-point cumulative counters are also walked backwards from the daemon's figure using the per-point rates the same reply carries, so the session-average trend is right across a backfill instead of a flat line at today's value.

## Core: history depth, and telling clients about it

`GetPointsPerRange()` was 560, once derived from a GUI width. That put the finest usable reach at 28 minutes, which a remote GUI can exhaust in a window barely wider than half a screen. It is now 1800 — 90 minutes at a 3 s delay — which costs 787 KB for the history list against 245 KB before.

That change alone would have broken mixed versions, so it comes with `EC_TAG_STATSGRAPH_DEPTH`. A client asking for more points than a range holds is not refused: the walk picks the first record at or before each step, so once the steps are finer than the records it returns the same one repeatedly, and with no timestamps on the wire the client draws those repeats as distinct samples on an axis that under-reports their age. The core now reports its depth and amulegui asks for no more than that. Daemons predating the tag omit it, which is indistinguishable from having the 560 they were built with, so that is what the client assumes — against one of those the graph is honestly shorter rather than quietly wrong.

## Known limits

Per-point timestamps are still not on the wire, so `HandlePacket` places points by stepping back at the requested scale. Within the depth the core now advertises that is exact; the reason it has to be advertised at all is that it would not be beyond it. Putting a timestamp array in the reply would remove the assumption entirely, and is the natural next step if the graphs ever grow a zoom or time-range control.

The initial backfill is bounded by what the core can serve at the requested scale, so a very wide Kad graph still opens partly filled and completes from live data.

## Testing

Built and run on macOS (Cocoa), Linux ARM64 (GTK/Cairo) and Windows ARM64 (CLANGARM64), monolithic and remote GUI, with all four graphs checked. The retention behaviour was verified against a live daemon across an hour: 28 minutes on connect decaying to 15 before the ring fixes, holding afterwards. All six targets build, 34/34 unit tests pass, and the `wxUSE_GRAPHICS_CONTEXT=0` fallback was force-compiled since no platform in the matrix exercises it.
