### PR TITLE
fix(ed2k): only mark a file published when it is published to a server

### DIFF
--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1269,7 +1269,18 @@ void CKnownFile::CreateOfferedFilePacket(CMemFile *files, CServer *pServer, CUpD
 
 	wxCHECK_RET(!(pClient && pServer), "pClient and pServer cannot both be non-null");
 
-	SetPublishedED2K(true);
+	// Only a publish to the server means "published". The flag exists solely
+	// so CSharedFileList::SendListToServer() can tell which files it still
+	// owes the server, and it is cleared when a server connection is made
+	// (CServerConnect). Setting it while answering a peer's browse request --
+	// which this same function serves, with pClient instead of pServer -- told
+	// the publisher those files were already offered, so they silently stopped
+	// being published until the next server (re)connect. It also woke the
+	// shared-files view once per file, for a browse that changes nothing the
+	// user can see (issue #898).
+	if (pServer) {
+		SetPublishedED2K(true);
+	}
 	files->WriteHash(GetFileHash());
 
 	uint32 nClientID = 0;


### PR DESCRIPTION
`CreateOfferedFilePacket()` serves two callers: publishing our share to the connected ed2k server, and answering a peer that browsed us. It set `m_PublishedED2K` for both.

That flag exists solely so `CSharedFileList::SendListToServer()` can tell which files it still owes the server — `GetPublishedED2K()` has exactly one consumer, the filter building each publish batch (`SharedFileList.cpp:1262`) — and it is reset only when a server connection is established (`ServerConnect.cpp:316/379/425`). So a single browse by a remote peer marked every shared file as already offered, and the publisher then skipped them until the next server (re)connect. Files stopped being published to the server because somebody looked at them.

It also woke the shared-files view once per file, through `SetPublishedED2K()` → `Notify_SharedFilesUpdateItem()`, for a browse that changes nothing the user can see. That is measurable but no longer dramatic: 5.4 µs per file on the current list control. Before the list rewrite the same notification did a linear `FindItem()` scan per file, making a large share's browse quadratic — the freeze reported in #898, from a build predating that rewrite.

Passing `pServer` is what makes a publish a publish, so gate on it.
