### PR TITLE
fix(gui): keep the window usable while a large share is hashed

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -278,6 +278,10 @@ void CDownloadListCtrl::BeginBatchUpdate()
 	// once. Used when reconciling the whole list against a fresh server
 	// snapshot after a reconnect (issue #444).
 	Freeze();
+	// Same reason as CSharedFilesCtrl::BeginBatchUpdate(): rows land unsorted
+	// and EndBatchUpdate() sorts once, while a live sort key makes macOS
+	// re-compare the whole list on every inserted row. See SuspendHeaderSort().
+	SuspendHeaderSort();
 	m_batchUpdate = true;
 }
 
@@ -289,6 +293,7 @@ void CDownloadListCtrl::EndBatchUpdate(bool doSort)
 	if (doSort) {
 		SortList();
 	}
+	RestoreHeaderSort();
 	Thaw();
 }
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -296,6 +296,31 @@ void CMuleDataViewCtrl::ShowSortCaret(unsigned column, unsigned order, SortTrigg
 	GetColumn(column)->SetSortOrder(ascending);
 }
 
+void CMuleDataViewCtrl::SuspendHeaderSort()
+{
+	if (m_headerSortSuspended) {
+		return;
+	}
+	m_headerSortSuspended = true;
+	for (unsigned i = 0; i < RealColumnCount(); ++i) {
+		if (GetColumn(i)->IsSortKey()) {
+			GetColumn(i)->UnsetAsSortKey();
+		}
+	}
+}
+
+void CMuleDataViewCtrl::RestoreHeaderSort()
+{
+	if (!m_headerSortSuspended) {
+		return;
+	}
+	m_headerSortSuspended = false;
+	if (!m_sort_orders.empty()) {
+		const CColPair &primary = m_sort_orders.front();
+		ShowSortCaret(primary.first, primary.second);
+	}
+}
+
 void CMuleDataViewCtrl::ApplySorting(unsigned column, unsigned order, SortTrigger trigger)
 {
 	// Push to the front: the most recently clicked column is primary, the

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -187,6 +187,25 @@ protected:
 	 */
 	void ShowSortCaret(unsigned column, unsigned order, SortTrigger trigger = SortTrigger::Programmatic);
 
+	/**
+	 * Drops the header's sort key for the duration of a bulk append, and puts
+	 * it back afterwards.
+	 *
+	 * The caret is drawn by marking a column as the control's sort key, which
+	 * the native backends read as an instruction to keep the view ordered
+	 * themselves -- and macOS acts on it per insertion: every RowInserted()
+	 * has NSOutlineView re-query the data source and re-run our Compare(), so
+	 * appending N rows costs O(N^2) even though each append is O(1) on our
+	 * side. Suspending the key for the burst leaves the rows in arrival order
+	 * (which the caller sorts once at the end anyway) and the comparisons
+	 * never happen.
+	 *
+	 * Balanced calls; nesting is not supported, and restoring re-draws the
+	 * caret from m_sort_orders, so a sort change during the burst is honoured.
+	 */
+	void SuspendHeaderSort();
+	void RestoreHeaderSort();
+
 	void LoadColumnSettings();
 	void SaveColumnSettings();
 
@@ -324,6 +343,8 @@ protected:
 	CListColumnStore m_columnStore;
 	ColumnWidthAdapter m_widthAdapter;
 	CSortingList m_sort_orders;
+	//! Set between SuspendHeaderSort() and RestoreHeaderSort().
+	bool m_headerSortSuspended = false;
 	bool m_hasPersistedWidths = false;
 
 	void OnColumnHeaderClick(wxDataViewEvent &event);

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -575,6 +575,10 @@ void CSharedFilesCtrl::BeginBatchUpdate()
 	// O(n), i.e. O(n^2) for a burst on a large share). Coalesce the repaints
 	// (Freeze) and defer the single sort to EndBatchUpdate().
 	Freeze();
+	// The rows arrive unsorted and EndBatchUpdate() sorts them once, so the
+	// header's sort key buys nothing here -- and on macOS it costs a re-query
+	// and a full comparison pass per inserted row. See SuspendHeaderSort().
+	SuspendHeaderSort();
 	m_batchUpdate = true;
 	m_batchFrozen = true;
 }
@@ -616,6 +620,7 @@ void CSharedFilesCtrl::EndBatchUpdate(bool doSort)
 		SortList();
 	}
 	m_batchRowsAppended = false;
+	RestoreHeaderSort();
 	// Skipped when ThawForDisplay() already ended the freeze: wx counts
 	// Freeze/Thaw and an unbalanced Thaw() asserts.
 	if (m_batchFrozen) {

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -599,7 +599,28 @@ void CSharedFilesCtrl::SortIfRowsAppended()
 		return;
 	}
 	m_batchRowsAppended = false;
-	SortList();
+	if (m_startupDrain) {
+		// The rows were appended without notifying the model, so this is the
+		// first it hears of them: FinishBulkLoad() sorts and issues the single
+		// Reset() that makes them exist for the control.
+		FinishBulkLoad();
+		ShowFilesCount();
+	} else {
+		SortList();
+	}
+}
+
+void CSharedFilesCtrl::SetStartupDrainMode(bool on)
+{
+	if (m_startupDrain == on) {
+		return;
+	}
+	m_startupDrain = on;
+	if (!on) {
+		// Anything appended since the last tick is still invisible to the
+		// model; flush before the caller ends the batch.
+		SortIfRowsAppended();
+	}
 }
 
 void CSharedFilesCtrl::SetHashingCount(size_t remaining)
@@ -662,10 +683,18 @@ void CSharedFilesCtrl::ShowFile(CKnownFile *file)
 		// and in-place UpdateItem() during the same poll stay correct.
 		const wxUIntPtr data = reinterpret_cast<wxUIntPtr>(file);
 		if (RowOfData(data) == -1) {
-			AppendItemDataNow(data);
+			if (m_startupDrain) {
+				// Silent append: the drain tick tells the model once, and
+				// refreshes the label, for everything since the last one.
+				AppendItemData(data);
+			} else {
+				AppendItemDataNow(data);
+			}
 			m_batchRowsAppended = true;
 			m_shownSize += file->GetFileSize();
-			ShowFilesCount();
+			if (!m_startupDrain) {
+				ShowFilesCount();
+			}
 		}
 		return;
 	}

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -85,6 +85,26 @@ public:
 
 	// Bracket a reconnect resync (issue #444) so the list repaints once
 	// (Freeze) and sorts once at the end rather than per updated/added row.
+	/**
+	 * While the startup hash drain runs, hold back the per-row model
+	 * notification and the files-count label.
+	 *
+	 * Each finished hash arrives as its own queued event, and
+	 * ProcessPendingEvents() runs the whole queue in one pass -- so with
+	 * thousands of them the main thread never returns to the run loop and the
+	 * window, already created by then, cannot paint. Per row the two costs are
+	 * wx's Cocoa Add(), which issues a full NSOutlineView reloadData, and
+	 * ShowFilesCount(), which searches the window hierarchy by name. Deferred,
+	 * both happen once per drain tick instead of once per file.
+	 *
+	 * Only for that drain: the tick flushes with FinishBulkLoad(), whose
+	 * Reset() rebuilds the view and drops the scroll position. That is
+	 * unobjectionable while the list is being populated for the first time and
+	 * would not be during amulegui's steady-state poll, which shares the same
+	 * batch machinery.
+	 */
+	void SetStartupDrainMode(bool on);
+
 	void BeginBatchUpdate();
 	void EndBatchUpdate(bool doSort = true);
 
@@ -336,6 +356,7 @@ private:
 	//! Rows appended since the last SortIfRowsAppended(). The batch appends
 	//! without sorting, so this is what makes a later sort worth running.
 	bool m_batchRowsAppended;
+	bool m_startupDrain = false;
 
 	//! Combined size of the displayed files (drives the "Total size:" label)
 	uint64 m_shownSize;

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1095,6 +1095,12 @@ bool CamuleApp::OnInit()
 		// stays O(1)) and the tick below sorts them into place, keeping the
 		// list ordered without paying a row-index rebuild per file.
 		UpdateStartupHashProgress();
+		if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd &&
+			theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
+			// Rows from the drain are announced to the model once per tick
+			// rather than once per file; see SetStartupDrainMode().
+			theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->SetStartupDrainMode(true);
+		}
 		m_splashPollTimer.SetOwner(this, ID_SPLASH_POLL_TIMER);
 		Bind(wxEVT_TIMER, &CamuleApp::OnSplashPollTimer, this, ID_SPLASH_POLL_TIMER);
 		// Once a second: this is the sort cadence now, not a counter
@@ -2141,6 +2147,9 @@ void CamuleApp::FinishStartupHashing()
 	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd &&
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
 		CSharedFilesCtrl *sharedList = theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl;
+		// Off first: it flushes whatever the last tick did not see, so the
+		// batch below closes with the model already knowing every row.
+		sharedList->SetStartupDrainMode(false);
 		sharedList->SetHashingCount(0);
 		// Ends the batch opened before the scan, without its sort: whatever
 		// was appended has just been sorted, either by the tick that brought


### PR DESCRIPTION
Sharing a folder whose files are not in `known.met` yet left the GUI showing only the splash for the whole hash, with the main window created but unable to paint. Two independent causes, one commit each.

## 1. The sort key made every insert re-sort the list

Each finished file lands in `CSharedFilesCtrl::ShowFile()`, which appends it and calls `RowInserted()`. The append is O(1) on our side — what #858 relied on — but on macOS that notification reaches `NSOutlineView`, which re-queries the data source and re-runs our `Compare()` over the whole list for *every* inserted row. A sample during the freeze put **3695 of 4002 stacks (92%)** in `wxCocoaDataViewControl::Add → outlineView:numberOfChildrenOfItem: → CompareItems`.

We only mark a column as the sort key so the header caret is drawn; rows are ordered by the list itself, from `m_sort_orders`. The native backends read that key as an instruction to keep the view sorted, and macOS acts on it per insertion. Since a batch appends unsorted and sorts once at the end anyway, the key is dropped for the duration and restored after — **13 stacks** in the same path afterwards.

Applied to both lists that take bursts: shared files, and downloads for the reconnect reconcile (#444) and amulegui's batched poll (#615).

## 2. The remaining per-row work still starved the run loop

Each hash completion is its own queued event, and `ProcessPendingEvents()` runs the entire queue in one pass, so thousands of them never let the main thread back to the run loop. Per file, wx's Cocoa `Add()` issues a full `reloadData` (214 of 400 stacks under `OnFinishedHashing`, recounting every row through `_uncachedNumberOfRows`), and `ShowFilesCount()` searches the window hierarchy by name for its label.

The drain already has a 1 Hz tick that sorts what arrived and updates the hashing count, so rows are now appended without notifying the model and the tick flushes them with one `FinishBulkLoad()`. No `reloadData` at all during the drain afterwards, and the window is up and usable while the list fills.

Scoped to the startup drain rather than every batch, because that flush resets the scroll position — acceptable while the list is first filling, not during amulegui's steady-state poll, which shares the same batch machinery. The mode is turned off before the batch closes, so the last tick's rows are flushed first.

## Verification

Both commits were also tested separately on a 5,000-file share. With the sort-key fix alone the drain is much faster but the window still arrives late, because the per-row `reloadData` and the label's window-hierarchy search still run for each of the 5,000 events. With the per-tick flush on top, the window is up and usable while the list fills.

- `known.met` comes out **byte-identical** with and without the change (1,280,005 bytes), so the same files are hashed and shared — only the moment the view is told changed
- the startup *scan* is unaffected at ~2.0 s either way (2026 ms vs 2106 ms): that path runs frozen, where the per-row cost does not arise
- macOS build clean; clang-format v18 whole-file clean; Tier-2 clang-tidy clean, 0 compiler errors

One caveat worth stating plainly: the burst is easiest to hit with many small files, which hash almost instantly. Large media files complete seconds apart and never flood the queue. The same burst shape occurs when a remote GUI syncs a large list, which is the downloads path covered by the first commit.
