### PR TITLE
Fix the graph average trends: accumulator overflow, session anchor, and integration direction

### DIFF
--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -636,7 +636,21 @@ unsigned CStatistics::GetHistoryForGui(unsigned cntPoints,
 		// instead of forcing amulegui to integrate locally from connect
 		// time (which would diverge whenever the GUI attaches to a
 		// long-running daemon).
-		HR *latest = pphr[cntFilled - 1];
+		// pphr was filled walking rbegin() -> rend(), so [0] is the newest
+		// record and [cntFilled - 1] the oldest -- the reverse of the
+		// graphData loop above, which deliberately reads it backwards to
+		// emit points oldest-first. Taking [cntFilled - 1] here reported
+		// the session total as it stood at the START of the reply, which
+		// the client then treats as the total at the END and integrates
+		// backwards from: subtracting the whole span's transfer from a
+		// figure already that stale drives it negative at once, and every
+		// point but the newest reads as a session average of zero.
+		//
+		// Harmless while replies carried a point or two, since the two
+		// ends were seconds apart. A backfill makes them the width of the
+		// graph. [0] is also always a real record -- the NULL sentinel
+		// this loop can append lands at the oldest end.
+		HR *latest = pphr[0];
 		if (latest) {
 			sessionDlKBytes = (uint64)latest->kBytesReceived;
 			sessionUlKBytes = (uint64)latest->kBytesSent;

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -168,7 +168,15 @@ protected:
 	std::deque<uint32> m_byte_history;
 	std::deque<uint64> m_tick_history;
 	uint32_t m_timespan;
-	uint32_t m_total;
+	// Sum of every sample currently inside the window. Wide because the
+	// sum is not a byte count: with count_average the samples are rates,
+	// and the graphs' running average holds a 5 minute window of them --
+	// 100 samples at the default 3 s spacing, which passes 2^32 once the
+	// mean rate reaches about 41 MB/s. Past that it wrapped, the
+	// subtraction below drove it further under, and the trend collapsed
+	// to nothing and climbed back over a full window. The individual
+	// samples in m_byte_history are fine at 32 bits; only their sum is not.
+	uint64_t m_total;
 	double m_rate;
 	double m_max_rate;
 	uint32_t m_tmp_sum;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -4196,37 +4196,65 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 	//
 	// ComputeAverages derives the session-average trend as
 	// kBytesReceived / sTimestamp, so it needs the cumulative figure as
-	// it stood at each point, but the daemon only sends the latest one.
-	// Storing that latest figure against every point (which is what this
-	// used to do) is close enough over the handful of points a steady
-	// poll returns, and turns the trend into a flat line at today's
-	// value over the several hundred a backfill returns.
+	// it stood at each point, while the daemon sends only the newest.
+	// The rest are reconstructed from the per-point rates this same reply
+	// carries -- a rectangle-rule integral, so it carries a few percent
+	// of error against a spiky signal.
 	//
-	// So walk it backwards instead: the newest point takes the daemon's
-	// own figure, and each earlier point subtracts the per-point rate
-	// that this same reply already carries. Only the session-average
-	// trend depends on this -- the current-rate trend is the daemon's
-	// per-point value verbatim, and the running average is rebuilt from
-	// those same per-point values.
+	// Which direction to integrate matters, because that error is divided
+	// by the point's timestamp. Going backwards from the newest puts it
+	// at the oldest point, and when a reply reaches back near the start of
+	// the daemon's session that divisor is a few seconds: a 3% error on
+	// several GB then reads as tens of MB/s where the truth is nearly
+	// zero, and past the session start the divisor goes negative and the
+	// trend flips sign entirely.
+	//
+	// So pick the end that is known exactly. If the reply spans the whole
+	// session the oldest point's total is zero by definition, and
+	// integrating forward from there leaves the error at the newest
+	// point, where it is divided by the full session length. Otherwise
+	// every timestamp in the window is large and backwards from the
+	// daemon's own newest figure is both exact where it starts and
+	// harmless where it ends.
 	std::vector<double> aKBytesDl(numPoints, 0.0);
 	std::vector<double> aKBytesUl(numPoints, 0.0);
 	std::vector<double> aKadTotal(numPoints, 0.0);
+	// Within one sample of zero means the oldest point IS the session's
+	// first sample -- the daemon answers with what it has, so a reply that
+	// reaches the start stops there rather than running past it. Testing
+	// for a timestamp at or below zero would almost never fire.
+	const double oldestTs = m_lastTimestamp - (double)(numPoints - 1) * m_sScale;
+	const bool spansSessionStart = oldestTs <= m_sScale;
 	{
-		double kDl = (double)sessionDlB;
-		double kUl = (double)sessionUlB;
-		double kKad = (double)sessionKadN;
-		for (size_t j = numPoints; j-- > 0;) {
-			aKBytesDl[j] = std::max(kDl, 0.0);
-			aKBytesUl[j] = std::max(kUl, 0.0);
-			aKadTotal[j] = std::max(kKad, 0.0);
+		auto rateAt = [&](size_t j, size_t offset) {
+			uint32 v;
+			memcpy(&v, raw + j * 16 + offset, 4);
+			return (double)ENDIAN_NTOHL(v);
+		};
 
-			uint32 dl, ul, kad;
-			memcpy(&dl, raw + j * 16 + 0, 4);
-			memcpy(&ul, raw + j * 16 + 4, 4);
-			memcpy(&kad, raw + j * 16 + 12, 4);
-			kDl -= (ENDIAN_NTOHL(dl) / 1024.0) * m_sScale;
-			kUl -= (ENDIAN_NTOHL(ul) / 1024.0) * m_sScale;
-			kKad -= (double)ENDIAN_NTOHL(kad) * m_sScale;
+		if (spansSessionStart) {
+			double kDl = 0.0, kUl = 0.0, kKad = 0.0;
+			for (size_t j = 0; j < numPoints; ++j) {
+				kDl += (rateAt(j, 0) / 1024.0) * m_sScale;
+				kUl += (rateAt(j, 4) / 1024.0) * m_sScale;
+				kKad += rateAt(j, 12) * m_sScale;
+				aKBytesDl[j] = kDl;
+				aKBytesUl[j] = kUl;
+				aKadTotal[j] = kKad;
+			}
+		} else {
+			double kDl = (double)sessionDlB;
+			double kUl = (double)sessionUlB;
+			double kKad = (double)sessionKadN;
+			for (size_t j = numPoints; j-- > 0;) {
+				aKBytesDl[j] = std::max(kDl, 0.0);
+				aKBytesUl[j] = std::max(kUl, 0.0);
+				aKadTotal[j] = std::max(kKad, 0.0);
+
+				kDl -= (rateAt(j, 0) / 1024.0) * m_sScale;
+				kUl -= (rateAt(j, 4) / 1024.0) * m_sScale;
+				kKad -= rateAt(j, 12) * m_sScale;
+			}
 		}
 	}
 
@@ -4300,6 +4328,18 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 		// stepping back from m_lastTimestamp at 1 s spacing (matches
 		// the scale we request in DoRequery).
 		const double pointTs = m_lastTimestamp - (double)(numPoints - 1 - i) * m_sScale;
+
+		// A reply can reach back past the moment the daemon's session
+		// began -- its history list is preallocated, so it answers with
+		// as many points as were asked for even when fewer exist. Those
+		// points reconstruct to a timestamp at or before zero, and
+		// ComputeAverages divides by it: at zero the session average is
+		// undefined and below it the whole trend changes sign. Drop them
+		// rather than store a value that cannot be drawn honestly.
+		if (pointTs <= 0.0) {
+			continue;
+		}
+
 		HR hr = { /* kBytesSent     */ aKBytesUl[i],
 			/* kBytesReceived */ aKBytesDl[i],
 			/* kBpsUpCur      */ ul_kbps,


### PR DESCRIPTION
Three defects in the statistics graphs' average trends. All of them predate #897 and none is a regression from it — what changed is that the graphs now show most of an hour of history instead of a few minutes, so faults that used to scroll past in seconds are on screen long enough to see. Each was found by looking at a screenshot and asking why one specific pixel was where it was.

## The running average collapsed on fast links

`CPreciseRateCounter::m_total` held the sum of every sample in the averaging window in a `uint32`. With `count_average` the samples are *rates*, not byte counts, and the graphs keep a five-minute window of them — 100 samples at the default 3 s spacing. The sum passes 2³² once the mean reaches about 41 MB/s. Past that it wrapped, the eviction loop's `m_total -= …` drove it further under, and the trend fell to near nothing and climbed back over a full averaging window, again and again for as long as the transfer stayed fast.

Reproduced against the real arithmetic: at 45,000 kB/s the average reports 3.5 MB/s instead of 46, and at 56,000 kB/s it reports 14.8 instead of 57. Both are exact at 64 bits.

What identified it was that every collapse on the reported graph began at the *same height* — a fixed value, not a fixed interval. That height was 33.5% of the axis, and the overflow threshold is 41,943 kB/s against a 125,004 kB/s axis: 33.5%.

The statistics tree's Max download/upload rate counters share the class. They sum actual bytes over 30 s rather than rates over 5 minutes, so their ceiling was around 143 MB/s; the same widening lifts it. Only the sum was too narrow — the individual samples stay 32 bits.

## The session total was reported from the wrong end of the reply

`GetHistoryForGui` fills its array walking `rbegin()` → `rend()`, so `[0]` is the newest record and `[cntFilled - 1]` the oldest. The `graphData` loop reads it backwards on purpose, to emit points oldest-first. The session totals below it then took `[cntFilled - 1]` — the oldest — against a comment saying "the latest sampled point".

amulegui integrates backwards from that figure to reconstruct the session average at each earlier point, so an anchor stale by the width of the reply sends the running total negative immediately. The clamp catching that reported a session average of zero for every point but the newest, which draws as a flat line along the axis with a single vertical jump at the right-hand edge.

Invisible while replies carried a point or two, since the two ends of one were seconds apart. A backfill makes them the width of the graph.

## The reconstruction integrated from the wrong end

With the anchor fixed, a second fault surfaced underneath. Only the newest cumulative figure is on the wire; the rest are reconstructed from the per-point rates in the same reply. That is a rectangle-rule integral over a spiky signal, so it carries a few percent of error — and `ComputeAverages` divides the result by the point's own timestamp, which decides whether that error is negligible or dominant.

Integrating backwards from the newest point put the error at the oldest one. Where a reply reaches back near the start of the daemon's session that divisor is one sample wide, so a 3% error on several GB read as tens of MB/s against a true value near zero. Points landing before the session began divided by a *negative* number and inverted the trend: a restarted daemon drew a session average falling from above the top of the plot.

Pick the end that is known exactly instead. A reply whose oldest point sits within one sample of zero spans the whole session, so that point's total is zero by definition — integrate forward from there and the error lands at the newest point, divided by the full session length. Any other reply has large timestamps throughout, so backwards from the daemon's own figure is exact where it starts and harmless where it ends.

Points reconstructing to a timestamp at or before zero are dropped rather than stored. The daemon's history list is preallocated, so it answers with as many points as were asked for even when fewer exist, and no honest value can be drawn for a moment before the session began.

## Which side each fix runs on

The accumulator width is in a shared header and affects both. The reply-anchor fix is daemon-side. The integration change is amulegui-side. A GUI updated without its core, or the reverse, gets a partial fix rather than a wrong one.

## Testing

Verified against a live remote core. The running average is smooth where it previously collapsed five times in forty minutes. The session average tracks correctly, having first been observed sitting flat on the axis with a single jump at the newest sample, and then — once the anchor was fixed — falling from above the top of the plot.

Both integration branches are covered. The core under test had been up nineteen minutes, so its history reaches its own session start: the reply's oldest point lands about one sample from zero and takes the forward branch, which is the case that produced the off-scale reading. Every steady-state reply afterwards carries a point or two with large timestamps and takes the backward branch.

Each fix was also checked on the side it runs on: the daemon-side anchor fix against a rebuilt core, the GUI-side integration change against a rebuilt GUI on an already-updated core.
