### PR TITLE
feat(core): remember what a peer looked like, in a clients.met trailer

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -710,6 +710,29 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 
 	ReGetClientSoft();
 
+	// Everything worth remembering about this peer is populated by now: the
+	// name came out of the hello tags above, the address from the connection,
+	// and ReGetClientSoft() has just resolved the software and version. The
+	// credit record is the only thing that outlives the connection, so this is
+	// where a peer stops being anonymous in the history.
+	//
+	// The session count is taken once per client object rather than once per
+	// call: an outgoing connection processes a hello answer as well as a
+	// hello, and a count that rose per packet would measure traffic instead of
+	// visits.
+	if (credits != nullptr) {
+		credits->UpdateMeta(m_Username,
+			m_dwUserIP,
+			m_nUserPort,
+			m_nKadPort,
+			m_nClientVersion,
+			m_clientSoft,
+			static_cast<uint8>(m_nSourceFrom),
+			GetObfuscationStatus(),
+			!m_metaSessionCounted);
+		m_metaSessionCounted = true;
+	}
+
 	m_byInfopacketsReceived |= IP_EDONKEYPROTPACK;
 
 	// check if at least CT_EMULEVERSION was received, all other tags are optional

--- a/src/ClientCredits.cpp
+++ b/src/ClientCredits.cpp
@@ -152,6 +152,44 @@ float CClientCredits::GetScoreRatio(uint32 dwForIP, bool cryptoavail)
 	return result;
 }
 
+void CClientCredits::UpdateMeta(const wxString &name,
+	uint32 ip,
+	uint16 port,
+	uint16 kadPort,
+	uint32 version,
+	uint8 clientSoft,
+	uint8 sourceFrom,
+	uint8 obfuscation,
+	bool countSession)
+{
+	const uint32 now = time(nullptr);
+	if (m_meta.firstSeen == 0) {
+		// First sighting since this peer got a credit record. For a peer we
+		// already had credits for before the metadata existed, "first" means
+		// the first time we could record it, not the start of the
+		// relationship -- nLastSeen is the only older evidence and it says
+		// nothing about when things began.
+		m_meta.firstSeen = now;
+	}
+	if (countSession) {
+		m_meta.sessions++;
+	}
+
+	// Last known wins: a peer that renamed itself or moved address is better
+	// described by what it looks like now than by what it looked like once.
+	// An empty name is not an update -- it means the handshake carried none.
+	if (!name.IsEmpty()) {
+		m_meta.name = name;
+	}
+	m_meta.lastIP = ip;
+	m_meta.lastPort = port;
+	m_meta.kadPort = kadPort;
+	m_meta.version = version;
+	m_meta.clientSoft = clientSoft;
+	m_meta.sourceFrom = sourceFrom;
+	m_meta.obfuscation = obfuscation;
+}
+
 void CClientCredits::SetLastSeen()
 {
 	m_pCredits->nLastSeen = time(NULL);

--- a/src/ClientCredits.h
+++ b/src/ClientCredits.h
@@ -48,6 +48,51 @@ public:
 	uint8_t abySecureIdent[MAXPUBKEYSIZE];
 };
 
+/**
+ * What we remember about a peer beyond its credits, for the clients history.
+ *
+ * Deliberately separate from CreditStruct: that one mirrors the fixed 119-byte
+ * on-disk record that aMule has always written and that eMule also reads, and
+ * it must stay exactly as it is. This travels in a trailer appended after those
+ * records, which older readers never look at (they consume `count` records and
+ * stop), so adding fields here cannot cost anyone their credit history.
+ *
+ * Every field is a last-known value, captured while the peer was connected.
+ * Nothing here is authoritative -- a peer can change name, address or client
+ * between sessions -- so it is for describing who someone was, not for
+ * identifying them. The hash remains the identity.
+ */
+class ClientMetaStruct
+{
+public:
+	wxString name;    //!< last nickname seen, capped on write
+	uint32 firstSeen; //!< first time we ever saw this peer
+	uint32 sessions;  //!< how many times we have seen it since
+	uint32 lastIP;    //!< last known address, also feeds GeoIP at display time
+	uint16 lastPort;
+	uint16 kadPort;
+	uint32 version;    //!< numeric client version, rendered as a string
+	uint8 clientSoft;  //!< eMule / aMule / MLDonkey / ...
+	uint8 sourceFrom;  //!< server, kad, passive, incoming
+	uint8 obfuscation; //!< obfuscation support/status
+
+	ClientMetaStruct()
+	: firstSeen(0)
+	, sessions(0)
+	, lastIP(0)
+	, lastPort(0)
+	, kadPort(0)
+	, version(0)
+	, clientSoft(0)
+	, sourceFrom(0)
+	, obfuscation(0)
+	{
+	}
+
+	//! Nothing worth persisting until we have actually met the peer once.
+	bool IsPopulated() const { return firstSeen != 0; }
+};
+
 enum EIdentState
 {
 	IS_NOTAVAILABLE,
@@ -87,7 +132,29 @@ public:
 	EIdentState GetIdentState() const { return m_identState; }
 	void SetIdentState(EIdentState state) { m_identState = state; }
 
+	const ClientMetaStruct &GetMeta() const { return m_meta; }
+	bool HasMeta() const { return m_meta.IsPopulated(); }
+	//! Load-time restore from the clients.met trailer.
+	void SetMeta(const ClientMetaStruct &meta) { m_meta = meta; }
+	/**
+	 * Record what a connected peer looks like right now.
+	 *
+	 * `countSession` is the caller's answer to "is this a new sighting?" --
+	 * the handshake can be processed more than once for one connection, and
+	 * a session count that grows per packet would say nothing.
+	 */
+	void UpdateMeta(const wxString &name,
+		uint32 ip,
+		uint16 port,
+		uint16 kadPort,
+		uint32 version,
+		uint8 clientSoft,
+		uint8 sourceFrom,
+		uint8 obfuscation,
+		bool countSession);
+
 private:
+	ClientMetaStruct m_meta;
 	EIdentState m_identState;
 	void InitalizeIdent();
 	CreditStruct *m_pCredits;

--- a/src/ClientCreditsList.cpp
+++ b/src/ClientCreditsList.cpp
@@ -56,6 +56,39 @@ CClientCreditsList::~CClientCreditsList()
 	delete static_cast<CryptoPP::RSASSA_PKCS1v15_SHA_Signer *>(m_pSignkey);
 }
 
+namespace
+{
+/**
+ * The clients.met metadata trailer.
+ *
+ * Appended after the fixed 119-byte credit records rather than folded into
+ * them, and the file version stays at CREDITFILE_VERSION on purpose. Bumping
+ * that version is what would break compatibility, not adding data: an older
+ * aMule meeting a version it does not know logs "Creditfile is outdated and
+ * will be replaced" and returns without loading a single record, and the next
+ * save then overwrites the file -- every credit gone, on nothing worse than
+ * running a previous build once. The same byte is also the format shared with
+ * the eMule lineage.
+ *
+ * The loader reads exactly `count` records and stops; it never checks the
+ * file length and never looks further. So anything after the last record is
+ * invisible to every reader that predates this, and they keep loading the
+ * credits they always did. The cost is that such a reader's *save* drops the
+ * trailer, losing the metadata but never the credits.
+ *
+ * The magic makes presence unambiguous, since absence is the normal state for
+ * a file last written by an older build.
+ */
+const char kMetaMagic[8] = { 'A', 'M', 'U', 'L', 'E', 'M', 'D', '1' };
+const uint8 kMetaVersion = 1;
+//! Names are attacker-supplied; cap what we store rather than what we read.
+//! Counted in characters, because that is what wxString::Left() takes -- a
+//! multi-byte name can therefore occupy more than this many bytes on disk,
+//! which the uint16 length field has ample room for. The cap is storage
+//! sanity, not a bound the format depends on.
+const size_t kMetaMaxNameChars = 64;
+} // namespace
+
 void CClientCreditsList::LoadList()
 {
 	CFile file;
@@ -162,8 +195,74 @@ void CClientCreditsList::LoadList()
 					    cDeleted)) %
 				    cDeleted);
 		}
+
+		LoadMetaTrailer(file);
 	} catch (const CSafeIOException &e) {
 		AddDebugLogLineC(logCredits, "IO error while loading clients.met file: " + e.what());
+	}
+}
+
+void CClientCreditsList::LoadMetaTrailer(CFile &file)
+{
+	// Optional by construction: a file written by any older build simply ends
+	// after the last record. Everything here is best-effort -- the credits are
+	// already loaded and must survive whatever this finds, so a trailer that is
+	// absent, truncated or unrecognised is dropped rather than treated as a
+	// corrupt file.
+	try {
+		const uint64 remaining = file.GetLength() - file.GetPosition();
+		if (remaining < sizeof(kMetaMagic) + 1 + 4) {
+			return;
+		}
+
+		char magic[sizeof(kMetaMagic)];
+		file.Read(magic, sizeof(magic));
+		if (memcmp(magic, kMetaMagic, sizeof(magic)) != 0) {
+			AddDebugLogLineN(logCredits, "Trailing data in clients.met is not a metadata block");
+			return;
+		}
+		const uint8 version = file.ReadUInt8();
+		if (version != kMetaVersion) {
+			// A newer aMule wrote it. Same reasoning as the file version: do
+			// not guess at a layout we do not know, just leave the metadata
+			// behind. The credits are unaffected either way.
+			AddDebugLogLineN(logCredits,
+				CFormat("clients.met metadata is version %u, expected %u -- ignoring") %
+					version % kMetaVersion);
+			return;
+		}
+
+		const uint32 entries = file.ReadUInt32();
+		uint32 restored = 0;
+		for (uint32 i = 0; i < entries; i++) {
+			const CMD4Hash key = file.ReadHash();
+			ClientMetaStruct meta;
+			meta.firstSeen = file.ReadUInt32();
+			meta.sessions = file.ReadUInt32();
+			meta.lastIP = file.ReadUInt32();
+			meta.lastPort = file.ReadUInt16();
+			meta.kadPort = file.ReadUInt16();
+			meta.version = file.ReadUInt32();
+			meta.clientSoft = file.ReadUInt8();
+			meta.sourceFrom = file.ReadUInt8();
+			meta.obfuscation = file.ReadUInt8();
+			meta.name = file.ReadString(true, sizeof(uint16));
+
+			// Entries whose credit record is gone -- expired by the 150-day
+			// prune above, or dropped by a save from a build that did not know
+			// about them -- describe a client we no longer track.
+			ClientMap::iterator it = m_mapClients.find(key);
+			if (it != m_mapClients.end()) {
+				it->second->SetMeta(meta);
+				restored++;
+			}
+		}
+		AddDebugLogLineN(
+			logCredits, CFormat("Restored metadata for %u of %u clients") % restored % entries);
+	} catch (const CSafeIOException &e) {
+		// Truncated or malformed: the credits are already in hand, so this is
+		// the end of what we can use, not a failure.
+		AddDebugLogLineN(logCredits, "Could not read clients.met metadata: " + e.what());
 	}
 }
 
@@ -211,11 +310,72 @@ void CClientCreditsList::SaveList()
 			// Write the actual number of structs
 			file.Seek(1);
 			file.WriteUInt32(count);
+
+			// Append the metadata after the records, where older readers
+			// never look. Seek to the end explicitly: the count fixup above
+			// left the position at byte 5.
+			file.Seek(0, wxFromEnd);
+			SaveMetaTrailer(file);
 		} catch (const CIOFailureException &e) {
 			AddDebugLogLineC(logCredits, "IO failure while saving clients.met: " + e.what());
 		}
 	} else {
 		AddDebugLogLineC(logCredits, "Failed to open existing creditfile!");
+	}
+}
+
+void CClientCreditsList::SaveMetaTrailer(CFile &file)
+{
+	// Only clients we have actually met since this existed carry metadata, so
+	// on a file inherited from an older build this writes nothing at all and
+	// the result stays byte-identical to what that build produced.
+	uint32 entries = 0;
+	for (const auto &entry : m_mapClients) {
+		const CClientCredits *cur = entry.second;
+		// Mirrors the record loop's own filter: a client with no traffic is
+		// not written above, so metadata for it would have no record to
+		// attach to on the next load.
+		if (cur->HasMeta() && (cur->GetUploadedTotal() || cur->GetDownloadedTotal())) {
+			entries++;
+		}
+	}
+	if (entries == 0) {
+		return;
+	}
+
+	try {
+		file.Write(kMetaMagic, sizeof(kMetaMagic));
+		file.WriteUInt8(kMetaVersion);
+		file.WriteUInt32(entries);
+
+		for (const auto &entry : m_mapClients) {
+			CClientCredits *cur = entry.second;
+			if (!cur->HasMeta() || !(cur->GetUploadedTotal() || cur->GetDownloadedTotal())) {
+				continue;
+			}
+			const ClientMetaStruct &meta = cur->GetMeta();
+			file.WriteHash(cur->GetKey());
+			file.WriteUInt32(meta.firstSeen);
+			file.WriteUInt32(meta.sessions);
+			file.WriteUInt32(meta.lastIP);
+			file.WriteUInt16(meta.lastPort);
+			file.WriteUInt16(meta.kadPort);
+			file.WriteUInt32(meta.version);
+			file.WriteUInt8(meta.clientSoft);
+			file.WriteUInt8(meta.sourceFrom);
+			file.WriteUInt8(meta.obfuscation);
+			// Two length bytes because CFileDataIO supports 0, 2 or 4 and
+			// rejects anything else -- a 1-byte prefix throws
+			// "Invalid length for string-length field" from inside the
+			// write, which the handler below would then swallow, leaving a
+			// trailer truncated mid-entry. The cap is enforced here, not by
+			// the field width.
+			file.WriteString(meta.name.Left(kMetaMaxNameChars), utf8strRaw, sizeof(uint16));
+		}
+	} catch (const CIOFailureException &e) {
+		// The records are already on disk and intact; losing the trailer costs
+		// the metadata only, which is why it is written last.
+		AddDebugLogLineC(logCredits, "IO failure while saving clients.met metadata: " + e.what());
 	}
 }
 

--- a/src/ClientCreditsList.h
+++ b/src/ClientCreditsList.h
@@ -31,6 +31,7 @@
 #include <map>
 
 class CClientCredits;
+class CFile;
 
 class CClientCreditsList
 {
@@ -60,6 +61,10 @@ public:
 
 protected:
 	void LoadList();
+	//! Optional metadata block after the credit records -- see the comment on
+	//! kMetaMagic for why it lives there rather than in the records.
+	void LoadMetaTrailer(CFile &file);
+	void SaveMetaTrailer(CFile &file);
 	void InitalizeCrypting();
 	bool CreateKeyPair();
 #ifdef _DEBUG

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -760,6 +760,9 @@ private:
 	uint16_t m_nUserPort;
 	int16 m_nServerPort;
 	uint32 m_nClientVersion;
+	//! Whether this connection has already been counted towards the peer's
+	//! session tally in its credit metadata. See ProcessHelloTypePacket.
+	bool m_metaSessionCounted = false;
 	uint32 m_cSendblock;
 	uint8 m_byEmuleVersion;
 	uint8 m_byDataCompVer;


### PR DESCRIPTION
First step towards showing client metadata (#425): giving the credit store something worth displaying.

`clients.met` records a peer's hash, totals, last-seen and public key, and nothing about who it is. Everything that would make a client list readable — name, address, software, version, origin, obfuscation — exists only while the peer is connected. On a node with 40,131 credit records, a history view built on this file today is 40,131 rows of opaque hash.

## Why not a new record format

The obvious approach is to add fields to the record and bump `CREDITFILE_VERSION`. That is the one change that must not be made. An older aMule meeting an unknown version logs *"Creditfile is outdated and will be replaced"*, returns without loading a single record, and the next save overwrites the file. Running a previous build once would cost every credit the user has. That version byte is also the format shared with the eMule lineage.

So the records and the version are untouched, and the new fields go in a trailer appended after them. The loader reads exactly `count` records and stops — it never checks the file length — so every existing reader loads the credits it always did and never sees the rest. An old build's save drops the trailer, losing the metadata but never the credits.

## What is stored

Last-known name, IP, port, Kad port, client software, version, source origin and obfuscation status — all captured at the end of `ProcessHelloTypePacket`, where the name, the address and the just-resolved software and version are populated.

Two fields are new rather than merely unpersisted. **First seen**: `nLastSeen` says when a peer was last around but nothing about when the relationship began, so a history cannot tell an old regular from someone who appeared yesterday. **Session count**: it separates a peer that transferred once at length from one that has come back two hundred times, which is most of what "known client" means. The tally is taken once per client object, not once per call, because an outgoing connection processes a hello answer as well as a hello and a count that rose per packet would measure traffic instead of visits.

## Testing

Against a real 4.6 MB `clients.met` from a production node:

| check | result |
|---|---|
| Load | all 40,131 records (40,092 known + 39 expired) |
| Save with nothing captured | zero trailing bytes — structurally identical to current output |
| Old-reader parser on a file *with* a trailer | reads all 40,131 records, ignores the trailing bytes |
| Synthetic round-trip | empty name, multi-byte UTF-8, over-cap name truncated, at-cap name intact, orphaned entry dropped; bytes consumed exactly |
| Truncated / no-magic / wrong-version / too-short trailer | all four still load the full credit set |

Then a live GUI session on a copy of that file: 17 peers captured, 1065/1065 bytes consumed, real nicknames including non-ASCII, software resolving to `SO_EMULE`/`SO_AMULE`/`SO_NEW2_MLDONKEY`, and versions decoding to real releases (aMule 2.3.1, aMule 3.0.1, eMule 0.50a).

No unit test yet: the verification above was run externally rather than in CI. A round-trip test is worth adding as a follow-up, since an on-disk format is exactly the thing that regresses silently.
