### PR TITLE
fix(appimage): stop the bundle loading the host's GLib and GTK modules

### DIFF
--- a/packaging/linux/appimage/AppRun
+++ b/packaging/linux/appimage/AppRun
@@ -36,6 +36,31 @@ export APPDIR="${HERE}"
 export PATH="${HERE}/usr/bin:${PATH}"
 export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH:-}"
 
+# Keep the host's GLib/GTK plugins out of the bundle. Both of these are set
+# after the plugin hooks above deliberately: linuxdeploy-plugin-gtk sets
+# neither, so nothing here is being overridden.
+#
+# GIO_MODULE_DIR: unset, GLib scans the path it was compiled with, which is
+# the host's /usr/lib/<triplet>/gio/modules. Those modules are built against
+# the host's GLib and get resolved against the older one bundled here, so
+# loading them fails --
+#
+#   /usr/lib/x86_64-linux-gnu/gvfs/libgvfscommon.so: undefined symbol:
+#     g_task_set_static_name
+#   Failed to load module: /usr/lib/x86_64-linux-gnu/gio/modules/libgvfsdbus.so
+#
+# (g_task_set_static_name arrived in GLib 2.76.) We bundle no GIO modules, so
+# this points at a directory that does not exist, which is the intent: it
+# stops the scan rather than redirecting it. aMule uses no GIO module -- the
+# failure was only ever noise on stderr (issue #898).
+export GIO_MODULE_DIR="${HERE}/usr/lib/gio/modules"
+
+# GTK_MODULES comes from the host session, and the bundled GTK cannot load a
+# host module any more than GIO can. Linux Mint exports xapp-gtk3-module,
+# which produces `Gtk-Message: Failed to load module "xapp-gtk3-module"` on
+# every start. These modules are desktop integration aMule does not use.
+unset GTK_MODULES
+
 # argv[0] dispatch. ARGV0 is set by the AppImage runtime; fall back to
 # $0 for direct invocation (e.g. when extracted via --appimage-extract).
 INVOCATION="${ARGV0:-$0}"


### PR DESCRIPTION
Starting the AppImage on Linux Mint prints three lines before the window appears, reported alongside #898:

```
Gtk-Message: Failed to load module "xapp-gtk3-module"
/usr/lib/x86_64-linux-gnu/gvfs/libgvfscommon.so: undefined symbol: g_task_set_static_name
Failed to load module: /usr/lib/x86_64-linux-gnu/gio/modules/libgvfsdbus.so
```

Both are the bundle reaching outside itself.

With `GIO_MODULE_DIR` unset, GLib scans the directory it was compiled with, which at runtime resolves to the *host's* `/usr/lib/<triplet>/gio/modules`. Those modules are built against the host's GLib and then linked against the older one shipped here, so the symbols they want are missing - `g_task_set_static_name` arrived in GLib 2.76.

`GTK_MODULES` comes straight from the host session. Mint exports `xapp-gtk3-module`, and the bundled GTK can no more load a host GTK module than GIO can.

`linuxdeploy-plugin-gtk` sets `GTK_PATH`, `GTK_EXE_PREFIX`, `GDK_PIXBUF_MODULE_FILE`, `GSETTINGS_SCHEMA_DIR` and the rest, but neither of these two - checked against the pinned commit, both grep to zero. So `AppRun` sets them after sourcing the plugin hooks, overriding nothing.

We bundle no GIO modules, so `GIO_MODULE_DIR` deliberately points at a directory that does not exist: the intent is to stop the scan, not to redirect it.

## Impact

Cosmetic. aMule uses no GIO module and none of XApp's desktop integration, which is why it starts and runs correctly through all three messages. They read like a fault, which is why they got reported.

## Testing

`bash -n` clean. Not otherwise verifiable here: reproducing needs a host whose GLib is newer than the bundle's, which is the Mint case. The reporter of #898 is running these AppImages and can confirm on his next run.
