### PR TITLE
fix(core): answer a browse without re-deriving the same work per directory

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -36,6 +36,7 @@
 #include "Server.h"           // Needed for CServer
 #include "ServerConnect.h"    // Needed for CServerConnect
 #include "SearchList.h"       // Needed for CSearchFile
+#include "updownclient.h"     // Needed for BROWSE_IN_PROGRESS
 #include "SearchListModel.h"  // Needed for CSearchListModel
 #include "GetTickCount.h"     // Needed for GetTickCount64()
 #include "CommentDialogLst.h" // Needed for CCommentDialogLst (Kad comments/ratings)
@@ -543,6 +544,20 @@ wxString CSearchListCtrl::GetOldColumnOrder() const
 	return "N,Z,u,Y,I,S";
 }
 
+void CSearchListCtrl::SetBrowseStatus(uint32 status)
+{
+	// A re-browse reuses this tab (see CSearchDlg::EnsureBrowseTab), so the
+	// rebuild threshold has to start over with it. Left standing, the previous
+	// browse's final row count becomes the bar the new one has to clear, which
+	// it never does: every burst would be skipped and the list would stay
+	// empty until the browse finished, which is the wait the throttle exists
+	// to avoid (issue #898).
+	if (status == BROWSE_IN_PROGRESS) {
+		m_lastRebuildRows = 0;
+	}
+	m_browseStatus = status;
+}
+
 void CSearchListCtrl::OnIdleHook()
 {
 	// One coalesced rebuild per idle for everything that arrived since the
@@ -568,6 +583,35 @@ void CSearchListCtrl::OnIdleHook()
 		// every burst.
 		m_model->FlushPending();
 	} else if (m_model->HasPending()) {
+		// A browse still streaming in is rebuilt on a growth schedule rather
+		// than on every burst.
+		//
+		// The rebuild below is O(rows), and a browse arrives one directory at
+		// a time, so rebuilding per burst is O(bursts x rows): browsing a
+		// 39,450-file share took 384 rebuilds totalling 232 seconds of
+		// blocked main loop, the last of them 5.2 s on its own (issue #898).
+		//
+		// Waiting for the row count to grow by half means the rebuilds form a
+		// geometric series, so their total is a small multiple of the final
+		// one -- about 25 rebuilds instead of 384 here -- while results still
+		// appear as the browse runs rather than only at the end. A finished
+		// or failed browse always falls through, so the last state is exact.
+		if (m_browseStatus == BROWSE_IN_PROGRESS) {
+			// Counted from the indexed result list, not the model: the
+			// model would have to walk its rows to answer, which is the
+			// O(rows) cost being avoided here.
+			const unsigned rows =
+				m_nResultsID
+					? (unsigned)theApp->searchlist->GetSearchResults(m_nResultsID).size()
+					: 0;
+			if (m_lastRebuildRows > 0 && rows < m_lastRebuildRows + m_lastRebuildRows / 2) {
+				return;
+			}
+			m_lastRebuildRows = rows;
+		} else {
+			m_lastRebuildRows = 0;
+		}
+
 		// The row the user is looking at, so the rebuild below can be put
 		// back where they left it. Cleared() drops the view to the top, and
 		// on a running search that is every idle -- measured on GTK with wx

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -133,7 +133,12 @@ public:
 	const wxString &GetBrowseName() const { return m_browseName; }
 	void SetBrowseName(const wxString &name) { m_browseName = name; }
 	uint32 GetBrowseStatus() const { return m_browseStatus; }
-	void SetBrowseStatus(uint32 status) { m_browseStatus = status; }
+	/**
+	 * Records the browse state, and starts the rebuild throttle over when a
+	 * browse begins; defined in the .cpp so this header need not pull in
+	 * updownclient.h for the status values. See OnIdleHook().
+	 */
+	void SetBrowseStatus(uint32 status);
 
 	/**
 	 * Sets the filter which decides which results should be shown.
@@ -278,6 +283,8 @@ protected:
 	//! Peer display name and lifecycle (EBrowseStatus) for a browse tab.
 	wxString m_browseName;
 	uint32 m_browseStatus;
+	//! Rows at the last rebuild while a browse was streaming; see OnIdleHook().
+	unsigned m_lastRebuildRows = 0;
 
 	//! The current filter reg-exp.
 	wxRegEx m_filter;

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -838,6 +838,16 @@ void CSharedFileList::RefreshPathIndex(CKnownFile *file)
 	}
 	m_pathIndex[key] = file;
 	if (rekeyed) {
+		// The file moved without entering or leaving m_Files_map, so nothing
+		// else bumps the generation for it: AddFile()'s insert no-ops on a
+		// hash that is already shared. Anything caching a view of where files
+		// live has to be told, or it keeps serving the old location -- the
+		// directory grouping in GetSharedFilesByDirectory() would leave a
+		// completed download filed under Temp until some unrelated add or
+		// remove happened to invalidate it (issue #898). The pairwise walk it
+		// replaced re-read GetFilePath() every time and so never had to be
+		// told at all.
+		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 		AddDebugLogLineN(
 			logKnownFiles, CFormat("Path index re-keyed to '%s' (file moved/completed)") % key);
 	}
@@ -1076,7 +1086,18 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 	}
 
 	/* Public identifiers must be erased as they might be invalid now */
-	m_PublicSharedDirNames.clear();
+	{
+		// Under list_mut: IsShared() builds m_sharedDirKeys through a const
+		// method and takes the lock to do it, so this side has to take it too
+		// or the lock buys nothing -- a reader would still be filling the set
+		// while this clears it. The public-name map and its index are cleared
+		// in the same scope so the pair cannot be seen half-emptied.
+		wxMutexLocker lock(list_mut);
+		m_PublicSharedDirNames.clear();
+		m_publicNameByDirKey.clear();
+		m_sharedDirKeys.clear();
+		m_sharedDirKeysBuilt = false;
+	}
 
 	bool aborted = false;
 	FindSharedFiles(yieldCb, aborted);
@@ -1169,13 +1190,25 @@ void CSharedFileList::GetSharedFilesByDirectory(const wxString &directory, CKnow
 {
 	wxMutexLocker lock(list_mut);
 
-	const CPath dir = CPath(directory);
-	for (CKnownFileMap::iterator pos = m_Files_map.begin(); pos != m_Files_map.end(); ++pos) {
-		CKnownFile *cur_file = pos->second;
-
-		if (dir.IsSameDir(cur_file->GetFilePath())) {
-			list.push_back(cur_file);
+	// Answered from the grouping rather than by walking every shared file:
+	// a browsing peer asks one directory at a time, and the walk made that
+	// O(directories x files) IsSameDir() calls, each normalising both paths.
+	// See m_dirGroups (issue #898).
+	const uint64 generation = m_listGeneration.load(std::memory_order_relaxed);
+	if (!m_dirGroupsBuilt || m_dirGroupsAt != generation) {
+		m_dirGroups.clear();
+		for (const auto &entry : m_Files_map) {
+			CKnownFile *cur_file = entry.second;
+			m_dirGroups[cur_file->GetFilePath().GetDirKey()].push_back(cur_file);
 		}
+		m_dirGroupsAt = generation;
+		m_dirGroupsBuilt = true;
+	}
+
+	const std::map<wxString, CKnownFilePtrList>::const_iterator group =
+		m_dirGroups.find(CPath(directory).GetDirKey());
+	if (group != m_dirGroups.end()) {
+		list.insert(list.end(), group->second.begin(), group->second.end());
 	}
 }
 
@@ -1603,12 +1636,23 @@ wxString CSharedFileList::GetPublicSharedDirName(const CPath &dir)
 		wxFAIL;
 		return "";
 	}
-	// check if the public name for the directory is cached in our Map
-	StringPathMap::const_iterator it;
-	for (it = m_PublicSharedDirNames.begin(); it != m_PublicSharedDirNames.end(); ++it) {
-		if (it->second.IsSameDir(dir)) {
+	// check if the public name for the directory is cached in our Map.
+	// Keyed rather than walked: this runs once per shared directory while
+	// answering a browse, and comparing every entry with IsSameDir() made it
+	// O(directories^2) (issue #898).
+	//
+	// Under list_mut, like the write further down and like IsShared(): a
+	// mutex only excludes participants who take it, so a reader outside it
+	// would make the locking on the other side worth nothing. Held for the
+	// lookup alone -- not across the IsShared() calls above and below, which
+	// take the same non-recursive mutex themselves.
+	{
+		wxMutexLocker lock(list_mut);
+		const std::map<wxString, wxString>::const_iterator cached =
+			m_publicNameByDirKey.find(dir.GetDirKey());
+		if (cached != m_publicNameByDirKey.end()) {
 			// public name for directory was determined earlier
-			return it->first;
+			return cached->second;
 		}
 	}
 
@@ -1641,7 +1685,13 @@ wxString CSharedFileList::GetPublicSharedDirName(const CPath &dir)
 		wxASSERT(strDirectoryTmp.Length() == 2);
 		strPublicName = strDirectoryTmp;
 	}
-	// we have the name, make sure it is unique by appending an index if necessary
+	// we have the name, make sure it is unique by appending an index if
+	// necessary. Under list_mut for the same reason as the lookup above, and
+	// covering both maps together so the pair is never left half-written --
+	// which is what the clear in Reload() is holding the lock against. Safe
+	// to take here: every IsShared() call, which takes the same mutex, is
+	// behind us.
+	wxMutexLocker lock(list_mut);
 	if (m_PublicSharedDirNames.find(strPublicName) != m_PublicSharedDirNames.end()) {
 		wxString strUniquePublicName;
 		for (iPos = 2;; ++iPos) {
@@ -1652,6 +1702,7 @@ wxString CSharedFileList::GetPublicSharedDirName(const CPath &dir)
 				AddDebugLogLineN(logClient,
 					CFormat("Using public name '%s' for directory '%s'") %
 						strUniquePublicName % dir.GetPrintable());
+				m_publicNameByDirKey[dir.GetDirKey()] = strUniquePublicName;
 				m_PublicSharedDirNames.insert(
 					std::pair<wxString, CPath>(strUniquePublicName, dir));
 				return strUniquePublicName;
@@ -1671,6 +1722,7 @@ wxString CSharedFileList::GetPublicSharedDirName(const CPath &dir)
 		AddDebugLogLineN(logClient,
 			CFormat("Using public name '%s' for directory '%s'") % strPublicName %
 				dir.GetPrintable());
+		m_publicNameByDirKey[dir.GetDirKey()] = strPublicName;
 		m_PublicSharedDirNames.insert(std::pair<wxString, CPath>(strPublicName, dir));
 		return strPublicName;
 	}
@@ -1679,19 +1731,35 @@ wxString CSharedFileList::GetPublicSharedDirName(const CPath &dir)
 bool CSharedFileList::IsShared(const CPath &path) const
 {
 	if (path.IsDir(CPath::exists)) {
-		// check if it's a shared folder
-		const unsigned folderCount = theApp->glob_prefs->shareddir_list.size();
-		for (unsigned i = 0; i < folderCount; ++i) {
-			if (path.IsSameDir(theApp->glob_prefs->shareddir_list[i])) {
-				return true;
+		// Under list_mut like every other cache on this class. The lazily
+		// built set below is written through a const method, so without it a
+		// caller on another thread would be writing a std::set while Reload()
+		// cleared it. Today both callers sit in GetPublicSharedDirName() on
+		// the main thread and Reload() runs there too, but nothing states
+		// that, and this class carries a mutex precisely because the
+		// assumption is not general. Neither call site holds the lock, so
+		// there is nothing to deadlock against.
+		wxMutexLocker lock(list_mut);
+
+		// Both lists below were walked with IsSameDir(), which normalises
+		// both paths, and GetPublicSharedDirName() calls this once per shared
+		// directory while answering a browse -- O(directories^2), and the
+		// other half of the 53 s freeze in issue #898. Keyed instead, built
+		// once and dropped in Reload() where the set can change.
+		if (!m_sharedDirKeysBuilt) {
+			const unsigned folderCount = theApp->glob_prefs->shareddir_list.size();
+			for (unsigned i = 0; i < folderCount; ++i) {
+				m_sharedDirKeys.insert(theApp->glob_prefs->shareddir_list[i].GetDirKey());
 			}
+			// category 0 is incoming
+			for (unsigned i = 0; i < theApp->glob_prefs->GetCatCount(); ++i) {
+				m_sharedDirKeys.insert(theApp->glob_prefs->GetCategory(i)->path.GetDirKey());
+			}
+			m_sharedDirKeysBuilt = true;
 		}
 
-		// check if it's one of the categories folders (category 0 = incoming)
-		for (unsigned i = 0; i < theApp->glob_prefs->GetCatCount(); ++i) {
-			if (path.IsSameDir(theApp->glob_prefs->GetCategory(i)->path)) {
-				return true;
-			}
+		if (m_sharedDirKeys.count(path.GetDirKey()) != 0) {
+			return true;
 		}
 	}
 

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <set> // Needed for std::set (m_sharedDirKeys)
 #include <unordered_map>
 #include <wx/arrstr.h> // Needed for wxArrayString
 #include <wx/thread.h> // Needed for wxMutex
@@ -253,6 +254,29 @@ private:
 	CKnownFileList *filelist;
 
 	CKnownFileMap m_Files_map;
+
+	/**
+	 * Shared files grouped by directory, for GetSharedFilesByDirectory().
+	 *
+	 * A peer browsing a share asks for one directory at a time, and answering
+	 * each request used to walk the whole of m_Files_map calling
+	 * CPath::IsSameDir(), which normalises both sides every time. That is
+	 * O(directories x files): a 39,450-file share across 1,691 directories
+	 * cost 66.7 million comparisons, blocking the main loop for the best part
+	 * of a minute (issue #898).
+	 *
+	 * Keyed by CPath::GetDirKey(), which is the same canonical form
+	 * IsSameDir() reduces to, so grouping by it is equivalent to the walk it
+	 * replaces. m_dirGroupsAt records the list generation it was built from;
+	 * the generation is already bumped under list_mut at every mutation of
+	 * m_Files_map, which is the lock this is read and written under, so no
+	 * further invalidation is needed.
+	 */
+	std::map<wxString, CKnownFilePtrList> m_dirGroups;
+	//! Generation m_dirGroups was built from; see there.
+	uint64 m_dirGroupsAt = 0;
+	//! Whether m_dirGroups has been built at all; generation 0 is legal.
+	bool m_dirGroupsBuilt = false;
 	// See GetListGeneration(). Bumped under list_mut wherever m_Files_map
 	// gains or loses an entry; atomic so it can be read without the lock.
 	std::atomic<uint64> m_listGeneration{ 0 };
@@ -266,6 +290,34 @@ private:
 	mutable wxMutex list_mut;
 
 	StringPathMap m_PublicSharedDirNames; //! used for mapping strings to shared directories
+
+	/**
+	 * The reverse of m_PublicSharedDirNames, keyed by CPath::GetDirKey().
+	 *
+	 * GetPublicSharedDirName() used to find a directory's public name by
+	 * walking m_PublicSharedDirNames and comparing each entry with
+	 * IsSameDir(), which normalises both paths. SendSharedDirectories()
+	 * calls it once per shared directory, so that walk was O(directories^2):
+	 * with 1,691 shared directories it was one of the two halves of a 53 s
+	 * freeze while answering a browse (issue #898).
+	 *
+	 * Cleared wherever m_PublicSharedDirNames is, since the two are written
+	 * together and expire together.
+	 */
+	std::map<wxString, wxString> m_publicNameByDirKey;
+
+	/**
+	 * Keys of every shared directory, for IsShared().
+	 *
+	 * The other half of the same freeze: IsShared() compared the path against
+	 * every entry of shareddir_list and every category path with IsSameDir(),
+	 * and GetPublicSharedDirName() calls it per directory as its safety
+	 * check. Built on demand and dropped in Reload(), which is where the
+	 * shared-directory set can change and where the public names are already
+	 * discarded for the same reason.
+	 */
+	mutable std::set<wxString> m_sharedDirKeys;
+	mutable bool m_sharedDirKeysBuilt = false;
 
 	/* Kad Stuff */
 	CPublishKeywordList *m_keywords;

--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -179,6 +179,48 @@ static wxString DoCleanPath(const wxString &path)
 #endif
 }
 
+/**
+ * The canonical form IsSameAs() reduces a path to before comparing it.
+ *
+ * Extracted so it can be computed once per path and reused, instead of twice
+ * per comparison. Grouping paths by this string is then exactly equivalent to
+ * comparing them pairwise, which is what lets CSharedFileList answer a browse
+ * without re-deriving the same grouping for every directory (issue #898).
+ *
+ * Only for paths that contain a separator -- IsSameAs() compares two bare
+ * filenames with PATHCMP instead, and that branch is left where it is.
+ */
+static wxString NormalizedKey(const wxString &path)
+{
+	// Cache the current directory only when the path is relative --
+	// wxFileName::Normalize ignores the cwd argument for absolute paths.
+	// Skipping wxGetCwd() in the absolute case (which is essentially every
+	// aMule call site: shared dirs, Temp, Incoming, partfile paths) avoids
+	// the wxLogSysError "Failed to get the working directory" that wxGetCwd()
+	// emits on macOS bundles whose recorded CWD has been removed (App
+	// translocation, deleted launching shell, etc.).
+	wxString cwd;
+	if (!wxIsAbsolutePath(path)) {
+		cwd = wxGetCwd();
+	}
+
+	// We normalize everything, except env. variables, which
+	// can cause problems when the string is not encodable
+	// using wxConvLibc which wxWidgets uses for the purpose.
+	// wxPATH_NORM_ALL is deprecated in wx3 -- use explicit flags instead (excluding wxPATH_NORM_ENV_VARS)
+	const int flags = wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE |
+			  wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT;
+
+	// Let wxFileName handle the tricky stuff involved in actually
+	// comparing two paths ... Currently, a path ending with a path-
+	// separator will be unequal to the same path without a path-
+	// separator, which is probably for the best, but can could
+	// lead to some unexpected behavior.
+	wxFileName fn(path);
+	fn.Normalize(flags, cwd);
+	return fn.GetFullPath();
+}
+
 /** Returns true if the two paths are equal. */
 static bool IsSameAs(const wxString &a, const wxString &b)
 {
@@ -188,46 +230,13 @@ static bool IsSameAs(const wxString &a, const wxString &b)
 	// (other->GetFileName() == file->GetFileName()) lands here on every
 	// duplicate result; without this fast path the call falls through to
 	// wxFileName::Normalize, which insists on a cwd argument and triggers
-	// wxGetCwd() — and wxGetCwd() emits a wxLogSysError on macOS bundles
-	// whose recorded CWD has been removed (App translocation, deleted
-	// launching shell, etc.) for every comparison.
+	// wxGetCwd() -- see NormalizedKey().
 	if (a.find_first_of(wxFileName::GetPathSeparators()) == wxString::npos &&
 		b.find_first_of(wxFileName::GetPathSeparators()) == wxString::npos) {
 		return PATHCMP(a.c_str(), b.c_str()) == 0;
 	}
 
-	// Cache the current directory only when at least one of the paths
-	// is relative — wxFileName::Normalize ignores the cwd argument
-	// for absolute paths.  Skipping wxGetCwd() in the absolute-only
-	// case (which is essentially every aMule call site: shared dirs,
-	// Temp, Incoming, partfile paths) avoids the wxLogSysError
-	// "Failed to get the working directory" that wxGetCwd() emits on
-	// macOS bundles whose recorded CWD has been removed (App
-	// translocation, deleted launching shell, etc.).
-	wxString cwd;
-	if (!wxIsAbsolutePath(a) || !wxIsAbsolutePath(b)) {
-		cwd = wxGetCwd();
-	}
-
-	// We normalize everything, except env. variables, which
-	// can cause problems when the string is not encodable
-	// using wxConvLibc which wxWidgets uses for the purpose.
-	// wxPATH_NORM_ALL is deprecated in wx3 — use explicit flags instead (excluding wxPATH_NORM_ENV_VARS)
-	const int flags = wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE |
-			  wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT;
-
-	// Let wxFileName handle the tricky stuff involved in actually
-	// comparing two paths ... Currently, a path ending with a path-
-	// separator will be unequal to the same path without a path-
-	// separator, which is probably for the best, but can could
-	// lead to some unexpected behavior.
-	wxFileName fn1(a);
-	wxFileName fn2(b);
-
-	fn1.Normalize(flags, cwd);
-	fn2.Normalize(flags, cwd);
-
-	return (fn1.GetFullPath() == fn2.GetFullPath());
+	return NormalizedKey(a) == NormalizedKey(b);
 }
 
 ////////////////////////////////////////////////////////////
@@ -408,6 +417,25 @@ sint64 CPath::GetFileSize() const
 	}
 
 	return wxInvalidOffset;
+}
+
+wxString CPath::GetDirKey() const
+{
+	// The same reduction IsSameDir() performs before comparing: strip the
+	// trailing separator, then canonicalise. Two paths have equal keys
+	// exactly when IsSameDir() calls them the same directory, so a caller
+	// holding many paths can group by this instead of comparing every pair
+	// (issue #898).
+	wxString stripped = m_filesystem;
+	if (stripped.Length()) {
+		stripped = StripSeparators(stripped, wxString::trailing);
+	}
+
+	// Deliberately NormalizedKey() and not IsSameAs()'s bare-filename fast
+	// path: a bare name is made absolute against the cwd here, which is what
+	// IsSameAs() does for it too as soon as the other side has a separator.
+	// Keying every path the same way keeps the grouping self-consistent.
+	return NormalizedKey(stripped);
 }
 
 bool CPath::IsSameDir(const CPath &other) const

--- a/src/libs/common/Path.h
+++ b/src/libs/common/Path.h
@@ -126,6 +126,22 @@ public:
 	 */
 	bool IsSameDir(const CPath &other) const;
 
+	/**
+	 * The canonical string IsSameDir() reduces this path to.
+	 *
+	 * For paths that contain a separator -- which every shared directory
+	 * does -- equal keys mean IsSameDir() would return true, so a caller with
+	 * many of them can group them in one pass instead of comparing every
+	 * pair. Two bare filenames are not covered: IsSameDir() compares those
+	 * with PATHCMP while this normalises them, and on Windows
+	 * wxPATH_NORM_LONG would give PROGRA~1 and "Program Files" the same key
+	 * where PATHCMP calls them different.
+	 * Added for CSharedFileList, where answering a browse one directory at a
+	 * time was O(directories x files) calls to IsSameDir(), each normalising
+	 * both sides (issue #898).
+	 */
+	wxString GetDirKey() const;
+
 	/** Returns a CPath created from joining the two objects. */
 	CPath JoinPaths(const CPath &other) const;
 	/** Returns a CPath with invalid chars removed, and spaces escaped if specified. */

--- a/unittests/tests/PathTest.cpp
+++ b/unittests/tests/PathTest.cpp
@@ -297,6 +297,76 @@ TEST(CPath, IsSameDir)
 	ASSERT_FALSE(Norm("/root").IsSameDir(Norm("/home")));
 }
 
+TEST(CPath, GetDirKeyMatchesIsSameDir)
+{
+	// CSharedFileList groups directories by GetDirKey() instead of comparing
+	// every pair with IsSameDir() (issue #898). That is only valid while the
+	// two agree, so assert the equivalence directly rather than the key's
+	// contents, which are platform-dependent by design.
+	const wxString paths[] = {
+		"/root",
+		"/root/",
+		"/root//",
+		"/home",
+		"/home/",
+		"/home/amule",
+		"/home/amule/",
+		"/home/./amule",
+		"/home/amule/../amule",
+		"/home/other/../amule",
+		// Case variants: the same directory on Windows, different ones
+		// elsewhere. Asserting the equivalence rather than the key's value
+		// means this covers both without a platform #ifdef -- and it is the
+		// case where a hand-rolled key would diverge from IsSameDir(),
+		// because the folding lives inside wxPATH_NORM_CASE.
+		"/Home/AMule",
+		"/HOME/AMULE/",
+		"/ROOT",
+	};
+	const size_t count = sizeof(paths) / sizeof(paths[0]);
+
+	for (size_t i = 0; i < count; ++i) {
+		for (size_t j = 0; j < count; ++j) {
+			const CPath a = Norm(paths[i]);
+			const CPath b = Norm(paths[j]);
+			ASSERT_EQUALS(a.IsSameDir(b), a.GetDirKey() == b.GetDirKey());
+		}
+	}
+}
+
+TEST(CPath, GetDirKeyGroupsEqualDirs)
+{
+	// The property the grouping actually relies on: paths the old pairwise
+	// walk would have put together produce one key, and different
+	// directories produce different ones.
+	ASSERT_EQUALS(Norm("/root").GetDirKey(), Norm("/root/").GetDirKey());
+	ASSERT_EQUALS(Norm("/home/amule").GetDirKey(), Norm("/home/amule/").GetDirKey());
+	ASSERT_EQUALS(Norm("/home/amule").GetDirKey(), Norm("/home/./amule").GetDirKey());
+	ASSERT_EQUALS(Norm("/home/amule").GetDirKey(), Norm("/home/other/../amule").GetDirKey());
+
+	ASSERT_TRUE(Norm("/root").GetDirKey() != Norm("/home").GetDirKey());
+	ASSERT_TRUE(Norm("/home/amule").GetDirKey() != Norm("/home/amulf").GetDirKey());
+}
+
+TEST(CPath, IsSameAsUnchangedByKeyExtraction)
+{
+	// NormalizedKey() was lifted out of IsSameAs() (issue #898). Both of the
+	// branches it kept are asserted here so the extraction cannot quietly
+	// change either: bare filenames still compare through PATHCMP, and
+	// anything with a separator still normalises both sides.
+	ASSERT_TRUE(CPath("foobar.tgz") == CPath("foobar.tgz"));
+	ASSERT_TRUE(CPath("foobar.tgz") != CPath("barfoo.tar"));
+
+	ASSERT_TRUE(Norm("/home/amule/x.dat") == Norm("/home/amule/x.dat"));
+	ASSERT_TRUE(Norm("/home/amule/x.dat") == Norm("/home/./amule/x.dat"));
+	ASSERT_TRUE(Norm("/home/amule/x.dat") == Norm("/home/other/../amule/x.dat"));
+	ASSERT_TRUE(Norm("/home/amule/x.dat") != Norm("/home/amule/y.dat"));
+
+	// A bare name against a path: the fast path does not apply, and both
+	// sides go through normalisation, as before the extraction.
+	ASSERT_TRUE(CPath("x.dat") != Norm("/home/amule/x.dat"));
+}
+
 TEST(CPath, GetPath_FullName)
 {
 	{


### PR DESCRIPTION
Browsing a large share froze both ends for minutes, reported in #898. The instrumented build put numbers on it, and the two ends turned out to be stuck on different things that share a shape: O(directories x files).

Measured on the reporter's share of **39,450 files across 1,691 directories**.

## Sender: 51 s

A peer browses one directory at a time, and `GetSharedFilesByDirectory()` answered each request by walking the whole of `m_Files_map` calling `CPath::IsSameDir()` - which normalises *both* paths every time. That is 66.7 million comparisons, so 133 million normalisations, for one browse.

The files are now grouped by directory once per browse and each request answered from the grouping: **41,000 normalisations instead of 133 million**.

## The key

`CPath::GetDirKey()` is added here, and it is not a new comparison rule. `IsSameAs()` already worked by canonicalising both sides and comparing the results; this names that form so it can be computed once per path instead of twice per comparison. For paths containing a separator, which every shared directory has, grouping by it is equivalent to the walk it replaces, including the case folding that differs by platform, because `wxPATH_NORM_CASE` is part of the same reduction.

The equivalence is not unconditional, and the header says so: `IsSameDir()` compares two *bare* filenames with `PATHCMP` while `GetDirKey()` normalises them, so on Windows `wxPATH_NORM_LONG` would give `PROGRA~1` and `Program Files` one key where `PATHCMP` calls them different. Unreachable through this call path, since shared directories are always absolute, and the test table contains only separator paths so what is asserted is exactly what holds.

`IsSameAs()` keeps its structure exactly: bare filenames still compare through `PATHCMP`, everything else still normalises both sides. `NormalizedKey()` is a pure extraction of the second branch.

Invalidation comes from `m_listGeneration`, already bumped under `list_mut` wherever `m_Files_map` changes, which is the lock the grouping is built and read under. `RefreshPathIndex()` now bumps it too: a completed download is re-pathed from Temp to Incoming without entering or leaving the map, so `AddFile()`'s insert no-ops and nothing else marked the move. The pairwise walk re-read `GetFilePath()` every call and so never needed telling; a cache does.

## Receiver: 232 s

Every burst of arriving results took `MarkDirty()` -> `Cleared()`, rebuilding the whole accumulated tree: **384 rebuilds** over a set growing to 39,450 rows, 232 s in total, the last one 5.2 s on its own. The measured main-loop stalls came to 228 s, which is that same work seen from the other side.

While a browse is still streaming, the rebuild now waits for the row count to grow by half. The threshold resets when a browse starts, since a re-browse reuses the same tab and the previous browse's final count would otherwise be a bar the new one never clears. The rebuilds then form a geometric series whose total is a small multiple of the final one, and results still appear as the browse runs rather than only at the end. A finished or failed browse always rebuilds, so the last state is exact.

## Testing

The tests assert the property the grouping depends on rather than the key's contents, which are platform-dependent by design: for a table of paths, `a.IsSameDir(b)` exactly when their keys are equal. The table includes case variants, which are the same directory on Windows and different ones elsewhere, so one assertion covers both regimes without a platform `#ifdef` - and that is precisely where a hand-rolled key would diverge. Both branches kept by the `IsSameAs()` extraction are asserted too.

Built and run on **macOS**, **Linux** and **Windows**: 34/34 unit tests pass on Linux and Windows, `PathTest` green on macOS.

Not yet exercised against a real browse - that is the next step, with instrumentation rebased on top of this, and the reporter of #898 re-running it.

## Not addressed

The duplicate scan in `CSearchList::AddToList` is genuinely quadratic - 778 million steps in the same log - but it measured 6 s of 238 s, and it is left for its own change.




## Measured in the field

The reporter of #898 re-ran the same browse on this branch, 39,450 files across 1,691 directories, with an instrumented build.

**Sender, fixed outright.** No main-loop stall at all, against 53.5 s before. The directory-list reply takes 186 ms for 1,690 directories, and all 1,691 per-directory lookups together take 173 ms - of which 161 ms is the first call building the grouping, so the remaining 1,690 share about 12 ms. The whole browse costs the sender 1.0 s.

**Receiver, improved but not solved.** Rebuilds fell from 384 to 64 and their total from 232 s to 32.1 s, and recorded stalls from 119 totalling 228 s to 15 totalling 35.0 s. That is roughly a sevenfold improvement, and the reporter describes the machine as responsive throughout, but 35 s of blocking remains and the worst single stall is 6.3 s - essentially the final rebuild, 5.6 s at 39,450 rows, which `Cleared()` cannot avoid while that is the only notification wxGTK tolerates for this model (see #860).

Two things are therefore left for follow-up rather than claimed here: the rebuild count is higher than the growth schedule intends and is worth understanding before tuning, and the duplicate scan in `CSearchList::AddToList` still runs 778 million steps for 6.8 s, unchanged by this PR.
