### PR TITLE
feat(amuleapi): GET /known_clients — the daemon's credit store over REST

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -215,6 +215,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 |-----------------------|---------------|
 | `GET /downloads`      | `name`, `size`, `progress`, `speed`, `status` |
 | `GET /clients`        | `name`, `software` |
+| `GET /known_clients`  | `name`, `software`, `first_seen`, `last_seen`, `sessions`, `total_uploaded`, `total_downloaded` |
 | `GET /shared`         | `name`, `size` |
 | `GET /servers`        | `name`, `users`, `ping`, `files` |
 | `GET /search/results` | `name`, `size`, `sources`, `rating` |
@@ -1130,6 +1131,73 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 ```
 
 **Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `403 forbidden` (guest token — browsing is `ADMIN`-only), `404 not_found` (no peer with that ecid), `405 method_not_allowed` (non-POST), `502 bad_gateway` (core accepted the request but returned no `search_id`), `503 ec_unavailable`.
+
+---
+
+### Known clients
+
+#### `GET /api/v0/known_clients`
+
+**Auth:** `GUEST`
+
+Lists every peer the daemon has ever exchanged data with, from its credit store.
+
+Distinct from [`GET /clients`](#get-apiv0clients), which lists the peers connected **right now**. The two differ in identity as well as content: a live client is keyed by `client_ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether a given record has a live counterpart at this moment.
+
+Standard [list envelope](#list-envelopes-and-pagination) under the `known_clients` key, with `limit` / `offset` / `sort` / `order`.
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=2"
+```
+
+```json
+{
+  "known_clients": [
+    {
+      "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00",
+      "client_name": "example-peer",
+      "ip": "192.0.2.10",
+      "port": 4665,
+      "kad_port": 4675,
+      "country_code": "de",
+      "software": "amule",
+      "version": "v2.3.1",
+      "source_origin": "kad",
+      "obfuscation": "supported",
+      "total_uploaded": 0,
+      "total_downloaded": 0,
+      "last_seen": 1786652714,
+      "first_seen": 1786652714,
+      "sessions": 1,
+      "online": false
+    }
+  ],
+  "total": 392, "offset": 0, "limit": 2
+}
+```
+
+| Field | Notes |
+|---|---|
+| `user_hash` | 32-char lowercase MD4. The identity; join with `/clients`. |
+| `client_name` | Peer-chosen name. Absent when never recorded. |
+| `ip`, `port`, `kad_port` | Last address the peer was seen at. Absent together. |
+| `country_code` | ISO 3166-1 alpha-2, lowercase, resolved by the daemon's GeoIP. Absent when GeoIP is off or the address does not resolve. Artwork: [`GET /flags/{code}.png`](#get-flagscodepng). |
+| `software`, `version` | Same tokens `GET /clients` uses. Absent together. |
+| `source_origin` | How the peer was first found — `server`, `kad`, `source_exchange`, `passive`, … |
+| `obfuscation` | Protocol-obfuscation state as of the last session. |
+| `total_uploaded`, `total_downloaded` | Lifetime bytes, from the credit record. Always present. |
+| `last_seen` | Unix seconds. Always present. |
+| `first_seen`, `sessions` | Present together, and only for a record the daemon holds metadata for. |
+| `online` | Whether this peer is connected right now, correlated by `user_hash`. |
+
+**Optional fields are omitted, never emitted empty.** A record written before the daemon kept per-peer metadata carries only the hash, the totals and `last_seen`; the rest are absent so a consumer can tell "never recorded" from "recorded as empty". On a long-lived node most records are of that kind.
+
+The reply is served from a **10-second cache**: it is a full walk of the credit store, which on a large node is tens of thousands of records. Paging therefore costs one EC roundtrip rather than one per page.
+
+The cache window is not visible in the data. A record for a peer that is **not** connected cannot change — credit totals only move during a transfer and `last_seen` only at disconnect — so the cached copy is exact. For a peer that **is** connected, `online`, `total_uploaded` and `total_downloaded` are taken from the live client state on every request, so a caller polling this endpoint sees a transferring peer's totals move each tick rather than in ten-second steps.
+
+**Errors:** `405 method_not_allowed` (non-GET/HEAD), `503 ec_unavailable`, `503 ec_unsupported` (the connected amuled predates the client-history request — it is never sent to a daemon that does not advertise support).
 
 ---
 

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -221,6 +221,15 @@ public:
 	{
 		return m_ECClient && m_ECClient->ServerSupportsSearchProgressUnion();
 	}
+	// True when amuled answers EC_OP_GET_CLIENT_HISTORY. Null-checked for the
+	// same reason as the union accessor above -- and the check is not optional
+	// even beyond that: a daemon predating the request reaches the
+	// unknown-opcode branch of ProcessRequest2(), which asserts rather than
+	// answering EC_OP_FAILED, so asking an old core takes it down.
+	bool IsServerClientHistoryActive() const
+	{
+		return m_ECClient && m_ECClient->ServerSupportsClientHistory();
+	}
 	// Version string of the connected core, from the EC AUTH_OK handshake.
 	// Empty when not connected (m_ECClient null) or when the daemon is old
 	// enough to omit the EC_TAG_SERVER_VERSION tag.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -24,6 +24,8 @@
 
 #include "Api.h"
 
+#include "ClientTagNames.h" // Needed for the shared client-tag token decoders
+
 #include "config.h" // AMULEAPI_STATIC_DIR (compile-time install path)
 #include "AmuleApiConfig.h"
 #include "App.h"
@@ -771,6 +773,19 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return ErrorResponse(405, "method_not_allowed", "only GET on /clients");
 		}
 		return HandleClients(req);
+	}
+
+	// /known_clients — the daemon's credit store, every peer it has ever
+	// exchanged data with. A separate resource rather than a sub-path of
+	// /clients: these are keyed by user hash, outlive the daemon process that
+	// would have issued an ECID, and carry stored history instead of live
+	// transfer state. Matched before /clients/{ecid} regardless, since that
+	// pattern accepts any single segment.
+	if (path == "/api/v0/known_clients") {
+		if (req.method != "GET" && req.method != "HEAD") {
+			return ErrorResponse(405, "method_not_allowed", "only GET on /known_clients");
+		}
+		return HandleKnownClients(req);
 	}
 
 	// /clients/{ecid} — single-peer detail (issue #422). GET/HEAD only;
@@ -2279,6 +2294,112 @@ void WriteClientObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 {
 	w.BeginObject();
 	WriteClientBaseFields(w, c);
+	w.EndObject();
+}
+
+// One EC_TAG_CLIENT entry of an EC_OP_CLIENT_HISTORY reply.
+//
+// Tag-absent means "the daemon has no such record for this peer", not "empty":
+// a record written before per-peer metadata existed carries only the hash, the
+// totals and a last-seen, and the fields below simply stay unset so the writer
+// can omit them. The numeric codes go through the same decoders the refresher
+// uses for live peers (ClientTagNames.h), so a consumer switching on "kad" or
+// "emule" gets the same token whichever endpoint produced it.
+webapi::KnownClientSnapshot DecodeKnownClient(const CECTag &entry)
+{
+	webapi::KnownClientSnapshot c;
+	c.user_hash = std::string(entry.GetMD4Data().Encode().Lower().utf8_str());
+
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_UPLOAD_TOTAL))
+		c.total_uploaded = t->GetInt();
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_DOWNLOAD_TOTAL))
+		c.total_downloaded = t->GetInt();
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_LAST_SEEN))
+		c.last_seen = static_cast<std::time_t>(t->GetInt());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_FIRST_SEEN))
+		c.first_seen = static_cast<std::time_t>(t->GetInt());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_SESSIONS))
+		c.sessions = static_cast<std::uint32_t>(t->GetInt());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_NAME))
+		c.client_name = std::string(t->GetStringData().utf8_str());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_USER_IP)) {
+		const std::uint32_t ip = static_cast<std::uint32_t>(t->GetInt());
+		if (ip != 0)
+			c.ip = std::string(Uint32toStringIP(ip).utf8_str());
+	}
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_USER_PORT))
+		c.port = static_cast<std::uint16_t>(t->GetInt());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_KAD_PORT))
+		c.kad_port = static_cast<std::uint16_t>(t->GetInt());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_COUNTRY))
+		c.country_code = std::string(t->GetStringData().Lower().utf8_str());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_SOFTWARE))
+		c.software = webapi::ClientSoftwareName(static_cast<std::uint32_t>(t->GetInt()));
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_SOFT_VER_STR))
+		c.version = std::string(t->GetStringData().utf8_str());
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_FROM))
+		c.source_origin = webapi::SourceOriginName(static_cast<std::uint32_t>(t->GetInt()));
+	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_OBFUSCATION_STATUS))
+		c.obfuscation = webapi::ClientObfuscationName(static_cast<std::uint8_t>(t->GetInt()));
+	return c;
+}
+
+// One credit-store record (GET /known_clients).
+//
+// Optional fields are omitted rather than emitted empty: a record written
+// before the daemon kept per-peer metadata genuinely has no name, address or
+// software, and a consumer should be able to tell "not recorded" from "recorded
+// as empty". The hash, the totals and last_seen are always present.
+void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c)
+{
+	w.BeginObject();
+	w.Key("user_hash");
+	w.ValueString(wxString::FromUTF8(c.user_hash.c_str()));
+	if (!c.client_name.empty()) {
+		w.Key("client_name");
+		w.ValueString(wxString::FromUTF8(c.client_name.c_str()));
+	}
+	if (!c.ip.empty()) {
+		w.Key("ip");
+		w.ValueString(wxString::FromUTF8(c.ip.c_str()));
+		w.Key("port");
+		w.ValueInt(static_cast<int64_t>(c.port));
+		w.Key("kad_port");
+		w.ValueInt(static_cast<int64_t>(c.kad_port));
+	}
+	if (!c.country_code.empty()) {
+		w.Key("country_code");
+		w.ValueString(wxString::FromUTF8(c.country_code.c_str()));
+	}
+	if (!c.software.empty()) {
+		w.Key("software");
+		w.ValueString(wxString::FromUTF8(c.software.c_str()));
+		w.Key("version");
+		w.ValueString(wxString::FromUTF8(c.version.c_str()));
+	}
+	if (!c.source_origin.empty()) {
+		w.Key("source_origin");
+		w.ValueString(wxString::FromUTF8(c.source_origin.c_str()));
+	}
+	if (!c.obfuscation.empty()) {
+		w.Key("obfuscation");
+		w.ValueString(wxString::FromUTF8(c.obfuscation.c_str()));
+	}
+	w.Key("total_uploaded");
+	w.ValueUInt(static_cast<uint64_t>(c.total_uploaded));
+	w.Key("total_downloaded");
+	w.ValueUInt(static_cast<uint64_t>(c.total_downloaded));
+	w.Key("last_seen");
+	w.ValueUInt(static_cast<uint64_t>(c.last_seen));
+	if (c.first_seen != 0) {
+		w.Key("first_seen");
+		w.ValueUInt(static_cast<uint64_t>(c.first_seen));
+		w.Key("sessions");
+		w.ValueUInt(static_cast<uint64_t>(c.sessions));
+	}
+	// Correlate with /clients by user_hash to reach the live peer.
+	w.Key("online");
+	w.ValueBool(c.online);
 	w.EndObject();
 }
 
@@ -4229,6 +4350,113 @@ bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::C
 // one peer: every list field plus the detail-only B fields. Bare
 // object (no list envelope), mirroring HandleDownloadDetail. 404 when
 // the ecid isn't in the current snapshot.
+CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+
+	// Never sent blind: a daemon predating EC_OP_GET_CLIENT_HISTORY reaches
+	// the unknown-opcode branch of ProcessRequest2(), which asserts before it
+	// reaches the EC_OP_FAILED it would otherwise answer with -- so simply
+	// trying the request takes the core down.
+	if (!m_app.IsServerClientHistoryActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve the client history");
+	}
+
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+
+	// The live peers, by hash. Read per request rather than inside the fetcher:
+	// the store is cached for 10 s while this changes every refresher tick.
+	//
+	// A record for a peer that is NOT connected cannot change -- the credit
+	// totals only move while a transfer is running, and last-seen only at
+	// disconnect -- so the cache is exact for those. The connected ones are
+	// the whole of what the cache could serve stale, and the refresher already
+	// holds their current totals, so they are patched over the cached record
+	// below. That makes the 10 s window invisible: a caller polling this
+	// endpoint sees a transferring peer's totals move every tick.
+	std::map<std::string, const webapi::ClientSnapshot *> live_by_hash;
+	const std::vector<webapi::ClientSnapshot> live = m_state.Clients();
+	for (const auto &c : live) {
+		if (!c.user_hash.empty())
+			live_by_hash[c.user_hash] = &c;
+	}
+
+	auto pair = m_known_clients_cache.GetOrFetch(
+		std::chrono::milliseconds(10000), [this]() -> TtlPair_KnownClients {
+			std::vector<webapi::KnownClientSnapshot> out;
+			std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_CLIENT_HISTORY));
+			const CECPacket *resp = m_app.SendRecvSerialized(req_ec.get());
+			std::time_t ts = 0;
+			if (resp) {
+				if (resp->GetOpCode() == EC_OP_CLIENT_HISTORY) {
+					out.reserve(resp->GetTagCount());
+					for (const CECTag &entry : *resp) {
+						if (entry.GetTagName() != EC_TAG_CLIENT)
+							continue;
+						out.push_back(DecodeKnownClient(entry));
+					}
+				}
+				ts = std::time(nullptr);
+				delete resp;
+			}
+			return TtlPair_KnownClients(std::move(out), ts);
+		});
+
+	if (pair.second == 0) {
+		return ErrorResponse(503, "ec_unavailable", "the EC connection is unavailable");
+	}
+
+	std::vector<webapi::KnownClientSnapshot> items = pair.first;
+	for (auto &c : items) {
+		const auto it = live_by_hash.find(c.user_hash);
+		c.online = it != live_by_hash.end();
+		if (!c.online)
+			continue;
+		// Only the fields a connected peer can move. Everything else on the
+		// record is what the store holds, which nothing touches while the peer
+		// is up.
+		c.total_uploaded = it->second->xfer_up_total;
+		c.total_downloaded = it->second->xfer_down_total;
+	}
+
+	static const ListComparators<webapi::KnownClientSnapshot> kComps = {
+		{ "name",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.client_name < b.client_name;
+			} },
+		{ "software",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.software < b.software;
+			} },
+		{ "first_seen",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.first_seen < b.first_seen;
+			} },
+		{ "last_seen",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.last_seen < b.last_seen;
+			} },
+		{ "sessions",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.sessions < b.sessions;
+			} },
+		{ "total_uploaded",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.total_uploaded < b.total_uploaded;
+			} },
+		{ "total_downloaded",
+			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
+				return a.total_downloaded < b.total_downloaded;
+			} },
+	};
+	return ListResponse(m_state, "known_clients", items, WriteKnownClientObject, params, kComps);
+}
+
 CHttpServer::Response CApiDispatcher::HandleClientDetail(
 	const CHttpServer::Request &req, const std::string &ecid_str)
 {

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -237,6 +237,7 @@ private:
 		const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleClients(const CHttpServer::Request &);
 	CHttpServer::Response HandleClientDetail(const CHttpServer::Request &, const std::string &ecid_str);
+	CHttpServer::Response HandleKnownClients(const CHttpServer::Request &);
 	// POST /clients/{ecid}/shared_files — browse a peer's shared file list
 	// ("View Files", #399). Returns a search_id addressed like any search:
 	// results via GET /search/results?search_id=, progress + SSE via the
@@ -323,9 +324,17 @@ private:
 	using TtlPair_StatsTree = std::pair<webapi::StatsTreeNode, std::time_t>;
 	using TtlPair_StatsGraphs = std::pair<webapi::StatsGraphs, std::time_t>;
 	using TtlPair_ServerInfo = std::pair<webapi::ServerInfoLog, std::time_t>;
+	// The credit store, for /known_clients. A 10 s TTL rather than the 1 s
+	// used above: the reply is the whole store -- megabytes, and ~10 ms of
+	// daemon main loop on a 40k-record node -- while the data behind it only
+	// moves when a peer connects or disconnects. It also means paging through
+	// the store costs one EC roundtrip rather than one per page, since each
+	// request slices the cached vector.
+	using TtlPair_KnownClients = std::pair<std::vector<webapi::KnownClientSnapshot>, std::time_t>;
 	webapi::CTtlCache<TtlPair_StatsTree> m_stats_tree_cache;
 	webapi::CTtlCache<TtlPair_StatsGraphs> m_stats_graphs_cache;
 	webapi::CTtlCache<TtlPair_ServerInfo> m_server_info_cache;
+	webapi::CTtlCache<TtlPair_KnownClients> m_known_clients_cache;
 	// /search/results is no longer cached here — the refresher owns
 	// the polling while a search is active (see CState::SearchProgress
 	// + RefresherTick). POST /search calls m_state.MarkSearchStarted.

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -629,6 +629,13 @@ bool CamuleapiApp::IsServerPartialUpdateActive()
 	return CaMuleExternalConnector::IsServerPartialUpdateActive();
 }
 
+bool CamuleapiApp::IsServerClientHistoryActive()
+{
+	// Same shape as IsServerPartialUpdateActive(): a const bool snapshot
+	// taken at login, so no mutex.
+	return CaMuleExternalConnector::IsServerClientHistoryActive();
+}
+
 wxString CamuleapiApp::GetDaemonVersion()
 {
 	// Serialize with the rest of the EC access: m_ECClient is torn down

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -96,6 +96,11 @@ public:
 	// entries we didn't see this tick" path.
 	bool IsServerPartialUpdateActive();
 
+	// True when amuled advertised EC_TAG_CAN_CLIENT_HISTORY during login,
+	// i.e. it answers EC_OP_GET_CLIENT_HISTORY. /known_clients returns 503
+	// rather than sending a request an older core would assert on.
+	bool IsServerClientHistoryActive();
+
 	// Version string of the connected amuled, captured from the
 	// EC_TAG_SERVER_VERSION tag of the AUTH_OK handshake. Empty string
 	// when EC is not (yet) connected, or when talking to a daemon old

--- a/src/webapi/ClientTagNames.h
+++ b/src/webapi/ClientTagNames.h
@@ -1,0 +1,61 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef WEBAPI_CLIENTTAGNAMES_H
+#define WEBAPI_CLIENTTAGNAMES_H
+
+#include <cstdint>
+#include <string>
+
+namespace webapi
+{
+
+/**
+ * Stable lowercase tokens for the numeric client tags EC ships.
+ *
+ * Shared rather than file-local because two paths decode the same tags: the
+ * refresher, for the live peers behind /clients, and the on-demand handler for
+ * /known_clients, whose records carry the same software, origin and
+ * obfuscation codes. Two copies would be free to drift, and the tokens are
+ * part of the API surface -- a consumer switching on "kad" must get the same
+ * answer whichever endpoint produced it.
+ *
+ * Deliberately not the GUI's rendering: these are protocol tokens, not
+ * display text, so they stay untranslated and stable.
+ */
+
+//! EC_TAG_CLIENT_SOFTWARE (ESoftwareType) to a token, e.g. "emule".
+const char *ClientSoftwareName(std::uint32_t code);
+
+//! EC_TAG_CLIENT_OBFUSCATION_STATUS (EObfuscationState) to a token.
+const char *ClientObfuscationName(std::uint8_t code);
+
+//! EC_TAG_CLIENT_FROM (ESourceFrom) to a token. Local and remote server both
+//! collapse to "server".
+std::string SourceOriginName(std::uint32_t from);
+
+} // namespace webapi
+
+#endif // WEBAPI_CLIENTTAGNAMES_H
+// File_checked_for_headers

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -28,6 +28,8 @@
 
 #include "Refresher.h"
 
+#include "ClientTagNames.h" // Needed for the shared client-tag token decoders
+
 #include "PrefsSchema.h"
 
 #include "State.h"
@@ -54,6 +56,93 @@
 
 namespace webapi
 {
+
+const char *ClientSoftwareName(std::uint32_t code)
+{
+	// Subset that covers the bulk of the live ed2k population —
+	// every client we'd ever realistically meet on the wire. SO_UNKNOWN
+	// and SO_COMPAT_UNK collapse to "unknown" / "compat" so consumers
+	// see a stable label even when amuled couldn't fingerprint the
+	// peer's software.
+	switch (code) {
+	case SO_EMULE:
+		return "emule";
+	case SO_CDONKEY:
+		return "cdonkey";
+	case SO_LXMULE:
+		return "lxmule";
+	case SO_AMULE:
+		return "amule";
+	case SO_SHAREAZA:
+	case SO_NEW2_SHAREAZA:
+	case SO_NEW_SHAREAZA:
+		return "shareaza";
+	case SO_EMULEPLUS:
+		return "emule_plus";
+	case SO_HYDRANODE:
+		return "hydranode";
+	case SO_NEW2_MLDONKEY:
+	case SO_MLDONKEY:
+	case SO_NEW_MLDONKEY:
+		return "mldonkey";
+	case SO_LPHANT:
+		return "lphant";
+	case SO_EDONKEYHYBRID:
+		return "edonkey_hybrid";
+	case SO_EDONKEY:
+		return "edonkey";
+	case SO_OLDEMULE:
+		return "old_emule";
+	case SO_UNKNOWN:
+		return "unknown";
+	case SO_COMPAT_UNK:
+		return "compat";
+	default:
+		return "unknown";
+	}
+}
+const char *ClientObfuscationName(std::uint8_t code)
+{
+	switch (code) {
+	case OBST_UNDEFINED:
+		return "undefined";
+	case OBST_ENABLED:
+		return "enabled";
+	case OBST_SUPPORTED:
+		return "supported";
+	case OBST_NOT_SUPPORTED:
+		return "not_supported";
+	case OBST_DISABLED:
+		return "disabled";
+	default:
+		return "unknown";
+	}
+}
+// Map EC_TAG_CLIENT_FROM (ESourceFrom, Constants.h) to a stable
+// lowercase token, mirroring the GUI's Origin column without leaking
+// the daemon locale. Local/remote server both collapse to "server".
+std::string SourceOriginName(std::uint32_t from)
+{
+	switch (from) {
+	case SF_LOCAL_SERVER:
+	case SF_REMOTE_SERVER:
+		return "server";
+	case SF_KADEMLIA:
+		return "kad";
+	case SF_SOURCE_EXCHANGE:
+		return "source_exchange";
+	case SF_PASSIVE:
+		return "passive";
+	case SF_LINK:
+		return "link";
+	case SF_SOURCE_SEEDS:
+		return "source_seeds";
+	case SF_SEARCH_RESULT:
+		return "search_result";
+	default:
+		return "unknown";
+	}
+}
 
 namespace
 {
@@ -614,69 +703,6 @@ const char *ClientIdentStateName(std::uint8_t code)
 	}
 }
 
-const char *ClientSoftwareName(std::uint32_t code)
-{
-	// Subset that covers the bulk of the live ed2k population —
-	// every client we'd ever realistically meet on the wire. SO_UNKNOWN
-	// and SO_COMPAT_UNK collapse to "unknown" / "compat" so consumers
-	// see a stable label even when amuled couldn't fingerprint the
-	// peer's software.
-	switch (code) {
-	case SO_EMULE:
-		return "emule";
-	case SO_CDONKEY:
-		return "cdonkey";
-	case SO_LXMULE:
-		return "lxmule";
-	case SO_AMULE:
-		return "amule";
-	case SO_SHAREAZA:
-	case SO_NEW2_SHAREAZA:
-	case SO_NEW_SHAREAZA:
-		return "shareaza";
-	case SO_EMULEPLUS:
-		return "emule_plus";
-	case SO_HYDRANODE:
-		return "hydranode";
-	case SO_NEW2_MLDONKEY:
-	case SO_MLDONKEY:
-	case SO_NEW_MLDONKEY:
-		return "mldonkey";
-	case SO_LPHANT:
-		return "lphant";
-	case SO_EDONKEYHYBRID:
-		return "edonkey_hybrid";
-	case SO_EDONKEY:
-		return "edonkey";
-	case SO_OLDEMULE:
-		return "old_emule";
-	case SO_UNKNOWN:
-		return "unknown";
-	case SO_COMPAT_UNK:
-		return "compat";
-	default:
-		return "unknown";
-	}
-}
-
-const char *ClientObfuscationName(std::uint8_t code)
-{
-	switch (code) {
-	case OBST_UNDEFINED:
-		return "undefined";
-	case OBST_ENABLED:
-		return "enabled";
-	case OBST_SUPPORTED:
-		return "supported";
-	case OBST_NOT_SUPPORTED:
-		return "not_supported";
-	case OBST_DISABLED:
-		return "disabled";
-	default:
-		return "unknown";
-	}
-}
-
 // Format an IP from EC_TAG_CLIENT_USER_IP. The EC tag holds a
 // 32-bit host-order IPv4; we render it dotted-quad. Returns "" for
 // zero IPs (commonly the case for clients we've never confirmed).
@@ -693,32 +719,6 @@ std::string FormatClientIpv4(std::uint32_t ip_he)
 		static_cast<unsigned>((ip_he >> 16) & 0xFFu),
 		static_cast<unsigned>((ip_he >> 24) & 0xFFu));
 	return std::string(buf);
-}
-
-// Map EC_TAG_CLIENT_FROM (ESourceFrom, Constants.h) to a stable
-// lowercase token, mirroring the GUI's Origin column without leaking
-// the daemon locale. Local/remote server both collapse to "server".
-std::string SourceOriginName(std::uint32_t from)
-{
-	switch (from) {
-	case SF_LOCAL_SERVER:
-	case SF_REMOTE_SERVER:
-		return "server";
-	case SF_KADEMLIA:
-		return "kad";
-	case SF_SOURCE_EXCHANGE:
-		return "source_exchange";
-	case SF_PASSIVE:
-		return "passive";
-	case SF_LINK:
-		return "link";
-	case SF_SOURCE_SEEDS:
-		return "source_seeds";
-	case SF_SEARCH_RESULT:
-		return "search_result";
-	default:
-		return "unknown";
-	}
 }
 
 // Merge a `CEC_UpDownClient_Tag` into an existing ClientSnapshot.

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -257,6 +257,41 @@ struct FileSnapshot
 //  * /clients → no filter, full set surfaced
 // (/downloads/{hash}/sources can filter by
 // upload_file_hash matching the partfile.)
+/**
+ * One peer from the daemon's credit store — GET /known_clients.
+ *
+ * Distinct from ClientSnapshot, which describes a peer we are connected to
+ * *now*: this is keyed by user hash rather than ECID, survives the daemon
+ * process that issued any ECID, and carries stored history rather than live
+ * transfer state. A peer can appear in both, correlated by user_hash.
+ *
+ * Every field except the hash and the totals is optional. A record written
+ * before the daemon kept per-peer metadata has no name, address or software,
+ * and the daemon simply omits those tags rather than inventing values.
+ */
+struct KnownClientSnapshot
+{
+	std::string user_hash; // 32-char lowercase hex MD4; the identity
+	std::string client_name;
+	std::string ip; // dotted-quad; "" when the record predates metadata
+	std::uint16_t port = 0;
+	std::uint16_t kad_port = 0;
+	std::string country_code; // ISO 3166-1 alpha-2, resolved daemon-side
+	std::string software;     // resolved name, e.g. "eMule"
+	std::string version;      // "v0.50.0"
+	std::string source_origin;
+	std::string obfuscation;
+	std::uint64_t total_uploaded = 0;
+	std::uint64_t total_downloaded = 0;
+	std::time_t first_seen = 0; // 0 when the record carries no metadata
+	std::time_t last_seen = 0;
+	std::uint32_t sessions = 0;
+	//! This peer is connected right now, correlated by user hash against the
+	//! live client list. Never by ECID: those mean nothing across daemon
+	//! restarts, while the hash is what the credit store is keyed on.
+	bool online = false;
+};
+
 struct ClientSnapshot
 {
 	std::uint32_t ecid = 0;

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# amuleapi 33-known-clients — GET /known_clients.
+#
+# /clients answers "who am I connected to right now", keyed by ECID.
+# This route answers "who have I ever exchanged data with", keyed by the
+# peer's user hash and read from the daemon's credit store, so it
+# survives the daemon process any ECID belonged to.
+#
+# What is asserted here:
+#
+#   * the envelope is the standard list shape — a `known_clients` array
+#     plus `total` / `offset` / `limit` — and paginates through the
+#     shared helpers, not a private implementation,
+#   * `limit` is clamped and a bad `limit` / `offset` / `order` is a 400,
+#     same contract as every other list endpoint,
+#   * every `sort` key the endpoint advertises is accepted and an
+#     unknown one is a 400,
+#   * each record carries the fields that are always recorded (user_hash,
+#     the totals, last_seen, online) and omits — rather than empties —
+#     the ones a pre-metadata record has no value for,
+#   * `user_hash` is a 32-char lowercase MD4, so it correlates with
+#     /clients `user_hash` directly,
+#   * a record for a connected peer reports live totals rather than the
+#     10-second-cached copy — the cache is exact for offline records,
+#     whose credit data cannot change, and must not be for online ones,
+#   * the response is cacheable (ETag) and honours If-None-Match,
+#   * HEAD returns headers with no body,
+#   * non-safe methods are 405.
+#
+# Note on an empty store: a fresh regtest daemon has met no peers, so
+# `total` is legitimately 0 and the per-record assertions skip
+# themselves rather than fail. Point the daemon at a config dir with a
+# populated clients.met to exercise them.
+#
+# Usage:
+#   amuleapi --config-dir=/tmp/amuleapi-regtest &
+#   ./33-known-clients.sh
+#
+# Exits 0 on success, 1 on any failed assertion, 2 on bring-up error.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+AUTH=()
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -D /tmp/amuleapi_33_head -o /tmp/amuleapi_33_body \
+		-w '%{http_code}' "${AUTH[@]}" "$@") || _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat /tmp/amuleapi_33_body)
+	CURL_HEAD=$(cat /tmp/amuleapi_33_head)
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS"
+	fi
+}
+
+_header() { echo "$CURL_HEAD" | awk -F': ' -v k="$1" 'tolower($1) == k {gsub(/\r/,""); print $2}'; }
+
+_jq() { echo "$CURL_BODY" | jq -r "$1" 2>/dev/null; }
+
+trap 'rm -f /tmp/amuleapi_33_head /tmp/amuleapi_33_body' EXIT
+
+command -v jq >/dev/null 2>&1 || _die "jq is required"
+
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
+fi
+
+echo "amuleapi 33-known-clients @ $HOST"
+
+# --- 0. Log in. ----------------------------------------------------
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
+	|| _die "could not log in for known-clients tests"
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# --- 1. The envelope. ---------------------------------------------
+_curl "$HOST/api/v0/known_clients"
+_assert_status 200 "GET /known_clients"
+
+if [ "$(_jq 'has("known_clients")')" = "true" ]; then
+	_pass "envelope has a known_clients array"
+else
+	_fail "envelope" "no known_clients key in: ${CURL_BODY:0:200}"
+fi
+
+for k in total offset limit; do
+	if [ "$(_jq "has(\"$k\")")" = "true" ]; then
+		_pass "envelope has $k"
+	else
+		_fail "envelope" "missing pagination key: $k"
+	fi
+done
+
+TOTAL=$(_jq '.total')
+echo "        (store holds $TOTAL record(s))"
+
+# --- 2. Pagination, through the shared helpers. -------------------
+_curl "$HOST/api/v0/known_clients?limit=1"
+_assert_status 200 "GET /known_clients?limit=1"
+N=$(_jq '.known_clients | length')
+if [ "${N:-0}" -le 1 ]; then
+	_pass "limit=1 returns at most one record (got ${N:-0})"
+else
+	_fail "limit=1" "returned $N records"
+fi
+
+_curl "$HOST/api/v0/known_clients?limit=1&offset=99999999"
+_assert_status 200 "GET /known_clients with a far offset"
+N=$(_jq '.known_clients | length')
+if [ "${N:-1}" -eq 0 ]; then
+	_pass "an offset past the end returns an empty page, not an error"
+else
+	_fail "far offset" "expected 0 records, got $N"
+fi
+
+for bad in "limit=abc" "limit=99999999999" "offset=-1" "order=sideways"; do
+	_curl "$HOST/api/v0/known_clients?$bad"
+	_assert_status 400 "GET /known_clients?$bad is rejected"
+done
+
+# --- 3. Sort keys. -------------------------------------------------
+for key in name software first_seen last_seen sessions total_uploaded total_downloaded; do
+	_curl "$HOST/api/v0/known_clients?sort=$key&limit=1"
+	_assert_status 200 "sort=$key is accepted"
+done
+_curl "$HOST/api/v0/known_clients?sort=nonsense"
+_assert_status 400 "an unknown sort key is rejected"
+
+_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=1"
+_assert_status 200 "sort=last_seen&order=desc is accepted"
+
+# --- 4. Record shape. ----------------------------------------------
+if [ "${TOTAL:-0}" -gt 0 ]; then
+	_curl "$HOST/api/v0/known_clients?limit=1"
+
+	for k in user_hash total_uploaded total_downloaded last_seen online; do
+		if [ "$(_jq ".known_clients[0] | has(\"$k\")")" = "true" ]; then
+			_pass "record always carries $k"
+		else
+			_fail "record shape" "missing always-present key: $k"
+		fi
+	done
+
+	HASH=$(_jq '.known_clients[0].user_hash')
+	if echo "$HASH" | grep -qE '^[0-9a-f]{32}$'; then
+		_pass "user_hash is a 32-char lowercase MD4 ($HASH)"
+	else
+		_fail "user_hash" "expected 32 lowercase hex chars, got: ${HASH:-<none>}"
+	fi
+
+	if [ "$(_jq '.known_clients[0].online | type')" = "boolean" ]; then
+		_pass "online is a boolean"
+	else
+		_fail "online" "expected boolean, got: $(_jq '.known_clients[0].online | type')"
+	fi
+
+	# Optional fields are omitted, never emitted empty: a record written
+	# before the daemon kept per-peer metadata has no name at all, and a
+	# consumer must be able to tell that from "recorded as empty".
+	EMPTY_NAMES=$(_jq '[.known_clients[] | select(has("client_name") and .client_name == "")] | length')
+	if [ "${EMPTY_NAMES:-0}" -eq 0 ]; then
+		_pass "no record carries an empty client_name (absent means unrecorded)"
+	else
+		_fail "optional fields" "$EMPTY_NAMES record(s) have client_name == \"\""
+	fi
+
+	# first_seen and sessions travel together — both come from the same
+	# metadata block, so one without the other means a decode bug.
+	MISMATCH=$(_jq '[.known_clients[] | select(has("first_seen") != has("sessions"))] | length')
+	if [ "${MISMATCH:-0}" -eq 0 ]; then
+		_pass "first_seen and sessions are present or absent together"
+	else
+		_fail "metadata pairing" "$MISMATCH record(s) have one without the other"
+	fi
+else
+	echo "  SKIP  record-shape assertions (the store is empty)"
+fi
+
+# --- 4b. An online record is not served stale. ---------------------
+# The store is cached for 10 s, which is exact for a peer that is NOT
+# connected — its credit record cannot change. An online peer's totals CAN
+# change, so they are patched from the live client state on every request.
+# Two polls a few seconds apart therefore have to move for a peer that is
+# actively transferring, well inside the cache window.
+#
+# Not compared against /clients: the lifetime totals live on the refresher's
+# snapshot but are not part of the /clients JSON, so there is nothing there to
+# compare with. Movement over time is the observable that matters anyway.
+_curl "$HOST/api/v0/known_clients?limit=500"
+ACTIVE_HASH=$(_jq '[.known_clients[] | select(.online)][0].user_hash')
+if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
+	BEFORE=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
+		| .total_downloaded + .total_uploaded")
+	sleep 4
+	_curl "$HOST/api/v0/known_clients?limit=500"
+	AFTER=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
+		| .total_downloaded + .total_uploaded")
+	if [ "${AFTER:-0}" -gt "${BEFORE:-0}" ]; then
+		_pass "an online record's totals move inside the cache window ($BEFORE -> $AFTER)"
+	else
+		# An online but idle peer is legitimately static, and cannot be told
+		# apart from a stale cache here. Only a moving one proves the patch.
+		echo "  SKIP  live-total check (the online peer is not transferring)"
+	fi
+else
+	echo "  SKIP  live-total check (no peer is connected)"
+fi
+
+# --- 5. Caching. ---------------------------------------------------
+_curl "$HOST/api/v0/known_clients?limit=1"
+ETAG=$(_header etag)
+if [ -n "$ETAG" ]; then
+	_pass "response carries an ETag"
+	_curl -H "If-None-Match: $ETAG" "$HOST/api/v0/known_clients?limit=1"
+	_assert_status 304 "If-None-Match on the same ETag is a 304"
+else
+	_fail "caching" "no ETag on /known_clients"
+fi
+
+# --- 6. HEAD and method rejection. ---------------------------------
+_curl -I "$HOST/api/v0/known_clients"
+_assert_status 200 "HEAD /known_clients"
+
+for m in POST PUT DELETE PATCH; do
+	_curl -X "$m" "$HOST/api/v0/known_clients"
+	_assert_status 405 "$m /known_clients is rejected"
+done
+
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "33-known-clients: all $TEST_COUNT assertions passed"
+	exit 0
+fi
+echo "33-known-clients: $FAIL_COUNT of $TEST_COUNT assertions FAILED"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -212,6 +212,7 @@ PHASES=(
 	30-shared-verify.sh
 	31-shared-directories.sh
 	32-country-flags.sh
+	33-known-clients.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
`GET /clients` already answers "who am I connected to right now", with both directions and per-direction file hashes, so the desktop Clients page's *Active* tab needs nothing from the API. Its *Known* tab — the daemon's credit store, added in #904 — had no counterpart at all. This adds one.

## `GET /api/v0/known_clients`

A separate resource rather than a sub-path of `/clients`. These records are keyed by **user hash**, outlive the daemon process any ECID belonged to, and carry stored history instead of live transfer state; nesting them under `/clients/` would imply a parent-child relationship that is not there, since a known client usually has no ECID at all. Correlate the two on `user_hash` — that is also what the `online` field is computed from.

It is matched ahead of `/clients/{ecid}` regardless: that pattern accepts any single segment, so a sibling path would otherwise be swallowed and handed to the detail handler.

Paging, sorting and the envelope come from the existing list helpers — `ParseListParams` / `BuildListWindow` / `WritePageMeta` — so `limit` / `offset` / `sort` / `order` behave exactly as on every other list endpoint, with seven sort keys.

## Freshness

Fetched on demand and coalesced through a 10 s `TtlCache` around `SendRecvSerialized`, the same shape the server-info handler uses. The reply is a full walk of the credit store, so paging costs one EC roundtrip rather than one per page.

The cache window is not visible in the data. A record with no live peer behind it **cannot** change — credit totals only move during a transfer, `last_seen` only at disconnect — so the cached copy is exact for it. For a peer that is connected, `online` and the two totals are taken from the refresher's snapshot on every request. Verified against a real transfer: `total_downloaded` moves on every poll, well inside the window.

## Capability gate

Behind the same accessor pattern as `EC_TAG_CAN_PARTIAL_UPDATE`, returning `503 ec_unsupported` when the daemon does not advertise `EC_TAG_CAN_CLIENT_HISTORY`. Not merely for consistency: a daemon predating the request reaches the unknown-opcode branch of `ProcessRequest2()`, which asserts before returning the `EC_OP_FAILED` it would otherwise answer with, so asking an old core takes it down.

## Shared decoders

`ClientSoftwareName`, `ClientObfuscationName` and `SourceOriginName` were file-local in `Refresher.cpp`. Both paths decode the same tags, and these tokens are API surface — a consumer switching on `"kad"` must get the same answer whichever endpoint produced it — so they move to `ClientTagNames.h` and the refresher uses the same definitions rather than a copy free to drift.

## Shape

Optional fields are omitted, never emitted empty. A record written before per-peer metadata existed (#902) carries only the hash, the totals and a `last_seen`; on a long-lived node that is most of them, and a consumer should be able to tell "never recorded" from "recorded as empty".

## Verification

Exercised against a live daemon holding 390 real records, not a fixture:

- 39 curl assertions in `unittests/curl-tests/amuleapi/33-known-clients.sh`, registered in `run-all.sh`
- decoding cross-checked — 9 eMule / 4 aMule / 1 MLDonkey, origins spread across kad / server / search_result
- `user_hash` correlation with `/clients` confirmed on a connected peer
- the live-totals path proven with an actual transfer running

`docs/api/REFERENCE.md` covers the endpoint, the field table, the omit-when-unrecorded rule and the cache semantics.
