### PR TITLE
perf(amuleapi): maintain the known-clients store instead of re-reading it

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1187,7 +1187,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `source_origin` | How the peer was first found — `server`, `kad`, `source_exchange`, `passive`, … |
 | `obfuscation` | Protocol-obfuscation state as of the last session. |
 | `total_uploaded`, `total_downloaded` | Lifetime bytes, from the credit record. Always present. |
-| `last_seen` | Unix seconds. Always present. For a peer that is connected this is *now* — it is being seen — so the online records are the newest in the store and sort to the top of `sort=last_seen&order=desc`. |
+| `last_seen` | Unix seconds. Always present. For a peer that is connected this is *now* — it is being seen — so the connected records are the most recent in the store under `sort=last_seen&order=desc`. A peer that left during the current tick carries the same timestamp and ties with them; ties keep a stable order across requests. |
 | `first_seen`, `sessions` | Present together, and only for a record the daemon holds metadata for. |
 | `online` | Whether this peer is connected right now, correlated by `user_hash`. |
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1187,7 +1187,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `source_origin` | How the peer was first found — `server`, `kad`, `source_exchange`, `passive`, … |
 | `obfuscation` | Protocol-obfuscation state as of the last session. |
 | `total_uploaded`, `total_downloaded` | Lifetime bytes, from the credit record. Always present. |
-| `last_seen` | Unix seconds. Always present. |
+| `last_seen` | Unix seconds. Always present. For a peer that is connected this is *now* — it is being seen — so the online records are the newest in the store and sort to the top of `sort=last_seen&order=desc`. |
 | `first_seen`, `sessions` | Present together, and only for a record the daemon holds metadata for. |
 | `online` | Whether this peer is connected right now, correlated by `user_hash`. |
 
@@ -1198,7 +1198,7 @@ The store is read from the daemon **once**, on the first request, and maintained
 - a peer that connects is added, with `first_seen` and `sessions` set to what the daemon recorded when it said hello;
 - a connected peer's `online`, `total_uploaded` and `total_downloaded` track the live client state;
 - a bare record gains its name, address, software and origin once its peer identifies;
-- a peer that leaves has `online` cleared and `last_seen` stamped at the moment it went.
+- a connected peer's `last_seen` is now, and a peer that leaves has `online` cleared with `last_seen` stamped at the moment it went.
 
 The cost is one EC roundtrip per amuleapi process, and the store stays resident from first use.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1193,9 +1193,14 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 **Optional fields are omitted, never emitted empty.** A record written before the daemon kept per-peer metadata carries only the hash, the totals and `last_seen`; the rest are absent so a consumer can tell "never recorded" from "recorded as empty". On a long-lived node most records are of that kind.
 
-The reply is served from a **10-second cache**: it is a full walk of the credit store, which on a large node is tens of thousands of records. Paging therefore costs one EC roundtrip rather than one per page.
+The store is read from the daemon **once**, on the first request, and maintained from there: every refresher tick folds the connected peers back in, so later requests never touch EC at all. That is sound rather than a shortcut — a record whose peer is not connected cannot change, since credit totals only move during a transfer and `last_seen` is written at disconnect. What the maintenance covers:
 
-The cache window is not visible in the data. A record for a peer that is **not** connected cannot change — credit totals only move during a transfer and `last_seen` only at disconnect — so the cached copy is exact. For a peer that **is** connected, `online`, `total_uploaded` and `total_downloaded` are taken from the live client state on every request, so a caller polling this endpoint sees a transferring peer's totals move each tick rather than in ten-second steps.
+- a peer that connects is added, with `first_seen` and `sessions` set to what the daemon recorded when it said hello;
+- a connected peer's `online`, `total_uploaded` and `total_downloaded` track the live client state;
+- a bare record gains its name, address, software and origin once its peer identifies;
+- a peer that leaves has `online` cleared and `last_seen` stamped at the moment it went.
+
+The cost is one EC roundtrip per amuleapi process, and the store stays resident from first use.
 
 **Errors:** `405 method_not_allowed` (non-GET/HEAD), `503 ec_unavailable`, `503 ec_unsupported` (the connected amuled predates the client-history request — it is never sent to a daemon that does not advertise support).
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2639,17 +2639,13 @@ std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query,
 // (no element copies) and `out_total` with the pre-slice count. Returns
 // a 400 when `params.sort` is set but absent from `comparators`.
 template <class T>
-std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &items,
+std::unique_ptr<CHttpServer::Response> BuildListWindowFromPtrs(std::vector<const T *> &ptrs,
 	const ListParams &params,
 	const ListComparators<T> &comparators,
 	std::vector<const T *> &out_window,
 	std::size_t &out_total)
 {
-	out_total = items.size();
-	std::vector<const T *> ptrs;
-	ptrs.reserve(items.size());
-	for (const auto &it : items)
-		ptrs.push_back(&it);
+	out_total = ptrs.size();
 
 	if (!params.sort.empty()) {
 		auto c = std::find_if(comparators.begin(), comparators.end(), [&](const auto &p) {
@@ -2667,6 +2663,25 @@ std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &ite
 	const std::size_t end = params.has_limit ? std::min(begin + params.limit, out_total) : out_total;
 	out_window.assign(ptrs.begin() + begin, ptrs.begin() + end);
 	return nullptr;
+}
+
+// Sort + window a list the caller owns as values. Thin wrapper over the
+// pointer form above: an endpoint whose records are not all in one contiguous
+// vector -- /known_clients, which serves most rows straight out of a shared
+// cache and only materialises the few it has to patch -- addresses that one
+// directly instead of copying the whole set to get a vector.
+template <class T>
+std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &items,
+	const ListParams &params,
+	const ListComparators<T> &comparators,
+	std::vector<const T *> &out_window,
+	std::size_t &out_total)
+{
+	std::vector<const T *> ptrs;
+	ptrs.reserve(items.size());
+	for (const auto &it : items)
+		ptrs.push_back(&it);
+	return BuildListWindowFromPtrs(ptrs, params, comparators, out_window, out_total);
 }
 
 // Emit the `total` / `offset` / `limit` pagination metadata. `limit`
@@ -2693,6 +2708,56 @@ std::string QueryOf(const CHttpServer::Request &req)
 // Helper for every list endpoint's envelope: the list under its named
 // key plus #357 pagination metadata. ec_unavailable + 503 is emitted here
 // so each handler doesn't repeat the check.
+// Envelope over records the caller addresses as pointers, so an endpoint whose
+// rows are not all in one vector does not have to build one. See
+// BuildListWindowFromPtrs.
+// State-free: takes no lock of its own, so a caller already holding CState's
+// read lock can build a response inside it. m_mu is not recursive -- a second
+// shared_lock taken while a writer is queued deadlocks -- so anything reached
+// from under WithKnownClients() must not touch the state again.
+template <class T, class WriterFn>
+CHttpServer::Response ListResponseFromPtrsUnlocked(const char *plural_key,
+	std::vector<const T *> &ptrs,
+	WriterFn write_item,
+	const ListParams &params,
+	const ListComparators<T> &comparators)
+{
+	std::vector<const T *> window;
+	std::size_t total = 0;
+	if (auto err = BuildListWindowFromPtrs(ptrs, params, comparators, window, total))
+		return *err;
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key(plural_key);
+	w.BeginArray();
+	for (const T *item : window)
+		write_item(w, *item);
+	w.EndArray();
+	WritePageMeta(w, total, params, window.size());
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+template <class T, class WriterFn>
+CHttpServer::Response ListResponseFromPtrs(const webapi::CState &state,
+	const char *plural_key,
+	std::vector<const T *> &ptrs,
+	WriterFn write_item,
+	const ListParams &params,
+	const ListComparators<T> &comparators)
+{
+	if (!state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+	return ListResponseFromPtrsUnlocked(plural_key, ptrs, write_item, params, comparators);
+}
+
 template <class T, class WriterFn>
 CHttpServer::Response ListResponse(const webapi::CState &state,
 	const char *plural_key,
@@ -4365,63 +4430,42 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 			503, "ec_unsupported", "the connected amuled does not serve the client history");
 	}
 
+	if (!m_state.HasFirstSnapshot()) {
+		return ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
+	}
+
 	ListParams params;
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 
-	// The live peers, by hash. Read per request rather than inside the fetcher:
-	// the store is cached for 10 s while this changes every refresher tick.
+	// One fetch per process. From here the refresher maintains it: every tick
+	// folds the connected peers back in, which is the whole of what can
+	// change -- a record whose peer is away cannot move, since credit totals
+	// only grow during a transfer and last-seen is written at disconnect. The
+	// remaining difference a re-read would show is the expiry prune the core
+	// applies when *it* starts, and amuleapi does not outlive a core restart.
 	//
-	// A record for a peer that is NOT connected cannot change -- the credit
-	// totals only move while a transfer is running, and last-seen only at
-	// disconnect -- so the cache is exact for those. The connected ones are
-	// the whole of what the cache could serve stale, and the refresher already
-	// holds their current totals, so they are patched over the cached record
-	// below. That makes the 10 s window invisible: a caller polling this
-	// endpoint sees a transferring peer's totals move every tick.
-	std::map<std::string, const webapi::ClientSnapshot *> live_by_hash;
-	const std::vector<webapi::ClientSnapshot> live = m_state.Clients();
-	for (const auto &c : live) {
-		if (!c.user_hash.empty())
-			live_by_hash[c.user_hash] = &c;
-	}
-
-	auto pair = m_known_clients_cache.GetOrFetch(
-		std::chrono::milliseconds(10000), [this]() -> TtlPair_KnownClients {
-			std::vector<webapi::KnownClientSnapshot> out;
-			std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_CLIENT_HISTORY));
-			const CECPacket *resp = m_app.SendRecvSerialized(req_ec.get());
-			std::time_t ts = 0;
-			if (resp) {
-				if (resp->GetOpCode() == EC_OP_CLIENT_HISTORY) {
-					out.reserve(resp->GetTagCount());
-					for (const CECTag &entry : *resp) {
-						if (entry.GetTagName() != EC_TAG_CLIENT)
-							continue;
-						out.push_back(DecodeKnownClient(entry));
-					}
-				}
-				ts = std::time(nullptr);
-				delete resp;
+	// Two concurrent first requests can both fetch; the second simply replaces
+	// the first with an equivalent store. Not worth a lock held across an EC
+	// roundtrip to avoid.
+	if (!m_state.KnownClientsLoaded()) {
+		std::vector<webapi::KnownClientSnapshot> rows;
+		std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_CLIENT_HISTORY));
+		const CECPacket *resp = m_app.SendRecvSerialized(req_ec.get());
+		if (!resp) {
+			return ErrorResponse(503, "ec_unavailable", "the EC connection is unavailable");
+		}
+		if (resp->GetOpCode() == EC_OP_CLIENT_HISTORY) {
+			rows.reserve(resp->GetTagCount());
+			for (const CECTag &entry : *resp) {
+				if (entry.GetTagName() != EC_TAG_CLIENT)
+					continue;
+				rows.push_back(DecodeKnownClient(entry));
 			}
-			return TtlPair_KnownClients(std::move(out), ts);
-		});
-
-	if (pair.second == 0) {
-		return ErrorResponse(503, "ec_unavailable", "the EC connection is unavailable");
-	}
-
-	std::vector<webapi::KnownClientSnapshot> items = pair.first;
-	for (auto &c : items) {
-		const auto it = live_by_hash.find(c.user_hash);
-		c.online = it != live_by_hash.end();
-		if (!c.online)
-			continue;
-		// Only the fields a connected peer can move. Everything else on the
-		// record is what the store holds, which nothing touches while the peer
-		// is up.
-		c.total_uploaded = it->second->xfer_up_total;
-		c.total_downloaded = it->second->xfer_down_total;
+		}
+		delete resp;
+		m_state.SetKnownClients(std::move(rows));
 	}
 
 	static const ListComparators<webapi::KnownClientSnapshot> kComps = {
@@ -4454,7 +4498,19 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 				return a.total_downloaded < b.total_downloaded;
 			} },
 	};
-	return ListResponse(m_state, "known_clients", items, WriteKnownClientObject, params, kComps);
+
+	// Built under the state's read lock: the store is never copied out, so the
+	// response is written straight from it.
+	CHttpServer::Response r;
+	m_state.WithKnownClients([&](const std::vector<webapi::KnownClientSnapshot> &rows) {
+		std::vector<const webapi::KnownClientSnapshot *> ptrs;
+		ptrs.reserve(rows.size());
+		for (const auto &rec : rows)
+			ptrs.push_back(&rec);
+		r = ListResponseFromPtrsUnlocked(
+			"known_clients", ptrs, WriteKnownClientObject, params, kComps);
+	});
+	return r;
 }
 
 CHttpServer::Response CApiDispatcher::HandleClientDetail(

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -4441,7 +4441,8 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 		if (!resp) {
 			return ErrorResponse(503, "ec_unavailable", "the EC connection is unavailable");
 		}
-		if (resp->GetOpCode() == EC_OP_CLIENT_HISTORY) {
+		const bool got_history = resp->GetOpCode() == EC_OP_CLIENT_HISTORY;
+		if (got_history) {
 			rows.reserve(resp->GetTagCount());
 			for (const CECTag &entry : *resp) {
 				if (entry.GetTagName() != EC_TAG_CLIENT)
@@ -4450,6 +4451,17 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 			}
 		}
 		delete resp;
+		if (!got_history) {
+			// An answer we cannot read latches nothing: the store is loaded
+			// once and never re-read, so installing an empty one here would
+			// serve an empty history for the life of the process. There is no
+			// reachable path today -- the daemon always answers this opcode
+			// and older ones are refused above -- but the cost of being wrong
+			// is permanent, and retrying next request is free.
+			return ErrorResponse(502,
+				"bad_gateway",
+				"the core answered the history request with an unknown reply");
+		}
 		m_state.SetKnownClients(std::move(rows));
 	}
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2744,21 +2744,6 @@ CHttpServer::Response ListResponseFromPtrsUnlocked(const char *plural_key,
 }
 
 template <class T, class WriterFn>
-CHttpServer::Response ListResponseFromPtrs(const webapi::CState &state,
-	const char *plural_key,
-	std::vector<const T *> &ptrs,
-	WriterFn write_item,
-	const ListParams &params,
-	const ListComparators<T> &comparators)
-{
-	if (!state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
-	return ListResponseFromPtrsUnlocked(plural_key, ptrs, write_item, params, comparators);
-}
-
-template <class T, class WriterFn>
 CHttpServer::Response ListResponse(const webapi::CState &state,
 	const char *plural_key,
 	const std::vector<T> &items,

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -324,17 +324,12 @@ private:
 	using TtlPair_StatsTree = std::pair<webapi::StatsTreeNode, std::time_t>;
 	using TtlPair_StatsGraphs = std::pair<webapi::StatsGraphs, std::time_t>;
 	using TtlPair_ServerInfo = std::pair<webapi::ServerInfoLog, std::time_t>;
-	// The credit store, for /known_clients. A 10 s TTL rather than the 1 s
-	// used above: the reply is the whole store -- megabytes, and ~10 ms of
-	// daemon main loop on a 40k-record node -- while the data behind it only
-	// moves when a peer connects or disconnects. It also means paging through
-	// the store costs one EC roundtrip rather than one per page, since each
-	// request slices the cached vector.
-	using TtlPair_KnownClients = std::pair<std::vector<webapi::KnownClientSnapshot>, std::time_t>;
 	webapi::CTtlCache<TtlPair_StatsTree> m_stats_tree_cache;
 	webapi::CTtlCache<TtlPair_StatsGraphs> m_stats_graphs_cache;
 	webapi::CTtlCache<TtlPair_ServerInfo> m_server_info_cache;
-	webapi::CTtlCache<TtlPair_KnownClients> m_known_clients_cache;
+	// /known_clients is NOT cached here. Its store is fetched once on first
+	// request and then maintained by the refresher (CState::ReconcileKnown
+	// Clients), so there is nothing to expire and nothing to re-read.
 	// /search/results is no longer cached here — the refresher owns
 	// the polling while a search is active (see CState::SearchProgress
 	// + RefresherTick). POST /search calls m_state.MarkSearchStarted.

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -155,6 +155,13 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			ApplyGetUpdateToClients(resp, cache, file_hash_by_ecid);
 		});
 		delete resp;
+
+		// Fold this tick's peers into the known-clients store, so it stays
+		// current from the update we already have rather than being re-read.
+		// A no-op until something has asked for /known_clients, so a daemon
+		// nobody queries never pays for it; after that it costs one hash
+		// lookup per connected peer, bounded by MaxConnections.
+		state.ReconcileKnownClients();
 	}
 
 	// /logs/serverinfo, /stats/tree, /stats/graphs/{graph} are NOT

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -24,6 +24,8 @@
 
 #include "State.h"
 
+#include <ctime>
+
 #include <mutex>
 #include <shared_mutex>
 #include <utility>
@@ -403,6 +405,107 @@ std::vector<ClientSnapshot> CState::Clients() const
 	for (const auto &kv : m_clients)
 		out.push_back(kv.second);
 	return out;
+}
+
+bool CState::KnownClientsLoaded() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	return m_known_loaded;
+}
+
+void CState::SetKnownClients(std::vector<KnownClientSnapshot> &&rows)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	m_known_clients = std::move(rows);
+	m_known_of_hash.clear();
+	m_known_online.clear();
+	for (std::size_t i = 0; i < m_known_clients.size(); ++i)
+		m_known_of_hash[m_known_clients[i].user_hash] = i;
+	m_known_loaded = true;
+	// The fetch describes the store as of a moment ago; the peers connected
+	// right now are already more current than parts of it.
+	ReconcileKnownClientsLocked();
+}
+
+void CState::InvalidateKnownClients()
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	m_known_clients.clear();
+	m_known_clients.shrink_to_fit();
+	m_known_of_hash.clear();
+	m_known_online.clear();
+	m_known_loaded = false;
+}
+
+void CState::ReconcileKnownClients()
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	if (!m_known_loaded)
+		return;
+	ReconcileKnownClientsLocked();
+}
+
+void CState::ReconcileKnownClientsLocked()
+{
+	const std::time_t now = std::time(nullptr);
+	std::set<std::size_t> still_online;
+
+	for (const auto &kv : m_clients) {
+		const ClientSnapshot &c = kv.second;
+		if (c.user_hash.empty())
+			continue;
+
+		auto it = m_known_of_hash.find(c.user_hash);
+		if (it == m_known_of_hash.end()) {
+			// A peer met since the store was read. The daemon wrote its
+			// credit record when the peer said hello, stamping first-seen
+			// and counting the session, so this reconstructs what it wrote
+			// rather than inventing anything.
+			KnownClientSnapshot k;
+			k.user_hash = c.user_hash;
+			k.first_seen = now;
+			k.sessions = 1;
+			m_known_clients.push_back(std::move(k));
+			it = m_known_of_hash.emplace(c.user_hash, m_known_clients.size() - 1).first;
+		}
+
+		KnownClientSnapshot &k = m_known_clients[it->second];
+		still_online.insert(it->second);
+		k.online = true;
+		k.total_uploaded = c.xfer_up_total;
+		k.total_downloaded = c.xfer_down_total;
+		// Identity, when the peer in front of us knows more than the record.
+		// A record only gains a name once the core writes its metadata, so a
+		// peer we have never finished a session with is otherwise nameless.
+		// Guarded on the live name being known: a peer mid-handshake has none
+		// and must not blank a stored one.
+		if (!c.client_name.empty()) {
+			k.client_name = c.client_name;
+			k.ip = c.ip;
+			k.port = c.port;
+			k.kad_port = c.kad_port;
+			k.country_code = c.country_code;
+			k.software = c.software;
+			k.version = c.software_version;
+			k.source_origin = c.source_origin;
+			k.obfuscation = c.obfuscation_status;
+		}
+	}
+
+	// Whoever was online last tick and is not in this one has gone. Found
+	// through the online set, so this costs the number of departures rather
+	// than a walk of the store.
+	for (const std::size_t idx : m_known_online) {
+		if (still_online.count(idx) != 0)
+			continue;
+		m_known_clients[idx].online = false;
+		// Seen until this moment, which is what the core writes to the record
+		// at its own disconnect handling. The stored value is the *previous*
+		// disconnect, so leaving it would show a peer that was here a second
+		// ago as last seen months back.
+		m_known_clients[idx].last_seen = now;
+	}
+	m_known_online.swap(still_online);
 }
 
 bool CState::FindDownload(const std::string &hash_hex, FileSnapshot &out) const

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -442,7 +442,13 @@ void CState::ReconcileKnownClientsLocked()
 
 	for (const auto &kv : m_clients) {
 		const ClientSnapshot &c = kv.second;
-		if (c.user_hash.empty())
+		// An all-zero hash is not an identity: it is what a peer that has not
+		// sent its hash yet reports, and every such peer would otherwise
+		// collapse into one fabricated record -- sharing a session count and
+		// a first-seen between unrelated clients. The daemon never writes one
+		// either; it creates a credit record from the hash in the hello. They
+		// get a row of their own once they identify.
+		if (c.user_hash.empty() || c.user_hash.find_first_not_of('0') == std::string::npos)
 			continue;
 
 		auto it = m_known_of_hash.find(c.user_hash);
@@ -602,16 +608,12 @@ void CState::ResetLists()
 	// tracking disappears, so no generation carry-over is needed here.)
 	m_searches.clear();
 	m_current_search_id = 0;
-	// The credit store goes with them. This runs when a tick has failed and
-	// the refresher is starting over; a transient EC failure that recovers
-	// then refetches rather than carrying on with what it had. A core that
-	// stays down takes the process with it after ~5 minutes, so the store
-	// never spans two cores.
-	m_known_clients.clear();
-	m_known_clients.shrink_to_fit();
-	m_known_of_hash.clear();
-	m_known_online.clear();
-	m_known_loaded = false;
+	// The credit store deliberately does NOT go with them. This runs when a
+	// tick failed against a socket that is still up, and dropping the store
+	// there would refetch the whole thing after one null tick -- the cost this
+	// endpoint exists to avoid. It cannot go stale across a daemon restart
+	// either: HandleEcConnectionLost() shuts amuleapi down the moment the
+	// socket drops, so the process never attaches to a second core.
 	// Logs + stats_tree + graphs survive EC reconnects on purpose —
 	// operator can see "EC disconnected at HH:MM" alongside earlier
 	// graph traffic; stats_tree's counters are amuled-uptime not

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -464,6 +464,7 @@ void CState::ReconcileKnownClientsLocked()
 			KnownClientSnapshot k;
 			k.user_hash = c.user_hash;
 			k.first_seen = now;
+			k.last_seen = now;
 			k.sessions = 1;
 			m_known_clients.push_back(std::move(k));
 			it = m_known_of_hash.emplace(c.user_hash, m_known_clients.size() - 1).first;
@@ -472,6 +473,11 @@ void CState::ReconcileKnownClientsLocked()
 		KnownClientSnapshot &k = m_known_clients[it->second];
 		still_online.insert(it->second);
 		k.online = true;
+		// A peer in front of us was last seen now, not whenever it previously
+		// disconnected. Leaving the stored value would report a peer that is
+		// connected as last seen months ago, and now is what the core writes
+		// to the record at its own disconnect handling anyway.
+		k.last_seen = now;
 		k.total_uploaded = c.xfer_up_total;
 		k.total_downloaded = c.xfer_down_total;
 		// Identity, when the peer in front of us knows more than the record.

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -427,16 +427,6 @@ void CState::SetKnownClients(std::vector<KnownClientSnapshot> &&rows)
 	ReconcileKnownClientsLocked();
 }
 
-void CState::InvalidateKnownClients()
-{
-	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	m_known_clients.clear();
-	m_known_clients.shrink_to_fit();
-	m_known_of_hash.clear();
-	m_known_online.clear();
-	m_known_loaded = false;
-}
-
 void CState::ReconcileKnownClients()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
@@ -461,17 +451,31 @@ void CState::ReconcileKnownClientsLocked()
 			// credit record when the peer said hello, stamping first-seen
 			// and counting the session, so this reconstructs what it wrote
 			// rather than inventing anything.
+			//
+			// sessions is left at zero deliberately: the offline-to-online
+			// transition below is what counts it, and this record is about
+			// to make that transition. Setting it here too would count the
+			// same arrival twice.
 			KnownClientSnapshot k;
 			k.user_hash = c.user_hash;
 			k.first_seen = now;
 			k.last_seen = now;
-			k.sessions = 1;
 			m_known_clients.push_back(std::move(k));
 			it = m_known_of_hash.emplace(c.user_hash, m_known_clients.size() - 1).first;
 		}
 
 		KnownClientSnapshot &k = m_known_clients[it->second];
 		still_online.insert(it->second);
+		// Offline to online is a new session, which is what the daemon counts:
+		// UpdateMeta() bumps it once per client object, at the hello. Counted
+		// on the transition rather than per tick for the same reason.
+		//
+		// It can over-count by one if a peer drops out of the update for a
+		// tick and returns -- an EC hiccup rather than a real reconnect. The
+		// daemon's own figure replaces this at the next fetch, so any drift
+		// lives no longer than the connection to that core.
+		if (!k.online)
+			k.sessions++;
 		k.online = true;
 		// A peer in front of us was last seen now, not whenever it previously
 		// disconnected. Leaving the stored value would report a peer that is
@@ -598,6 +602,16 @@ void CState::ResetLists()
 	// tracking disappears, so no generation carry-over is needed here.)
 	m_searches.clear();
 	m_current_search_id = 0;
+	// The credit store goes with them. This runs when a tick has failed and
+	// the refresher is starting over; a transient EC failure that recovers
+	// then refetches rather than carrying on with what it had. A core that
+	// stays down takes the process with it after ~5 minutes, so the store
+	// never spans two cores.
+	m_known_clients.clear();
+	m_known_clients.shrink_to_fit();
+	m_known_of_hash.clear();
+	m_known_online.clear();
+	m_known_loaded = false;
 	// Logs + stats_tree + graphs survive EC reconnects on purpose —
 	// operator can see "EC disconnected at HH:MM" alongside earlier
 	// graph traffic; stats_tree's counters are amuled-uptime not

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -29,6 +29,7 @@
 #include <ctime>
 #include <functional>
 #include <map>
+#include <set>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -1138,6 +1139,41 @@ public:
 	// /clients and filter by role on their side.
 	std::vector<ClientSnapshot> Clients() const;
 
+	// --- Known clients (the daemon's credit store) -------------------------
+	//
+	// Fetched once, then maintained: the refresher folds every tick's live
+	// peers in, so the store stays current without ever being re-read. What
+	// only a refetch could give is the expiry prune the core applies at its
+	// own startup, so the trigger is a daemon session change rather than a
+	// timer -- see InvalidateKnownClients().
+	//
+	// Held rather than copied out: this is the whole store, tens of thousands
+	// of records, so a by-value accessor would cost more per request than the
+	// EC roundtrip it saves. Readers run under the shared lock instead.
+	bool KnownClientsLoaded() const;
+	//! Install the first fetch and reconcile it against the current peers.
+	void SetKnownClients(std::vector<KnownClientSnapshot> &&rows);
+	//! Drop what we hold, so the next request fetches again. For a daemon that
+	//! turns out to be a different process than the one we loaded from.
+	void InvalidateKnownClients();
+	/**
+	 * Fold this tick's peers into the store.
+	 *
+	 * A record whose peer is not connected cannot change -- credit totals only
+	 * move during a transfer, last-seen only at disconnect -- so this touches
+	 * only the connected ones, of which there are at most MaxConnections. No-op
+	 * until the store has been loaded, so a daemon nobody asks about never
+	 * pays for it.
+	 */
+	void ReconcileKnownClients();
+	//! Read the store under the shared lock. The callback must not call back
+	//! into CState, and must not retain the reference.
+	template <class F> void WithKnownClients(F &&fn) const
+	{
+		std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+		fn(static_cast<const std::vector<KnownClientSnapshot> &>(m_known_clients));
+	}
+
 	std::vector<ServerSnapshot> Servers() const;
 	// Results / progress for one search. search_id == 0 resolves to the
 	// current (most-recently-started) search; an unknown id yields an empty
@@ -1276,6 +1312,16 @@ private:
 	FileMap m_files;
 
 	std::map<std::uint32_t, ClientSnapshot> m_clients;
+	// See the Known clients block above. m_known_loaded distinguishes "loaded
+	// and genuinely empty" from "never fetched".
+	std::vector<KnownClientSnapshot> m_known_clients;
+	std::map<std::string, std::size_t> m_known_of_hash;
+	bool m_known_loaded = false;
+	//! Rows currently flagged online, so a peer that left is found without
+	//! walking the store.
+	std::set<std::size_t> m_known_online;
+	//! MUST be called with m_mu held for writing.
+	void ReconcileKnownClientsLocked();
 	std::map<std::uint32_t, ServerSnapshot> m_servers;
 	std::vector<std::string> m_amule_log_lines;
 	ServerInfoLog m_server_info;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1144,12 +1144,12 @@ public:
 	// Fetched once, then maintained: the refresher folds every tick's live
 	// peers in, so the store stays current without ever being re-read. What
 	// only a refetch could give is the expiry prune the core applies at its
-	// own startup. amuleapi never attaches to a second core -- ConnectAndRun
-	// runs once, and a sustained EC failure exits the process for a
-	// supervisor to restart the pair -- so the store cannot outlive the core
-	// it was read from. It is still dropped by ResetLists(), the refresher's
-	// start-over path after a failed tick, so a transient EC failure that
-	// recovers refetches rather than carrying on with what it had.
+	// own startup, and that cannot happen underneath us: HandleEcConnectionLost
+	// shuts amuleapi down the moment the EC socket drops, so the process never
+	// attaches to a second core. The store therefore lives for the life of the
+	// process, with no invalidation path -- deliberately, since the obvious
+	// place to add one (ResetLists, which fires on a failed tick against a live
+	// socket) would refetch the whole store for a single null tick.
 	//
 	// Held rather than copied out: this is the whole store, tens of thousands
 	// of records, so a by-value accessor would cost more per request than the
@@ -1322,6 +1322,14 @@ private:
 	// See the Known clients block above. m_known_loaded distinguishes "loaded
 	// and genuinely empty" from "never fetched".
 	std::vector<KnownClientSnapshot> m_known_clients;
+	// Indices, deliberately, not pointers: the reconcile appends while it
+	// iterates, and a reallocation would dangle anything holding addresses.
+	// Rows are only ever appended for the same reason -- an erase would
+	// invalidate every index past it.
+	//
+	// Keyed on the same lowercase hex the live snapshot uses (both go through
+	// CMD4Hash::Encode().Lower()); a case mismatch would silently give every
+	// peer a second row.
 	std::map<std::string, std::size_t> m_known_of_hash;
 	bool m_known_loaded = false;
 	//! Rows currently flagged online, so a peer that left is found without

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1144,8 +1144,12 @@ public:
 	// Fetched once, then maintained: the refresher folds every tick's live
 	// peers in, so the store stays current without ever being re-read. What
 	// only a refetch could give is the expiry prune the core applies at its
-	// own startup, so the trigger is a daemon session change rather than a
-	// timer -- see InvalidateKnownClients().
+	// own startup. amuleapi never attaches to a second core -- ConnectAndRun
+	// runs once, and a sustained EC failure exits the process for a
+	// supervisor to restart the pair -- so the store cannot outlive the core
+	// it was read from. It is still dropped by ResetLists(), the refresher's
+	// start-over path after a failed tick, so a transient EC failure that
+	// recovers refetches rather than carrying on with what it had.
 	//
 	// Held rather than copied out: this is the whole store, tens of thousands
 	// of records, so a by-value accessor would cost more per request than the
@@ -1153,9 +1157,6 @@ public:
 	bool KnownClientsLoaded() const;
 	//! Install the first fetch and reconcile it against the current peers.
 	void SetKnownClients(std::vector<KnownClientSnapshot> &&rows);
-	//! Drop what we hold, so the next request fetches again. For a daemon that
-	//! turns out to be a different process than the one we loaded from.
-	void InvalidateKnownClients();
 	/**
 	 * Fold this tick's peers into the store.
 	 *
@@ -1164,6 +1165,12 @@ public:
 	 * only the connected ones, of which there are at most MaxConnections. No-op
 	 * until the store has been loaded, so a daemon nobody asks about never
 	 * pays for it.
+	 *
+	 * The store only grows between fetches: a peer met here is added and never
+	 * removed, because a record leaving the daemon's own store means expiry,
+	 * which it applies at its startup and we pick up on the next fetch. Growth
+	 * is one row per distinct peer met, bounded by real traffic and reset with
+	 * everything else by ResetLists().
 	 */
 	void ReconcileKnownClients();
 	//! Read the store under the shared lock. The callback must not call back

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -209,13 +209,16 @@ fi
 # Not compared against /clients: the lifetime totals live on the refresher's
 # snapshot but are not part of the /clients JSON, so there is nothing there to
 # compare with. Movement over time is the observable that matters anyway.
-_curl "$HOST/api/v0/known_clients?limit=500"
+# Sorted, for the same reason as the row check below: an unsorted page of a
+# large store contains no online records at all, and the check would skip
+# itself forever while looking like it had run.
+_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
 ACTIVE_HASH=$(_jq '[.known_clients[] | select(.online)][0].user_hash')
 if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
 	BEFORE=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
 		| .total_downloaded + .total_uploaded")
 	sleep 4
-	_curl "$HOST/api/v0/known_clients?limit=500"
+	_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
 	AFTER=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
 		| .total_downloaded + .total_uploaded")
 	if [ "${AFTER:-0}" -gt "${BEFORE:-0}" ]; then
@@ -234,19 +237,37 @@ fi
 # the refresher added it. Any live peer carrying a user hash must therefore
 # appear here -- if it does not, the maintenance has stopped and the endpoint
 # is quietly serving a frozen snapshot.
+#
+# Sorted by last_seen descending and read one page: a connected peer is last
+# seen *now*, so the online records are the newest in the store and cannot be
+# pushed off the first page by anything else. `limit` is clamped to 500 by the
+# shared parser, which is well above MaxConnections -- asking for the whole
+# store instead would silently return only the first 500 records and look like
+# a maintenance failure.
 LIVE_HASHES=$(curl -s --max-time 10 "${AUTH[@]}" "$HOST/api/v0/clients?limit=500" \
 	| jq -r '.clients[].user_hash // empty' | sort -u)
 if [ -n "$LIVE_HASHES" ]; then
-	_curl "$HOST/api/v0/known_clients?limit=50000"
+	_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
 	MISSING=0
+	CHECKED=0
 	for h in $LIVE_HASHES; do
+		CHECKED=$((CHECKED+1))
 		FOUND=$(_jq "[.known_clients[] | select(.user_hash == \"$h\")] | length")
 		[ "${FOUND:-0}" -eq 0 ] && MISSING=$((MISSING+1))
 	done
 	if [ "$MISSING" -eq 0 ]; then
-		_pass "every connected peer has a known-clients row ($(echo "$LIVE_HASHES" | wc -w | tr -d ' ') checked)"
+		_pass "every connected peer has a known-clients row ($CHECKED checked)"
 	else
-		_fail "maintenance" "$MISSING connected peer(s) have no row — the store is not being updated"
+		_fail "maintenance" "$MISSING of $CHECKED connected peer(s) have no row" \
+			"the refresher is not folding live peers into the store"
+	fi
+
+	# And they are flagged as connected, not merely present.
+	ONLINE_N=$(_jq '[.known_clients[] | select(.online)] | length')
+	if [ "${ONLINE_N:-0}" -gt 0 ]; then
+		_pass "connected peers are flagged online ($ONLINE_N)"
+	else
+		_fail "online flag" "no record is flagged online while peers are connected"
 	fi
 else
 	echo "  SKIP  per-peer row check (no peer is connected)"

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -21,9 +21,9 @@
 #     the ones a pre-metadata record has no value for,
 #   * `user_hash` is a 32-char lowercase MD4, so it correlates with
 #     /clients `user_hash` directly,
-#   * a record for a connected peer reports live totals rather than the
-#     10-second-cached copy — the cache is exact for offline records,
-#     whose credit data cannot change, and must not be for online ones,
+#   * the store is maintained rather than re-read: a connected peer's row
+#     tracks the live client state, and a peer met since the first request
+#     is added rather than waiting for a refetch,
 #   * the response is cacheable (ETag) and honours If-None-Match,
 #   * HEAD returns headers with no body,
 #   * non-safe methods are 405.
@@ -201,12 +201,10 @@ else
 	echo "  SKIP  record-shape assertions (the store is empty)"
 fi
 
-# --- 4b. An online record is not served stale. ---------------------
-# The store is cached for 10 s, which is exact for a peer that is NOT
-# connected — its credit record cannot change. An online peer's totals CAN
-# change, so they are patched from the live client state on every request.
-# Two polls a few seconds apart therefore have to move for a peer that is
-# actively transferring, well inside the cache window.
+# --- 4b. The store is maintained, not re-read. ---------------------
+# It is fetched once and kept current by the refresher, so a connected peer's
+# totals move between polls without any refetch. A peer that is NOT connected
+# cannot change, so nothing is expected to move for it.
 #
 # Not compared against /clients: the lifetime totals live on the refresher's
 # snapshot but are not part of the /clients JSON, so there is nothing there to
@@ -221,7 +219,7 @@ if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
 	AFTER=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
 		| .total_downloaded + .total_uploaded")
 	if [ "${AFTER:-0}" -gt "${BEFORE:-0}" ]; then
-		_pass "an online record's totals move inside the cache window ($BEFORE -> $AFTER)"
+		_pass "a connected peer's totals move without a refetch ($BEFORE -> $AFTER)"
 	else
 		# An online but idle peer is legitimately static, and cannot be told
 		# apart from a stale cache here. Only a moving one proves the patch.
@@ -229,6 +227,29 @@ if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
 	fi
 else
 	echo "  SKIP  live-total check (no peer is connected)"
+fi
+
+# --- 4c. Every connected peer has a row. ---------------------------
+# The store is fetched once, so a peer met afterwards can only be present if
+# the refresher added it. Any live peer carrying a user hash must therefore
+# appear here -- if it does not, the maintenance has stopped and the endpoint
+# is quietly serving a frozen snapshot.
+LIVE_HASHES=$(curl -s --max-time 10 "${AUTH[@]}" "$HOST/api/v0/clients?limit=500" \
+	| jq -r '.clients[].user_hash // empty' | sort -u)
+if [ -n "$LIVE_HASHES" ]; then
+	_curl "$HOST/api/v0/known_clients?limit=50000"
+	MISSING=0
+	for h in $LIVE_HASHES; do
+		FOUND=$(_jq "[.known_clients[] | select(.user_hash == \"$h\")] | length")
+		[ "${FOUND:-0}" -eq 0 ] && MISSING=$((MISSING+1))
+	done
+	if [ "$MISSING" -eq 0 ]; then
+		_pass "every connected peer has a known-clients row ($(echo "$LIVE_HASHES" | wc -w | tr -d ' ') checked)"
+	else
+		_fail "maintenance" "$MISSING connected peer(s) have no row — the store is not being updated"
+	fi
+else
+	echo "  SKIP  per-peer row check (no peer is connected)"
 fi
 
 # --- 5. Caching. ---------------------------------------------------


### PR DESCRIPTION
`/known_clients` (#909) fetched the whole credit store behind a TTL and rebuilt a patched copy of it per request. Both halves were wrong for a payload this size.

## Maintained, not re-read

The store is read once, on the first request, and maintained from there: the refresher folds each tick's connected peers back in, so no later request touches EC at all.

That is sound rather than a shortcut — a record whose peer is not connected **cannot** change, since credit totals only move during a transfer and `last_seen` is written at disconnect. The maintenance covers the rest:

- a peer that connects is **added**, with `first_seen` set to now and `sessions` counted on its arrival — not read from the daemon, but the same values it recorded when that peer said hello
- a connected peer's `online` and totals track the live client state
- a bare record gains its name, address, software and origin once its peer identifies
- a connected peer's `last_seen` is **now** — it is being seen — and a peer that leaves has `online` cleared with `last_seen` stamped at the moment it went

- a peer that reconnects has `sessions` counted on the offline-to-online transition, which is when the daemon counts it too

The only thing a re-read would add is the 150-day expiry prune the core applies at *its* startup, and that cannot happen underneath us: `HandleEcConnectionLost()` shuts amuleapi down the moment the EC socket drops, so the process never attaches to a second core. The store therefore lives for the life of the process and has no invalidation path — deliberately. The obvious place to add one, `ResetLists()`, fires on a tick that failed against a socket that is still up, and would refetch the whole store for a single null tick.

A reply carrying an unexpected opcode answers `502` rather than installing an empty store: with the store read once, latching an empty one would serve an empty history until the process ended. No path reaches it today — the daemon always answers this opcode and older ones are refused before the request goes out — but the cost of being wrong is permanent while retrying next request is free.

Between fetches the store only grows: a peer met is added and never removed, since a record leaving the daemon's own store means expiry, which it applies at startup and we pick up on the next fetch. Growth is one row per distinct peer met, bounded by real traffic and cleared with everything else on reset.

## No per-request copy

`CTtlCache` returns its payload by value. That is free for the small things it was written for (a stats tree, a log string) and cost **two full copies of tens of thousands of records** here — more than the roundtrip the cache existed to avoid. Responses are now written straight out of the state under its read lock.

`BuildListWindow` and the list envelope gain pointer-taking forms so an endpoint whose rows are not all in one vector does not have to build one; the value-taking versions delegate to them and every existing caller is untouched. The unlocked variant exists because `CState`'s mutex is not recursive — anything reached from under `WithKnownClients()` must not take it again.

## Measured

On a 40,000-record store, same core and query, three runs each:

| | steady state |
|---|---|
| before (#909) | ~11.0 ms/req |
| after | **~7.3 ms/req** |

Plus zero EC roundtrips after the first call, where before it was one every 10 s.

## Verified against a live core

Not just compiled. The curl phase now asserts the maintenance itself, exercised with 15 connected peers and a running transfer:

```
PASS  a connected peer's totals move without a refetch (1496489934 -> 1584226254)
PASS  every connected peer has a known-clients row (15 checked)
PASS  connected peers are flagged online (15)
41 assertions passed
```

If the refresher ever stops folding peers in, those fail rather than the endpoint quietly serving a frozen snapshot. Observed by hand alongside them: new peers added (40000 → 40010 synthetic, 392 → 395 live), identity filled in on previously bare records, and `online` cleared with `last_seen` stamped the second a peer left.

Both assertions were initially broken in a way worth noting, since it is the failure mode they exist to prevent: they asked for the whole store, which the shared parser silently clamps to 500 records. On a large store the live-total check found no online record and skipped itself every run while appearing to pass, and the row check inspected the first 500 records and reported a maintenance failure that was not one. Ordering online records first — which the `last_seen` change above makes deterministic — is what lets them address the right rows.



