### PR TITLE
fix(gui): order the search actions by consequence, and rule off the filters

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3501,11 +3501,11 @@ msgid "Download"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3558,11 +3558,11 @@ msgid "Download"
 msgstr "التحميل"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3618,13 +3618,13 @@ msgid "Download"
 msgstr "Descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Llimpiar Campos"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Resultáu de la gueta"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Llimpiar Campos"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3550,11 +3550,11 @@ msgid "Download"
 msgstr "Изтегляне"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3500,11 +3500,11 @@ msgid "Download"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3606,13 +3606,13 @@ msgid "Download"
 msgstr "Baixada"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Buida els camps"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Resultat de la cerca"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Buida els camps"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3609,13 +3609,13 @@ msgid "Download"
 msgstr "Stahování"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Vyprázdnit pole"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Výsledek hledání"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Vyprázdnit pole"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3569,11 +3569,11 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3604,13 +3604,13 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Setze Felder zurück."
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Suchresultate:"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Setze Felder zurück."
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:40+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3629,13 +3629,13 @@ msgid "Download"
 msgstr "Κατέβασμα"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Επαναφορά πεδίων"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Αποτέλεσμα Αναζήτησης"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Επαναφορά πεδίων"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3501,11 +3501,11 @@ msgid "Download"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3603,13 +3603,13 @@ msgid "Download"
 msgstr "Descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Reiniciar los campos"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Resultado de la búsqueda"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Reiniciar los campos"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3607,13 +3607,13 @@ msgid "Download"
 msgstr "Tõmbamine"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Lähtesta väljad"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Otsingu tulemus"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Lähtesta väljad"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3608,13 +3608,13 @@ msgid "Download"
 msgstr "Deskargatu"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Eremuak garbitu"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Bilaketa emaitza"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Eremuak garbitu"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3608,13 +3608,13 @@ msgid "Download"
 msgstr "Lataa"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Nollaa kentät"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Haun tulos"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Nollaa kentät"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3601,13 +3601,13 @@ msgid "Download"
 msgstr "Réception"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Réinitialiser les Champs"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Résultat de la recherche"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Réinitialiser les Champs"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3617,13 +3617,13 @@ msgid "Download"
 msgstr "Descargar"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Borrar campos"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Resultados da busca"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Borrar campos"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3583,13 +3583,13 @@ msgid "Download"
 msgstr "הורדה"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "אפס שדות"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "תוצאות מסנן"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "אפס שדות"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3579,13 +3579,13 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Rezultati pretrage"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3586,13 +3586,13 @@ msgid "Download"
 msgstr "Letöltés"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Mezők törlése"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Keresés eredménye"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Mezők törlése"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3609,12 +3609,12 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Azzera campi"
-
-#: src/muuli_wdr.cpp
 msgid "Clear Search Results"
 msgstr "Cancella Risultati Ricerca"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Azzera campi"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3608,13 +3608,13 @@ msgid "Download"
 msgstr "ダウンロード"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "フィールドをリセット"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "フィルタの結果"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "フィールドをリセット"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3629,13 +3629,13 @@ msgid "Download"
 msgstr "내려받기"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "항목 초기화"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "필터링 결과"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "항목 초기화"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3642,13 +3642,13 @@ msgid "Download"
 msgstr "Atsiųsti"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Atstatyti laukelius"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Filtruoti rezultatus"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Atstatyti laukelius"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3528,12 +3528,12 @@ msgid "Download"
 msgstr "Lejupielādēt"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "Clear Search Results"
 msgstr "Notīrīt meklēšanas rezultātus"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3611,13 +3611,13 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Velden leegmaken"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Zoekresultaat"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Velden leegmaken"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3628,13 +3628,13 @@ msgid "Download"
 msgstr "Nedlasting"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Nullstill felta"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Filtrér resultat"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Nullstill felta"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:48+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3622,13 +3622,13 @@ msgid "Download"
 msgstr "Pobieranie"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Zresetuj pola"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Wynik wyszukiwania"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Zresetuj pola"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3605,12 +3605,12 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Reiniciar Campos"
-
-#: src/muuli_wdr.cpp
 msgid "Clear Search Results"
 msgstr "Limpar os Resultados da Busca"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Reiniciar Campos"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3614,13 +3614,13 @@ msgid "Download"
 msgstr "Download"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Limpar campos"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Resultados de Pesquisas"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Limpar campos"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3617,13 +3617,13 @@ msgid "Download"
 msgstr "Descarcă"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Resetare câmpuri"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Rezultat căutare"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Resetare câmpuri"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3631,12 +3631,12 @@ msgid "Download"
 msgstr "Скачать"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Сбросить значения"
-
-#: src/muuli_wdr.cpp
 msgid "Clear Search Results"
 msgstr "Очистить результаты поиска"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Сбросить значения"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3637,13 +3637,13 @@ msgid "Download"
 msgstr "Pridobi"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Ponastavi polja"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Rezultat iskanja"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Ponastavi polja"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3621,13 +3621,13 @@ msgid "Download"
 msgstr "Shkarkime"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Reseto fushat"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Rezultatet e filterit"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Reseto fushat"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3606,13 +3606,13 @@ msgid "Download"
 msgstr "Hämta"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Återställ fält"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Sökresultat"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Återställ fält"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3500,11 +3500,11 @@ msgid "Download"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3594,13 +3594,13 @@ msgid "Download"
 msgstr "İndir"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Alanları Sıfırla"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Arama Sonucu"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Alanları Sıfırla"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3638,13 +3638,13 @@ msgid "Download"
 msgstr "Звантаження"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "Очистити поля"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "Здобутки пошуку"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "Очистити поля"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3499,11 +3499,11 @@ msgid "Download"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
+msgid "Clear Search Results"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Clear Search Results"
+msgid "Reset Fields"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3601,12 +3601,12 @@ msgid "Download"
 msgstr "下载"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "重置表单"
-
-#: src/muuli_wdr.cpp
 msgid "Clear Search Results"
 msgstr "清除搜索结果"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "重置表单"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-13 13:03+0200\n"
+"POT-Creation-Date: 2026-08-14 10:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:54+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3599,13 +3599,13 @@ msgid "Download"
 msgstr "下載"
 
 #: src/muuli_wdr.cpp
-msgid "Reset Fields"
-msgstr "清空欄位"
-
-#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "Clear Search Results"
 msgstr "搜尋結果"
+
+#: src/muuli_wdr.cpp
+msgid "Reset Fields"
+msgstr "清空欄位"
 
 #: src/muuli_wdr.cpp
 msgid "Results"

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -159,6 +159,7 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	// Not there initially.
 	s_search_sizer->Show(s_extended_sizer, false);
 	s_search_sizer->Show(s_filter_sizer, false);
+	ApplyFilterSeparator(false);
 
 	// Clear-history button, sitting in the action row directly after "Reset
 	// Fields" -- next to the other one-shot commands rather than among the
@@ -178,22 +179,28 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	// The separator is inserted with it and tracked so the pref-driven hide
 	// takes both away; leaving a stray divider behind would open a gap in the
 	// row wherever history is switched off.
-	if (wxWindow *resetBtn = FindWindow(IDC_SEARCH_RESET)) {
-		if (wxSizer *row = resetBtn->GetContainingSizer()) {
+	// Anchored ahead of Clear Search Results, so the three read most to least
+	// destructive rightwards (issue #911). Inserting after Reset Fields, as
+	// this did, put the one that discards saved terms between the two used
+	// most.
+	if (wxWindow *clearResultsBtn = FindWindow(IDC_CLEAR_RESULTS)) {
+		if (wxSizer *row = clearResultsBtn->GetContainingSizer()) {
 			size_t at = row->GetItemCount();
 			size_t index = 0;
 			for (const wxSizerItem *item : row->GetChildren()) {
-				if (item->GetWindow() == resetBtn) {
-					at = index + 1;
+				if (item->GetWindow() == clearResultsBtn) {
+					at = index;
 					break;
 				}
 				++index;
 			}
+			// Button first, then its divider, so both land before the anchor
+			// and the row stays button|divider|button all the way across.
+			m_clearHistoryBtn = new wxButton(this, wxID_ANY, _("Clear Search History"));
+			row->Insert(at, m_clearHistoryBtn, wxSizerFlags().Center().Border(wxALL, 5));
 			m_clearHistorySep = new wxStaticLine(
 				this, wxID_ANY, wxDefaultPosition, wxSize(-1, 20), wxLI_VERTICAL);
-			row->Insert(at, m_clearHistorySep, wxSizerFlags().Center().Border(wxALL, 5));
-			m_clearHistoryBtn = new wxButton(this, wxID_ANY, _("Clear Search History"));
-			row->Insert(at + 1, m_clearHistoryBtn, wxSizerFlags().Center().Border(wxALL, 5));
+			row->Insert(at + 1, m_clearHistorySep, wxSizerFlags().Center().Border(wxALL, 5));
 			m_clearHistoryBtn->Bind(wxEVT_BUTTON, &CSearchDlg::OnBnClickedClearHistory, this);
 		}
 	}
@@ -201,6 +208,18 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	ApplySearchHistoryPref();
 
 	Layout();
+}
+
+void CSearchDlg::ApplyFilterSeparator(bool shown)
+{
+	// The rule introduces the filter row, so it goes away with it: left behind
+	// it would sit under the action buttons with nothing beneath, reading as a
+	// border on the search box rather than a divider. Found by id rather than
+	// held as a member because muuli_wdr owns it -- the row it divides is
+	// static, unlike the clear-history pair built here.
+	if (wxWindow *sep = FindWindow(ID_FILTER_SEPARATOR)) {
+		sep->Show(shown);
+	}
 }
 
 void CSearchDlg::ApplySearchHistoryPref()
@@ -735,6 +754,7 @@ void CSearchDlg::OnExtendedSearchChange(wxCommandEvent &event)
 void CSearchDlg::OnFilterCheckChange(wxCommandEvent &event)
 {
 	s_search_sizer->Show(s_filter_sizer, event.IsChecked());
+	ApplyFilterSeparator(event.IsChecked());
 	Layout();
 
 	int nPages = m_notebook->GetPageCount();

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -270,6 +270,8 @@ public:
 	// Called at construction and live from PrefsUnifiedDlg::OnOk when the
 	// checkbox changes, so no restart is needed (issue #697).
 	void ApplySearchHistoryPref();
+	//! Show or hide the rule above the filter row, tracking the row itself.
+	void ApplyFilterSeparator(bool shown);
 
 private:
 	// Replaces the Name field in its sizer slot with the control type the

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -356,15 +356,31 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item43->Add( item50, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticLine *item51 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item43->Add( item51, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxButton *item52 = new wxButton( parent, IDC_SEARCH_RESET, _("Reset Fields"), wxDefaultPosition, wxDefaultSize, 0 );
-    item52->Enable( false );
-    item43->Add( item52, wxSizerFlags().Center().Border(wxALL, 5) );
-    wxStaticLine *item53 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
-    item43->Add( item53, wxSizerFlags().Center().Border(wxALL, 5) );
+    // Ordered most to least destructive rightwards, so the mildest sits at the
+    // edge where it is easiest to hit and the one that discards saved terms is
+    // furthest from it (issue #911). CSearchDlg inserts "Clear Search History"
+    // ahead of Clear Search Results at runtime, giving:
+    //   Clear Search History | Clear Search Results | Reset Fields
+    // Reset Fields last also puts it directly above "Reset Filters" in the row
+    // below, which is the control it parallels.
     wxButton *item54 = new wxButton( parent, IDC_CLEAR_RESULTS, _("Clear Search Results"), wxDefaultPosition, wxDefaultSize, 0 );
     item54->Enable( false );
     item43->Add( item54, wxSizerFlags().Center().Border(wxALL, 5) );
+    wxStaticLine *item53 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
+    item43->Add( item53, wxSizerFlags().Center().Border(wxALL, 5) );
+    wxButton *item52 = new wxButton( parent, IDC_SEARCH_RESET, _("Reset Fields"), wxDefaultPosition, wxDefaultSize, 0 );
+    item52->Enable( false );
+    item43->Add( item52, wxSizerFlags().Center().Border(wxALL, 5) );
     item1->Add( item43, wxSizerFlags().Center().Border(wxALL, 5) );
+    // Rule between the buttons and the filter row (issue #911): with extended
+    // parameters and filtering both on, five rows of fields run together, and
+    // this marks where the search parameters stop and what filters the results
+    // already on screen begins. Full width rather than the button row's extent
+    // -- that row is centred and sized to its contents, so tracking it would
+    // mean measuring it. Shown and hidden with the row it introduces; see
+    // CSearchDlg::ApplyFilterSeparator().
+    wxStaticLine *item61 = new wxStaticLine( parent, ID_FILTER_SEPARATOR, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
+    item1->Add( item61, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT, 5) );
     // Filter row goes BELOW the action buttons (issue #698): filtering is not a
     // search parameter -- it applies to results already on screen and is not
     // touched by "Reset Fields" -- so grouping it with the search parameters

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -85,6 +85,11 @@ extern wxSizer *s_filter_sizer;
 // new id here would mean renumbering every later one. 10493 is the next free
 // value file-wide.
 #define ID_FILTER_RESET 10493
+// Divides the action buttons from the filter row. Carries an id so the dialog
+// can show and hide it with the row it introduces -- a rule left behind on its
+// own would sit under the buttons with nothing beneath it. Numbered out of
+// block for the same reason as ID_FILTER_RESET.
+#define ID_FILTER_SEPARATOR 10508
 #define IDC_STARTS 10018
 #define IDC_SEARCHMORE 10019
 #define IDC_CANCELS 10020


### PR DESCRIPTION
Closes #911.

## Action buttons, ordered by consequence

The three rightmost ran `Reset Fields | Clear Search History | Clear Search Results`, which put the one that discards saved terms between the two used most. They now run most to least destructive rightwards:

```
Clear Search History | Clear Search Results | Reset Fields
```

The mildest sits at the edge, where it is easiest to hit and hardest to miss, and the most invasive is furthest from it. `Reset Fields` last also lands it directly above `Reset Filters` in the row below, which is the control it parallels; the two were misaligned before.

`Clear Search History` is inserted at runtime, since it is gated on the remember-history preference, so it moves by re-anchoring: ahead of `Clear Search Results` rather than after `Reset Fields`. Its divider is inserted with it as before, so switching the preference off still takes both away without leaving a gap or a double divider.

## A rule above the filter row

With extended parameters and filtering both on, five rows of fields ran together. A rule now marks where the search parameters stop and what filters the results already on screen begins.

Full width rather than the button row's extent, as discussed on the issue: that row is centred and sized to its contents, so tracking it would mean measuring it, and the plain rule is the conventional look.

It is shown and hidden with the row it introduces. Left behind it would sit under the buttons with nothing beneath, reading as a border on the search box - the same trap the clear-history divider already documents.

## Catalogs

No string is added or removed. The churn is the two button labels swapping position in the POT, which follows source order: the count is 1984 either side and no catalog loses a translation.

## Testing

Built and checked by hand on macOS: the new order, the rule appearing and disappearing with the filter row, and the clear-history pair still vanishing cleanly when the preference is off. clang-format and both clang-tidy tiers clean.
