### PR TITLE
Fix browse and search tabs: result count, browse identity, and focus stealing

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2068,7 +2068,7 @@ Lists every search amuled currently holds — including ones started by a **diff
 }
 ```
 
-`search_id` is the value to pass to [`GET /search/results`](#get-apiv0searchresults) (`?search_id=`) to read that search's hits, or to [`POST /search/stop`](#post-apiv0searchstop) to stop it. `kind` is `"local"` | `"global"` | `"kad"`, same vocabulary as `POST /search`'s `type`. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/results`'s `progress.state`.
+`search_id` is the value to pass to [`GET /search/results`](#get-apiv0searchresults) (`?search_id=`) to read that search's hits, or to [`POST /search/stop`](#post-apiv0searchstop) to stop it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/results`'s `progress.state`.
 
 amuled only tracks multiple concurrent searches for clients that advertise multi-search support; `amuleapi` does, so this always reflects the full live set. `searches` is an empty array when amuled holds no searches, never an error.
 
@@ -2151,7 +2151,7 @@ Each result carries `sources` as a nested `{total, complete}` object — `total`
 The `progress` object carries the same `state` / `kind` / `percent` fields as the [`search_progress`](EVENTS.md#search_progress) SSE event, so REST pollers and stream consumers interpret progress identically. (The event additionally carries a `results` count, since — unlike this response — it has no `results` array beside it.)
 
 - `state` — `"running"` while the search is in flight, `"finished"` once amuled reports completion, `"idle"` when no search has run this session. This single field is canonical and replaces the older `complete` / `active` booleans (derive them as `complete = state == "finished"`, `active = state == "running"`).
-- `kind` — the originally-requested search type (`"local"` | `"global"` | `"kad"`).
+- `kind` — the originally-requested search type (`"local"` | `"global"` | `"kad"` | `"browse"`).
 - `percent` — `[0, 100]`, computed by amuled for every search kind from its `EC_TAG_SEARCH_LIFECYCLE_PERCENT` tag. For **global** it is the real server-queue progress. For **Kad** — which has no measurable mid-flight progress — it is a cosmetic time-ramp off the fixed 45 s keyword-search lifetime, capped at 99 until amuled authoritatively reports completion (`EC_TAG_SEARCH_LIFECYCLE_STATE` = finished), at which point it snaps to 100. Treat the Kad value as a liveliness indicator, not an accurate estimate.
 
 A client that wants to wait for completion polls while `state == "running"`. Because amuled now reports the lifecycle state directly (no sentinel decode), `state == "running"` unambiguously means in-flight even for Kad — there is no longer any "is `percent: 0` a stalled Kad search or no search at all?" ambiguity; check `state` instead. A Kad search that hits its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — `state` flips to `finished` and `percent` jumps to 100 ahead of the ramp.

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2071,6 +2071,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2110,6 +2110,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2138,6 +2138,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Gueta web dende un interface remotu nun tien xacíu"
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2104,6 +2104,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2070,6 +2070,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2130,6 +2130,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La recerca web des de la interfície remota no té sentit."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2139,6 +2139,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2115,6 +2115,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2135,6 +2135,10 @@ msgstr "EC_TAG_FRIEND_SHARED erfordert EC_TAG_FRIEND oder EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websuche mit der Fernsteuerungsschnittstelle macht keinen Sinn."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:40+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2148,6 +2148,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Η αναζήτηση από τον ιστό από απομακρυσμένο περιβάλλον δεν έχει κανένα νόημα."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2071,6 +2071,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2138,6 +2138,10 @@ msgstr "EC_TAG_FRIEND_SHARED requiere EC_TAG_FRIEND o EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "La búsqueda web desde una interfaz remota no tiene sentido."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2131,6 +2131,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Web Otsing kaugtöökohast ei oma mõtet."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2132,6 +2132,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Urruneko interfazeko Web bilaketak ez du zentzurik."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2132,6 +2132,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Verkkohaku etäliittymästä ei ole mielekästä."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2136,6 +2136,10 @@ msgstr "EC_TAG_FRIEND_SHARED nécessite EC_TAG_FRIEND ou bien EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Une recherche Web par une interface distante n'a aucun sens."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2148,6 +2148,10 @@ msgstr "EC_TAG_FRIEND_SHARED precisa de EC_TAG_FRIEND ou EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ten sentido usar WebSearch dende unha interface remota."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2127,6 +2127,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "לא הגיוני לבצע חיפוש-רשתי מתוך ממשק מרוחק."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2124,6 +2124,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2122,6 +2122,10 @@ msgstr "EC_TAG_FRIEND_SHARED igényel EC_TAG_FRIEND vagy EC_TAG_CLIENT értéket
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Webes keresésnek a távoli felületről nincs értelme."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2138,6 +2138,10 @@ msgstr "EC_TAG_FRIEND_SHARED richiede EC_TAG_FRIEND o EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Non ha senso usare la ricerca Web da interfaccia remota."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2134,6 +2134,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "リモートインタフェイスからWebSearchする意味がありません。"
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2146,6 +2146,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "원격 인터페이스로부터 웹검색은 좋지않은 선택입니다."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2155,6 +2155,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "www paieška iš nutolusios programos neturi prasmės."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2094,6 +2094,10 @@ msgstr "EC_TAG_FRIEND_SHARED nepieciešams EC_TAG_FRIEND vai EC_TAG_CLIENT."
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2133,6 +2133,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "WebSearch vanaf afstand is zinloos."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2146,6 +2146,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nettsøk frå fjern adresse gir ikkje meining."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:48+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2141,6 +2141,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Szukanie przez WWW ze zdalnych interfejsów nie ma sensu."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2134,6 +2134,10 @@ msgstr "EC_TAG_FRIEND_SHARED requer EC_TAG_FRIEND ou EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa web pela interface remota não faz sentido."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2138,6 +2138,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Pesquisa na web a partir da interface remota não faz sentido."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2138,6 +2138,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Nu are nici un sens căutarea web de pe interfața distantă."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2150,6 +2150,10 @@ msgstr "EC_TAG_FRIEND_SHARED требует EC_TAG_FRIEND или EC_TAG_CLIENT."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "При удалённом использовании aMule веб-поиск бесполезен."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2151,6 +2151,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Spletno iskanje iz oddaljenega vmesnika nima smisla."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2141,6 +2141,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Kerkimi WebSearch nga Remote eshte i kote."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2130,6 +2130,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Websök från fjärrgränssnitt är meningslöst."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2070,6 +2070,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2129,6 +2129,10 @@ msgstr "EC_TAG_FRIEND_SHARED, EC_TAG_FRIEND veya EC_TAG_CLIENT gerektirir."
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Uzak arayüzden Web araması yapmak anlamsız."
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2151,6 +2151,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "Веб-пошук через віддалений інтерфейс не має сенсу. "
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2069,6 +2069,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2130,6 +2130,10 @@ msgstr "EC_TAG_FRIEND_SHARED 需要 EC_TAG_FRIEND 或 EC_TAG_CLIENT。"
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "远程界面使用网络搜索没有意义。"
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 10:50+0200\n"
+"POT-Creation-Date: 2026-08-14 11:53+0200\n"
 "PO-Revision-Date: 2026-08-13 11:54+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2128,6 +2128,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 msgid "WebSearch from remote interface makes no sense."
 msgstr "從遠端界面使用網頁搜尋功能沒有意義。"
+
+#: src/ExternalConn.cpp
+msgid "A browse is not a search that can be started."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Search in progress. Refetch results in a moment!"

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2390,6 +2390,20 @@ static CECPacket *Get_EC_Response_Server(const CECPacket *request)
 // allocator: a browse is just another addressable result set, so it draws from
 // the same disjoint id space and LRU eviction as a normal search — no separate
 // range needed. Defined after s_ecSearches.
+// The one invariant this file's kind reporting rests on: SearchType is cast
+// straight to uint8 for EC_TAG_SEARCH_LIFECYCLE_KIND, so its members have to
+// carry the EC_SEARCH_TYPE numbers. A comment saying so is what let a browse
+// nearly be given 3, which is EC_SEARCH_WEB -- state it where the compiler
+// checks it instead.
+static_assert(static_cast<int>(LocalSearch) == EC_SEARCH_LOCAL,
+	"SearchType and EC_SEARCH_TYPE must agree: LocalSearch");
+static_assert(static_cast<int>(GlobalSearch) == EC_SEARCH_GLOBAL,
+	"SearchType and EC_SEARCH_TYPE must agree: GlobalSearch");
+static_assert(
+	static_cast<int>(KadSearch) == EC_SEARCH_KAD, "SearchType and EC_SEARCH_TYPE must agree: KadSearch");
+static_assert(static_cast<int>(BrowseSearch) == EC_SEARCH_BROWSE,
+	"SearchType and EC_SEARCH_TYPE must agree: BrowseSearch");
+
 static uint32 AllocateBrowseSearchId();
 
 // Reply to a browse request. Multi-search clients get the allocated search ID
@@ -2491,6 +2505,13 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		if (subtag) {
 			CFriend *Friend = theApp->friendlist->FindFriend(subtag->GetInt());
 			if (Friend) {
+				// Describe the browse before the results start arriving, so
+				// the search list can report it as one (kind + peer name)
+				// rather than as a nameless search of the scalar kind.
+				if (browseId) {
+					theApp->searchlist->RegisterBrowseSearch(
+						browseId, Friend->GetName(), subtag->GetInt());
+				}
 				theApp->friendlist->RequestSharedFileList(Friend, browseId);
 				response = BuildBrowseReply(browseId, reftag);
 			} else {
@@ -2499,6 +2520,10 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		} else if ((subtag = tag->GetTagByName(EC_TAG_CLIENT))) {
 			CUpDownClient *client = theApp->clientlist->FindClientByECID(subtag->GetInt());
 			if (client) {
+				if (browseId) {
+					theApp->searchlist->RegisterBrowseSearch(
+						browseId, client->GetUserName(), client->ECID());
+				}
 				client->SetBrowseSearchId(browseId);
 				client->RequestSharedFileList();
 				response = BuildBrowseReply(browseId, reftag);
@@ -2848,6 +2873,13 @@ static CECPacket *Get_EC_Response_Search_List()
 		// known.second is the same string GetSearchStringById(sid) would
 		// look up -- already have it from this map entry, no need to re-find.
 		entry.AddTag(EC_TAG_SEARCH_NAME, known.second);
+		// A browse also carries the peer it is listing: without it a remote
+		// GUI cannot build a browse tab at all, since a tab with no ecid is
+		// by definition not a browse (CSearchListCtrl::IsBrowse).
+		const uint32 browsePeer = theApp->searchlist->GetBrowsePeerEcid(sid);
+		if (browsePeer) {
+			entry.AddTag(CECTag(EC_TAG_CLIENT, browsePeer));
+		}
 		entry.AddTag(EC_TAG_SEARCH_LIFECYCLE_KIND,
 			static_cast<uint64_t>(
 				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleKindById(sid))));
@@ -3109,6 +3141,11 @@ static CECPacket *Get_EC_Response_Search(const CECPacket *request, bool multiSea
 
 	if (search_type == EC_SEARCH_WEB) {
 		response = wxTRANSLATE("WebSearch from remote interface makes no sense.");
+	} else if (search_type == EC_SEARCH_BROWSE) {
+		// Reported by the daemon, never accepted here: a browse is started
+		// by EC_OP_FRIEND, and the mapping below would otherwise fall
+		// through its final ternary and quietly start a local search.
+		response = wxTRANSLATE("A browse is not a search that can be started.");
 	} else {
 		SearchType core_search_type = (search_type == EC_SEARCH_GLOBAL) ? GlobalSearch
 					      : (search_type == EC_SEARCH_KAD)  ? KadSearch

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -24,6 +24,10 @@
 
 #include "GuiEvents.h"
 #include "amule.h"
+#ifndef CLIENT_GUI
+#include "ClientList.h"   // Needed for FindClientByECID (Browse_Started)
+#include "updownclient.h" // Needed for IsBrowseEcInitiated (Browse_Started)
+#endif
 #include <common/MenuIDs.h> // MP_PAUSE/STOP/RESUME/CANCEL + MP_PRIO* for the
 #ifndef AMULE_DAEMON
 #include "CommentDialog.h"         // CCommentDialog::DropReferencesTo
@@ -729,7 +733,18 @@ void Browse_Started(uint32 NOT_ON_DAEMON(ecid), wxString NOT_ON_DAEMON(name), ui
 {
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
-		theApp->amuledlg->m_searchwnd->EnsureBrowseTab(ecid, name, (wxUIntPtr)searchID);
+		// Reveal only what this user started. The notification carries no such
+		// flag and CMuleNotifier stops at three arguments, but the client it
+		// names already knows -- so ask it rather than widen the notifier for
+		// one bool. CLIENT_GUI has neither this lookup nor a path that raises
+		// this notification (it is sent from CUpDownClient, which is core
+		// only), so there is nothing to answer there.
+		bool reveal = true;
+#ifndef CLIENT_GUI
+		const CUpDownClient *browsed = theApp->clientlist->FindClientByECID(ecid);
+		reveal = !(browsed && browsed->IsBrowseEcInitiated());
+#endif
+		theApp->amuledlg->m_searchwnd->EnsureBrowseTab(ecid, name, (wxUIntPtr)searchID, reveal);
 	}
 #endif
 }

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -1194,7 +1194,7 @@ bool CSearchDlg::ActivateBrowseTabIfOpen(uint32 peerEcid)
 	return false;
 }
 
-void CSearchDlg::EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUIntPtr searchID)
+void CSearchDlg::EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUIntPtr searchID, bool reveal)
 {
 	// A re-browse of the same peer refreshes the existing tab: rekey its
 	// result-routing ID to the new one (the daemon may allocate a fresh ID) and
@@ -1207,7 +1207,7 @@ void CSearchDlg::EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUI
 		return;
 	}
 
-	CreateNewTab(userName, searchID);
+	CreateNewTab(userName, searchID, reveal);
 	if (CSearchListCtrl *page = GetSearchList(searchID)) {
 		page->SetBrowseEcid(peerEcid);
 		page->SetBrowseName(userName);
@@ -1219,7 +1219,7 @@ void CSearchDlg::EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUI
 	// toolbar button state, not just the panel content. Only on tab creation,
 	// never on a refresh or a streaming result, which would yank the panel out
 	// from under the user.
-	if (theApp->amuledlg) {
+	if (reveal && theApp->amuledlg) {
 		theApp->amuledlg->ShowSearchWindow();
 	}
 }

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -196,7 +196,19 @@ public:
 	// searchID is the result-routing ID (daemon-allocated over EC, or the local
 	// client pointer in the monolithic client); if the tab already exists its
 	// routing ID is rekeyed to searchID. Shared by monolithic and amuleGUI.
-	void EnsureBrowseTab(uint32 peerEcid, const wxString &userName, wxUIntPtr searchID);
+	/**
+	 * Finds or creates the "View Files" tab for a peer.
+	 *
+	 * @param reveal Select the new tab and bring the Search panel forward.
+	 *   True when the local user asked for this browse, which is the point of
+	 *   clicking View Files. False for one this client did not initiate --
+	 *   another GUI's browse, or one already running when we attached -- which
+	 *   must not pull the panel or the selection away from whatever the user
+	 *   is doing, possibly mid-typing (same rule as a discovered search,
+	 *   amule-org/amule#703).
+	 */
+	void EnsureBrowseTab(
+		uint32 peerEcid, const wxString &userName, wxUIntPtr searchID, bool reveal = true);
 
 	// "View Files": if a browse tab for this peer's ECID is already open, bring
 	// the Search panel forward, select that tab, and return true. Lets the

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -957,7 +957,7 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	// revealing it would pull this user's panel and selection away for
 	// something they never asked for -- the same rule the discovered-search
 	// path follows.
-	const bool ecInitiated = sender->GetBrowseSearchId() != 0;
+	const bool ecInitiated = sender->IsBrowseEcInitiated();
 
 	if (!sender->GetBrowseSearchId()) {
 		const uint32 localBrowseId = AllocateEd2kId();

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -956,8 +956,11 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	// EC one afterwards. An EC-initiated browse belongs to another client, so
 	// revealing it would pull this user's panel and selection away for
 	// something they never asked for -- the same rule the discovered-search
-	// path follows.
+	// path follows. Gated with its use: there is no tab to reveal in a
+	// daemon build, and an unread value there is a dead store.
+#ifndef AMULE_DAEMON
 	const bool ecInitiated = sender->IsBrowseEcInitiated();
+#endif
 
 	if (!sender->GetBrowseSearchId()) {
 		const uint32 localBrowseId = AllocateEd2kId();

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -939,8 +939,24 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	// client; use it so the union/per-ID poll and the LRU ring can address these
 	// results. A monolithic local browse leaves it 0 and keeps the historical
 	// per-client-pointer key.
-	wxUIntPtr searchID = sender->GetBrowseSearchId() ? static_cast<wxUIntPtr>(sender->GetBrowseSearchId())
-							 : reinterpret_cast<wxUIntPtr>(sender);
+	// A local browse used to key its results on the client pointer, which no
+	// remote client can address -- it is this process's memory, so the browse
+	// was invisible to amulegui, amuleweb and amuleapi while an EC-initiated
+	// one (which is handed a real id) showed up everywhere, including in this
+	// GUI. Give it the same kind of id so the two directions match. It is also
+	// safer: a pointer is reused once the client is freed, so two browses of
+	// different peers could collide on one key.
+	//
+	// Allocated once and pinned on the client, not per packet -- a browse
+	// arrives in several -- and registered so it is listed like any other
+	// search, with its kind and peer, which is what lets a remote GUI rebuild
+	// it as a browse tab rather than a nameless search.
+	if (!sender->GetBrowseSearchId()) {
+		const uint32 localBrowseId = AllocateEd2kId();
+		sender->SetBrowseSearchId(localBrowseId);
+		RegisterBrowseSearch(localBrowseId, sender->GetUserName(), sender->ECID());
+	}
+	wxUIntPtr searchID = static_cast<wxUIntPtr>(sender->GetBrowseSearchId());
 
 #ifndef AMULE_DAEMON
 	// Find-or-create the peer's "View Files" tab, keyed by ECID (so two peers

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -362,6 +362,16 @@ void CSearchList::StoreSearches() const
 	std::vector<uint32_t> ids;
 	ids.reserve(m_searchStrings.size());
 	for (const auto &kv : m_searchStrings) {
+		// Browses are deliberately not persisted. They are a snapshot of one
+		// peer's share taken while that peer was connected, so restoring one
+		// resurrects a listing for someone who is very likely gone -- and a
+		// large share would spend the MAX_STORED_SEARCHES budget that exists
+		// for the user's own searches. They are in m_searchStrings only so
+		// the search list can report them by peer name while they are live.
+		std::map<uint32_t, SearchType>::const_iterator kind = m_searchKinds.find(kv.first);
+		if (kind != m_searchKinds.end() && kind->second == BrowseSearch) {
+			continue;
+		}
 		ids.push_back(kv.first);
 	}
 	std::sort(ids.begin(), ids.end(), [this](uint32_t a, uint32_t b) {
@@ -1177,6 +1187,23 @@ wxString CSearchList::GetSearchStringById(uint32_t searchID) const
 bool CSearchList::IsKnownSearchId(uint32_t searchID) const
 {
 	return m_searchStrings.count(searchID) != 0 || m_browseBar.count(searchID) != 0;
+}
+
+uint32 CSearchList::GetBrowsePeerEcid(uint32 searchID) const
+{
+	std::map<uint32_t, uint32>::const_iterator it = m_browsePeers.find(searchID);
+	return it != m_browsePeers.end() ? it->second : 0;
+}
+
+void CSearchList::RegisterBrowseSearch(uint32 searchID, const wxString &peerName, uint32 peerEcid)
+{
+	// All three, not just the kind: Save() iterates m_searchStrings and then
+	// reads the other two with .at(), so an id present in one and missing
+	// from another throws when the searches are persisted.
+	m_searchStrings[searchID] = peerName;
+	m_searchKinds[searchID] = BrowseSearch;
+	m_searchStartTimes[searchID] = time(nullptr);
+	m_browsePeers[searchID] = peerEcid;
 }
 
 SearchType CSearchList::GetSearchLifecycleKindById(wxUIntPtr searchID) const

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -951,6 +951,14 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	// arrives in several -- and registered so it is listed like any other
 	// search, with its kind and peer, which is what lets a remote GUI rebuild
 	// it as a browse tab rather than a nameless search.
+	// Whether this browse was asked for here. Read before the id is assigned
+	// below, because that assignment is what makes a local browse look like an
+	// EC one afterwards. An EC-initiated browse belongs to another client, so
+	// revealing it would pull this user's panel and selection away for
+	// something they never asked for -- the same rule the discovered-search
+	// path follows.
+	const bool ecInitiated = sender->GetBrowseSearchId() != 0;
+
 	if (!sender->GetBrowseSearchId()) {
 		const uint32 localBrowseId = AllocateEd2kId();
 		sender->SetBrowseSearchId(localBrowseId);
@@ -963,7 +971,8 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	// sharing a nick don't collapse into one tab, and a re-browse refreshes the
 	// same tab). Marks the tab as browsing; the terminal paths flip it to
 	// finished/failed via Notify_Browse_Status.
-	theApp->amuledlg->m_searchwnd->EnsureBrowseTab(sender->ECID(), sender->GetUserName(), searchID);
+	theApp->amuledlg->m_searchwnd->EnsureBrowseTab(
+		sender->ECID(), sender->GetUserName(), searchID, !ecInitiated);
 #endif
 
 	const CMemFile packet(in_packet, size);

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -46,11 +46,32 @@ namespace Kademlia
 class CUInt128;
 }
 
+/**
+ * What kind of search an id names.
+ *
+ * The values are pinned, not incidental. They are cast straight to uint8 and
+ * shipped as EC_TAG_SEARCH_LIFECYCLE_KIND, where they have to line up with
+ * EC_SEARCH_TYPE in ECCodes.abstract, and CSearchList::Save() writes the same
+ * byte into the saved-searches file. So a member's number is part of both the
+ * wire protocol and an on-disk format, and renumbering one silently
+ * reinterprets the other.
+ *
+ * Note the gap: 3 belongs to EC_SEARCH_WEB, which has no counterpart here.
+ * Appending BrowseSearch without saying so would have handed it that value and
+ * made every browse report itself as a web search.
+ */
 enum SearchType
 {
-	LocalSearch,
-	GlobalSearch,
-	KadSearch
+	LocalSearch = 0,
+	GlobalSearch = 1,
+	KadSearch = 2,
+	// 3 is EC_SEARCH_WEB -- deliberately skipped, see above.
+	//! A "View Files" browse of one peer's share. Shares the id space and
+	//! the lifecycle machinery with real searches, but is started by
+	//! EnsureBrowseTab rather than a query, and is the kind a remote GUI
+	//! needs in order to rebuild the right sort of tab for a browse it did
+	//! not start itself.
+	BrowseSearch = 4
 };
 
 typedef std::vector<CSearchFile *> CSearchResultList;
@@ -261,6 +282,25 @@ public:
 	// button). Kad is authoritative via IsOrWasKadSearch even if the recorded
 	// entry was pruned; unknown ids fall back to the scalar.
 	SearchType GetSearchLifecycleKindById(wxUIntPtr searchID) const;
+	/**
+	 * Records a browse under @a searchID so it appears in the search list
+	 * like any other entry.
+	 *
+	 * A browse gets a real id from the same space as searches, but nothing
+	 * described it: with no entry here its kind fell back to the scalar and
+	 * it had no name at all, so a remote GUI listing the daemon's searches
+	 * saw a nameless one it could only rebuild as an ordinary search tab.
+	 *
+	 * Writes all three of the per-id maps, which are maintained as a triple
+	 * -- Save() walks m_searchStrings and reaches for the other two with
+	 * .at(), so a partial entry turns saving into an exception rather than a
+	 * missing field.
+	 */
+	void RegisterBrowseSearch(uint32 searchID, const wxString &peerName, uint32 peerEcid);
+	//! ECID of the peer a browse id is listing, 0 if not a browse. Reported
+	//! so a remote GUI can build a browse tab that is actually tied to its
+	//! peer -- a tab with no ecid is not a browse at all (IsBrowse()).
+	uint32 GetBrowsePeerEcid(uint32 searchID) const;
 	// Result count for the current search; 0 if idle.
 	std::size_t GetCurrentSearchResultCount() const;
 	// Unified 0..100 completion for the current search, surfaced via
@@ -502,6 +542,8 @@ private:
 	//! m_searchType (which only tracks the most-recently-started search).
 	//! Pruned in RemoveResults.
 	std::map<uint32_t, SearchType> m_searchKinds;
+	//! Peer ecid per browse id; see RegisterBrowseSearch().
+	std::map<uint32_t, uint32> m_browsePeers;
 
 	//! This search's original query string, keyed by id (same lifetime as
 	//! m_searchKinds -- recorded in StartNewSearch, pruned in RemoveResults).

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -333,17 +333,23 @@ size_t CSearchListCtrl::GetItemCount() const
 	}
 	size_t shown = 0;
 	const CSearchResultList &results = theApp->searchlist->GetSearchResults(m_nResultsID);
+	// Results, not rows: one per top-level hit, whatever is expanded.
+	//
+	// This used to add the children of expanded groups, which was right when
+	// the tab was a wxListCtrl and an expanded child really was another row --
+	// the count and the row count were the same number. Under the data view
+	// they are not: children are model nodes, nothing recomputes the label on
+	// expand or collapse (there is no handler), and the tab therefore reported
+	// whichever expansion state happened to be current when some unrelated
+	// event last refreshed it. Two clients showing identical lists disagreed
+	// by exactly the children someone had opened.
+	//
+	// It also makes the label's own arithmetic add up: GetHiddenItemCount()
+	// has always counted top-level results only, so "shown/(shown + hidden)"
+	// was mixing rows with results.
 	for (CSearchFile *file : results) {
 		if (!file->GetParent() && ShouldShow(file)) {
 			++shown;
-			if (file->HasChildren() && IsExpanded(CSearchListModel::ToItem(file))) {
-				const CSearchResultList &children = file->GetChildren();
-				for (const CSearchFile *child : children) {
-					if (IsFiltered(child)) {
-						++shown;
-					}
-				}
-			}
 		}
 	}
 	return shown;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3725,10 +3725,32 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 				// client, so it must not pull the selection away from whatever
 				// the local user is looking at -- possibly mid-typing in the
 				// search box (got3nks, amule-org/amule#703).
-				theApp->amuledlg->m_searchwnd->CreateNewTab(
-					(nameTag ? nameTag->GetStringData() : wxString()) + " (0)",
-					sid,
-					false);
+				// A browse the daemon is serving for someone else, or one
+				// still running from before this GUI attached, arrives here
+				// like any other search -- it shares the id space. Rebuild it
+				// as a browse tab rather than a search tab, which is what the
+				// kind is reported for. Daemons predating EC_SEARCH_BROWSE
+				// never send it, so the test simply fails there and the tab is
+				// built the way it always was.
+				const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+				const CECTag *peerTag = entry.GetTagByName(EC_TAG_CLIENT);
+				const uint32 peerEcid = peerTag ? static_cast<uint32>(peerTag->GetInt()) : 0;
+				// Only with a real peer: EnsureBrowseTab keys on the ecid and
+				// an ecid of 0 is not "unknown peer", it is what every
+				// ordinary search tab carries -- GetBrowseList(0) would match
+				// the first of those and repoint it at this browse. A daemon
+				// that reports the kind without the peer therefore falls
+				// through to the plain tab, which is what it built before.
+				if (kindTag && kindTag->GetInt() == BrowseSearch && peerEcid) {
+					theApp->amuledlg->m_searchwnd->EnsureBrowseTab(peerEcid,
+						nameTag ? nameTag->GetStringData() : wxString(),
+						sid);
+				} else {
+					theApp->amuledlg->m_searchwnd->CreateNewTab(
+						(nameTag ? nameTag->GetStringData() : wxString()) + " (0)",
+						sid,
+						false);
+				}
 				// Reachability fix (#641): without this, a discovered tab never
 				// gets polled for progress at all (Phase1Done only loops over
 				// m_activeSearches), so its hit count, progress bar and "!"

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3744,7 +3744,8 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 				if (kindTag && kindTag->GetInt() == BrowseSearch && peerEcid) {
 					theApp->amuledlg->m_searchwnd->EnsureBrowseTab(peerEcid,
 						nameTag ? nameTag->GetStringData() : wxString(),
-						sid);
+						sid,
+						false);
 				} else {
 					theApp->amuledlg->m_searchwnd->CreateNewTab(
 						(nameTag ? nameTag->GetStringData() : wxString()) + " (0)",

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -680,10 +680,20 @@ EC_DETAIL_INC_UPDATE    0x04
 Type Enum
 Name EC_SEARCH_TYPE
 DataType uint8
+## These share their numeric values with CSearchList's own SearchType, which
+## is cast straight to uint8 for EC_TAG_SEARCH_LIFECYCLE_KIND. Keep the two in
+## step: a value that means one thing here and another there is not detectable
+## on the wire.
 EC_SEARCH_LOCAL         0x00
 EC_SEARCH_GLOBAL        0x01
 EC_SEARCH_KAD           0x02
 EC_SEARCH_WEB           0x03
+## A "View Files" browse. Reported by the daemon so a remote GUI can rebuild a
+## browse tab for one it did not start itself; never accepted as the type of a
+## search to start. Daemons predating it simply never send it, and the clients
+## that read the kind compare it for equality rather than switching on it, so
+## an unknown value stays inert on either side of a version mismatch.
+EC_SEARCH_BROWSE        0x04
 [/Section]
 
 [Section Content]

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -470,6 +470,17 @@ public:
 	// terminal paths can stamp m_browseStatus. 0 = not an EC-initiated browse
 	// (monolithic local browse keeps the pointer-keyed path).
 	uint32 GetBrowseSearchId() const { return m_browseSearchId; }
+	/**
+	 * Whether this browse was asked for by a remote client rather than here.
+	 *
+	 * The id is pinned by the EC handler before the request goes out, and a
+	 * browse started locally has none until its results arrive, so its presence
+	 * at request time is what tells the two apart. Named because both the
+	 * result path and the browse-started notification have to make the same
+	 * call: a browse someone else asked for must not pull this user's panel or
+	 * tab selection.
+	 */
+	bool IsBrowseEcInitiated() const { return m_browseSearchId != 0; }
 	void SetBrowseSearchId(uint32 id) { m_browseSearchId = id; }
 	EBrowseStatus GetBrowseStatus() const { return m_browseStatus; }
 	void SetBrowseStatus(EBrowseStatus s) { m_browseStatus = s; }

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5418,6 +5418,11 @@ wxString SearchKindToString(std::uint8_t kind)
 		return wxString::FromAscii("local");
 	case EC_SEARCH_KAD:
 		return wxString::FromAscii("kad");
+	case EC_SEARCH_BROWSE:
+		// A "View Files" browse of one peer's share. Reported, never
+		// accepted by SearchTypeFromString: browses are not started
+		// through the search endpoint.
+		return wxString::FromAscii("browse");
 	case EC_SEARCH_GLOBAL:
 	default:
 		return wxString::FromAscii("global");


### PR DESCRIPTION
Five fixes in the search and browse paths. They were found in sequence — each one uncovered the next — but they are independent and are separate commits.

## The tab counter disagreed between the two apps

The same search reported 247 hits in amule and 261 in amulegui, over lists that were visually identical. `GetItemCount()` was adding the children of expanded groups, so it counted rows rather than hits.

That was right when the tab was a `wxListCtrl`: an expanded child really was another row and the two numbers were the same. Under the data view they are not. Children are model nodes, and nothing recomputes the label when one is expanded or collapsed — there is no handler for either — so the tab kept whichever expansion state happened to be current when some unrelated event last refreshed it. Two clients showing the same list disagreed by exactly the children someone had opened, and collapsing them again did not put it back.

It now counts top-level hits that pass the filter, whatever is expanded. That also makes the label's own arithmetic add up: `GetHiddenItemCount()` has always counted top-level results only and says so, so the `shown/(shown + hidden)` form was mixing rows with results whenever a group was open.

## A browse is now a search kind

A browse gets a real search id from the same space as searches, but nothing said it was one: it had no name and no recorded kind, so a remote GUI listing the daemon's searches saw a nameless entry it could only rebuild as an ordinary search tab.

`SearchType` gains `BrowseSearch`, with `EC_SEARCH_BROWSE` reserved beside it. The values are pinned rather than appended: `SearchType` is cast straight to `uint8` for `EC_TAG_SEARCH_LIFECYCLE_KIND` and written into the saved-searches file, and **3 already belongs to `EC_SEARCH_WEB`** — appending would have handed browses that number and reported every one of them as a web search. Four `static_assert`s now hold the two enums together, so the next person gets a build error rather than a wire value that means two things.

`RegisterBrowseSearch()` records a browse's kind, peer name and peer ecid — all three of the per-id maps, because `Save()` walks one and reaches for the others with `.at()`, so a partial entry turns saving into an exception. Browses are then skipped when persisting: they are a snapshot of a peer's share taken while that peer was connected, so restoring one resurrects a listing for someone long gone, and a large share would spend the budget that exists for the user's own searches.

The peer ecid travels with the kind because a browse tab is defined by it — `CSearchListCtrl::IsBrowse()` is `m_browseEcid != 0`. A discovered browse is rebuilt as a browse tab only when both arrive.

Reported, never accepted: the start-search op rejects `EC_SEARCH_BROWSE` rather than letting it fall through the type mapping and quietly start a local search. amuleapi reports it as `"browse"`, which is what `docs/api/EVENTS.md` has documented all along while the code said `"global"`.

## A local browse now has a real id

A browse started from the local GUI keyed its results on the client pointer cast to an integer. That is this process's memory, so no remote client could address it: browsing a friend from amulegui showed up in the monolithic UI as well, because the core is the one doing the browsing and renders what it receives, while a browse started in the monolithic UI was invisible to amulegui, amuleweb and amuleapi. One direction worked and the other did not, for no reason a user could see.

It now gets the same kind of id an EC-initiated browse gets, pinned on the client and registered, so both directions produce a browse that is listed like any other search. A pointer was also the wrong sort of key: it is reused once the client is freed, so two browses of different peers could land on the same one.

## Neither app steals focus for someone else's browse

`EnsureBrowseTab` selects the new tab and brings the Search panel forward. That is right when the local user clicked View Files — revealing it is the point — and wrong for a browse this client did not initiate, which is now possible in both directions. Discovered searches already had this rule (#703); browses reached the same situation by a different path and did not.

One flag rather than a second entry point: `EnsureBrowseTab` takes `reveal`, defaulting to true so every existing caller keeps the behaviour it had, and the paths reporting someone else's browse pass false.

The tab is opened by two different routes and both needed it — the result path, and `Notify_Browse_Started`, which fires for a local and an EC-initiated browse alike. The notification carries no such flag and `CMuleNotifier` stops at three arguments, so rather than widen it for one bool the handler asks the client it already names. That test has one home, `CUpDownClient::IsBrowseEcInitiated()`, used by both paths instead of each spelling out the same comparison.

## Backwards compatibility

Both directions of a version mismatch fall back to the old behaviour, because the new information is advisory and the consumer requires it affirmatively.

An older amulegui reads the kind with an equality test rather than a switch, so an unknown value is inert and the browse appears as a plain search tab — what it did before. An older daemon sends neither the kind nor the peer, and the discovery loop requires **both** before building a browse tab, so a partial signal always lands on the old path rather than a half-configured new one. An older amuleapi labels the kind `"global"`, exactly as it does today. Browses are not persisted at all, so an older daemon never meets the new value in the saved-searches file.

## Testing

Built and run on macOS, monolithic and remote GUI against each other, with browses started from each side. Checked that a browse started in either app appears in the other without moving the panel or the selection, that clicking View Files locally still reveals its tab, and that both apps now report the same result count for the same search. 34/34 unit tests pass; clang-format, clang-tidy Tier-1 and Tier-2 clean; Debug and Release both build, Debug specifically because a duplicate enum value is a `duplicate case value` error there and invisible in Release.
