### PR TITLE
fix(cmake): drop the dead glibc probe that noisily fails on macOS and mingw

### DIFF
--- a/cmake/glib21.cmake
+++ b/cmake/glib21.cmake
@@ -9,27 +9,6 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 	check_include_file (fcntl.h HAVE_FCNTL_H)
 	check_include_file (sys/resource.h HAVE_SYS_RESOURCE_H)
 	check_include_file (sys/statvfs.h HAVE_SYS_STATVFS_H)
-
-	set (TEST_APP "#include <features.h>
-		#ifdef __GNU_LIBRARY__
-			#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1) || (__GLIBC__ > 2)
-				Lucky GNU user
-			#endif
-		#endif"
-	)
-
-	execute_process (COMMAND echo ${TEST_APP}
-		COMMAND ${CMAKE_C_COMPILER} -E -xc -
-		OUTPUT_VARIABLE GLIB_TEST_OUTPUT
-	)
-
-	string (REGEX MATCH "Lucky GNU user" MATCH "${GLIB_TEST_OUTPUT}")
-
-	if (${MATCH})
-		set (__GLIBC__ TRUE)
-		message (STATUS "glibc -- found")
-	endif()
-
 	check_function_exists (posix_fallocate HAVE_POSIX_FALLOCATE)
 endif()
 


### PR DESCRIPTION
Every `cmake -B build` on macOS and mingw-w64 prints a compiler fatal error:

```
<stdin>:1:10: fatal error: 'features.h' file not found
    1 | #include <features.h>
      |          ^~~~~~~~~~~~
1 error generated.
```

It comes from the glib-2.1 check in `cmake/glib21.cmake`, carried over from the autoconf build. It pipes a test translation unit into `$CC -E` and captures only `OUTPUT_VARIABLE`, so the compiler's stderr goes straight to the terminal. `features.h` is a glibc header, so the affected jobs are MacOS Debug/Release and mingw-w64 Debug/Release; Ubuntu is quiet only because glibc ships the header. It is also the only probe in that file that forgets `ERROR_VARIABLE` - the `inttypes.h`, `PRId32` and `strerror_r` checks below it all capture stderr, which is why they are silent.

The probe has no effect to lose:

- **It cannot succeed on any platform.** `if (${MATCH})` expands to `if (Lucky GNU user)`, three bare arguments, which CMake evaluates as false. That is why `-- glibc -- found` appears in no CI job, Ubuntu included.
- **Nothing reads the result.** `set (__GLIBC__ TRUE)` sets a CMake variable that has no entry in `config.h.cm` and no other reference in the tree.
- **The real `__GLIBC__` uses are unrelated.** `src/amule.cpp` and `src/Parser.cpp` test the compiler's own glibc macro, which glibc defines through `features.h` on its own. They behave identically with or without this block.

### Verification

Configured with the full CI flag set before and after, on a platform without `features.h` and one with it:

| Platform | `config.h` | Configure status output |
|---|---|---|
| macOS arm64, clang | byte-identical | identical, minus the 4 error lines |
| Ubuntu 26.04 arm64, gcc, glibc | identical apart from `GITDATE` | identical |

The file keeps its name. What remains in it is ordinary header and function probing, and renaming would only add churn to an unrelated set of call sites.
