### PR TITLE
fix(gui): let the search list copy eD2k links for a whole selection

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6316,6 +6316,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6629,10 +6633,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6419,6 +6419,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6744,10 +6748,6 @@ msgstr "الغاء الخادم"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "الغاء كل الخادمات"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6537,6 +6537,10 @@ msgstr "Guetar ficheros rellacionaos (eD2k, gueta llocal)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar l'enllaz eD2k al cartafueyos"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copiar los enllaces eD2k al cartafueyos"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6861,10 +6865,6 @@ msgstr "Desaniciar sirvidores"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Desaniciar tolos sirvidores"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copiar los enllaces eD2k al cartafueyos"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6394,6 +6394,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6718,10 +6722,6 @@ msgstr "Премахване на сървър"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Изтриване на всички сървъри"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6315,6 +6315,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6628,10 +6632,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6508,6 +6508,10 @@ msgstr "Cerca fitxers relacionats (eD2k, servidor local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia l'enllaç eD2k al porta-retalls"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copia els enllaços eD2k al porta-retalls"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6830,10 +6834,6 @@ msgstr "Esborra els servidors"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Esborra tots els servidors"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copia els enllaços eD2k al porta-retalls"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6516,6 +6516,10 @@ msgstr "Vyhledat související soubory (eD2k, lokální server)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Zkopírovat eD2k odkaz do schránky"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6842,10 +6846,6 @@ msgstr "Vzdálené servery"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Odstranit všechny servery"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6437,6 +6437,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6761,10 +6765,6 @@ msgstr "Fjern server"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Fjern Alle servere"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6504,6 +6504,10 @@ msgstr "Suche verwandte Dateien (eD2k, lokale Server)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopiere eD2k-Verweise in die Zwischenablage"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6826,10 +6830,6 @@ msgstr "Entferne die Server"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Alle Server entfernen"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopiere eD2k-Verweise in die Zwischenablage"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:40+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6549,6 +6549,10 @@ msgstr "Αναζήτηση παρόμοιων αρχείων (στο eD2k, το�
 msgid "Copy eD2k link to clipboard"
 msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρο"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Αντιγραφή συνδέσμων eD2k στο πρόχειρο"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6873,10 +6877,6 @@ msgstr "Αφαίρεση διακομιστών"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Διαγράψτε όλους τους διακομιστές"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Αντιγραφή συνδέσμων eD2k στο πρόχειρο"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6316,6 +6316,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6629,10 +6633,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6488,6 +6488,10 @@ msgstr "Buscar archivos relacionados (eD2k, servidor local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar el enlace eD2k al portapapeles"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copiar los enlaces eD2k al portapapeles"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Actualmente no estás conectado a un servidor que admita la función de búsqueda de 'Archivos Relacionados'"
@@ -6809,10 +6813,6 @@ msgstr "Borrar los servidores"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Eliminar todos los servidores"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copiar los enlaces eD2k al portapapeles"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6513,6 +6513,10 @@ msgstr "Otsi seotud faile (eD2k, kohalik server)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopeeri eD2k link lõikepuhvrisse"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopeeri eD2k lingid lõikepuhvrisse"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6836,10 +6840,6 @@ msgstr "Eemalda serverid"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Eemalda kõik serverid"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopeeri eD2k lingid lõikepuhvrisse"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6512,6 +6512,10 @@ msgstr "Bilatu erlazionatutako fitxategiak (eD2k, zerbitzari lokala)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiatu ed2k lotura arbelera"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopiatu eD2k loturak arbelera"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6834,10 +6838,6 @@ msgstr "Ezabatu zerbitzariak"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Kendu zerbitzari guztiak"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopiatu eD2k loturak arbelera"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6512,6 +6512,10 @@ msgstr "Hae tähän liittyviä tiedostoja (eD2k, paikallinen palvelin)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopioi eD2k-linkki leikepöydälle"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopioi eD2k-linkit leikepöydälle"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6834,10 +6838,6 @@ msgstr "Poista palvelimet"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Poista kaikki palvelimet"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopioi eD2k-linkit leikepöydälle"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6482,6 +6482,10 @@ msgstr "Chercher les fichiers liés (eD2k, serveur local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copier le lien eD2k dans le presse-papiers"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copier les liens eD2k dans le presse-papiers"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Vous n'êtes actuellement pas connecté à un serveur prenant en charge la fonction de recherche de fichiers associés"
@@ -6802,10 +6806,6 @@ msgstr "Supprimer les serveurs"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Supprimer tous les serveurs"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copier les liens eD2k dans le presse-papiers"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6518,6 +6518,10 @@ msgstr "Procurar ficheiros relacionados (eD2k, busca local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar a ligazón eD2k ó portapapeis"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copia as ligazóns eD2k ó portapapeis"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6840,10 +6844,6 @@ msgstr "Borrar servidores"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Borrar todos os servidores"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copia as ligazóns eD2k ó portapapeis"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6476,6 +6476,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6799,10 +6803,6 @@ msgstr "הסר שרתים"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "הסר את כל השרתים"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6461,6 +6461,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6789,10 +6793,6 @@ msgstr "Odstrani servera"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Odstrani sve servere"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6484,6 +6484,10 @@ msgstr "Kapcsolódó fájlok keresése (eD2k, helyi kiszolgáló)"
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k hivatkozás másolása a vágólapra"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "eD2k hivatkozások másolása a vágólapra"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6803,10 +6807,6 @@ msgstr "Kiszolgálók eltávolítása"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Összes kiszolgáló eltávolítása"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "eD2k hivatkozások másolása a vágólapra"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6471,6 +6471,10 @@ msgstr "Cerca file correlati (eD2k, server locale)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copia il collegamento eD2k negli appunti"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copia il collegamento eD2k negli appunti"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Al momento non sei connesso ad un server che supporta la Ricerca di File Correlati"
@@ -6785,10 +6789,6 @@ msgstr "Rimuovi i server"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Rimuovi tutti i server"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copia il collegamento eD2k negli appunti"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6507,6 +6507,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6828,10 +6832,6 @@ msgstr "サーバを削除する"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "全てのサーバを削除する"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6541,6 +6541,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6871,10 +6875,6 @@ msgstr "서버를 삭제"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "모든 서버를 삭제"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6565,6 +6565,10 @@ msgstr "Ieškoti panašių failų (eD2k, vietiniame serveryje)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopijuoti eD2k nuorodą į talpyklę"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopijuoti eD2k nuorodas į talpyklę"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6892,10 +6896,6 @@ msgstr "Pašalinti serverius"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Pašalinti visus serverius"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopijuoti eD2k nuorodas į talpyklę"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6356,6 +6356,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopēt eD2k saiti starpliktuvē"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopēt eD2k saites starpliktuvē"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Jūs pašlaik neesiet pieslēgts serverim, kas atbalsta saistīto datņu meklēšanas funkciju"
@@ -6675,10 +6679,6 @@ msgstr "Noņemt atlasītos serverus"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Noņemt visus serverus"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopēt eD2k saites starpliktuvē"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6513,6 +6513,10 @@ msgstr "Zoek gelijkwaardige bestanden (eD2k, lokale server)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopieer eD2k-link naar klembord"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopieer eD2k-links naar klembord"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6835,10 +6839,6 @@ msgstr "Verwijder servers"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Verwijder alle servers"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopieer eD2k-links naar klembord"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6542,6 +6542,10 @@ msgstr "Søk beslekta filer (eD2k, lokal tenar)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopier eD2k lenkje til skrivebordet"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopier eD2k lenkjer til skrivebordet"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6866,10 +6870,6 @@ msgstr "Ta bort tenarar"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Fjern alle tenarar"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopier eD2k lenkjer til skrivebordet"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:48+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6545,6 +6545,10 @@ msgstr "Szukaj powiązanych plików (eD2k, serwer lokalny)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiuj link eD2k do schowka"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Skopiuj linki eD2k do schowka"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6871,10 +6875,6 @@ msgstr "Usuń serwery"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Usuń wszystkie serwery"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Skopiuj linki eD2k do schowka"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6468,6 +6468,10 @@ msgstr "Procurando arquivos relacionados (eD2k, servidor local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para área de transferência"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copiar ligações eD2k para área de transferência"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Você não está atualmente conectado a um servidor que suporta a função \"Arquivos Relacionados\""
@@ -6782,10 +6786,6 @@ msgstr "Apagar servidores"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Remover todos os servidores"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copiar ligações eD2k para área de transferência"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6520,6 +6520,10 @@ msgstr "Procurar ficheiros relacionados (eD2k, servidor local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiar ligação eD2k para a área de transferência"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copiar ligações eD2k para a área de transferência"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6842,10 +6846,6 @@ msgstr "Remover os servidores"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Remover todos os servidores"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copiar ligações eD2k para a área de transferência"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6528,6 +6528,10 @@ msgstr "Caută fișiere asociate (eD2k, server local)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Copiază link-ul eD2k în memoria temporară"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Copiază link-urile eD2k în memoria temporară"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6853,10 +6857,6 @@ msgstr "Elimină servere"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Elimină toate serverele"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Copiază link-urile eD2k în memoria temporară"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6517,6 +6517,10 @@ msgstr "Искать связанные файлы (eD2k, локально)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Копировать ссылку eD2k в буфер"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Копировать eD2k ссылки в буфер"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "В настоящий момент вы не подключены к серверу, поддерживающему функцию поиска связанных файлов"
@@ -6835,10 +6839,6 @@ msgstr "Удалить выбранные серверы"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Удалить все серверы"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Копировать eD2k ссылки в буфер"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6562,6 +6562,10 @@ msgstr "Poišči sorodne datoteke (eD2k, krajevni strežnik)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Skopiraj povezavo eD2k na odložišče"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Skopiraj povezave eD2k na odložišče"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6890,10 +6894,6 @@ msgstr "Odstrani strežnike"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Odstrani vse strežnike"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Skopiraj povezave eD2k na odložišče"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6532,6 +6532,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6856,10 +6860,6 @@ msgstr "Hiq Serverat"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Hiq te gjithe Serverat"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6508,6 +6508,10 @@ msgstr "Sök relaterade filer (eD2k, lokal server)"
 msgid "Copy eD2k link to clipboard"
 msgstr "Kopiera eD2k-länken till urklipp"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Kopiera eD2k länkar till Urklipp"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6830,10 +6834,6 @@ msgstr "Ta bort servrar"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Ta bort alla servrar"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Kopiera eD2k länkar till Urklipp"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6315,6 +6315,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6628,10 +6632,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6475,6 +6475,10 @@ msgstr "İlgili dosyaları ara (eD2k, yerel sunucu)"
 msgid "Copy eD2k link to clipboard"
 msgstr "eD2k bağlantısını panoya kopyala"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "eD2k bağlantısını panoya kopyala"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "Şu anda İlgili Dosyalar arama işlevini destekleyen bir sunucuya bağlı değilsiniz"
@@ -6795,10 +6799,6 @@ msgstr "Sunucuları kaldır"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Bütün sunucuları kaldır"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "eD2k bağlantısını panoya kopyala"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6569,6 +6569,10 @@ msgstr "Пошук схожих файлів (eD2k, місцевий серве�
 msgid "Copy eD2k link to clipboard"
 msgstr "Скопіювати eD2k посилання до буферу обміну"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "Скопіювати eD2k посилання до буферу обміну"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6896,10 +6900,6 @@ msgstr "Видалити сервери"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "Видалити всі сервери"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "Скопіювати eD2k посилання до буферу обміну"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6314,6 +6314,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard"
 msgstr ""
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr ""
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr ""
@@ -6627,10 +6631,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6464,6 +6464,10 @@ msgstr "搜索相关文件（eD2k，本地服务器）"
 msgid "Copy eD2k link to clipboard"
 msgstr "复制eD2k链接至剪贴板"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "复制eD2k链接至剪贴板"
+
 #: src/SearchListCtrl.cpp
 msgid "You are not currently connected to a server supporting the Related Files search function"
 msgstr "当前未连接到支持“相关文件”搜索功能的服务器"
@@ -6778,10 +6782,6 @@ msgstr "删除服务器"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "删除所有服务器"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "复制eD2k链接至剪贴板"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 11:53+0200\n"
+"POT-Creation-Date: 2026-08-14 12:55+0200\n"
 "PO-Revision-Date: 2026-08-13 11:54+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6494,6 +6494,10 @@ msgstr "搜尋相關檔案 (eD2k，本地伺服器)"
 msgid "Copy eD2k link to clipboard"
 msgstr "複製 eD2k 連結到剪貼簿"
 
+#: src/SearchListCtrl.cpp src/ServerListCtrl.cpp
+msgid "Copy eD2k links to clipboard"
+msgstr "複製 eD2k 連結到剪貼簿"
+
 #: src/SearchListCtrl.cpp
 #, fuzzy
 msgid "You are not currently connected to a server supporting the Related Files search function"
@@ -6813,10 +6817,6 @@ msgstr "移除伺服器"
 #: src/ServerListCtrl.cpp
 msgid "Remove all servers"
 msgstr "移除所有伺服器"
-
-#: src/ServerListCtrl.cpp
-msgid "Copy eD2k links to clipboard"
-msgstr "複製 eD2k 連結到剪貼簿"
 
 #: src/ServerListCtrl.cpp
 msgid "Reconnect to server"

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -712,11 +712,16 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 		menu.Append(MP_SEARCHRELATED, _("Search related files (eD2k, local server)"));
 		menu.Append(MP_GETCOMMENTS, _("Show all comments"));
 		menu.AppendSeparator();
-		menu.Append(MP_GETED2KLINK, _("Copy eD2k link to clipboard"));
+		// Singular or plural to match what it will copy, the same way the
+		// server list labels it. OnPopupGetUrl has always walked the whole
+		// selection and joined the links with newlines -- it was only ever
+		// the menu that stopped it being handed more than one.
+		const bool single = (GetSelectedItemCount() == 1);
+		menu.Append(MP_GETED2KLINK,
+			single ? _("Copy eD2k link to clipboard") : _("Copy eD2k links to clipboard"));
 
-		const bool enable = (GetSelectedItemCount() == 1);
-		menu.Enable(MP_GETED2KLINK, enable);
-		menu.Enable(MP_GETCOMMENTS, enable);
+		// Comments stays single-only: it opens a modal dialog for one result.
+		menu.Enable(MP_GETCOMMENTS, single);
 		menu.Enable(MP_MENU_CATS, (theApp->glob_prefs->GetCatCount() > 1));
 
 		PopupMenu(&menu, event.GetPosition());


### PR DESCRIPTION
Selecting several search results and asking for their eD2k links gave a greyed-out menu entry, so the only way to collect more than one link was to copy them one at a time.

Nothing but the menu was stopping it. `OnPopupGetUrl` has always walked the whole selection and joined the links with newlines, and the download and preview entries directly above it are already multi-selection aware. The enable line simply lumped `MP_GETED2KLINK` in with `MP_GETCOMMENTS`, which does need a single result because it opens a modal dialog for one file.

This drops the link entry from that gate and labels it singular or plural to match what it will copy, the same way `CServerListCtrl` already labels the equivalent server entry. Both labels are existing msgids, so the catalogs are unchanged.

Not a regression from the wxDataView port: `git show 563f3b297^:src/SearchListCtrl.cpp` carries the identical gate under the comment `// These should only be enabled for single-selections`, and the pre-port handler also looped over every selection.

### Testing

Built and exercised on macOS: multi-select in a search result list, copy, and confirm the clipboard holds one `ed2k://` link per selected result. Single selection still reads "Copy eD2k link to clipboard" and comments stays single-only.
