### PR TITLE
feat(gui): show a browsed peer's shared files as a folder tree

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -68,6 +68,7 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 		amuleDlg.cpp
 		AboutDialog.cpp
 		VersionCheck.cpp
+		BrowseListModel.cpp
 		CatDialog.cpp
 		ChatSelector.cpp
 		ChatWnd.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6297,6 +6297,14 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6400,6 +6400,14 @@ msgstr "غير مقيم"
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6519,6 +6519,15 @@ msgstr "Non evaluada"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Zarrar toles llingüetes"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:37+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6375,6 +6375,14 @@ msgstr "Няма оценки"
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6296,6 +6296,14 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6490,6 +6490,15 @@ msgstr "Sense Valorar"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Tanca totes les pestanyes"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:38+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6498,6 +6498,15 @@ msgstr "Nehodnocené"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Zavřít všechny taby"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6419,6 +6419,15 @@ msgstr "Ikke anslået"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Luk alle tabs"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:39+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6486,6 +6486,15 @@ msgstr "Nicht bewertet"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Alle Reiter schließen"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:40+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6531,6 +6531,15 @@ msgstr "Μη αποτιμημένο"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Κλείσιμο όλων των καρτελών"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6297,6 +6297,14 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6470,6 +6470,15 @@ msgstr "Tasa de bits"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Códec"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Cerrar todas las pestañas"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6495,6 +6495,15 @@ msgstr "Pole hinnatud"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Sulge kõik lehed"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6494,6 +6494,15 @@ msgstr "Kalifikatu gabea"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Itxi fitxa guztiak"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:42+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6494,6 +6494,15 @@ msgstr "Ei luokitusta"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Sulje kaikki välilehdet"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6464,6 +6464,15 @@ msgstr "Débit binaire"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Codec"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Fermer tous les onglets"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:43+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6500,6 +6500,15 @@ msgstr "Non evaluada"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Pechar todas as lapelas"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6457,6 +6457,14 @@ msgstr "לא מדורג"
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:44+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6443,6 +6443,15 @@ msgstr "Bez ocjene"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Zatvori sve oznake"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6466,6 +6466,15 @@ msgstr "Nincs értékelve"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Az összes fül bezárása"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:45+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6453,6 +6453,15 @@ msgstr "Bitrate"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Codec"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Chiudi tutte le schede"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6489,6 +6489,15 @@ msgstr "評価されていません"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "全てのタブを閉める"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6523,6 +6523,15 @@ msgstr "선택되지 않은"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "모든 탭 닫기"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:46+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6547,6 +6547,15 @@ msgstr "Nevertinta"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Užverti visas korteles"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6338,6 +6338,15 @@ msgstr "Bitu pārraides ātrums"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Kodeks"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Aizvērt visas cilnes"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6495,6 +6495,15 @@ msgstr "Niet beoordeeld"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Sluit alle tabbladen"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:47+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6524,6 +6524,15 @@ msgstr "Ikkje gitt verdi"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Stengje alle faneblad"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:48+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6527,6 +6527,15 @@ msgstr "Nieoceniony"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Zamknij wszystkie karty"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6450,6 +6450,15 @@ msgstr "Taxa de Bits"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Codec"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Fechar todas as abas"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:49+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6502,6 +6502,15 @@ msgstr "Não avaliado"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Fechar todos os separadores"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6510,6 +6510,15 @@ msgstr "Nu este apreciat"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Închide toate ferestrele"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:50+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6499,6 +6499,15 @@ msgstr "Битрейт"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Кодек"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Закрыть все вкладки"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6544,6 +6544,15 @@ msgstr "Ni ocenjena"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Zapri vse zavihke"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:51+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6514,6 +6514,15 @@ msgstr "E pavotuar"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Mbylli te gjitha tabelat"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6490,6 +6490,15 @@ msgstr "Inte betygsatt"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Stäng alla flikar"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:55+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6296,6 +6296,14 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6457,6 +6457,15 @@ msgstr "Akış hızı"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "Kodlama"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Tüm sekmeleri kapat"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6551,6 +6551,15 @@ msgstr "Без рейтингу"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "Закрити всі вкладки"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6295,6 +6295,14 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Codec"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Collapse all"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:53+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6446,6 +6446,15 @@ msgstr "比特率"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr "编解码器"
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "关闭所有分页"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 12:55+0200\n"
+"POT-Creation-Date: 2026-08-14 13:50+0200\n"
 "PO-Revision-Date: 2026-08-13 11:54+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6476,6 +6476,15 @@ msgstr "未評價"
 #: src/SearchListCtrl.cpp
 msgid "Codec"
 msgstr ""
+
+#: src/SearchListCtrl.cpp
+msgid "Expand all"
+msgstr ""
+
+#: src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Collapse all"
+msgstr "關閉所有分頁"
 
 #: src/SearchListCtrl.cpp
 msgid "Download in category"

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -1,0 +1,205 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "BrowseListModel.h"
+
+#include "SearchFile.h"
+#include "SearchList.h"
+#include "SearchListCtrl.h"
+#include "amule.h"
+
+CBrowseListModel::CBrowseListModel(CSearchListCtrl *owner)
+: CSearchListModel(owner)
+{
+}
+
+bool CBrowseListModel::IsFolder(const wxDataViewItem &item) const
+{
+	return item.IsOk() && m_folderAddresses.count(item.GetID()) != 0;
+}
+
+void CBrowseListModel::RebuildFolders() const
+{
+	for (auto &entry : m_folders) {
+		entry.second->m_files.clear();
+	}
+	m_looseFiles.clear();
+
+	if (!m_owner->GetSearchId()) {
+		return;
+	}
+
+	const CSearchResultList &results = theApp->searchlist->GetSearchResults(m_owner->GetSearchId());
+	for (CSearchFile *file : results) {
+		if (file->GetParent() || !m_owner->ShouldShow(file)) {
+			continue;
+		}
+
+		const wxString &directory = file->GetDirectory();
+		if (directory.IsEmpty()) {
+			m_looseFiles.push_back(file);
+			continue;
+		}
+
+		auto it = m_folders.find(directory);
+		if (it == m_folders.end()) {
+			it = m_folders.emplace(directory, std::make_unique<CBrowseFolderNode>(directory))
+				     .first;
+			m_folderAddresses.insert(it->second.get());
+		}
+		it->second->m_files.push_back(file);
+	}
+}
+
+unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataViewItemArray &children) const
+{
+	if (!item.IsOk()) {
+		RebuildFolders();
+
+		unsigned int count = 0;
+		for (const auto &entry : m_folders) {
+			// A folder whose results have all gone away, or are all
+			// filtered out, is not drawn -- its node stays allocated so
+			// that any item the control still holds remains readable.
+			if (!entry.second->m_files.empty()) {
+				children.Add(ToItem(entry.second.get()));
+				++count;
+			}
+		}
+		for (CSearchFile *file : m_looseFiles) {
+			children.Add(CSearchListModel::ToItem(file));
+			++count;
+		}
+		return count;
+	}
+
+	if (IsFolder(item)) {
+		const CBrowseFolderNode *folder = ToFolder(item);
+		for (CSearchFile *file : folder->m_files) {
+			children.Add(CSearchListModel::ToItem(file));
+		}
+		return folder->m_files.size();
+	}
+
+	// A result under a folder still groups its own alternative sources.
+	return CSearchListModel::GetChildren(item, children);
+}
+
+wxDataViewItem CBrowseListModel::GetParent(const wxDataViewItem &item) const
+{
+	if (!item.IsOk() || IsFolder(item)) {
+		return wxDataViewItem(); // folders sit at the top level
+	}
+
+	CSearchFile *file = ToFile(item);
+	if (file->GetParent()) {
+		return CSearchListModel::GetParent(item);
+	}
+
+	const wxString &directory = file->GetDirectory();
+	if (directory.IsEmpty()) {
+		return wxDataViewItem();
+	}
+
+	const auto it = m_folders.find(directory);
+	return it != m_folders.end() ? ToItem(it->second.get()) : wxDataViewItem();
+}
+
+bool CBrowseListModel::IsContainer(const wxDataViewItem &item) const
+{
+	if (!item.IsOk()) {
+		return true; // invisible root
+	}
+	if (IsFolder(item)) {
+		return true;
+	}
+	return CSearchListModel::IsContainer(item);
+}
+
+bool CBrowseListModel::HasContainerColumns(const wxDataViewItem &item) const
+{
+	if (IsFolder(item)) {
+		return false;
+	}
+	return CSearchListModel::HasContainerColumns(item);
+}
+
+void CBrowseListModel::GetValue(wxVariant &variant, const wxDataViewItem &item, unsigned int col) const
+{
+	if (!IsFolder(item)) {
+		CSearchListModel::GetValue(variant, item, col);
+		return;
+	}
+
+	// Every column has a type the control will try to read, so a folder has
+	// to answer for all of them even though it only has a name.
+	switch (col) {
+	case COL_NAME:
+		variant = ToFolder(item)->GetName();
+		break;
+
+	case COL_RATING:
+		variant << wxDataViewIconText(wxEmptyString, wxIcon());
+		break;
+
+	default:
+		variant = wxEmptyString;
+		break;
+	}
+}
+
+bool CBrowseListModel::GetAttr(const wxDataViewItem &item, unsigned int col, wxDataViewItemAttr &attr) const
+{
+	if (!IsFolder(item)) {
+		return CSearchListModel::GetAttr(item, col, attr);
+	}
+
+	// The colours the base model picks encode a result's download state,
+	// which a folder does not have. Bold instead, so the grouping reads as
+	// structure rather than as a result in some unexplained state.
+	attr.SetBold(true);
+	return true;
+}
+
+int CBrowseListModel::Compare(
+	const wxDataViewItem &item1, const wxDataViewItem &item2, unsigned int column, bool ascending) const
+{
+	const bool folder1 = IsFolder(item1);
+	const bool folder2 = IsFolder(item2);
+
+	if (folder1 != folder2) {
+		// Folders first, whatever the sort column and direction: they are
+		// the structure the results sit in, and interleaving them with the
+		// loose results would read as an ordering accident.
+		return folder1 ? -1 : 1;
+	}
+
+	if (folder1) {
+		const int result = ToFolder(item1)->GetName().CmpNoCase(ToFolder(item2)->GetName());
+		return ascending ? result : -result;
+	}
+
+	return CSearchListModel::Compare(item1, item2, column, ascending);
+}
+// File_checked_for_headers

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -48,10 +48,10 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path) const
 
 	// Split off the last segment: whichever separator appears last is the
 	// one this peer uses, so a name containing the other one stays intact.
-	const int slash = static_cast<int>(path.find_last_of("/\\"));
-	CBrowseFolderNode *parent = NULL;
+	const size_t slash = path.find_last_of("/\\");
+	CBrowseFolderNode *parent = nullptr;
 	wxString name = path;
-	if (slash != static_cast<int>(wxString::npos)) {
+	if (slash != wxString::npos) {
 		name = path.Mid(slash + 1);
 		const wxString parentPath = path.Left(slash);
 		// A leading or doubled separator leaves an empty parent path,

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -39,10 +39,56 @@ bool CBrowseListModel::IsFolder(const wxDataViewItem &item) const
 	return item.IsOk() && m_folderAddresses.count(item.GetID()) != 0;
 }
 
+CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path) const
+{
+	const auto existing = m_folders.find(path);
+	if (existing != m_folders.end()) {
+		return existing->second.get();
+	}
+
+	// Split off the last segment: whichever separator appears last is the
+	// one this peer uses, so a name containing the other one stays intact.
+	const int slash = static_cast<int>(path.find_last_of("/\\"));
+	CBrowseFolderNode *parent = NULL;
+	wxString name = path;
+	if (slash != static_cast<int>(wxString::npos)) {
+		name = path.Mid(slash + 1);
+		const wxString parentPath = path.Left(slash);
+		// A leading or doubled separator leaves an empty parent path,
+		// which is no directory at all -- this node is a root.
+		if (!parentPath.IsEmpty()) {
+			parent = EnsureFolder(parentPath);
+		}
+	}
+
+	CBrowseFolderNode *node = m_folders.emplace(path, std::make_unique<CBrowseFolderNode>(name, parent))
+					  .first->second.get();
+	m_folderAddresses.insert(node);
+	if (!parent) {
+		m_rootFolders.push_back(node);
+	}
+	return node;
+}
+
 void CBrowseListModel::RebuildFolders() const
 {
+	// Once per change, not once per query. The control asks for the root's
+	// children several times per rebuild -- twice from OnIdleHook alone, to
+	// save and restore expansion around a Cleared() -- and this walks every
+	// result, which on a large share is the cost the browse throttle exists
+	// to keep down (issue #898).
+	const unsigned generation = GetContentGeneration();
+	const wxUIntPtr searchId = m_owner->GetSearchId();
+	if (m_foldersValid && m_foldersGeneration == generation && m_foldersSearchId == searchId) {
+		return;
+	}
+	m_foldersValid = true;
+	m_foldersGeneration = generation;
+	m_foldersSearchId = searchId;
+
 	for (auto &entry : m_folders) {
 		entry.second->m_files.clear();
+		entry.second->m_subfolders.clear();
 	}
 	m_looseFiles.clear();
 
@@ -62,14 +108,37 @@ void CBrowseListModel::RebuildFolders() const
 			continue;
 		}
 
-		auto it = m_folders.find(directory);
-		if (it == m_folders.end()) {
-			it = m_folders.emplace(directory, std::make_unique<CBrowseFolderNode>(directory))
-				     .first;
-			m_folderAddresses.insert(it->second.get());
-		}
-		it->second->m_files.push_back(file);
+		EnsureFolder(directory)->m_files.push_back(file);
 	}
+
+	// Relink the hierarchy. Done as a second pass rather than while
+	// creating the nodes, because the links are cleared on every rebuild
+	// while the nodes outlive it: a folder created for an earlier refresh
+	// still has to be reattached to its parent on this one.
+	//
+	// Unconditionally, empty or not. Whether a folder is worth drawing
+	// depends on what is under it at any depth, which is not knowable until
+	// every link exists -- so that question is asked at GetChildren() time
+	// instead, once the tree is whole.
+	for (const auto &entry : m_folders) {
+		CBrowseFolderNode *node = entry.second.get();
+		if (node->GetParent()) {
+			node->GetParent()->m_subfolders.push_back(node);
+		}
+	}
+}
+
+bool CBrowseListModel::HasContent(const CBrowseFolderNode *folder)
+{
+	if (!folder->m_files.empty()) {
+		return true;
+	}
+	for (const CBrowseFolderNode *sub : folder->m_subfolders) {
+		if (HasContent(sub)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataViewItemArray &children) const
@@ -78,12 +147,12 @@ unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataVie
 		RebuildFolders();
 
 		unsigned int count = 0;
-		for (const auto &entry : m_folders) {
+		for (CBrowseFolderNode *folder : m_rootFolders) {
 			// A folder whose results have all gone away, or are all
 			// filtered out, is not drawn -- its node stays allocated so
 			// that any item the control still holds remains readable.
-			if (!entry.second->m_files.empty()) {
-				children.Add(ToItem(entry.second.get()));
+			if (HasContent(folder)) {
+				children.Add(ToItem(folder));
 				++count;
 			}
 		}
@@ -96,10 +165,18 @@ unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataVie
 
 	if (IsFolder(item)) {
 		const CBrowseFolderNode *folder = ToFolder(item);
+		unsigned int count = 0;
+		for (CBrowseFolderNode *sub : folder->m_subfolders) {
+			if (HasContent(sub)) {
+				children.Add(ToItem(sub));
+				++count;
+			}
+		}
 		for (CSearchFile *file : folder->m_files) {
 			children.Add(CSearchListModel::ToItem(file));
+			++count;
 		}
-		return folder->m_files.size();
+		return count;
 	}
 
 	// A result under a folder still groups its own alternative sources.
@@ -108,8 +185,13 @@ unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataVie
 
 wxDataViewItem CBrowseListModel::GetParent(const wxDataViewItem &item) const
 {
-	if (!item.IsOk() || IsFolder(item)) {
-		return wxDataViewItem(); // folders sit at the top level
+	if (!item.IsOk()) {
+		return wxDataViewItem();
+	}
+
+	if (IsFolder(item)) {
+		CBrowseFolderNode *parent = ToFolder(item)->GetParent();
+		return parent ? ToItem(parent) : wxDataViewItem();
 	}
 
 	CSearchFile *file = ToFile(item);

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -40,18 +40,24 @@
 class CBrowseFolderNode
 {
 public:
-	explicit CBrowseFolderNode(const wxString &name)
+	CBrowseFolderNode(const wxString &name, CBrowseFolderNode *parent)
 	: m_name(name)
+	, m_parent(parent)
 	{
 	}
 
+	//! This folder's own name, not its path: the tree shows the rest.
 	const wxString &GetName() const noexcept { return m_name; }
+	CBrowseFolderNode *GetParent() const noexcept { return m_parent; }
 
-	//! The results filed under this folder, refreshed on every rebuild.
+	//! Sub-folders and the results filed directly here. Both are rebuilt
+	//! from scratch on every refresh; the nodes themselves outlive it.
+	std::vector<CBrowseFolderNode *> m_subfolders;
 	std::vector<CSearchFile *> m_files;
 
 private:
 	wxString m_name;
+	CBrowseFolderNode *m_parent;
 };
 
 /**
@@ -63,11 +69,19 @@ private:
  * group by, and nothing about its model should have to know that folders are
  * a possibility.
  *
- * The grouping is one level deep, one node per distinct directory string.
- * The protocol hands us a set of directory names (OP_ASKSHAREDFILESDIRANS,
- * one response per directory), not a hierarchy, and the names are the remote
- * host's own -- splitting them into a deeper tree would mean guessing at a
- * path separator that may be '\', '/', or neither.
+ * The directory strings nest. A peer names each shared directory by walking
+ * up from it for as long as the parent is also shared and joining that run
+ * (CSharedFileList::GetPublicSharedDirName), so what arrives is a relative
+ * path -- "Shared/Movies/Action" -- rather than a flat label or an absolute
+ * path. Splitting it back into segments reproduces the peer's own layout.
+ *
+ * Both separators are split on. The sender uses its own platform's
+ * wxFileName::GetPathSeparator(), so a Windows peer sends backslashes and a
+ * POSIX peer forward slashes, and there is nothing in the packet saying
+ * which. A directory whose name genuinely contains the other platform's
+ * separator would split into segments that were never real folders; that is
+ * the trade eMule makes here too, and it costs a cosmetic mis-grouping
+ * rather than a wrong file.
  *
  * Peers that answer the older whole-list request send no directory at all
  * (ClientTCPSocket, OP_ASKSHAREDFILESANSWER passes an empty string). Those
@@ -114,17 +128,32 @@ private:
 	 * keeps no copy of the result set (see CSearchListModel) and the folders
 	 * are derived from whatever it holds right now.
 	 *
-	 * Nodes are keyed by directory name and never erased while the model
+	 * Nodes are keyed by their full path and never erased while the model
 	 * lives: the control may still be holding an item for a folder whose
 	 * last result just went away, and that pointer has to stay readable. A
-	 * node with no files is simply not reported as a child.
+	 * node with nothing under it is simply not reported as a child.
 	 */
 	void RebuildFolders() const;
 
-	//! Directory name -> node. unique_ptr so that a rebuild that inserts a
-	//! new directory cannot move the existing nodes: the control holds their
-	//! addresses as item IDs.
+	//! Returns the node for @a path, creating it and every missing ancestor.
+	CBrowseFolderNode *EnsureFolder(const wxString &path) const;
+
+	//! Whether anything at all is under @a folder, at any depth. A folder
+	//! that only holds other empty folders is not worth a row.
+	static bool HasContent(const CBrowseFolderNode *folder);
+
+	//! Full path -> node. unique_ptr so that a rebuild that inserts a new
+	//! directory cannot move the existing nodes: the control holds their
+	//! addresses as item IDs, and so do the parent links.
 	mutable std::map<wxString, std::unique_ptr<CBrowseFolderNode>> m_folders;
+
+	//! The nodes with no parent, in insertion order of first appearance.
+	mutable std::vector<CBrowseFolderNode *> m_rootFolders;
+
+	//! What the cached grouping above was built from; see RebuildFolders().
+	mutable bool m_foldersValid = false;
+	mutable unsigned m_foldersGeneration = 0;
+	mutable wxUIntPtr m_foldersSearchId = 0;
 
 	//! Every address in m_folders, for IsFolder(). The item is a bare void*
 	//! with nothing to distinguish it, so membership here is what makes the

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -29,6 +29,7 @@
 
 #include <map>    // Needed for std::map (the folder registry)
 #include <memory> // Needed for std::unique_ptr (stable folder node addresses)
+#include <set>    // Needed for std::set (the folder-address lookup)
 
 /**
  * A folder in a browsed peer's shared-file listing.
@@ -87,6 +88,15 @@ private:
  * (ClientTCPSocket, OP_ASKSHAREDFILESANSWER passes an empty string). Those
  * results have no folder to sit under and stay at the top level, so browsing
  * such a peer looks exactly like it did before folders existed.
+ *
+ * The incremental add path does not know about folders, and does not need to.
+ * CSearchListModel::FlushPending() announces every parentless result under
+ * the invisible root, which is not where this model puts them -- but
+ * incremental notifications are only enabled on __WXOSX__, and
+ * wxCocoaDataViewControl::Add() discards the items it is given and calls
+ * [NSOutlineView reloadData], which re-reads the tree through GetChildren().
+ * GTK and MSW take the Cleared() branch, which re-reads it too. Either way
+ * the grouping below is what the control ends up drawing.
  */
 class CBrowseListModel : public CSearchListModel
 {

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -1,0 +1,140 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef BROWSELISTMODEL_H
+#define BROWSELISTMODEL_H
+
+#include "SearchListModel.h"
+
+#include <map>    // Needed for std::map (the folder registry)
+#include <memory> // Needed for std::unique_ptr (stable folder node addresses)
+
+/**
+ * A folder in a browsed peer's shared-file listing.
+ *
+ * Not a CSearchFile: it has no hash, no size and no sources, and every
+ * operation the search list offers on a result is meaningless for it. It
+ * exists only to be a wxDataViewItem the control can draw and expand.
+ */
+class CBrowseFolderNode
+{
+public:
+	explicit CBrowseFolderNode(const wxString &name)
+	: m_name(name)
+	{
+	}
+
+	const wxString &GetName() const noexcept { return m_name; }
+
+	//! The results filed under this folder, refreshed on every rebuild.
+	std::vector<CSearchFile *> m_files;
+
+private:
+	wxString m_name;
+};
+
+/**
+ * The model behind a browse tab: the same result list as a search, grouped
+ * under the directories the peer reported.
+ *
+ * Extends rather than alters CSearchListModel, because a browse is the only
+ * place folders exist -- an ordinary Kad/eD2k search has no directory to
+ * group by, and nothing about its model should have to know that folders are
+ * a possibility.
+ *
+ * The grouping is one level deep, one node per distinct directory string.
+ * The protocol hands us a set of directory names (OP_ASKSHAREDFILESDIRANS,
+ * one response per directory), not a hierarchy, and the names are the remote
+ * host's own -- splitting them into a deeper tree would mean guessing at a
+ * path separator that may be '\', '/', or neither.
+ *
+ * Peers that answer the older whole-list request send no directory at all
+ * (ClientTCPSocket, OP_ASKSHAREDFILESANSWER passes an empty string). Those
+ * results have no folder to sit under and stay at the top level, so browsing
+ * such a peer looks exactly like it did before folders existed.
+ */
+class CBrowseListModel : public CSearchListModel
+{
+public:
+	explicit CBrowseListModel(CSearchListCtrl *owner);
+
+	bool IsFolder(const wxDataViewItem &item) const wxOVERRIDE;
+
+	// wxDataViewModel interface. Each of these has to answer for folder
+	// items, which the base class would hand to ToFile() and read as a
+	// CSearchFile.
+	void GetValue(wxVariant &variant, const wxDataViewItem &item, unsigned int col) const wxOVERRIDE;
+	bool GetAttr(const wxDataViewItem &item, unsigned int col, wxDataViewItemAttr &attr) const wxOVERRIDE;
+	wxDataViewItem GetParent(const wxDataViewItem &item) const wxOVERRIDE;
+	bool IsContainer(const wxDataViewItem &item) const wxOVERRIDE;
+	//! False for a folder: it is a section header with a name and nothing
+	//! else, unlike a grouped result, which is a row in its own right.
+	bool HasContainerColumns(const wxDataViewItem &item) const wxOVERRIDE;
+	unsigned int GetChildren(const wxDataViewItem &item, wxDataViewItemArray &children) const wxOVERRIDE;
+	int Compare(const wxDataViewItem &item1,
+		const wxDataViewItem &item2,
+		unsigned int column,
+		bool ascending) const wxOVERRIDE;
+
+private:
+	static CBrowseFolderNode *ToFolder(const wxDataViewItem &item)
+	{
+		return static_cast<CBrowseFolderNode *>(item.GetID());
+	}
+	static wxDataViewItem ToItem(const CBrowseFolderNode *folder)
+	{
+		return wxDataViewItem(const_cast<CBrowseFolderNode *>(folder));
+	}
+
+	/**
+	 * Re-files the current results under their directories.
+	 *
+	 * Called from the const tree accessors, because the model deliberately
+	 * keeps no copy of the result set (see CSearchListModel) and the folders
+	 * are derived from whatever it holds right now.
+	 *
+	 * Nodes are keyed by directory name and never erased while the model
+	 * lives: the control may still be holding an item for a folder whose
+	 * last result just went away, and that pointer has to stay readable. A
+	 * node with no files is simply not reported as a child.
+	 */
+	void RebuildFolders() const;
+
+	//! Directory name -> node. unique_ptr so that a rebuild that inserts a
+	//! new directory cannot move the existing nodes: the control holds their
+	//! addresses as item IDs.
+	mutable std::map<wxString, std::unique_ptr<CBrowseFolderNode>> m_folders;
+
+	//! Every address in m_folders, for IsFolder(). The item is a bare void*
+	//! with nothing to distinguish it, so membership here is what makes the
+	//! difference between a folder and a result answerable at all.
+	mutable std::set<const void *> m_folderAddresses;
+
+	//! Results the peer reported with no directory. Top level, next to the
+	//! folders.
+	mutable std::vector<CSearchFile *> m_looseFiles;
+};
+
+#endif // BROWSELISTMODEL_H
+// File_checked_for_headers

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -37,6 +37,7 @@
 #include "ServerConnect.h"    // Needed for CServerConnect
 #include "SearchList.h"       // Needed for CSearchFile
 #include "updownclient.h"     // Needed for BROWSE_IN_PROGRESS
+#include "BrowseListModel.h"  // Needed for CBrowseListModel
 #include "SearchListModel.h"  // Needed for CSearchListModel
 #include "GetTickCount.h"     // Needed for GetTickCount64()
 #include "CommentDialogLst.h" // Needed for CCommentDialogLst (Kad comments/ratings)
@@ -359,7 +360,7 @@ CSearchFile *CSearchListCtrl::GetFocusedFile() const
 {
 	wxDataViewItemArray selections;
 	GetSelections(selections);
-	if (selections.empty()) {
+	if (selections.empty() || m_model->IsFolder(selections[0])) {
 		return NULL;
 	}
 	return CSearchListModel::ToFile(selections[0]);
@@ -373,6 +374,9 @@ std::vector<CSearchFile *> CSearchListCtrl::GetSelectedFiles() const
 	std::vector<CSearchFile *> files;
 	files.reserve(selections.GetCount());
 	for (const wxDataViewItem &item : selections) {
+		if (m_model->IsFolder(item)) {
+			continue;
+		}
 		if (CSearchFile *file = CSearchListModel::ToFile(item)) {
 			files.push_back(file);
 		}
@@ -380,10 +384,30 @@ std::vector<CSearchFile *> CSearchListCtrl::GetSelectedFiles() const
 	return files;
 }
 
+void CSearchListCtrl::SetBrowseEcid(uint32 ecid)
+{
+	const bool wasBrowse = IsBrowse();
+	m_browseEcid = ecid;
+
+	// Only on the transition into browsing. A re-browse of the same peer
+	// comes back through here with the same ECID, and swapping the model
+	// again would throw away the folders the user has open.
+	if (!ecid || wasBrowse) {
+		return;
+	}
+
+	m_model = new CBrowseListModel(this);
+	AssociateModel(m_model);
+	m_model->DecRef(); // the control now holds the only reference
+}
+
 int CSearchListCtrl::GetSelectedItemCount() const
 {
-	wxDataViewItemArray selections;
-	return static_cast<int>(const_cast<CSearchListCtrl *>(this)->GetSelections(selections));
+	// Results, not rows. A browse tab has folders in the tree, and every
+	// caller of this is asking how many things it can act on -- a menu it is
+	// about to enable, a download it is about to queue. Counting a selected
+	// folder would enable an action with nothing behind it.
+	return static_cast<int>(GetSelectedFiles().size());
 }
 
 int CSearchListCtrl::CompareFilesByColumn(

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -362,10 +362,16 @@ CSearchFile *CSearchListCtrl::GetFocusedFile() const
 {
 	wxDataViewItemArray selections;
 	GetSelections(selections);
-	if (selections.empty() || m_model->IsFolder(selections[0])) {
-		return NULL;
+	// The first selected result, not the first selected item: a folder
+	// picked up alongside one would otherwise make this give up, while
+	// GetSelectedItemCount() -- which counts results -- still enables the
+	// menu entry that calls it.
+	for (const wxDataViewItem &item : selections) {
+		if (!m_model->IsFolder(item)) {
+			return CSearchListModel::ToFile(item);
+		}
 	}
-	return CSearchListModel::ToFile(selections[0]);
+	return nullptr;
 }
 
 std::vector<CSearchFile *> CSearchListCtrl::GetSelectedFiles() const
@@ -844,7 +850,7 @@ void CSearchListCtrl::SetSubtreeExpanded(const wxDataViewItem &item, bool expand
 	wxDataViewItemArray children;
 	m_model->GetChildren(item, children);
 	for (const wxDataViewItem &child : children) {
-		if (m_model->IsContainer(child)) {
+		if (m_model->IsFolder(child)) {
 			SetSubtreeExpanded(child, expand);
 		}
 	}

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -355,6 +355,31 @@ size_t CSearchListCtrl::GetItemCount() const
 	return shown;
 }
 
+CSearchFile *CSearchListCtrl::GetFocusedFile() const
+{
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+	if (selections.empty()) {
+		return NULL;
+	}
+	return CSearchListModel::ToFile(selections[0]);
+}
+
+std::vector<CSearchFile *> CSearchListCtrl::GetSelectedFiles() const
+{
+	wxDataViewItemArray selections;
+	GetSelections(selections);
+
+	std::vector<CSearchFile *> files;
+	files.reserve(selections.GetCount());
+	for (const wxDataViewItem &item : selections) {
+		if (CSearchFile *file = CSearchListModel::ToFile(item)) {
+			files.push_back(file);
+		}
+	}
+	return files;
+}
+
 int CSearchListCtrl::GetSelectedItemCount() const
 {
 	wxDataViewItemArray selections;
@@ -757,10 +782,7 @@ void CSearchListCtrl::OnSelectionChanged(wxDataViewEvent &WXUNUSED(event))
 void CSearchListCtrl::OnPopupGetUrl(wxCommandEvent &WXUNUSED(event))
 {
 	wxString URIs;
-	wxDataViewItemArray selections;
-	GetSelections(selections);
-	for (const wxDataViewItem &item : selections) {
-		CSearchFile *file = CSearchListModel::ToFile(item);
+	for (CSearchFile *file : GetSelectedFiles()) {
 		URIs += theApp->CreateED2kLink(file) + "\n";
 	}
 	if (!URIs.IsEmpty()) {
@@ -770,12 +792,7 @@ void CSearchListCtrl::OnPopupGetUrl(wxCommandEvent &WXUNUSED(event))
 
 void CSearchListCtrl::OnGetComments(wxCommandEvent &WXUNUSED(event))
 {
-	wxDataViewItemArray selections;
-	GetSelections(selections);
-	if (selections.empty()) {
-		return;
-	}
-	CSearchFile *file = CSearchListModel::ToFile(selections[0]);
+	CSearchFile *file = GetFocusedFile();
 	if (file) {
 		// Same dialog the download list uses; its "Get from Kad" button drives
 		// the on-demand community ratings/comments lookup for this result.
@@ -786,20 +803,19 @@ void CSearchListCtrl::OnGetComments(wxCommandEvent &WXUNUSED(event))
 
 void CSearchListCtrl::OnRazorStatsCheck(wxCommandEvent &WXUNUSED(event))
 {
-	wxDataViewItemArray selections;
-	GetSelections(selections);
-	if (selections.empty()) {
+	CSearchFile *file = GetFocusedFile();
+	if (!file) {
 		return;
 	}
-	CSearchFile *file = CSearchListModel::ToFile(selections[0]);
 	theApp->amuledlg->LaunchUrl(thePrefs::GetStatsServerURL() + file->GetFileHash().Encode());
 }
 
 void CSearchListCtrl::OnRelatedSearch(wxCommandEvent &WXUNUSED(event))
 {
-	wxDataViewItemArray selections;
-	GetSelections(selections);
-	if (selections.empty()) {
+	// Every selected result, not just the focused one: the keyword this
+	// builds is a "related" query over all of their hashes.
+	const std::vector<CSearchFile *> files = GetSelectedFiles();
+	if (files.empty()) {
 		return;
 	}
 
@@ -809,8 +825,7 @@ void CSearchListCtrl::OnRelatedSearch(wxCommandEvent &WXUNUSED(event))
 		theApp->searchlist->StopSearch(true);
 		theApp->amuledlg->m_searchwnd->ResetControls();
 		wxString keyword("related");
-		for (const wxDataViewItem &item : selections) {
-			CSearchFile *file = CSearchListModel::ToFile(item);
+		for (const CSearchFile *file : files) {
 			keyword << "::" << file->GetFileHash().Encode();
 		}
 		CastByID(IDC_SEARCHNAME, theApp->amuledlg->m_searchwnd, wxTextEntry)->SetValue(keyword);
@@ -903,10 +918,7 @@ void CSearchListCtrl::DownloadSelected(int category)
 	downloadlist->BeginBatchUpdate();
 #endif
 
-	wxDataViewItemArray selections;
-	GetSelections(selections);
-	for (const wxDataViewItem &item : selections) {
-		CSearchFile *file = CSearchListModel::ToFile(item);
+	for (CSearchFile *file : GetSelectedFiles()) {
 		// Exempt from "Hide Known Files" before queueing, so the row
 		// survives the status change this is about to cause. Results are
 		// only grouped when their hashes match (CSearchList::AddResult), so

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -61,6 +61,8 @@ wxBEGIN_EVENT_TABLE(CSearchListCtrl, CMuleDataViewCtrl)
 	EVT_MENU(MP_RAZORSTATS, CSearchListCtrl::OnRazorStatsCheck)
 	EVT_MENU(MP_SEARCHRELATED, CSearchListCtrl::OnRelatedSearch)
 	EVT_MENU(MP_GETCOMMENTS, CSearchListCtrl::OnGetComments)
+	EVT_MENU(MP_EXPANDALL, CSearchListCtrl::OnExpandAll)
+	EVT_MENU(MP_COLLAPSEALL, CSearchListCtrl::OnCollapseAll)
 	EVT_MENU(MP_RESUME, CSearchListCtrl::OnPopupDownload)
 	EVT_MENU_RANGE(MP_ASSIGNCAT, MP_ASSIGNCAT + 99, CSearchListCtrl::OnPopupDownload)
 wxEND_EVENT_TABLE()
@@ -735,6 +737,19 @@ void CSearchListCtrl::OnSortingChanged()
 
 void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 {
+	// A folder row is not a result: none of the actions below apply to it,
+	// and GetSelectedItemCount() counts results, so it would otherwise get
+	// no menu at all. Remembered rather than re-derived when the handler
+	// runs, because a right-click does not select the row on every platform.
+	m_contextFolder = m_model->IsFolder(event.GetItem()) ? event.GetItem() : wxDataViewItem();
+	if (m_contextFolder.IsOk()) {
+		wxMenu menu;
+		menu.Append(MP_EXPANDALL, _("Expand all"));
+		menu.Append(MP_COLLAPSEALL, _("Collapse all"));
+		PopupMenu(&menu, event.GetPosition());
+		return;
+	}
+
 	if (GetSelectedItemCount()) {
 		// No title -- see the identical rationale in the pre-port version
 		// (wxMenu's title parameter renders inconsistently or not at all
@@ -812,6 +827,41 @@ void CSearchListCtrl::OnPopupGetUrl(wxCommandEvent &WXUNUSED(event))
 	if (!URIs.IsEmpty()) {
 		theApp->CopyTextToClipboard(URIs.RemoveLast());
 	}
+}
+
+void CSearchListCtrl::SetSubtreeExpanded(const wxDataViewItem &item, bool expand)
+{
+	if (!item.IsOk()) {
+		return;
+	}
+
+	// Parent first when opening, last when closing: a row cannot be
+	// expanded while an ancestor of it is still collapsed.
+	if (expand) {
+		Expand(item);
+	}
+
+	wxDataViewItemArray children;
+	m_model->GetChildren(item, children);
+	for (const wxDataViewItem &child : children) {
+		if (m_model->IsContainer(child)) {
+			SetSubtreeExpanded(child, expand);
+		}
+	}
+
+	if (!expand) {
+		Collapse(item);
+	}
+}
+
+void CSearchListCtrl::OnExpandAll(wxCommandEvent &WXUNUSED(event))
+{
+	SetSubtreeExpanded(m_contextFolder, true);
+}
+
+void CSearchListCtrl::OnCollapseAll(wxCommandEvent &WXUNUSED(event))
+{
+	SetSubtreeExpanded(m_contextFolder, false);
 }
 
 void CSearchListCtrl::OnGetComments(wxCommandEvent &WXUNUSED(event))

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -162,11 +162,33 @@ public:
 	size_t GetHiddenItemCount() const;
 
 	/**
-	 * Returns the number of results currently shown (root results plus
-	 * children of expanded parents) -- equivalent to the old
-	 * wxListCtrl::GetItemCount() this tab used to report in its title.
+	 * Returns the number of results currently shown: one per top-level hit
+	 * that passes the filter, whatever is expanded.
 	 */
 	size_t GetItemCount() const;
+
+	/**
+	 * The selected result, or NULL if nothing is selected -- or if what is
+	 * selected is not a result at all.
+	 *
+	 * Every item in this control is a wxDataViewItem holding a bare pointer,
+	 * and ToFile() turns one back into a CSearchFile with an unchecked cast.
+	 * That is safe while results are the only thing in the tree; a browse
+	 * grouped by folder will put nodes in it that are not results, and a
+	 * handler that casts one anyway reads whatever is at that address.
+	 *
+	 * These two accessors exist so that there is one place to answer the
+	 * question instead of a dozen. The check itself lands with the folder
+	 * nodes -- until something can actually be a folder, there is nothing
+	 * to reject, and every item here is a result.
+	 */
+	CSearchFile *GetFocusedFile() const;
+
+	/**
+	 * Every selected item that is a result, skipping any that are not.
+	 * @see GetFocusedFile
+	 */
+	std::vector<CSearchFile *> GetSelectedFiles() const;
 
 	/**
 	 * Returns the number of currently selected rows.

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -184,14 +184,10 @@ public:
 	 *
 	 * Every item in this control is a wxDataViewItem holding a bare pointer,
 	 * and ToFile() turns one back into a CSearchFile with an unchecked cast.
-	 * That is safe while results are the only thing in the tree; a browse
-	 * grouped by folder will put nodes in it that are not results, and a
-	 * handler that casts one anyway reads whatever is at that address.
-	 *
-	 * These two accessors exist so that there is one place to answer the
-	 * question instead of a dozen. The check itself lands with the folder
-	 * nodes -- until something can actually be a folder, there is nothing
-	 * to reject, and every item here is a result.
+	 * In a browse tab the tree also holds folder nodes, which are not
+	 * results, and a handler that casts one anyway reads whatever is at that
+	 * address. These two accessors ask the model (IsFolder) first, so the
+	 * question is answered in one place rather than at every call site.
 	 */
 	CSearchFile *GetFocusedFile() const;
 
@@ -313,6 +309,11 @@ protected:
 
 	//! ECID of the browsed peer for a "View Files" tab, or 0 for a search tab.
 	uint32 m_browseEcid;
+
+	//! The folder the context menu was opened on, if it was opened on one.
+	//! A right-click does not select the row on every platform, so the
+	//! handlers cannot ask for the selection when they run.
+	wxDataViewItem m_contextFolder;
 	//! Peer display name and lifecycle (EBrowseStatus) for a browse tab.
 	wxString m_browseName;
 	uint32 m_browseStatus;
@@ -366,6 +367,17 @@ protected:
 	void OnRazorStatsCheck(wxCommandEvent &event);
 	void OnRelatedSearch(wxCommandEvent &event);
 	void OnGetComments(wxCommandEvent &event);
+	void OnExpandAll(wxCommandEvent &event);
+	void OnCollapseAll(wxCommandEvent &event);
+
+	/**
+	 * Expands or collapses @a item and everything under it.
+	 *
+	 * Only folders are containers worth walking here; a grouped result's
+	 * children are alternative sources, and opening those wholesale is not
+	 * what "expand all" on a folder means.
+	 */
+	void SetSubtreeExpanded(const wxDataViewItem &item, bool expand);
 	void OnPopupDownload(wxCommandEvent &event);
 
 	/**

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -123,7 +123,18 @@ public:
 	 * ordinary search tab.
 	 */
 	uint32 GetBrowseEcid() const { return m_browseEcid; }
-	void SetBrowseEcid(uint32 ecid) { m_browseEcid = ecid; }
+	/**
+	 * Marks this tab as browsing @a ecid, and swaps in the model that groups
+	 * results by the folders the peer reported.
+	 *
+	 * The model is chosen here rather than in the constructor because that is
+	 * where the answer first exists: CSearchDlg::EnsureBrowseTab creates an
+	 * ordinary tab and only then tells it who it is browsing. The tab has no
+	 * results yet at that point, so there is nothing to migrate.
+	 *
+	 * Defined in the .cpp: the swap needs CBrowseListModel to be complete.
+	 */
+	void SetBrowseEcid(uint32 ecid);
 	bool IsBrowse() const { return m_browseEcid != 0; }
 
 	// Peer display name and lifecycle (EBrowseStatus) for a browse tab. Held on

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -110,6 +110,10 @@ void CSearchListModel::DropReferencesTo(CSearchFile *file)
 		model->m_pendingChanged.erase(
 			std::remove(model->m_pendingChanged.begin(), model->m_pendingChanged.end(), file),
 			model->m_pendingChanged.end());
+		// A derived model may be holding this pointer in a cache of its own
+		// (CBrowseListModel files results under their folder), and this is
+		// the only signal it gets that the result has died.
+		++model->m_contentGeneration;
 	}
 }
 

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -120,6 +120,7 @@ void CSearchListModel::NotifyFileAdded(CSearchFile *file)
 		return;
 	}
 	m_pendingAdded.push_back(file);
+	++m_contentGeneration;
 }
 
 void CSearchListModel::NotifyFileUpdated(CSearchFile *file)
@@ -128,13 +129,17 @@ void CSearchListModel::NotifyFileUpdated(CSearchFile *file)
 		MarkDirty();
 		return;
 	}
+	// Values, not membership -- but "hide known files" turns on a result's
+	// own status, so a change can move it in or out of the shown set.
 	m_pendingChanged.push_back(file);
+	++m_contentGeneration;
 }
 
 void CSearchListModel::NotifyFilterChanged()
 {
 	// User action: reset now rather than waiting for idle.
 	DropPending();
+	++m_contentGeneration;
 	m_pendingReset = false;
 	Cleared();
 }

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -72,12 +72,28 @@ public:
 	//! tree should be re-evaluated (some rows may appear/disappear).
 	void NotifyFilterChanged();
 
+	/**
+	 * Bumped whenever something happens that could change which results are
+	 * shown, or how they are grouped.
+	 *
+	 * For derived models that cache a view of the result set: this model
+	 * itself caches nothing and re-reads on every query, but a browse groups
+	 * its results by folder, and rederiving that grouping on every query is
+	 * O(results) against a control that asks several times per rebuild.
+	 * Comparing this instead makes the cost per change rather than per query.
+	 */
+	unsigned GetContentGeneration() const noexcept { return m_contentGeneration; }
+
 	//! Forces the next flush to be a full Cleared(). Group formation needs
 	//! one: making an existing result a container leaves the control's tree
 	//! inconsistent on GTK/MSW under any incremental notification (got3nks,
 	//! PR #796 review, after ItemChanged() and delete+re-add both failed to
 	//! make those backends re-derive container-ness).
-	void MarkDirty() { m_pendingReset = true; }
+	void MarkDirty()
+	{
+		m_pendingReset = true;
+		++m_contentGeneration;
+	}
 
 	//! Applies whatever the arrivals since the last flush added up to, one
 	//! batch per idle (CSearchListCtrl::OnIdle). Returns true if it was a
@@ -186,6 +202,10 @@ protected:
 private:
 	//! Set when only a full rebuild will do; see MarkDirty().
 	bool m_pendingReset = false;
+
+	//! See GetContentGeneration(). Wrapping is harmless: it is only ever
+	//! compared for equality against the value at the last cache fill.
+	unsigned m_contentGeneration = 0;
 
 	//! Arrivals waiting to be reported incrementally: new rows, and rows
 	//! whose values changed. Held as pointers between the notification and

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -111,6 +111,19 @@ public:
 	 */
 	static void DropReferencesTo(CSearchFile *file);
 
+	/**
+	 * Whether @a item is a grouping node rather than a result.
+	 *
+	 * Always false here: in a search, every item is a CSearchFile. A browse
+	 * grouped by folder (CBrowseListModel) puts nodes in the tree that are
+	 * not results, and this is how a caller holding a wxDataViewItem -- a
+	 * bare void* with nothing to distinguish it -- can find out before
+	 * handing it to ToFile().
+	 */
+	virtual bool IsFolder(const wxDataViewItem &WXUNUSED(item)) const { return false; }
+
+	//! Unchecked: the caller is responsible for having ruled out a folder
+	//! first, via IsFolder() or by knowing the model has none.
 	static CSearchFile *ToFile(const wxDataViewItem &item)
 	{
 		return static_cast<CSearchFile *>(item.GetID());
@@ -165,9 +178,12 @@ public:
 		unsigned int column,
 		bool ascending) const wxOVERRIDE;
 
-private:
+protected:
+	//! Protected rather than private: CBrowseListModel derives the folder
+	//! grouping from the same live result set, reached through the owner.
 	CSearchListCtrl *m_owner;
 
+private:
 	//! Set when only a full rebuild will do; see MarkDirty().
 	bool m_pendingReset = false;
 

--- a/src/include/common/MenuIDs.h
+++ b/src/include/common/MenuIDs.h
@@ -51,6 +51,9 @@ enum
 	MP_EXPORTCOLLECTION,
 	MP_GETCOMMENTS,
 	MP_SEARCHRELATED,
+	// Folder rows in a browse tab (CBrowseListModel)
+	MP_EXPANDALL,
+	MP_COLLAPSEALL,
 	// For comments
 	MP_CMT,
 


### PR DESCRIPTION
Closes #910.

Browsing a friend's shared files listed everything the peer shared as one flat run, with the directory it came from readable only in a column that sits off the right edge by default. A peer sharing a few hundred files across a dozen directories gave no way to see the shape of what was there.

### What it does

Results are now grouped under the directories the peer reported, nested to whatever depth the peer's own layout has. The directory strings carry that structure already: a peer names each shared directory by walking up from it for as long as the parent is also shared and joining that run (`CSharedFileList::GetPublicSharedDirName`), so what arrives is a relative path like `Shared/Movies/Action` rather than a flat label. Splitting it back into segments reproduces the peer's layout.

Both separators are split on. The sender uses its own platform's `wxFileName::GetPathSeparator()` and the packet does not say which, so a Windows peer sends backslashes and a POSIX peer forward slashes. A directory whose name genuinely contains the other platform's separator splits into segments that were never real folders — the same trade eMule makes here, costing a cosmetic mis-grouping rather than a wrong file.

Right-clicking a folder offers **Expand all / Collapse all** over that folder's subtree. Folder rows had no menu at all otherwise: every entry in the file menu acts on results.

### Structure

`CBrowseListModel` extends `CSearchListModel` rather than altering it — a Kad/eD2k search has no directory to group by, and nothing about its model should have to know folders are a possibility. The model is installed when the tab learns it is browsing (`SetBrowseEcid`), which is the first point the answer exists and while the tab is still empty.

### Two things that needed fixing to make it safe

**Unchecked casts.** A `wxDataViewItem` is a bare `void*`, and `ToFile()` is a `static_cast` with no check — fine while every item was a `CSearchFile`, but a folder node cast to `CSearchFile*` reads whatever is at that address. Handlers now go through `GetFocusedFile()`/`GetSelectedFiles()`, which ask the model whether an item is a folder first. `GetSelectedItemCount()` counts results too, so selecting a folder cannot enable an action with nothing behind it.

**Cost per query vs cost per change.** The grouping walk is O(results), and the control asks for the root's children several times per rebuild — twice from `OnIdleHook` alone, saving and restoring expansion around a `Cleared()`. On a large share that multiplies exactly the cost the browse rebuild throttle exists to contain (issue #898). The model rebuilds on a content-generation counter instead, so the walk happens per change rather than per query. The throttle itself is untouched and still governs full rebuilds.

### Compatibility

A peer that answers the older whole-list request sends no directory at all. Those results stay at the top level, so browsing such a peer looks exactly as it did before.

### Notes

`Expand all` and `Collapse all` are new msgids — no expand/collapse string existed in the catalogs to reuse. Regenerated in a separate commit.

Known limitation, pre-existing: the expansion save/restore in `OnIdleHook` only walks root items, so during a still-streaming browse an expanded sub-folder collapses on each throttled rebuild. Top-level folders survive. Worth a follow-up rather than a behaviour change to the throttle path inside this PR.

### Testing

Built and exercised on macOS, Linux ARM64 and Windows ARM64. Ordinary search tabs are unaffected: they keep the search model, and the only shared-code change is the accessor refactor, which is behaviour-neutral there.
