### PR TITLE
fix(gui): bound the browse folder tree against a hostile directory listing

### DIFF
--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -168,6 +168,12 @@ unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataVie
 	}
 
 	if (IsFolder(item)) {
+		// Here too, not only on the root branch: this is the path that
+		// reads the cached CSearchFile pointers, so it is the one that has
+		// to see a generation bump. The call is a comparison once the
+		// grouping is current.
+		RebuildFolders();
+
 		const CBrowseFolderNode *folder = ToFolder(item);
 		unsigned int count = 0;
 		for (CBrowseFolderNode *sub : folder->m_subfolders) {

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -44,6 +44,11 @@ namespace
 //!
 //! Which separator survives a mixed run is whichever came first; the peer's
 //! own choice is not knowable from the packet either way.
+//!
+//! Collapsing runs also rewrites the one string where a doubled separator
+//! means something: a UNC name arrives as "\\server\share" and is keyed as
+//! "\server\share". It is a label here and nothing resolves it, so this
+//! costs a backslash in a folder row rather than a wrong lookup.
 wxString NormalizeDirectory(const wxString &path)
 {
 	wxString normalized;

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -145,6 +145,7 @@ void CBrowseListModel::RebuildFolders() const
 		entry.second->m_subfolders.clear();
 	}
 	m_looseFiles.clear();
+	m_fileParents.clear();
 
 	if (!m_owner->GetSearchId()) {
 		return;
@@ -156,16 +157,19 @@ void CBrowseListModel::RebuildFolders() const
 			continue;
 		}
 
-		// Normalised here, and identically in GetParent(): the node keys
-		// are the canonical form, so the two have to agree or a result
-		// would be filed under a folder its own parent lookup misses.
+		// The one place a directory string is normalised, because this is
+		// the one place it becomes a key. GetParent() reads the answer
+		// back from m_fileParents rather than deriving it again, so there
+		// is no second spelling of this to keep in step.
 		const wxString directory = NormalizeDirectory(file->GetDirectory());
 		if (directory.IsEmpty()) {
 			m_looseFiles.push_back(file);
 			continue;
 		}
 
-		EnsureFolder(directory)->m_files.push_back(file);
+		CBrowseFolderNode *folder = EnsureFolder(directory);
+		folder->m_files.push_back(file);
+		m_fileParents.emplace(file, folder);
 	}
 
 	// Relink the hierarchy. Done as a second pass rather than while
@@ -262,14 +266,15 @@ wxDataViewItem CBrowseListModel::GetParent(const wxDataViewItem &item) const
 		return CSearchListModel::GetParent(item);
 	}
 
-	// Same normalisation RebuildFolders() filed it under.
-	const wxString directory = NormalizeDirectory(file->GetDirectory());
-	if (directory.IsEmpty()) {
-		return wxDataViewItem();
-	}
+	// Read back from the grouping walk rather than re-derived from the
+	// directory string. This is the traversal path and wx asks per item, so
+	// it does no string work at all: RebuildFolders() knew the node when it
+	// filed the result, and a result the peer gave no directory is simply
+	// absent, which is the invisible root.
+	RebuildFolders();
 
-	const auto it = m_folders.find(directory);
-	return it != m_folders.end() ? ToItem(it->second.get()) : wxDataViewItem();
+	const auto it = m_fileParents.find(file);
+	return it != m_fileParents.end() ? ToItem(it->second) : wxDataViewItem();
 }
 
 bool CBrowseListModel::IsContainer(const wxDataViewItem &item) const

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -31,15 +31,38 @@
 
 namespace
 {
-//! A peer's directory string can end in a separator, and can double them up
-//! inside, either of which leaves a segment with no name. Stripping them
-//! keeps "Shared/Movies/" and "Shared/Movies" one folder instead of two, the
-//! second of them a blank row. All separators strips to nothing, which is no
+//! Canonical form of a peer's directory string: runs of separators collapsed
+//! to one, and a trailing separator dropped.
+//!
+//! The nodes are keyed by this string, so anything left un-normalised is a
+//! spelling that gets its own folder: "Shared/Movies", "Shared//Movies" and
+//! "Shared/Movies/" all name one directory, and keying them apart would draw
+//! a sibling row per spelling, all three showing "Movies". A trailing
+//! separator additionally leaves the last segment empty, which is the blank
+//! row. A string of nothing but separators normalises to empty, which is no
 //! directory at all.
-wxString StripTrailingSeparators(const wxString &path)
+//!
+//! Which separator survives a mixed run is whichever came first; the peer's
+//! own choice is not knowable from the packet either way.
+wxString NormalizeDirectory(const wxString &path)
 {
-	const size_t end = path.find_last_not_of("/\\");
-	return end == wxString::npos ? wxString() : path.Left(end + 1);
+	wxString normalized;
+	normalized.reserve(path.length());
+
+	bool lastWasSeparator = false;
+	for (const wxUniChar ch : path) {
+		const bool separator = (ch == '/' || ch == '\\');
+		if (separator && lastWasSeparator) {
+			continue;
+		}
+		normalized += ch;
+		lastWasSeparator = separator;
+	}
+
+	if (lastWasSeparator && !normalized.IsEmpty()) {
+		normalized.RemoveLast();
+	}
+	return normalized;
 }
 } // namespace
 
@@ -74,7 +97,10 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path, size_t d
 	CBrowseFolderNode *parent = nullptr;
 	wxString name = path;
 	if (slash != wxString::npos && depth < MAX_FOLDER_DEPTH) {
-		const wxString parentPath = StripTrailingSeparators(path.Left(slash));
+		// Already canonical, and so is every prefix of it: the callers
+		// normalise, so there is no run to collapse here and the last
+		// separator cannot be trailing.
+		const wxString parentPath = path.Left(slash);
 		if (parentPath.IsEmpty()) {
 			// A leading separator leaves no parent path, which is no
 			// directory at all -- this node is a root under its own
@@ -131,9 +157,9 @@ void CBrowseListModel::RebuildFolders() const
 		}
 
 		// Normalised here, and identically in GetParent(): the node keys
-		// are the stripped form, so the two have to agree or a result
+		// are the canonical form, so the two have to agree or a result
 		// would be filed under a folder its own parent lookup misses.
-		const wxString directory = StripTrailingSeparators(file->GetDirectory());
+		const wxString directory = NormalizeDirectory(file->GetDirectory());
 		if (directory.IsEmpty()) {
 			m_looseFiles.push_back(file);
 			continue;
@@ -237,7 +263,7 @@ wxDataViewItem CBrowseListModel::GetParent(const wxDataViewItem &item) const
 	}
 
 	// Same normalisation RebuildFolders() filed it under.
-	const wxString directory = StripTrailingSeparators(file->GetDirectory());
+	const wxString directory = NormalizeDirectory(file->GetDirectory());
 	if (directory.IsEmpty()) {
 		return wxDataViewItem();
 	}

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -29,6 +29,20 @@
 #include "SearchListCtrl.h"
 #include "amule.h"
 
+namespace
+{
+//! A peer's directory string can end in a separator, and can double them up
+//! inside, either of which leaves a segment with no name. Stripping them
+//! keeps "Shared/Movies/" and "Shared/Movies" one folder instead of two, the
+//! second of them a blank row. All separators strips to nothing, which is no
+//! directory at all.
+wxString StripTrailingSeparators(const wxString &path)
+{
+	const size_t end = path.find_last_not_of("/\\");
+	return end == wxString::npos ? wxString() : path.Left(end + 1);
+}
+} // namespace
+
 CBrowseListModel::CBrowseListModel(CSearchListCtrl *owner)
 : CSearchListModel(owner)
 {
@@ -57,9 +71,9 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path, size_t d
 	wxString name = path;
 	if (slash != wxString::npos && depth < MAX_FOLDER_DEPTH) {
 		name = path.Mid(slash + 1);
-		const wxString parentPath = path.Left(slash);
-		// A leading or doubled separator leaves an empty parent path,
-		// which is no directory at all -- this node is a root.
+		const wxString parentPath = StripTrailingSeparators(path.Left(slash));
+		// A leading separator leaves an empty parent path, which is no
+		// directory at all -- this node is a root.
 		if (!parentPath.IsEmpty()) {
 			parent = EnsureFolder(parentPath, depth + 1);
 		}
@@ -106,7 +120,10 @@ void CBrowseListModel::RebuildFolders() const
 			continue;
 		}
 
-		const wxString &directory = file->GetDirectory();
+		// Normalised here, and identically in GetParent(): the node keys
+		// are the stripped form, so the two have to agree or a result
+		// would be filed under a folder its own parent lookup misses.
+		const wxString directory = StripTrailingSeparators(file->GetDirectory());
 		if (directory.IsEmpty()) {
 			m_looseFiles.push_back(file);
 			continue;
@@ -209,7 +226,8 @@ wxDataViewItem CBrowseListModel::GetParent(const wxDataViewItem &item) const
 		return CSearchListModel::GetParent(item);
 	}
 
-	const wxString &directory = file->GetDirectory();
+	// Same normalisation RebuildFolders() filed it under.
+	const wxString directory = StripTrailingSeparators(file->GetDirectory());
 	if (directory.IsEmpty()) {
 		return wxDataViewItem();
 	}

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -39,7 +39,7 @@ bool CBrowseListModel::IsFolder(const wxDataViewItem &item) const
 	return item.IsOk() && m_folderAddresses.count(item.GetID()) != 0;
 }
 
-CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path) const
+CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path, size_t depth) const
 {
 	const auto existing = m_folders.find(path);
 	if (existing != m_folders.end()) {
@@ -48,16 +48,20 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path) const
 
 	// Split off the last segment: whichever separator appears last is the
 	// one this peer uses, so a name containing the other one stays intact.
+	//
+	// Stops at MAX_FOLDER_DEPTH: the peer chose this string and nothing
+	// validates it, so the remainder is left as one folder name rather than
+	// split into as many levels as it has separators.
 	const size_t slash = path.find_last_of("/\\");
 	CBrowseFolderNode *parent = nullptr;
 	wxString name = path;
-	if (slash != wxString::npos) {
+	if (slash != wxString::npos && depth < MAX_FOLDER_DEPTH) {
 		name = path.Mid(slash + 1);
 		const wxString parentPath = path.Left(slash);
 		// A leading or doubled separator leaves an empty parent path,
 		// which is no directory at all -- this node is a root.
 		if (!parentPath.IsEmpty()) {
-			parent = EnsureFolder(parentPath);
+			parent = EnsureFolder(parentPath, depth + 1);
 		}
 	}
 

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -63,19 +63,29 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path, size_t d
 	// Split off the last segment: whichever separator appears last is the
 	// one this peer uses, so a name containing the other one stays intact.
 	//
-	// Stops at MAX_FOLDER_DEPTH: the peer chose this string and nothing
-	// validates it, so the remainder is left as one folder name rather than
-	// split into as many levels as it has separators.
+	// Two bounds apply, and they stop different things. The depth argument
+	// caps this function's own recursion, which one long string drives. The
+	// node's depth caps the tree, which many strings drive between them: the
+	// early return above hands back a node with the parents it already has,
+	// so without that check a peer could add a capped run per packet and
+	// nest for as long as it kept sending. Where either bites, the remainder
+	// stays one folder name instead of being split further.
 	const size_t slash = path.find_last_of("/\\");
 	CBrowseFolderNode *parent = nullptr;
 	wxString name = path;
 	if (slash != wxString::npos && depth < MAX_FOLDER_DEPTH) {
-		name = path.Mid(slash + 1);
 		const wxString parentPath = StripTrailingSeparators(path.Left(slash));
-		// A leading separator leaves an empty parent path, which is no
-		// directory at all -- this node is a root.
-		if (!parentPath.IsEmpty()) {
-			parent = EnsureFolder(parentPath, depth + 1);
+		if (parentPath.IsEmpty()) {
+			// A leading separator leaves no parent path, which is no
+			// directory at all -- this node is a root under its own
+			// last segment.
+			name = path.Mid(slash + 1);
+		} else {
+			CBrowseFolderNode *candidate = EnsureFolder(parentPath, depth + 1);
+			if (candidate->GetDepth() + 1 < MAX_FOLDER_DEPTH) {
+				parent = candidate;
+				name = path.Mid(slash + 1);
+			}
 		}
 	}
 

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -44,12 +44,18 @@ public:
 	CBrowseFolderNode(const wxString &name, CBrowseFolderNode *parent)
 	: m_name(name)
 	, m_parent(parent)
+	, m_depth(parent ? parent->m_depth + 1 : 0)
 	{
 	}
 
 	//! This folder's own name, not its path: the tree shows the rest.
 	const wxString &GetName() const noexcept { return m_name; }
 	CBrowseFolderNode *GetParent() const noexcept { return m_parent; }
+
+	//! Distance from a root. Held on the node rather than counted on
+	//! demand because it is what bounds the tree across directory strings,
+	//! and the readers that walk it recurse: see MAX_FOLDER_DEPTH.
+	size_t GetDepth() const noexcept { return m_depth; }
 
 	//! Sub-folders and the results filed directly here. Both are rebuilt
 	//! from scratch on every refresh; the nodes themselves outlive it.
@@ -59,6 +65,7 @@ public:
 private:
 	wxString m_name;
 	CBrowseFolderNode *m_parent;
+	size_t m_depth;
 };
 
 /**
@@ -146,24 +153,41 @@ private:
 	void RebuildFolders() const;
 
 	/**
-	 * Deepest nesting built out of one directory string.
+	 * Most nodes the tree is ever deep, counted end to end and not per
+	 * directory string.
 	 *
-	 * The string is whatever the peer put in the packet, up to 64 KB
+	 * The strings are whatever the peer put in the packets, each up to 64 KB
 	 * (CFileDataIO::ReadString defaults to a uint16 length) and checked by
-	 * nothing between the socket and here. Each segment costs a recursion
-	 * level and a node keyed by its own prefix of the string, so a listing
-	 * naming a directory with 65,535 separators would cost that many frames
-	 * and the sum of all those prefixes in live wxStrings.
+	 * nothing between the socket and here. Two separate costs follow from
+	 * that, and they need two separate bounds:
+	 *
+	 * Per string, every segment is a recursion level in EnsureFolder() and a
+	 * node keyed by its own prefix, so one directory named with 65,535
+	 * separators is that many frames and the sum of all those prefixes in
+	 * live wxStrings. The depth argument to EnsureFolder() stops it.
+	 *
+	 * Across strings, chains compose: EnsureFolder() hands back an existing
+	 * node with the parents it already has, so a path bottoming out on one an
+	 * earlier string created inherits everything above it. Counting calls
+	 * cannot see that -- a peer sending directories shortest-first adds a
+	 * capped run per packet and nests without limit. So a node also carries
+	 * its own depth (CBrowseFolderNode::GetDepth) and refuses to be attached
+	 * past this, which is the bound HasContent() and
+	 * CSearchListCtrl::SetSubtreeExpanded() need: both recurse over the tree
+	 * rather than over any one string.
 	 *
 	 * A peer names a directory by joining the run of shared directories it
 	 * belongs to (CSharedFileList::GetPublicSharedDirName), so a real one is
-	 * a handful of segments deep. Past this, the remainder is left as one
-	 * folder name rather than split further.
+	 * a handful of segments deep and nothing legitimate comes near this.
+	 * Where either bound bites, the remainder is left as one folder name
+	 * rather than split further.
 	 */
 	static const size_t MAX_FOLDER_DEPTH = 64;
 
 	//! Returns the node for @a path, creating it and every missing ancestor.
-	//! @a depth is the recursion level, bounded by MAX_FOLDER_DEPTH.
+	//! @a path must have no trailing separator (see StripTrailingSeparators).
+	//! @a depth is this function's own recursion level; see MAX_FOLDER_DEPTH
+	//! for why the node's depth is checked as well.
 	CBrowseFolderNode *EnsureFolder(const wxString &path, size_t depth = 0) const;
 
 	//! Whether anything at all is under @a folder, at any depth. A folder

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -145,8 +145,26 @@ private:
 	 */
 	void RebuildFolders() const;
 
+	/**
+	 * Deepest nesting built out of one directory string.
+	 *
+	 * The string is whatever the peer put in the packet, up to 64 KB
+	 * (CFileDataIO::ReadString defaults to a uint16 length) and checked by
+	 * nothing between the socket and here. Each segment costs a recursion
+	 * level and a node keyed by its own prefix of the string, so a listing
+	 * naming a directory with 65,535 separators would cost that many frames
+	 * and the sum of all those prefixes in live wxStrings.
+	 *
+	 * A peer names a directory by joining the run of shared directories it
+	 * belongs to (CSharedFileList::GetPublicSharedDirName), so a real one is
+	 * a handful of segments deep. Past this, the remainder is left as one
+	 * folder name rather than split further.
+	 */
+	static const size_t MAX_FOLDER_DEPTH = 64;
+
 	//! Returns the node for @a path, creating it and every missing ancestor.
-	CBrowseFolderNode *EnsureFolder(const wxString &path) const;
+	//! @a depth is the recursion level, bounded by MAX_FOLDER_DEPTH.
+	CBrowseFolderNode *EnsureFolder(const wxString &path, size_t depth = 0) const;
 
 	//! Whether anything at all is under @a folder, at any depth. A folder
 	//! that only holds other empty folders is not worth a row.

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -185,7 +185,8 @@ private:
 	static const size_t MAX_FOLDER_DEPTH = 64;
 
 	//! Returns the node for @a path, creating it and every missing ancestor.
-	//! @a path must have no trailing separator (see StripTrailingSeparators).
+	//! @a path must be canonical (see NormalizeDirectory), which every prefix
+	//! this recurses onto then is too.
 	//! @a depth is this function's own recursion level; see MAX_FOLDER_DEPTH
 	//! for why the node's depth is checked as well.
 	CBrowseFolderNode *EnsureFolder(const wxString &path, size_t depth = 0) const;

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -27,9 +27,10 @@
 
 #include "SearchListModel.h"
 
-#include <map>    // Needed for std::map (the folder registry)
-#include <memory> // Needed for std::unique_ptr (stable folder node addresses)
-#include <set>    // Needed for std::set (the folder-address lookup)
+#include <map>           // Needed for std::map (the folder registry)
+#include <memory>        // Needed for std::unique_ptr (stable folder node addresses)
+#include <set>           // Needed for std::set (the folder-address lookup)
+#include <unordered_map> // Needed for std::unordered_map (result -> its folder)
 
 /**
  * A folder in a browsed peer's shared-file listing.
@@ -216,6 +217,20 @@ private:
 	//! Results the peer reported with no directory. Top level, next to the
 	//! folders.
 	mutable std::vector<CSearchFile *> m_looseFiles;
+
+	//! Which folder RebuildFolders() filed each shown result under, recorded
+	//! as it files them. GetParent() is on the traversal path rather than
+	//! the rebuild path and wx asks it per item, so it resolves through this
+	//! instead of re-deriving the key from the result's directory string.
+	//!
+	//! Written by the grouping walk itself, so it cannot come to describe a
+	//! different grouping than the one drawn. A result the peer gave no
+	//! directory is absent rather than present-and-null: it has no folder,
+	//! which is what a missing entry already means.
+	//!
+	//! Costs an entry per shown result, on top of the same pointer already
+	//! held in its folder's m_files.
+	mutable std::unordered_map<const CSearchFile *, CBrowseFolderNode *> m_fileParents;
 };
 
 #endif // BROWSELISTMODEL_H

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -182,6 +182,13 @@ private:
 	 * a handful of segments deep and nothing legitimate comes near this.
 	 * Where either bound bites, the remainder is left as one folder name
 	 * rather than split further.
+	 *
+	 * What this bounds is the recursion and the depth of the tree, which is
+	 * the crash. It is not a bound on memory: a capped string still leaves
+	 * about MAX_FOLDER_DEPTH nodes, each keyed by its own prefix of it, so a
+	 * 64 KB directory name costs a few MB of live keys rather than the GBs
+	 * it would unbounded -- and that still scales with how many such strings
+	 * the peer sends.
 	 */
 	static const size_t MAX_FOLDER_DEPTH = 64;
 


### PR DESCRIPTION
Follow-up to #917, from a re-read of `CBrowseListModel` after it merged. Only master is affected - the folder tree has not been in a release, so no shipped build has this.

### The directory strings are unvalidated remote input

`EnsureFolder()` splits a peer-supplied directory string into a chain of nodes, recursing once per separator. Nothing checks the string on the way in:

- `ClientTCPSocket`'s `OP_ASKSHAREDFILESDIRANS` reads it with `data.ReadString(...)`, and `CFileDataIO::ReadString` defaults to `lenBytes = 2`, so up to 65,535 bytes
- `ProcessSharedFileList` passes it into `CSearchFile::m_directory` unexamined
- `EnsureFolder` then splits it

Two different costs come out of that, and they need two different bounds.

**Per string.** One directory named with 65,535 separators is 65,535 stack frames. The memory is worse: each level holds its own copy of the parent path alive across the recursive call and inserts a map key of that length, so the peak is the sum of every prefix - around 2.1 GB of live `wxString` for a 64 KB name, with the same volume of copying to build it. The `depth` argument to `EnsureFolder()` bounds this.

**Across strings.** Chains compose. `EnsureFolder()` returns an existing node with the parent chain it already has, so a path bottoming out on one an earlier string created inherits everything above it. A peer choosing the order can send directories shortest-first - `D1` of 64 segments, `D2 = D1 + 64`, `D3 = D2 + 64` - keeping every call inside a per-call cap while the tree grows 64 levels per packet. So `CBrowseFolderNode` carries its own distance from a root and `EnsureFolder()` refuses to attach past the cap. That is the bound `HasContent()` and `CSearchListCtrl::SetSubtreeExpanded()` need, since both recurse over the tree rather than over any one string.

Modelling both algorithms exactly and running the shortest-first order against each:

| packets | per-call cap only | node-depth cap |
|---|---|---|
| 1 | 63 | 63 |
| 2 | 127 | 63 |
| 8 | 511 | 63 |
| 100 | 6,399 | 63 |
| 1,000 | 63,999 | 63 |

A peer names a shared directory by joining the run of shared directories it belongs to (`CSharedFileList::GetPublicSharedDirName`), so a real one is a handful of segments deep and nothing legitimate comes near 64. Where either bound bites, the remainder is left as one folder name rather than split further, so a hostile listing draws one absurd row instead of taking the client with it.

Both bounds are on the recursion and on the depth of the tree, which is the crash. Neither is a bound on memory, and the figure above should not be read as one: a capped 64 KB name still leaves about 64 nodes, each keyed by its own prefix of it, which is a few MB of live keys rather than GBs - and that still scales with how many such strings the peer sends.

### Also here

**Directory strings are canonicalised before they are keyed.** The nodes are keyed by the string, so any spelling left un-normalised gets its own folder. `"Shared/Movies/"` split to an empty last segment and drew a blank row under `"Shared/Movies"`; `"Shared//Movies"` keyed as itself and drew a second sibling, also showing `Movies`. Separator runs are now collapsed and a trailing separator dropped, at the single point where a string becomes a key. `GetParent()` reads its answer back from what the grouping walk recorded rather than deriving it a second way, so it does no string work on the traversal path and cannot come to disagree with the grouping. Came in with #917 rather than with the cap.

**`GetChildren()` only rebuilt on the root branch.** `RebuildFolders()` was called under the invisible root only, while the branch that reads the cached `CSearchFile*` never re-derived them. That branch is what the generation counter is for: `CSearchListModel::DropReferencesTo()` bumps it when a result is destroyed, the only signal the model gets that a pointer it filed under a folder has died. No live path reaches it today, because the control walks top-down in every rebuild and `RemoveResults()` closes the tab before deleting anything; this makes the invalidation reachable from both entry points rather than resting on traversal order.

### Testing

Built on macOS arm64 and Ubuntu arm64, clean in the changed file, clang-format clean. The depth bound and the key canonicalisation are verified against a model of the algorithm, which is where the table above comes from. `CBrowseListModel` is GUI-side with private folder machinery, so there is no unit-test seam, and I have not driven a hostile listing through a real peer.


