### PR TITLE
perf(gui): refresh the clients page once a second, not ten times

### DIFF
--- a/src/ClientsListCtrl.cpp
+++ b/src/ClientsListCtrl.cpp
@@ -141,13 +141,20 @@ void CClientsListCtrl::SetClients(std::vector<Row> &&rows)
 			}
 		}
 		if (sameSet) {
-			for (Row &row : m_rows) {
-				row = *incoming[row.ecid];
-			}
+			// Only the rows that actually moved. Refreshing all of them cost a
+			// repaint per visible row on every tick even when nothing had
+			// changed, which on a page that never sits still is most of the
+			// work it was doing (issue #920).
+			//
 			// Per row rather than a blanket Refresh() so the control's own
 			// viewport gate applies -- off-screen rows cost nothing -- and so a
 			// live sort column still gets the chance to reorder.
-			for (const Row &row : m_rows) {
+			for (Row &row : m_rows) {
+				const Row &fresh = *incoming[row.ecid];
+				if (row == fresh) {
+					continue;
+				}
+				row = fresh;
 				RefreshItemData(static_cast<wxUIntPtr>(row.ecid));
 			}
 			return;

--- a/src/ClientsListCtrl.h
+++ b/src/ClientsListCtrl.h
@@ -114,6 +114,25 @@ public:
 		uint64 sessionDown = 0;
 		uint64 totalUp = 0;
 		uint64 totalDown = 0;
+
+		/**
+		 * Whole-row comparison, so a caller asking "did this row change"
+		 * cannot test a subset by accident.
+		 *
+		 * ecid is excluded: rows are matched on it, so two rows being compared
+		 * always share one. Everything else is displayed, and anything that
+		 * moves has to reach the screen.
+		 */
+		bool operator==(const Row &other) const
+		{
+			return nameCell == other.nameCell && name == other.name &&
+			       software == other.software && version == other.version && ip == other.ip &&
+			       port == other.port && sourceFrom == other.sourceFrom && files == other.files &&
+			       upSpeed == other.upSpeed && downSpeed == other.downSpeed &&
+			       sessionUp == other.sessionUp && sessionDown == other.sessionDown &&
+			       totalUp == other.totalUp && totalDown == other.totalDown;
+		}
+		bool operator!=(const Row &other) const { return !(*this == other); }
 	};
 
 	/**

--- a/src/ClientsWnd.cpp
+++ b/src/ClientsWnd.cpp
@@ -357,6 +357,22 @@ void CClientsWnd::UpdateAll()
 		if (c == nullptr) {
 			return;
 		}
+		// Built at most once per peer, and only if something asks for it. It
+		// is the most expensive thing here -- a country lookup and several
+		// string copies -- and it used to be built twice for every peer, once
+		// for the history entry and again for the pane row. Lazily, because a
+		// peer that neither pane shows and that the history does not want
+		// should not pay for one at all (issue #920).
+		ClientNameCell cell;
+		bool haveCell = false;
+		auto nameCell = [&]() -> const ClientNameCell & {
+			if (!haveCell) {
+				cell = MakeClientNameCell(c);
+				haveCell = true;
+			}
+			return cell;
+		};
+
 		if (wantLive && !c->GetUserHash().IsEmpty()) {
 			CClientHistoryListCtrl::LiveClient entry;
 			entry.uploaded = c->GetUploadedTotal();
@@ -369,7 +385,7 @@ void CClientsWnd::UpdateAll()
 			entry.port = c->GetUserPort();
 			entry.clientSoft = static_cast<uint8>(c->GetClientSoft());
 			entry.sourceFrom = static_cast<uint8>(c->GetSourceFrom());
-			entry.nameCell = MakeClientNameCell(c);
+			entry.nameCell = nameCell();
 			// A history row describes a peer we may not be talking to, so it
 			// carries no live download-state badge even when we are.
 			entry.nameCell.showState = false;
@@ -389,7 +405,7 @@ void CClientsWnd::UpdateAll()
 		}
 		CClientsListCtrl::Row row;
 		row.ecid = c->ECID();
-		row.nameCell = MakeClientNameCell(c);
+		row.nameCell = nameCell();
 		row.name = c->GetUserName();
 		row.software = c->GetSoftStr();
 		row.version = c->GetSoftVerStr();

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1702,13 +1702,6 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 	}
 #endif
 
-	// The clients page shows live speeds and transfer totals, so it needs the
-	// one-second cadence rather than the five-second block below. Only while
-	// it is the page on screen: off-screen the repaint would draw nothing.
-	if (m_clientswnd && m_activewnd == static_cast<wxWindow *>(m_clientswnd)) {
-		m_clientswnd->UpdateAll();
-	}
-
 	if (msCur - msPrev5 > 5000) { // every 5 seconds
 		msPrev5 = msCur;
 		ShowTransferRate();
@@ -1735,6 +1728,17 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 
 	if (msCur - msPrev1 > 1000) { // every second
 		msPrev1 = msCur;
+
+		// The clients page shows live speeds and transfer totals, so it wants
+		// a per-second refresh -- and no more. This timer fires at 10 Hz, so
+		// outside this block the whole sweep ran ten times a second: every
+		// peer the core knows re-read, both panes rebuilt and the known-client
+		// store reconciled, for a display that changes once a second at most
+		// (issue #920). Only while the page is on screen: off-screen the
+		// repaint would draw nothing.
+		if (m_clientswnd && m_activewnd == static_cast<wxWindow *>(m_clientswnd)) {
+			m_clientswnd->UpdateAll();
+		}
 		if (m_CurrentBlinkBitmap == Toolbar_Blink) {
 			m_CurrentBlinkBitmap = Toolbar_Messages;
 			SetMessagesTool();


### PR DESCRIPTION
Fixes #920.

The GUI timer fires every **100 ms**. `OnGUITimer` throttles its work into an every-second block and an every-five-second block — and the clients page's update sat outside both, so the whole sweep ran **ten times a second**: every peer the core knows re-read, both panes rebuilt, and the known-client store reconciled, for a display whose values move once a second at most. The comment above the call claimed the one-second cadence it did not actually have.

That is the reporter's "the upload speed is updated very often - over 5 Hz". Moving the call inside the existing every-second block is the bulk of the fix.

Two things the sweep did per tick made it worse, and both are worth fixing regardless of cadence:

**Rows were refreshed whether or not they had changed.** The in-place path exists so that a poll does not rebuild the model, but it then asked the control to repaint every row anyway — so an idle list still cost a repaint per visible row, ten times a second. `Row` gains a whole-row comparison, the same shape `ClientNameCell` already uses, so the test cannot drift from the fields it guards; only rows that actually moved are refreshed.

**The name cell was built twice per peer** — once for the history entry, again for the pane row — and the history build ran *before* the pane filter, so a peer that neither pane shows still paid for one. It is the most expensive thing in the sweep: a country lookup plus several string copies. It is now built at most once per peer, and only when something asks for it, so a user who never opens the Known tab pays nothing for peers with no files.

Live sorting is unchanged. A re-sort is still scheduled when a refreshed row's list is ordered by a live column; there is simply one tick per second instead of ten, and idle rows no longer trigger one at all.

Reported against monolithic aMule, but `amuleDlg.cpp` is in `GUI_SOURCES`: the same sweep ran at 10 Hz in amulegui too. Only the downstream repaints were quieter there, because its data changes when an EC poll lands.

## Testing

Cause established from the code — a 100 ms timer with an ungated call — rather than from a profile: the GUI could not be driven here to measure. Asked the reporter on #920 to check whether it brings his 30% down, and how many records his `clients.met` holds, since the Known tab's cost scales with that.
