### PR TITLE
fix(build): let Boost 1.92's asio through the deprecation gate

### DIFF
--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -50,9 +50,22 @@
 
 // Trip the compile if we accidentally pull a deprecated Asio API back in.
 #define BOOST_ASIO_NO_DEPRECATED
+// Boost 1.92's asio declares several exception types with a user-provided
+// destructor and no matching copy constructor, which is the P0806 deprecation
+// -Wdeprecated-copy-with-user-provided-dtor reports. The build promotes it to
+// an error, so from that release on this header set fails the compile on its
+// own. Suppressed only across these includes, exactly as CryptoPP_Inc.h does
+// for the same warning: nothing about our own translation unit is affected.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#endif
 #include <boost/asio.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/version.hpp>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 //
 // Do away with building Boost.System, adding lib paths...

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -28,6 +28,13 @@
 
 #include <wx/string.h>
 
+// See the note in LibSocketAsio.cpp: Boost 1.92's asio trips
+// -Wdeprecated-copy-with-user-provided-dtor, which this build treats as an
+// error. Suppressed across the includes only.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#endif
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/post.hpp>
@@ -38,6 +45,9 @@
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/optional.hpp>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #include <zlib.h>
 


### PR DESCRIPTION
Homebrew moved to **Boost 1.92.0**, whose asio declares several exception types with a user-provided destructor and no matching copy constructor — the P0806 deprecation that `-Wdeprecated-copy-with-user-provided-dtor` reports. This build promotes that warning to an error, so from 1.92 on the header set fails the compile on its own, before any of our code is reached:

```
/opt/homebrew/include/boost/asio/multiple_exceptions.hpp:38:11: error: definition of implicit
copy constructor for 'multiple_exceptions' is deprecated because it has a user-provided
destructor [-Werror,-Wdeprecated-copy-with-user-provided-dtor]
/opt/homebrew/include/boost/asio/execution/bad_executor.hpp:38:11: error: ...
/opt/homebrew/include/boost/asio/executor.hpp:47:11: error: ...
```

**Every macOS job on the current runner image fails this way regardless of content.** Re-running the CI for unmodified master — the same commit `84c12c85` that passed the day before, with nothing changed but the runner's Boost bottle — fails both macOS jobs identically. A translations-only PR (#918, 49 `.po` files) fails the same way.

Suppressed across the Boost includes only, in the two files that pull them in, exactly as `CryptoPP_Inc.h` already does for this same warning on cryptopp's headers. Nothing about our own translation units is affected, and the suppression is scoped with `push` / `pop` around the include block rather than left open.

## Testing

Verified against 1.92 locally rather than by inference: upgraded Homebrew's Boost to 1.92.0, reproduced the three errors first, then confirmed monolithic, amulegui, amuled and amuleapi all build clean with the pragma in place.
