### PR TITLE
fix(net): don't go deaf on a connection that arrives during startup

### DIFF
--- a/src/ListenSocket.cpp
+++ b/src/ListenSocket.cpp
@@ -128,7 +128,15 @@ void CListenSocket::Process()
 		}
 	}
 
-	if (m_pending) {
+	// SocketAvailable() as well as m_pending: the socket layer arms one
+	// async accept at a time and only re-arms it from AcceptWith(), so a
+	// connection it accepted but we then declined to take -- OnAccept()
+	// bails out when the app is not running yet -- leaves the acceptor
+	// idle with m_pending clear. Nothing would ever call AcceptWith()
+	// again and the listen socket would stay deaf for the rest of the
+	// session, with the kernel still completing handshakes into a backlog
+	// no one reads. Taking it here re-arms the acceptor.
+	if (m_pending || SocketAvailable()) {
 		OnAccept();
 	}
 }

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1157,6 +1157,18 @@ bool CamuleApp::OnInit()
 	// The user can start pressing buttons like mad if he feels like it.
 	m_app_state = APP_STATE_RUNNING;
 
+	// The listen socket has been bound since ReinitializeNetwork(), so a peer
+	// -- typically one that had us in its source list moments ago -- can have
+	// connected while the rest of this ran. CListenSocket::OnAccept() declines
+	// those, because until the line above there was no loaded client list to
+	// hand them to, and declining leaves the connection sitting unread. Take
+	// it now that we are running: it re-arms the socket layer's acceptor,
+	// which otherwise would not happen before the first core timer tick, five
+	// seconds from now and well after we have asked a server for a HighID.
+	if (listensocket) {
+		listensocket->Process();
+	}
+
 	{
 #ifndef AMULE_DAEMON
 		if (firstRunWizardShown) {


### PR DESCRIPTION
Fixes #924.

The listen socket is bound in `ReinitializeNetwork()`, long before the part files, shared files and client list are loaded and the app marks itself running. A peer connecting in that window — likely, since peers that were talking to us seconds ago still hold our address — is accepted by the socket layer, which posts an accept notification.

`CListenSocket::OnAccept()` opens with `m_pending = theApp->IsRunning()`, so during startup it clears the flag and returns without taking the connection. That leaves the socket layer holding an accepted socket with its acceptor un-armed: `async_accept` is re-armed only from `AcceptWith()`, whose only caller is `OnAccept()`, which `Process()` enters only when `m_pending` is set. Nothing ever sets it again.

The socket stays bound, so the kernel keeps completing handshakes into a backlog nobody reads — the port still probes as open while aMule accepts nothing for the rest of the session. Outbound connections are unaffected, so the visible symptom is a LowID that reconnecting cannot clear: only a restart helps, and only until it happens again.

The notification is delivered during startup because the splash pumps the event loop to paint its progress bar. That is also why this is monolithic-only — the splash and its `wxSafeYield` sit behind `AMULE_SHOW_SPLASH`, and amuled dispatches nothing before it is running.

## Testing

Held 40 connections open across startup, then made one more 35 seconds later and checked whether it became an fd of the process or stayed in the kernel backlog:

```
before: late connection from port 62008 -> NOT accepted (kernel backlog only)
after:  late connection from port 61939 -> ACCEPTED by the process
```

The port was listening in both runs, which is the reported "port probes as open but LowID" state.
