### PR TITLE
fix(gui): show every timestamp the way the user's locale writes one

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1822,10 +1822,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:32+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1861,10 +1861,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1884,10 +1884,6 @@ msgstr "Renomar ficheru"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9007,6 +9003,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1855,10 +1855,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1821,10 +1821,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1879,10 +1879,6 @@ msgstr "Reanomena"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%d/%m/%y %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8951,6 +8947,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%d/%m/%y %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1872,10 +1872,6 @@ msgstr "Přejmenování souboru"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8949,6 +8945,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1865,10 +1865,6 @@ msgstr "Omdøb fil"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.2f MB"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1886,10 +1886,6 @@ msgstr "Datei umbenennen"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8965,6 +8961,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1892,10 +1892,6 @@ msgstr "Μετονομασία αρχείου"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9025,6 +9021,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1822,10 +1822,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:35+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1889,10 +1889,6 @@ msgstr "Renombrar el archivo"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8946,6 +8942,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1880,10 +1880,6 @@ msgstr "Faili ümbernimetamine"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%H:%M:%S %d/%m/%y"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8954,6 +8950,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%H:%M:%S %d/%m/%y"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:36+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1881,10 +1881,6 @@ msgstr "Fitxategia berrizendatu"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8954,6 +8950,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:36+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1881,10 +1881,6 @@ msgstr "Tiedoston uudelleennimeäminen"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f KB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8954,6 +8950,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1872,10 +1872,6 @@ msgstr "Renommer"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f Mo/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H : %M : %S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8904,6 +8900,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H : %M : %S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1899,10 +1899,6 @@ msgstr "Cambiar o nome do ficheiro"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8975,6 +8971,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1871,10 +1871,6 @@ msgstr "שינוי שם לקובץ"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.2f מ\"ב"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d·%H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8926,6 +8922,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d·%H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1872,10 +1872,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1875,10 +1875,6 @@ msgstr "Fájl átnevezés"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y.%m.%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8920,6 +8916,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y.%m.%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1877,10 +1877,6 @@ msgstr "Rinomina file"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8907,6 +8903,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1880,10 +1880,6 @@ msgstr "ファイルの改名"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8954,6 +8950,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1890,10 +1890,6 @@ msgstr "파일 이름변경"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9006,6 +9002,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1897,10 +1897,6 @@ msgstr "Pervadinti failą"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9045,6 +9041,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1846,10 +1846,6 @@ msgstr ""
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y.%m.%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8742,6 +8738,9 @@ msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y.%m.%d %H:%M:%S"
 
 #~ msgid "IP:"
 #~ msgstr "IP:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1881,10 +1881,6 @@ msgstr "Naam wijzigen"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8960,6 +8956,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1890,10 +1890,6 @@ msgstr "Døyp om fil"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f·kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d·%H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9015,6 +9011,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d·%H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1888,10 +1888,6 @@ msgstr "Zmień nazwę"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9003,6 +8999,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1873,10 +1873,6 @@ msgstr "Renomear"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8905,6 +8901,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1887,10 +1887,6 @@ msgstr "Renomear ficheiro"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8963,6 +8959,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1885,10 +1885,6 @@ msgstr "Redenumire fișier"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8981,6 +8977,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1886,10 +1886,6 @@ msgstr "Переименовать файл"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f МБ/с"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8971,6 +8967,9 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1895,10 +1895,6 @@ msgstr "Preimenuj datoteko"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MiB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%d.%m.%y %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9020,6 +9016,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%d.%m.%y %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1885,10 +1885,6 @@ msgstr "Riemertim i failit"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8986,6 +8982,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:43+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1879,10 +1879,6 @@ msgstr "Byt namn på fil"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f kB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H.%M.%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8951,6 +8947,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H.%M.%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1821,10 +1821,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1865,10 +1865,6 @@ msgstr "Dosya yeniden adlandır"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8932,6 +8928,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1893,10 +1893,6 @@ msgstr "Змінити назву файлу"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f кбайт/с"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y.%m.%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -9050,6 +9046,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y.%m.%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1820,10 +1820,6 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MB/s"
-msgstr ""
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1869,10 +1869,6 @@ msgstr "重命名文件"
 #, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f MB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8898,6 +8894,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 22:54+0200\n"
+"POT-Creation-Date: 2026-08-15 23:10+0200\n"
 "PO-Revision-Date: 2026-08-14 21:45+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1879,10 +1879,6 @@ msgstr "更改檔名"
 #, fuzzy, c-format
 msgid "%.1f MB/s"
 msgstr "%.1f KB/s"
-
-#: src/DownloadListCtrl.cpp
-msgid "%y/%m/%d %H:%M:%S"
-msgstr "%y/%m/%d %H:%M:%S"
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -8926,6 +8922,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "%y/%m/%d %H:%M:%S"
+#~ msgstr "%y/%m/%d %H:%M:%S"
 
 #, fuzzy
 #~ msgid "Remote prefix:"

--- a/src/ChatSelector.cpp
+++ b/src/ChatSelector.cpp
@@ -83,7 +83,7 @@ void CChatSession::AddText(const wxString &text, const wxTextAttr &style, bool n
 			if (line.IsEmpty()) {
 				SetDefaultStyle(COLOR_BLACK);
 
-				AppendText(" [" + wxDateTime::Now().FormatISOTime() + "] ");
+				AppendText(" [" + wxDateTime::Now().Format("%X") + "] ");
 			}
 		}
 
@@ -130,7 +130,7 @@ CChatSession *CChatSelector::StartSession(uint64 client_id, const wxString &clie
 	text = wxString(" *** ") +
 	       wxString(CFormat(_("Chat-Session Started: %s (%s:%u) - %s %s")) % client_name %
 			Uint32toStringIP(IP_FROM_GUI_ID(client_id)) % PORT_FROM_GUI_ID(client_id) %
-			wxDateTime::Now().FormatISODate() % wxDateTime::Now().FormatISOTime());
+			FormatLocalDate(wxDateTime::Now()) % wxDateTime::Now().Format("%X"));
 
 	chatsession->AddText(text, COLOR_RED);
 	AddPage(chatsession, client_name, show, 0);

--- a/src/ClientHistoryListCtrl.cpp
+++ b/src/ClientHistoryListCtrl.cpp
@@ -357,8 +357,9 @@ wxString CClientHistoryListCtrl::GetItemColumnText(wxUIntPtr item, unsigned colu
 		return row->identityKnown ? OriginToText(row->sourceFrom) : wxString();
 
 	case COLUMN_HISTORY_FIRST_SEEN:
-		return row->firstSeen == 0 ? wxString()
-					   : wxDateTime(static_cast<time_t>(row->firstSeen)).FormatDate();
+		return row->firstSeen == 0
+			       ? wxString()
+			       : FormatLocalDateTime(wxDateTime(static_cast<time_t>(row->firstSeen)));
 
 	case COLUMN_HISTORY_LAST_SEEN:
 		// A date is the wrong answer for a peer that is here now -- and the
@@ -370,7 +371,7 @@ wxString CClientHistoryListCtrl::GetItemColumnText(wxUIntPtr item, unsigned colu
 		if (row->lastSeen == 0) {
 			return wxEmptyString;
 		}
-		return wxDateTime(static_cast<time_t>(row->lastSeen)).FormatDate();
+		return FormatLocalDateTime(wxDateTime(static_cast<time_t>(row->lastSeen)));
 
 	case COLUMN_HISTORY_SESSIONS:
 		if (row->sessions == 0) {

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -44,7 +44,8 @@
 #include "SourceListCtrl.h"
 #include "Statistics.h" // Needed for theStats (free space), FREE_SPACE_UNKNOWN
 #include "TransferWnd.h"
-#include "muuli_wdr.h" // Needed for ID_DLOADLIST
+#include "muuli_wdr.h"      // Needed for ID_DLOADLIST
+#include "OtherFunctions.h" // Needed for FormatLocalDateTime
 
 namespace
 {
@@ -910,14 +911,14 @@ wxString CDownloadListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) c
 
 	case COLUMN_DL_LASTSEENCOMPLETE:
 		if (file->lastseencomplete) {
-			return wxDateTime(file->lastseencomplete).Format(_("%y/%m/%d %H:%M:%S"));
+			return FormatLocalDateTime(wxDateTime(file->lastseencomplete));
 		}
 		return _("Unknown");
 
 	case COLUMN_DL_LASTRECEPTION: {
 		const time_t lastReceived = file->GetLastChangeDatetime();
 		if (lastReceived) {
-			return wxDateTime(lastReceived).Format(_("%y/%m/%d %H:%M:%S"));
+			return FormatLocalDateTime(wxDateTime(lastReceived));
 		}
 		return _("Unknown");
 	}

--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -210,7 +210,7 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 			bufferS = wxString(_("Unknown")).MakeLower();
 		} else {
 			wxDateTime last_seen(part->lastseencomplete);
-			bufferS = last_seen.FormatISODate() + " " + last_seen.FormatISOTime();
+			bufferS = FormatLocalDateTime(last_seen);
 		}
 		CastChild(IDC_LASTSEENCOMPL, wxControl)->SetLabel(bufferS);
 	}
@@ -242,14 +242,14 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 		bufferS = wxString(_("Unknown")).MakeLower();
 	} else {
 		wxDateTime ds(m_file->GetDateShared());
-		bufferS = ds.FormatISODate() + " " + ds.FormatISOTime();
+		bufferS = FormatLocalDateTime(ds);
 	}
 	CastChild(IDC_FD_SHARE_SINCE, wxControl)->SetLabel(bufferS);
 	if (m_file->GetLastUpload() == 0) {
 		bufferS = wxString(_("Unknown")).MakeLower();
 	} else {
 		wxDateTime lu(m_file->GetLastUpload());
-		bufferS = lu.FormatISODate() + " " + lu.FormatISOTime();
+		bufferS = FormatLocalDateTime(lu);
 	}
 	CastChild(IDC_FD_SHARE_LASTUP, wxControl)->SetLabel(bufferS);
 

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -112,6 +112,20 @@ wxString CastSecondsToHM(uint32 count, uint16 msecs)
 	}
 }
 
+wxString FormatLocalDateTime(const wxDateTime &when)
+{
+	// %x %X: both halves come from LC_TIME, so a locale that writes the day
+	// first, or separates with dots, or wants a 12-hour clock, gets what it
+	// writes -- and every timestamp in the interface agrees, because they
+	// all arrive here.
+	return when.Format("%x %X");
+}
+
+wxString FormatLocalDate(const wxDateTime &when)
+{
+	return when.Format("%x");
+}
+
 // Codec FOURCC -> human-readable name. Mapping inspired by eMule AI's
 // MediaInfo.cpp (GPL v2+). Implementation rewritten for wx + a small
 // initial set; extend as needed. Unknown / unrecognised codec IDs

--- a/src/OtherFunctions.h
+++ b/src/OtherFunctions.h
@@ -26,7 +26,8 @@
 #ifndef OTHERFUNCTIONS_H
 #define OTHERFUNCTIONS_H
 
-#include <wx/intl.h> // Needed for wxLANGUAGE_ constants
+#include <wx/datetime.h> // Needed for wxDateTime
+#include <wx/intl.h>     // Needed for wxLANGUAGE_ constants
 
 #include "Types.h"       // Needed for uint16, uint32 and uint64
 #include "Preferences.h" // Needed for AllCategoryFilter enumeration
@@ -215,6 +216,23 @@ wxString CastItoIShort(uint64 number);
 wxString CastItoSpeed(uint32 bytes);
 // Converts an amount of seconds to human readable time.
 wxString CastSecondsToHM(uint32 seconds, uint16 msecs = 0);
+/**
+ * A timestamp written the way the user's locale writes one.
+ *
+ * "%x %X", so the day/month order, the separators and the 12- or 24-hour
+ * clock all come from LC_TIME rather than from us. Every timestamp the
+ * interface shows goes through here, so the choice is made once instead of
+ * per call site -- which is how they came to disagree with each other
+ * (amule-org/amule#925).
+ *
+ * Not for the log or for anything on the wire. An ISO 8601 stamp sorts
+ * lexicographically, cannot be read day-first or month-first by mistake and
+ * survives being pasted into a bug report by someone in another locale, all
+ * of which matter more there than looking familiar does.
+ */
+wxString FormatLocalDateTime(const wxDateTime &when);
+// Date-only form of the above, for a column too narrow to carry both.
+wxString FormatLocalDate(const wxDateTime &when);
 // Maps an ed2k FT_MEDIA_CODEC FOURCC / format string to a friendlier
 // display name (e.g. "H264" -> "H.264", "XVID" -> "Xvid"). Unknown
 // values pass through unchanged. Used by SearchListCtrl to render the

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -45,6 +45,7 @@
 #include "kademlia/utils/UInt128.h"
 
 #include "ClientList.h"
+#include "OtherFunctions.h" // Needed for FormatLocalDateTime
 
 wxBEGIN_EVENT_TABLE(CServerWnd, wxPanel)
 	EVT_BUTTON(ID_ADDTOLIST, CServerWnd::OnBnClickedAddserver)
@@ -278,7 +279,7 @@ void CServerWnd::UpdateED2KInfo()
 		// as it does locally -- no CLIENT_GUI gate needed.
 		if (theApp->GetED2KConnectedSince().IsValid()) {
 			InfoInsertRow(ED2KInfoList, 4, _("Connected since:"));
-			InfoSetValue(ED2KInfoList, 4, theApp->GetED2KConnectedSince().Format("%x %X"));
+			InfoSetValue(ED2KInfoList, 4, FormatLocalDateTime(theApp->GetED2KConnectedSince()));
 		}
 	} else {
 		// No data
@@ -317,7 +318,7 @@ void CServerWnd::UpdateKadInfo()
 				InfoInsertRow(KadInfoList, next_row, _("Connected since:"));
 				InfoSetValue(KadInfoList,
 					next_row++,
-					theApp->GetKadConnectedSince().Format("%x %X"));
+					FormatLocalDateTime(theApp->GetKadConnectedSince()));
 			}
 			InfoInsertRow(KadInfoList, next_row, _("Connection State:"));
 			InfoSetValue(KadInfoList,

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -50,6 +50,7 @@
 #include "DownloadQueue.h"    // Needed for CDownloadQueue
 #include "TransferWnd.h"      // Needed for CTransferWnd
 #include "Logger.h"           // Needed for AddLogLine
+#include "OtherFunctions.h"   // Needed for FormatLocalDateTime
 
 wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualDataViewCtrl)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CSharedFilesCtrl::OnItemRightClicked)
@@ -403,14 +404,14 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 	case COLUMN_SHARED_SINCE:
 		if (file->GetDateShared()) {
 			wxDateTime ds(file->GetDateShared());
-			return ds.FormatISODate() + " " + ds.FormatISOTime();
+			return FormatLocalDateTime(ds);
 		}
 		return wxEmptyString;
 
 	case COLUMN_SHARED_LASTUP:
 		if (file->GetLastUpload()) {
 			wxDateTime lu(file->GetLastUpload());
-			return lu.FormatISODate() + " " + lu.FormatISOTime();
+			return FormatLocalDateTime(lu);
 		}
 		return wxEmptyString;
 


### PR DESCRIPTION
Closes #925.

The interface wrote dates four different ways. `Networks > ED2K Info` used `"%x %X"` and so followed `LC_TIME`; the log, the shared-files columns and the file-details dialog wrote ISO 8601; the downloads columns wrote `%y/%m/%d`, which is neither the locale's order nor a full year.

They all go through one helper now — `FormatLocalDateTime()` in `OtherFunctions` — so the format is a single decision rather than one per call site, which is how they came to disagree in the first place. `ED2K Info` was already correct and moves to the helper too, so there is no site left holding its own copy of the format.

### Sites changed

| Location | File |
| :--- | :--- |
| Downloads > Last seen complete / Last reception | `DownloadListCtrl.cpp` |
| Shared files > Shared since / Last upload | `SharedFilesCtrl.cpp` |
| File details > Last seen complete / Shared since / Last upload | `FileDetailDialog.cpp` |
| Messages > per-message stamp, session header | `ChatSelector.cpp` |
| Clients > First seen / Last seen | `ClientHistoryListCtrl.cpp` |
| Networks > ED2K Info, Kad | `ServerWnd.cpp` |

The reporter listed four rows; the file-details dialog, the Messages tab and the Clients columns were not in the report and are the same defect.

`Clients > First seen / Last seen` were already locale-aware via `FormatDate()` but date-only. They now carry the time, like every other column showing one.

### The downloads format was a translatable string

It was wrapped in `_()`, so the format itself was a msgid and translators had been hand-rolling locale support in the catalogs. Ten override it (`ca`, `et_EE`, `fr`, `he`, `hu`, `lv`, `nn`, `sl`, `sv`, `uk`), and two are broken as shipped: `he` and `nn` carry U+00B7 MIDDLE DOT where the separating space belongs, so those users read `15/08/26·19:30:00`. (`fr`'s U+00A0 before each colon is correct French typography, not a bug.)

Moving the site to the helper retires the msgid and every override with it. That is the only catalog change: one msgid removed, none added.

### Deliberately unchanged

`CLogger::DoLines` builds one stamp for the GUI log pane, stdout **and** the on-disk logfile. ISO 8601 there sorts lexicographically, cannot be misread day-first or month-first, and survives being pasted into a bug report by someone in another locale — and localising it would change the logfile format and daemon stdout, not just the pane.

`WebServer.cpp` writes an HTTP header date with `strftime`; RFC 9110 fixes that to exactly that form in the C locale.

`amuleapi` emits raw epoch integers in JSON, which is what an API should do. `amulecmd`, `ed2k`, `wxCas` and `fileview` have no offending sites.

### Testing

Built on macOS arm64. Verified by sweeping every date/time formatting call in `src/` rather than working from the reported list, so the set above is the complete GUI surface.

`%x %X` was checked against wx on GTK directly, since macOS auto-disables `ENABLE_NLS` and so cannot demonstrate it:

| `LC_TIME` | rendered |
| :--- | :--- |
| `en_US.UTF-8` | `08/15/2026 07:30:00 PM` |
| `en_GB.UTF-8` | `15/08/26 19:30:00` |
| `it_IT.UTF-8` | `15/08/2026 19:30:00` |

The `en_US` row is the `MM/DD/YYYY XX:XX:XX PM` the report calls correct for ED2K Info, so the other panels now agree with the one that was already right.

Worth noting before someone reports it as a regression: glibc defines `%x` with a two-digit year for `en_GB`, so a British user still reads `15/08/26` in the downloads columns. That is the locale's choice rather than ours — the short year in the report came from aMule hardcoding `%y`, and overriding `%x` to force four digits would put us back to picking formats ourselves, which is what made these panels disagree in the first place.
