### PR TITLE
feat(gui): show how much of the shared total is actually completed

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -7041,6 +7041,16 @@ msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
@@ -7049,11 +7059,6 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
-msgstr ""
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:32+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -7170,6 +7170,16 @@ msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "مجموع حجم ملفات المشاركة : %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "مجموع حجم ملفات المشاركة : %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "ملفات مشاركة (%i)"
@@ -7179,11 +7189,6 @@ msgstr[1] "ملفات مشاركة (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "ملفات مشاركة (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "مجموع حجم ملفات المشاركة : %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -7285,6 +7285,16 @@ msgstr[1] "Recargar los tos ficheros compartíos"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Tamañu total de ficheros compartíos: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamañu total de ficheros compartíos: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Ficheros Compartíos (%i)"
@@ -7294,11 +7304,6 @@ msgstr[1] "Ficheros Compartíos (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamañu total de ficheros compartíos: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -7143,6 +7143,16 @@ msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Общ размер на споределните файлове : %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общ размер на споределните файлове : %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Споделени файлове (%i)"
@@ -7152,11 +7162,6 @@ msgstr[1] "Споделени файлове (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Споделени файлове (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общ размер на споределните файлове : %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7040,6 +7040,16 @@ msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
@@ -7048,11 +7058,6 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
-msgstr ""
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -7246,6 +7246,16 @@ msgstr[1] "Recarrega els compartits"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Mida total dels fitxers compartits: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Mida total dels fitxers compartits: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Fitxers compartits (%i)"
@@ -7255,11 +7265,6 @@ msgstr[1] "Fitxers compartits (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Mida total dels fitxers compartits: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -7269,6 +7269,16 @@ msgstr[2] "Znovu načíst vaše sdílené soubory"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Celková velikost sdílených souborů: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Celková velikost sdílených souborů: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Sdílené soubory (%i)"
@@ -7279,11 +7289,6 @@ msgstr[2] "Sdílené soubory (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Celková velikost sdílených souborů: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -7190,6 +7190,16 @@ msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Total Størrelse Af Delte Filer: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total Størrelse Af Delte Filer: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Delte Filer (%i)"
@@ -7199,11 +7209,6 @@ msgstr[1] "Delte Filer (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte Filer (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total Størrelse Af Delte Filer: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -7241,6 +7241,16 @@ msgstr[1] "Freigegebene Dateien neu laden"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Gesamtgröße der freigegebenen Dateien: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Gesamtgröße der freigegebenen Dateien: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Freigegebene Dateien (%i)"
@@ -7250,11 +7260,6 @@ msgstr[1] "Freigegebene Dateien (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Gesamtgröße der freigegebenen Dateien: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -7301,6 +7301,16 @@ msgstr[1] "Επαναφόρτωση των κοινόχρηστων αρχείω
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Κοινόχρηστα αρχεία (%i)"
@@ -7310,11 +7320,6 @@ msgstr[1] "Κοινόχρηστα αρχεία (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Συνολικό μέγεθος κοινόχρηστων αρχείων: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -7041,6 +7041,16 @@ msgstr[1] ""
 
 #: src/SharedFilesCtrl.cpp
 #, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
@@ -7049,11 +7059,6 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
-msgstr ""
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:35+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -7223,6 +7223,16 @@ msgstr[1] "Recargar los archivos compartidos"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Tamaño total de los archivos compartidos: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total de los archivos compartidos: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Archivos compartidos (%i)"
@@ -7232,11 +7242,6 @@ msgstr[1] "Archivos compartidos (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total de los archivos compartidos: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -7256,6 +7256,16 @@ msgstr[1] "Lae oma jagatud failid uuesti"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Jagatud failide suurus kokku: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jagatud failide suurus kokku: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Jagatud failid (%i)"
@@ -7265,11 +7275,6 @@ msgstr[1] "Jagatud failid (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jagatud failide suurus kokku: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:36+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -7252,6 +7252,16 @@ msgstr[1] "Berritu zure partekatutako fitxategiak"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Guztira partekatutako fitxategi tamaina: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Guztira partekatutako fitxategi tamaina: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Partekatutako fitxategiak (%i)"
@@ -7261,11 +7271,6 @@ msgstr[1] "Partekatutako fitxategiak (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Guztira partekatutako fitxategi tamaina: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:36+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -7252,6 +7252,16 @@ msgstr[1] "Uudelleenlataa jaetut tiedostot"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Jaetut tiedostot (%i)"
@@ -7261,11 +7271,6 @@ msgstr[1] "Jaetut tiedostot (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Jaettujen tiedostojen yhteenlaskettu koko: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -7180,6 +7180,16 @@ msgstr[0] "%u fichier partagé a été exporté vers « %s »."
 msgstr[1] "%u fichiers partagés ont été exportés vers « %s »."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Taille totale des Fichiers Partagés : %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Taille totale des Fichiers Partagés : %s"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
@@ -7190,11 +7200,6 @@ msgstr[1] "Fichiers partagés (%i, hachage de %u autres fichiers)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Taille totale des Fichiers Partagés : %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -7256,6 +7256,16 @@ msgstr[1] "Recargar os seus ficheiros compartidos"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Tamaño total dos ficheiros compartidos: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamaño total dos ficheiros compartidos: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Ficheiros compartidos (%i)"
@@ -7265,11 +7275,6 @@ msgstr[1] "Ficheiros compartidos (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamaño total dos ficheiros compartidos: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -7227,6 +7227,16 @@ msgstr[1] "טען מחדש את הקבצים המשותפים שלך"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "גודל כולל של קבצים משותפים: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "גודל כולל של קבצים משותפים: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "קבצים משותפים (%i)"
@@ -7236,11 +7246,6 @@ msgstr[1] "קבצים משותפים (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "גודל כולל של קבצים משותפים: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -7221,6 +7221,16 @@ msgstr[2] "Korisnik %s (%u) dijeli direktorije %s"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Ukupna velicina dijeljenih fajlova: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Dijeljeni fajlovi (%i)"
@@ -7231,11 +7241,6 @@ msgstr[2] "Dijeljeni fajlovi (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dijeljeni fajlovi (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Ukupna velicina dijeljenih fajlova: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -7214,6 +7214,16 @@ msgstr[0] "Megosztott fájlok frissítése"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Megosztott fájlok teljes mérete: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Megosztott fájlok teljes mérete: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Megosztott fájlok (%i)"
@@ -7222,11 +7232,6 @@ msgstr[0] "Megosztott fájlok (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Megosztott fájlok teljes mérete: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -7184,6 +7184,16 @@ msgstr[0] "Esportato %u file condiviso in '%s'"
 msgstr[1] "Esportati %u file condivisi in '%s'."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Dimensione totale file condivisi: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensione totale file condivisi: %s"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
@@ -7194,11 +7204,6 @@ msgstr[1] "File condivisi (%i, hashing di altri %u file in corso)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensione totale file condivisi: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -7251,6 +7251,16 @@ msgstr[0] "共有ファイルを再ロードする"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "共有ファイルの合計サイズ： %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共有ファイルの合計サイズ： %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "共有ファイル（%i）"
@@ -7259,11 +7269,6 @@ msgstr[0] "共有ファイル（%i）"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共有ファイルの合計サイズ： %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -7300,6 +7300,16 @@ msgstr[1] "공유된 파일을 다시 읽어들임"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "공유파일의 전체 크기: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "공유파일의 전체 크기: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "공유된 파일(%i)"
@@ -7309,11 +7319,6 @@ msgstr[1] "공유된 파일(%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "공유파일의 전체 크기: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -7325,6 +7325,16 @@ msgstr[2] "Atnaujinti dalinamų failų sąrašą"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Bendras dalinamų failų dydis: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Bendras dalinamų failų dydis: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Dalinami failai (%i)"
@@ -7335,11 +7345,6 @@ msgstr[2] "Dalinami failai (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Bendras dalinamų failų dydis: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7089,6 +7089,16 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Kopīgoto datņu kopējais izmērs: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Kopīgoto datņu kopējais izmērs: %s"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
@@ -7100,11 +7110,6 @@ msgstr[2] "Kopīgotās datnes (%i, skaitļo %u kontrolsummu)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Kopīgotās datnes (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Kopīgoto datņu kopējais izmērs: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -7251,6 +7251,16 @@ msgstr[1] "Laad uw gedeelde bestanden opnieuw"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Totale grootte van gedeelde bestanden: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totale grootte van gedeelde bestanden: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Gedeelde bestanden (%i)"
@@ -7260,11 +7270,6 @@ msgstr[1] "Gedeelde bestanden (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totale grootte van gedeelde bestanden: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -7294,6 +7294,16 @@ msgstr[1] "Lastar inn att delte filer"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Total storleik på delte filer: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storleik på delte filer: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Delte filer (%i)"
@@ -7303,11 +7313,6 @@ msgstr[1] "Delte filer (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storleik på delte filer: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -7297,6 +7297,16 @@ msgstr[2] "Przeładuj twoje udostępnione pliki"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Łączny rozmiar udostępnianych plików: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Łączny rozmiar udostępnianych plików: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Udostępnione pliki (%i)"
@@ -7307,11 +7317,6 @@ msgstr[2] "Udostępnione pliki (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Łączny rozmiar udostępnianych plików: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -7181,6 +7181,16 @@ msgstr[0] "Exportado %u arquivo compartilhado para '%s'."
 msgstr[1] "Exportados %u arquivos compartilhados para '%s'."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Tamanho total de compartilhados: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total de compartilhados: %s"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
@@ -7191,11 +7201,6 @@ msgstr[1] "Arquivos Compartilhados (%i, fazendo hash de %u ou mais)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total de compartilhados: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -7260,6 +7260,16 @@ msgstr[1] "Recarregar os seus ficheiros partilhados"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Tamanho total dos Ficheiros Partilhados: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Tamanho total dos Ficheiros Partilhados: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Ficheiros Partilhados (%i)"
@@ -7269,11 +7279,6 @@ msgstr[1] "Ficheiros Partilhados (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Tamanho total dos Ficheiros Partilhados: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -7275,6 +7275,16 @@ msgstr[2] "Reîncărcați fișierele partajate"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Dimensiunea totală a fișierelor partajate: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Dimensiunea totală a fișierelor partajate: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Fișiere partajate (%i)"
@@ -7285,11 +7295,6 @@ msgstr[2] "Fișiere partajate (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Dimensiunea totală a fișierelor partajate: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -7242,6 +7242,16 @@ msgstr[1] "Экспортированы %u общих файла в «%s»."
 msgstr[2] "Экспортировано %u общих файлов в «%s»."
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Общий размер публикуемых файлов: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Общий размер публикуемых файлов: %s"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
@@ -7253,11 +7263,6 @@ msgstr[2] "Общие файлы (%i, вычисляется хеш для %u)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Общие файлы (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Общий размер публикуемых файлов: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -7317,6 +7317,16 @@ msgstr[3] "Ponovno naloži deljene datoteke"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Skupna velikost deljenih datotek: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Skupna velikost deljenih datotek: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Deljene datoteke (%i)"
@@ -7328,11 +7338,6 @@ msgstr[3] "Deljene datoteke (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Skupna velikost deljenih datotek: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -7284,6 +7284,16 @@ msgstr[1] "Ringarko failet e ndara"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Totali i madhesise se faileve te ndara: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Totali i madhesise se faileve te ndara: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Faile te ndara (%i)"
@@ -7293,11 +7303,6 @@ msgstr[1] "Faile te ndara (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Totali i madhesise se faileve te ndara: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:43+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -7246,6 +7246,16 @@ msgstr[1] "Återladda dina delade filer"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Total storlek på Delade filer: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Total storlek på Delade filer: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Utdelade filer (%i)"
@@ -7255,11 +7265,6 @@ msgstr[1] "Utdelade filer (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Total storlek på Delade filer: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7040,6 +7040,16 @@ msgstr[1] "பயனர் %s (%u) பகிர்ந்த கோப்பக�
 
 #: src/SharedFilesCtrl.cpp
 #, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
@@ -7048,11 +7058,6 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
-msgstr ""
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -7209,6 +7209,16 @@ msgstr[1] "Paylaşılan dosyalarınızı yeniden yükleyin"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Paylaşılan Dosyalar (%i)"
@@ -7218,11 +7228,6 @@ msgstr[1] "Paylaşılan Dosyalar (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Paylaşılan Dosyaların Toplam Boyutu: %s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -7325,6 +7325,16 @@ msgstr[2] "Перезавантажити ваші спільні файли"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "Загальний розмір спільних файлів: %s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "Загальний розмір спільних файлів: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "Спільні файли (%i)"
@@ -7335,11 +7345,6 @@ msgstr[2] "Спільні файли (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "Загальний розмір спільних файлів: %s"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7038,6 +7038,16 @@ msgstr[0] ""
 
 #: src/SharedFilesCtrl.cpp
 #, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] ""
@@ -7045,11 +7055,6 @@ msgstr[0] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
-msgstr ""
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -7177,6 +7177,16 @@ msgstr[0] "导出了 %u 个共享文件到 '%s'。"
 msgstr[1] "导出了 %u 个共享文件到 '%s'。"
 
 #: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "共享文件大小总和：%s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "共享文件大小总和：%s"
+
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
@@ -7187,11 +7197,6 @@ msgstr[1] "共享的文件 (%i，正在计算另外 %u 个文件的哈希值）"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "共享文件大小总和：%s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-14 13:50+0200\n"
+"POT-Creation-Date: 2026-08-15 22:54+0200\n"
 "PO-Revision-Date: 2026-08-14 21:45+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -7226,6 +7226,16 @@ msgstr[0] "重新載入分享的檔案"
 
 #: src/SharedFilesCtrl.cpp
 #, fuzzy, c-format
+msgid "Total size of Shared Files: %s (%s completed)"
+msgstr "檔案總容量：%s"
+
+#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
+#, c-format
+msgid "Total size of Shared Files: %s"
+msgstr "檔案總容量：%s"
+
+#: src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
 msgid "Shared Files (%i, hashing %u more)"
 msgid_plural "Shared Files (%i, hashing %u more)"
 msgstr[0] "分享檔案 (%i)"
@@ -7234,11 +7244,6 @@ msgstr[0] "分享檔案 (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
-
-#: src/SharedFilesCtrl.cpp src/SharedFilesWnd.cpp src/Statistics.cpp
-#, c-format
-msgid "Total size of Shared Files: %s"
-msgstr "檔案總容量：%s"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -1032,6 +1032,87 @@ void CSharedFilesCtrl::EndBulkUpdate()
 	}
 }
 
+uint64 CSharedFilesCtrl::ShownIncompleteBytes() const
+{
+	if (!theApp->downloadqueue) {
+		return 0;
+	}
+
+	std::vector<CPartFile *> parts;
+#ifdef CLIENT_GUI
+	// CDownQueueRem is a std::map keyed by ECID, with no CopyFileList().
+	// This file is compiled per executable rather than into muleappgui
+	// (cmake/source-vars.cmake), so the two builds really do see their own
+	// download queue here.
+	parts.reserve(theApp->downloadqueue->size());
+	for (const auto &entry : *theApp->downloadqueue) {
+		parts.push_back(entry.second);
+	}
+#else
+	theApp->downloadqueue->CopyFileList(parts);
+#endif
+
+	uint64 missing = 0;
+	for (CPartFile *part : parts) {
+		if (!part) {
+			continue;
+		}
+		// Upcast before the row lookup: the list keys its rows by the
+		// CKnownFile the share holds, which is what was stored.
+		const CKnownFile *known = part;
+		if (RowOfData(reinterpret_cast<wxUIntPtr>(known)) == -1) {
+			continue;
+		}
+		const uint64 size = part->GetFileSize();
+		const uint64 obtained = part->GetCompletedSize();
+		if (obtained < size) {
+			missing += size - obtained;
+		}
+	}
+	return missing;
+}
+
+void CSharedFilesCtrl::UpdateTotalSize()
+{
+	// The label lives in the statistics box (the bottom pane of the shared
+	// splitter), a different window from this list, so reach it through the
+	// shared-files window rather than GetParent(). Resolved once; see the
+	// note on m_freeSpaceLabel.
+	if (!theApp->amuledlg || !theApp->amuledlg->m_sharedfileswnd) {
+		return;
+	}
+	if (!m_totalSizeLabel) {
+		m_totalSizeLabel =
+			CastByName("sharedFilesTotalSize", theApp->amuledlg->m_sharedfileswnd, wxStaticText);
+		if (!m_totalSizeLabel) {
+			return;
+		}
+	}
+
+	// The total is the sum of the Size column, which shows a part file's
+	// final size. That answers "how much am I sharing" but not "how much of
+	// it do I have", and the two differ by however much is still to
+	// download -- 400 GB of it in the report that prompted this (#927). Both
+	// are shown rather than one replaced, so the total still adds up to its
+	// own column.
+	// "completed", the word the Downloads list already uses for this same
+	// quantity (its Completed column), rather than "complete": what is being
+	// counted is bytes obtained, not files that are finished.
+	const uint64 missing = ShownIncompleteBytes();
+	const wxString text =
+		missing ? CFormat(_("Total size of Shared Files: %s (%s completed)")) %
+				  CastItoXBytes(m_shownSize) % CastItoXBytes(m_shownSize - missing)
+			: CFormat(_("Total size of Shared Files: %s")) % CastItoXBytes(m_shownSize);
+
+	// SetLabel() repaints even when the text is unchanged, and the GUI timer
+	// calls this once a second for as long as the panel is up.
+	if (m_totalSizeLabel->GetLabel() == text) {
+		return;
+	}
+	m_totalSizeLabel->SetLabel(text);
+	m_totalSizeLabel->GetParent()->Layout();
+}
+
 void CSharedFilesCtrl::UpdateFreeSpace()
 {
 	if (!theApp->amuledlg || !theApp->amuledlg->m_sharedfileswnd) {
@@ -1061,18 +1142,7 @@ void CSharedFilesCtrl::ShowFilesCount()
 		label->SetLabel(CFormat(_("Shared Files (%i)")) % ItemDataCount());
 	}
 
-	// Combined size of the shown files. The label lives in the statistics box
-	// (the bottom pane of the shared splitter), a different window from this
-	// list, so reach it through the shared-files window rather than GetParent().
-	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd) {
-		wxStaticText *totalLabel =
-			CastByName("sharedFilesTotalSize", theApp->amuledlg->m_sharedfileswnd, wxStaticText);
-		if (totalLabel) {
-			totalLabel->SetLabel(
-				CFormat(_("Total size of Shared Files: %s")) % CastItoXBytes(m_shownSize));
-			totalLabel->GetParent()->Layout();
-		}
-	}
+	UpdateTotalSize();
 
 	label->GetParent()->Layout();
 	// If file list was updated, the "selection" is involved too, if we chose to show clients for all

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -188,6 +188,17 @@ public:
 	 */
 	void UpdateFreeSpace();
 
+	/**
+	 * Redraws the "Total size of Shared Files:" label.
+	 *
+	 * Also driven by the GUI timer, because unlike the total itself the
+	 * completed figure beside it moves while nothing about the list changes:
+	 * part files gain bytes as they download. Sets the label only when the
+	 * text actually differs, since this runs once a second for as long as
+	 * the panel is up.
+	 */
+	void UpdateTotalSize();
+
 	/** Map a (virtual) row index to its file, or NULL if out of range. */
 	CKnownFile *FileAtRow(long row) const { return reinterpret_cast<CKnownFile *>(ItemAt(row)); }
 
@@ -361,9 +372,26 @@ private:
 	//! Combined size of the displayed files (drives the "Total size:" label)
 	uint64 m_shownSize;
 
+	/**
+	 * Bytes the displayed part files have yet to obtain.
+	 *
+	 * m_shownSize is the sum of the Size column, and that column shows a part
+	 * file's final size, not what is on disk yet. Subtracting this gives the
+	 * figure the total is shown next to (issue #927).
+	 *
+	 * Walks the download queue and asks the row index whether each part file
+	 * is displayed, rather than walking the displayed files and asking each
+	 * whether it is a part file: there are at most as many part files as
+	 * there are downloads, against a share that can hold tens of thousands.
+	 */
+	uint64 ShownIncompleteBytes() const;
+
 	//! The "Free space:" label, resolved by name on first use. Lives in the
 	//! statistics box, so it cannot be reached through GetParent().
 	wxStaticText *m_freeSpaceLabel = nullptr;
+
+	//! The "Total size of Shared Files:" label, resolved the same way.
+	wxStaticText *m_totalSizeLabel = nullptr;
 
 	// The virtual-list model, sorting, live auto-sort and selection
 	// preservation all live in CMuleVirtualDataViewCtrl now.

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -640,6 +640,9 @@ void CamuleDlg::UpdateFreeSpaceLabels()
 	}
 	if (IsDialogVisible(DT_SHARED_WND) && m_sharedfileswnd && m_sharedfileswnd->sharedfilesctrl) {
 		m_sharedfileswnd->sharedfilesctrl->UpdateFreeSpace();
+		// The completed figure beside the total moves without the list
+		// changing, so it cannot wait for the next add or remove.
+		m_sharedfileswnd->sharedfilesctrl->UpdateTotalSize();
 	}
 }
 


### PR DESCRIPTION
Closes #927.

The report is 2.2 TB shown against 1.8 TB measured on disk, and its diagnosis is right: the total sums `CKnownFile::GetFileSize()`, which for a part file is its final size, and part files are in the share (`CPartFile` calls `SafeAddKFile` on itself). `CPartFile::GetCompletedSize()` exists and neither the label nor the statistics tree used it.

### Both figures, not one instead of the other

The Size column shows `GetFileSize()` for every row, so the total is exactly the sum of the column it sits under. Replacing it with the completed size would leave a label that no longer totals its own column, which is a worse defect than the one being fixed. So the completed figure goes beside it, and only when something displayed is incomplete:

```
Total size of Shared Files: 2.42 TB (1.86 TB completed)
```

With nothing incomplete the label is unchanged.

"Completed" is the word the Downloads list already uses for this quantity (`COLUMN_DL_COMPLETED`), and the file-details dialog for "Completed Size :".

### Cost

Only part files can differ from their final size, and there are at most as many of those as there are downloads. So this walks the download queue and asks the row index whether each one is displayed, rather than walking a share that can hold tens of thousands and asking each file whether it is a part file.

The figure moves while the list does not, so the GUI timer refreshes it on the tick that already updates the free-space label. Both are gated on the panel being visible, and the label is set only when the text differs, since `SetLabel()` repaints either way and this now runs once a second.

### Notes

The statistics tree's `shared_size` is deliberately untouched: it is exposed through the API stats tree, so redefining it is a change for consumers rather than a display fix.

`CDownQueueRem` has no `CopyFileList()`, so the queue walk is `#ifdef`-split. This file is compiled per executable rather than into `muleappgui`, so both builds see their own queue; `GetCompletedSize()` is populated over EC in the remote build.

New msgid, catalogs regenerated in a separate commit.

### Testing

Built on macOS arm64 and Ubuntu arm64, both the `amule` and `amulegui` targets, clean in the changed files and clang-format clean.
