### PR TITLE
feat: label byte sizes and rates with IEC units, matching the arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ strongly recommended.**
 
 Under `Preferences → Connection`, set the limits to roughly **80 %
 of your actual line speed** to avoid saturating the upstream and
-starving your own traffic. Values are in **kilobytes per second**
-(kB/s); ISP advertised speeds are usually in **megabits per
-second** (Mbps). To convert, multiply Mbps by **125**.
+starving your own traffic. Values are in **kibibytes per second**
+(KiB/s, units of 1024 bytes); ISP advertised speeds are usually in
+**megabits per second** (Mbps). To convert, multiply Mbps by **122**.
 
-> Example: a 100 Mbps / 20 Mbps fibre line → roughly 12 500 kB/s
-> downstream and 2 500 kB/s upstream. Set the limits to about
-> 10 000 down / 2 000 up to stay below the line cap.
+> Example: a 100 Mbps / 20 Mbps fibre line → roughly 12 200 KiB/s
+> downstream and 2 440 KiB/s upstream. Set the limits to about
+> 9 800 down / 1 950 up to stay below the line cap.
 
 ## Reporting Bugs
 

--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -505,17 +505,17 @@ isn't immediately obvious or has changed across protocol versions.
 
 | Tag                                | Code     | Type     | Description |
 | ---------------------------------- | -------- | -------- | ----------- |
-| `EC_TAG_CONN_DL_CAP`               | `0x1301` | `uint32` | Download line capacity (kB/s) |
-| `EC_TAG_CONN_UL_CAP`               | `0x1302` | `uint32` | Upload line capacity (kB/s) |
-| `EC_TAG_CONN_MAX_DL`               | `0x1303` | `uint32` | Max download speed (kB/s) |
-| `EC_TAG_CONN_MAX_UL`               | `0x1304` | `uint32` | Max upload speed (kB/s) |
+| `EC_TAG_CONN_DL_CAP`               | `0x1301` | `uint32` | Download line capacity (KiB/s) |
+| `EC_TAG_CONN_UL_CAP`               | `0x1302` | `uint32` | Upload line capacity (KiB/s) |
+| `EC_TAG_CONN_MAX_DL`               | `0x1303` | `uint32` | Max download speed (KiB/s) |
+| `EC_TAG_CONN_MAX_UL`               | `0x1304` | `uint32` | Max upload speed (KiB/s) |
 | `EC_TAG_CONN_SLOT_ALLOCATION`      | `0x1305` | `uint32` | Upload slot allocation |
 | `EC_TAG_CONN_MAX_FILE_SOURCES`     | `0x1309` | `uint16` | Max sources per file |
 | `EC_TAG_CONN_MAX_CONN`             | `0x130A` | `uint16` | Max connections |
 
 > **Note**: `EC_TAG_CONN_MAX_DL`, `EC_TAG_CONN_MAX_UL`, and
 > `EC_TAG_CONN_SLOT_ALLOCATION` were widened from `uint16` to `uint32`
-> to support speeds above 65534 kB/s (~524 Mbps) required on modern
+> to support speeds above 65534 KiB/s (~537 Mbps) required on modern
 > gigabit connections. EC clients reading these tags should use
 > `GetInt()` (which handles any integer width); clients sending them
 > should encode them as 32-bit values.

--- a/docs/IP2Country.md
+++ b/docs/IP2Country.md
@@ -47,7 +47,7 @@ Open `Preferences → IP2Country`. The tab looks like this:
 │                                                      │
 │ [Update now]    ☑ Auto-update on startup            │
 │                                                      │
-│ Status: Loaded (9.0 MB) — Data by DB-IP.com         │
+│ Status: Loaded (9.0 MiB) — Data by DB-IP.com        │
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -212,8 +212,8 @@ If the feature is enabled but flags don't appear:
 
 | Status                                                       | Meaning                                                              |
 |--------------------------------------------------------------|----------------------------------------------------------------------|
-| `Status: Loaded (X.X MB) — Data by <provider>`               | Database open, country lookups working.                              |
-| `Status: Loaded (X.X MB)` (no attribution)                   | Hand-installed `.mmdb` — aMule has no record of where it came from.  |
+| `Status: Loaded (X.X MiB) — Data by <provider>`              | Database open, country lookups working.                              |
+| `Status: Loaded (X.X MiB)` (no attribution)                  | Hand-installed `.mmdb` — aMule has no record of where it came from.  |
 | `Status: Failed to load — click 'Update now' to refresh.`    | The file is there but isn't a valid `.mmdb`. Click `Update now`.     |
 | `Status: Not found — click 'Update now' to download.`        | No `geoip.mmdb` at the expected path. Click `Update now`.            |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,12 +51,13 @@ Under `Preferences → Connection`, set the limits to roughly **80 % of
 your actual line speed** to avoid saturating the upstream and starving
 your own traffic.
 
-The values are in **kilobytes per second** (kB/s). ISP advertised speed
-is usually in **megabits per second** (Mbps); divide by 8 for kB/s.
+The values are in **kibibytes per second** (KiB/s, units of 1024 bytes).
+ISP advertised speed is usually in **megabits per second** (Mbps); to
+convert, multiply Mbps by **122**.
 
-> Example: a 100 Mbps / 20 Mbps fibre line → roughly 10000 kB/s
-> downstream and 2000 kB/s upstream. Set the *limits* to about 8000
-> down / 1600 up to stay below the line cap.
+> Example: a 100 Mbps / 20 Mbps fibre line → roughly 12200 KiB/s
+> downstream and 2440 KiB/s upstream. Set the *limits* to about 9800
+> down / 1950 up to stay below the line cap.
 
 ### 3. Pick what you share
 

--- a/docs/amulesig.md
+++ b/docs/amulesig.md
@@ -27,8 +27,8 @@ in the order below.
 | 3       | 0           | 0         | Server IP (dot-quad)                    | 0          |
 | 4       | 0           | 0         | Server port                             | 0          |
 | 5       | 0           | 0         | `H` or `L` (High-/Low-ID)               | 0          |
-| 6       | 0.0         | As online | Download speed in kB/s                  | As online  |
-| 7       | 0.0         | As online | Upload speed in kB/s                    | As online  |
+| 6       | 0.0         | As online | Download speed in KiB/s                  | As online  |
+| 7       | 0.0         | As online | Upload speed in KiB/s                    | As online  |
 | 8       | 0           | As online | Number of clients waiting for upload    | As online  |
 | 9       | 0           | As online | Number of shared files                  | As online  |
 | 10      | As online   | As online | Nick used on the eD2k network           | As online  |

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -726,11 +726,11 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
+msgid " KiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp
@@ -1247,7 +1247,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1821,7 +1821,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2371,7 +2371,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2468,11 +2468,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3118,7 +3118,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
+msgid "KiB/s"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
@@ -3444,16 +3444,16 @@ msgstr ""
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
+msgid "MiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
+msgid "GiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5196,11 +5196,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
+msgid "TiB"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -5226,7 +5222,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7405,7 +7401,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8194,22 +8190,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8374,7 +8370,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:32+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -740,11 +740,11 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
+msgid " KiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp
@@ -1271,7 +1271,7 @@ msgstr "فصل الإتصال"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1860,7 +1860,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2410,7 +2410,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2509,11 +2509,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3168,7 +3168,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
+msgid "KiB/s"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
@@ -3499,16 +3499,16 @@ msgstr "اقل حجم"
 msgid "Bytes"
 msgstr "بايت"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
+msgid "MiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
+msgid "GiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5276,11 +5276,7 @@ msgstr[0] "بايت"
 msgstr[1] "بايت"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
+msgid "TiB"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -5307,7 +5303,7 @@ msgstr[0] "بايت"
 msgstr[1] "بايت"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7535,7 +7531,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8331,22 +8327,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8511,7 +8507,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -758,13 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1291,8 +1290,8 @@ msgstr "Desconeutáu"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1881,9 +1880,9 @@ msgstr "Renomar ficheru"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2462,8 +2461,8 @@ msgstr "%.2f%% fináu."
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2562,11 +2561,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3224,8 +3223,8 @@ msgstr "Esbillar too"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3559,17 +3558,17 @@ msgstr "Tamañu mín"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5362,12 +5361,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5392,8 +5387,8 @@ msgstr[0] "byte/seg"
 msgstr[1] "bytes/seg"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7653,8 +7648,8 @@ msgstr "El nivel de fieltráu de IP actual ye %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Llímites del anchor de banda: Xuba: %u kB/s, Baxada: %u kB/s\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8507,23 +8502,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8696,8 +8691,8 @@ msgid "Download: "
 msgstr "Descargáu:"
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Xuba: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9003,6 +8998,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -738,12 +738,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " кБ/с"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1266,7 +1266,7 @@ msgstr "Връзката е разпадната"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1854,7 +1854,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2406,7 +2406,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2506,11 +2506,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3161,8 +3161,8 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "кБ/с"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3491,17 +3491,17 @@ msgstr "Минимален размер"
 msgid "Bytes"
 msgstr "Байта"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5261,12 +5261,8 @@ msgstr[0] "Байта"
 msgstr[1] "байта"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
+msgid "TiB"
 msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5292,7 +5288,7 @@ msgstr[0] "Байта"
 msgstr[1] "Байта"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7508,7 +7504,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8302,22 +8298,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8482,7 +8478,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
@@ -8787,6 +8783,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " kB/s"
+#~ msgstr " кБ/с"
+
+#~ msgid "kB/s"
+#~ msgstr "кБ/с"
 
 #, fuzzy
 #~ msgid "Percent of total files"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -725,11 +725,11 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
+msgid " KiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp
@@ -1246,7 +1246,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1820,7 +1820,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2370,7 +2370,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2467,11 +2467,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3117,7 +3117,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
+msgid "KiB/s"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
@@ -3443,16 +3443,16 @@ msgstr ""
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
+msgid "MiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
+msgid "GiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5195,11 +5195,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
+msgid "TiB"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -5225,7 +5221,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7404,7 +7400,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8193,22 +8189,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8373,7 +8369,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:33+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -758,12 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1288,8 +1288,8 @@ msgstr "Desconnectat"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1877,8 +1877,8 @@ msgstr "Reanomena"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2454,8 +2454,8 @@ msgstr "%.1f%% fet"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2554,11 +2554,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3212,8 +3212,8 @@ msgstr "Selecciona-ho tot"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3547,17 +3547,17 @@ msgstr "Mida Mín."
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5337,12 +5337,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5367,8 +5363,8 @@ msgstr[0] "byte/seg"
 msgstr[1] "bytes/seg"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7618,8 +7614,8 @@ msgstr "El nivell actual del filtre IP és %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Límits d'ample de banda: Pujada: %u kB/s, Baixada: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8451,23 +8447,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8640,8 +8636,8 @@ msgid "Download: "
 msgstr "Baixant: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, pujant: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8947,6 +8943,21 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%d/%m/%y %H:%M:%S"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -760,12 +760,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Odesílání: %.1f%s (%.1f) | Stahování: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1293,8 +1293,8 @@ msgstr "Odpojeno"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1870,8 +1870,8 @@ msgstr "Přejmenování souboru"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2447,8 +2447,8 @@ msgstr "%.2f%% dokončeno"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2547,11 +2547,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3213,8 +3213,8 @@ msgstr "Označit vše"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3548,17 +3548,17 @@ msgstr "Min. velikost"
 msgid "Bytes"
 msgstr "bajtů"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5343,12 +5343,8 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5374,8 +5370,8 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7638,7 +7634,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8450,23 +8446,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8638,8 +8634,8 @@ msgid "Download: "
 msgstr "Stahování: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, odesílání: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8945,6 +8941,21 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -743,12 +743,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1274,7 +1274,7 @@ msgstr "Afbrudt"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1862,9 +1862,9 @@ msgstr "Omdøb fil"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.2f MB"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2415,8 +2415,8 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2515,11 +2515,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3177,8 +3177,8 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3510,17 +3510,17 @@ msgstr "Min Størrelse"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5292,12 +5292,8 @@ msgstr[0] "Bytes"
 msgstr[1] "Bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
+msgid "TiB"
 msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5323,7 +5319,7 @@ msgstr[0] "kB/s"
 msgstr[1] "kB/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7556,7 +7552,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8351,23 +8347,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8540,8 +8536,8 @@ msgid "Download: "
 msgstr "Download: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upload: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8846,6 +8842,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
 
 #, fuzzy
 #~ msgid "Percent of total files"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -765,12 +765,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1296,8 +1296,8 @@ msgstr "Verbindung getrennt"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1884,8 +1884,8 @@ msgstr "Datei umbenennen"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2459,8 +2459,8 @@ msgstr "%.1f%% erledigt"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2559,11 +2559,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3217,8 +3217,8 @@ msgstr "Alles auswählen"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3545,17 +3545,17 @@ msgstr "Mindestgröße"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5333,12 +5333,8 @@ msgstr[0] "Byte"
 msgstr[1] "Bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5363,8 +5359,8 @@ msgstr[0] "Byte/Sek"
 msgstr[1] "Bytes/Sek"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7611,8 +7607,8 @@ msgstr "Momentane IP-Filterstufe ist %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Bandbreiteneinstellungen: Hoch: %u kB/s, Herunter: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8460,23 +8456,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8649,8 +8645,8 @@ msgid "Download: "
 msgstr "Download: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upload: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8961,6 +8957,21 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:34+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -763,13 +763,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1300,8 +1299,8 @@ msgstr "Αποσυνδεδεμένο"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1889,9 +1888,9 @@ msgstr "Μετονομασία αρχείου"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2471,8 +2470,8 @@ msgstr "%.2f%% ολοκληρώθηκαν"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2571,11 +2570,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3235,8 +3234,8 @@ msgstr "Επιλογή όλων"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3570,17 +3569,17 @@ msgstr "Ελάχιστο μέγεθος"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5373,12 +5372,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5403,8 +5398,8 @@ msgstr[0] "byte/δευτερόλεπτο"
 msgstr[1] "bytes/δευτερόλεπτο"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7669,8 +7664,8 @@ msgstr "Το τρέχον επίπεδο IPFilter είναι %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Ευρυζωνικά όρια: Πάνω: %u kB/s, Κάτω: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8525,23 +8520,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8714,8 +8709,8 @@ msgid "Download: "
 msgstr "Μεταφόρτωση"
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Ανέβασμα: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9021,6 +9016,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -726,11 +726,11 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
+msgid " KiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp
@@ -1247,7 +1247,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1821,7 +1821,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2371,7 +2371,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2468,11 +2468,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3118,7 +3118,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
+msgid "KiB/s"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
@@ -3444,16 +3444,16 @@ msgstr ""
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
+msgid "MiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
+msgid "GiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5196,11 +5196,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
+msgid "TiB"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -5226,7 +5222,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7405,7 +7401,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8194,22 +8190,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8374,7 +8370,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:35+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -770,12 +770,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1300,8 +1300,8 @@ msgstr "Desconectado"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1887,8 +1887,8 @@ msgstr "Renombrar el archivo"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2462,8 +2462,8 @@ msgstr "%.1f%% terminado"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2562,11 +2562,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3218,8 +3218,8 @@ msgstr "Seleccionar todo"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3544,17 +3544,17 @@ msgstr "Tamaño mínimo"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5329,12 +5329,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5359,8 +5355,8 @@ msgstr[0] "byte/s"
 msgstr[1] "bytes/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7593,8 +7589,8 @@ msgstr "El nivel de filtrado de IP actual es %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Límites del ancho de banda: subida: %u kB/s, bajada: %u kB/s\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8442,23 +8438,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8631,8 +8627,8 @@ msgid "Download: "
 msgstr "Descargado: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, subida: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8942,6 +8938,21 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -758,13 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1289,8 +1288,8 @@ msgstr "Pole ühendust"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1877,9 +1876,9 @@ msgstr "Faili ümbernimetamine"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2455,8 +2454,8 @@ msgstr "%.2f%% tehtud"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2555,11 +2554,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3213,8 +3212,8 @@ msgstr "Vali kõik"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3548,17 +3547,17 @@ msgstr "Vähim Suurus"
 msgid "Bytes"
 msgstr "Baiti"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5340,12 +5339,8 @@ msgstr[0] "baiti"
 msgstr[1] "baiti"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5370,8 +5365,8 @@ msgstr[0] "baiti/sek"
 msgstr[1] "baiti/sek"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7623,8 +7618,8 @@ msgstr "Kehtiv IPFilter Tase on %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Ribalaiuse piirangud: Üles :%u kB/s, Alla: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8454,23 +8449,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8643,8 +8638,8 @@ msgid "Download: "
 msgstr "Tõmbamine: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Saatmine: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8950,6 +8945,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%H:%M:%S %d/%m/%y"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:36+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -759,13 +759,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1290,8 +1289,8 @@ msgstr "Deskonektatuta"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1878,9 +1877,9 @@ msgstr "Fitxategia berrizendatu"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2456,8 +2455,8 @@ msgstr "%.1f%% egina"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2556,11 +2555,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3214,8 +3213,8 @@ msgstr "Hautatu dena"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3549,17 +3548,17 @@ msgstr "Gutx. tamaina"
 msgid "Bytes"
 msgstr "Byte"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5340,12 +5339,8 @@ msgstr[0] "byte"
 msgstr[1] "byte"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5370,8 +5365,8 @@ msgstr[0] "byte/seg"
 msgstr[1] "byte/seg"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7619,8 +7614,8 @@ msgstr "Uneko IPiragazki maila %d da.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Banda-zabalera mugak: Gora: %u kB/s, Behera: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8454,23 +8449,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8643,8 +8638,8 @@ msgid "Download: "
 msgstr "Deskargak: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Igoerak: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8950,6 +8945,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:36+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -759,13 +759,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " KB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1290,8 +1289,8 @@ msgstr "Yhteys katkaistu"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f KB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1878,9 +1877,9 @@ msgstr "Tiedoston uudelleennimeäminen"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f KB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2456,8 +2455,8 @@ msgstr "%.1f%% valmiina"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f KB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2556,11 +2555,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3214,8 +3213,8 @@ msgstr "Valitse kaikki"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "KB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3549,17 +3548,17 @@ msgstr "Vähimmäiskoko"
 msgid "Bytes"
 msgstr "Tavua"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5340,12 +5339,8 @@ msgstr[0] "tavu"
 msgstr[1] "tavua"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5370,8 +5365,8 @@ msgstr[0] "tavu/s"
 msgstr[1] "tavua/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7619,8 +7614,8 @@ msgstr "Nykyinen IP-suodatustaso on %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Kaistarajoitukset: Ylös: %u KB/s, Alas: %u KB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8454,23 +8449,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8643,8 +8638,8 @@ msgid "Download: "
 msgstr "Lataus: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " KB/s, Lähetys: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8950,6 +8945,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " KB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "KB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -765,12 +765,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " Mo/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " Ko/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1294,8 +1294,8 @@ msgstr "Déconnecté"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f Ko/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1870,8 +1870,8 @@ msgstr "Renommer"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f Mo/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2445,8 +2445,8 @@ msgstr "%.1f%% effectué"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f Ko/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2546,12 +2546,12 @@ msgid "Other / set manually"
 msgstr "Autre / définir manuellement"
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
-msgstr "Limite d’envoi (ko/s, 0 = illimitée) :"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
-msgstr "Limite de téléchargement (ko/s, 0 = illimitée) :"
+msgid "Download limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
 msgid "Networks & ports"
@@ -3209,8 +3209,8 @@ msgstr "Tout sélectionner"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "Ko/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3535,17 +3535,17 @@ msgstr "Taille Minimum"
 msgid "Bytes"
 msgstr "Octets"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "Ko"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "Mo"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "Go"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5304,12 +5304,8 @@ msgstr[0] "octet"
 msgstr[1] "octets"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "ko"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "To"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5334,8 +5330,8 @@ msgstr[0] "octet/sec"
 msgstr[1] "octets/sec"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "Mo/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7551,8 +7547,8 @@ msgstr "Le niveau actuel d'IPFilter est %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Limites de la bande passante : E : %u ko/s, R : %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8400,23 +8396,23 @@ msgstr "%.0f o"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f Ko"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f Mo"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f Go"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f To"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8589,8 +8585,8 @@ msgid "Download: "
 msgstr "Réception : "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " Ko/s, Émission : "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8900,6 +8896,21 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid " MB/s"
+#~ msgstr " Mo/s"
+
+#~ msgid " kB/s"
+#~ msgstr " Ko/s"
+
+#~ msgid "kB/s"
+#~ msgstr "Ko/s"
+
+#~ msgid "kB"
+#~ msgstr "ko"
+
+#~ msgid "MB/s"
+#~ msgstr "Mo/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H : %M : %S"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -778,12 +778,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1309,8 +1309,8 @@ msgstr "Desconectado"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1897,8 +1897,8 @@ msgstr "Cambiar o nome do ficheiro"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2472,8 +2472,8 @@ msgstr "%.1f%% feito"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2572,11 +2572,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3230,8 +3230,8 @@ msgstr "Seleccionar todo"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3558,17 +3558,17 @@ msgstr "Tamaño mínimo"
 msgid "Bytes"
 msgstr "Octetos"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5347,12 +5347,8 @@ msgstr[0] "octeto"
 msgstr[1] "octetos"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5377,8 +5373,8 @@ msgstr[0] "octeto/seg"
 msgstr[1] "octetos/seg"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7626,8 +7622,8 @@ msgstr "O nivel de filtrado de IP actual está %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Límites de ancho de banda: Subida: %u kB/s, Baixada: %u kB/s\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8474,23 +8470,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8663,8 +8659,8 @@ msgid "Download: "
 msgstr "Descargado: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Enviado: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8971,6 +8967,21 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:37+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -745,13 +745,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "מ\"ב/ש"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " ק\"ב/ש"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1281,7 +1280,7 @@ msgstr "מנותק"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1868,9 +1867,9 @@ msgstr "שינוי שם לקובץ"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.2f מ\"ב"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2426,8 +2425,8 @@ msgstr "%.2f%% הושלם"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f ק\"ב/ש"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2526,11 +2525,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3190,8 +3189,8 @@ msgstr "בחר הכל"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "ק\"ב/ש"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3524,17 +3523,17 @@ msgstr "גודל מנימלי"
 msgid "Bytes"
 msgstr "בתים"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "ק\"ב"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "מ\"ב"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "ג\"ב"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5310,12 +5309,8 @@ msgstr[0] "בית"
 msgstr[1] "בית"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "ק\"ב"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "ט\"ב"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5341,8 +5336,8 @@ msgstr[0] "בייט/שניה"
 msgstr[1] "בייט/שניה"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "מ\"ב/ש"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7592,7 +7587,7 @@ msgstr "רמת סינום IP נוכחית היא %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8427,23 +8422,23 @@ msgstr "%.0f בתים"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f ק\"ב"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f מ\"ב"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f ג\"ב"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f ט\"ב"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8615,8 +8610,8 @@ msgid "Download: "
 msgstr "מוריד: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " ק\"ב/ש, העלאה: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8922,6 +8917,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "מ\"ב/ש"
+
+#~ msgid " kB/s"
+#~ msgstr " ק\"ב/ש"
+
+#~ msgid "kB/s"
+#~ msgstr "ק\"ב/ש"
+
+#~ msgid "kB"
+#~ msgstr "ק\"ב"
+
+#~ msgid "MB/s"
+#~ msgstr "מ\"ב/ש"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d·%H:%M:%S"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -745,13 +745,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1280,7 +1279,7 @@ msgstr "Prekinuta veza"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1869,9 +1868,9 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "MB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2424,7 +2423,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2523,11 +2522,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3186,8 +3185,8 @@ msgstr "Izaberite sve"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3520,17 +3519,17 @@ msgstr "Minimalna velicina"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5305,12 +5304,8 @@ msgstr[1] "Bytes"
 msgstr[2] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5337,8 +5332,8 @@ msgstr[1] "kBytes/sec"
 msgstr[2] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7587,7 +7582,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8382,22 +8377,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8562,7 +8557,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
@@ -8868,6 +8863,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #, fuzzy
 #~ msgid "Percent of total files"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -759,12 +759,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1286,8 +1286,8 @@ msgstr "Szétkapcsolva"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1873,8 +1873,8 @@ msgstr "Fájl átnevezés"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2446,8 +2446,8 @@ msgstr "%.1f%% kész"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2546,11 +2546,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3199,8 +3199,8 @@ msgstr "Mindent kijelöl"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3527,17 +3527,17 @@ msgstr "Min. méret"
 msgid "Bytes"
 msgstr "bájt"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5323,12 +5323,8 @@ msgid_plural "bytes"
 msgstr[0] "bájt"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5352,8 +5348,8 @@ msgid_plural "bytes/sec"
 msgstr[0] "bájt/mp"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7585,8 +7581,8 @@ msgstr "IP szűrő szintje jelenleg %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Sávszélesség korlátok: Fel: %u kB/s, Le: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8420,23 +8416,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8609,8 +8605,8 @@ msgid "Download: "
 msgstr "Letöltés: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Feltöltés: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8916,6 +8912,21 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y.%m.%d %H:%M:%S"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:38+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -770,12 +770,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1299,8 +1299,8 @@ msgstr "Disconnesso"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1875,8 +1875,8 @@ msgstr "Rinomina file"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2450,8 +2450,8 @@ msgstr "%.1f%% completato"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2551,12 +2551,12 @@ msgid "Other / set manually"
 msgstr "Altro / imposta manualmente"
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
-msgstr "Limite di upload (kB/s, 0 = illimitato):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
-msgstr "Limite di download (kB/s, 0 = illimitato):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
 msgid "Networks & ports"
@@ -3214,8 +3214,8 @@ msgstr "Seleziona tutto"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3540,17 +3540,17 @@ msgstr "Dimensione minima"
 msgid "Bytes"
 msgstr "Byte"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5309,12 +5309,8 @@ msgstr[0] "byte"
 msgstr[1] "byte"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5339,8 +5335,8 @@ msgstr[0] "byte/s"
 msgstr[1] "byte/sec"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7555,8 +7551,8 @@ msgstr "Il livello IPFilter attuale è %d\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Limiti di banda: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8403,23 +8399,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8592,8 +8588,8 @@ msgid "Download: "
 msgstr "Download: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upload: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8903,6 +8899,21 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -757,13 +757,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1289,8 +1288,8 @@ msgstr "切断"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1877,9 +1876,9 @@ msgstr "ファイルの改名"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2458,8 +2457,8 @@ msgstr "%.2f%%終わりました"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2558,11 +2557,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3215,8 +3214,8 @@ msgstr "全ての選択"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3549,17 +3548,17 @@ msgstr "最小サイズ"
 msgid "Bytes"
 msgstr "B"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5345,12 +5344,8 @@ msgid_plural "bytes"
 msgstr[0] "バイト"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5374,8 +5369,8 @@ msgid_plural "bytes/sec"
 msgstr[0] "B/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7618,7 +7613,7 @@ msgstr "現在のIPフィルタ段階は%dです。\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8454,23 +8449,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8643,8 +8638,8 @@ msgid "Download: "
 msgstr "ダウンロード： "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s、アップロード： "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8950,6 +8945,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -760,14 +760,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-#, fuzzy
-msgid " kB/s"
-msgstr "kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1299,8 +1297,8 @@ msgstr "연결이 끊김"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1887,9 +1885,9 @@ msgstr "파일 이름변경"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2470,8 +2468,8 @@ msgstr "%.2f%% 완료"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2570,11 +2568,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3236,8 +3234,8 @@ msgstr "모두 선택"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3570,17 +3568,17 @@ msgstr "최소 크기"
 msgid "Bytes"
 msgstr "바이트"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5367,12 +5365,8 @@ msgstr[0] "bytes"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5398,8 +5392,8 @@ msgstr[0] "bytes/s"
 msgstr[1] "bytes/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7671,7 +7665,7 @@ msgstr "현재 IP 차단 수준은 %d입니다.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8505,23 +8499,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8695,8 +8689,8 @@ msgid "Download: "
 msgstr "내려받기: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr "올려주기, kB/s: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9002,6 +8996,23 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#, fuzzy
+#~ msgid " kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -763,13 +763,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1304,8 +1303,8 @@ msgstr "Neprisijungta"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1894,9 +1893,9 @@ msgstr "Pervadinti failą"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2479,8 +2478,8 @@ msgstr "%.2f%% baigta"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2579,11 +2578,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3248,8 +3247,8 @@ msgstr "Pažymėti viską"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3583,17 +3582,17 @@ msgstr "Min dydis"
 msgid "Bytes"
 msgstr "Baitai"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5382,12 +5381,8 @@ msgstr[1] "baitai"
 msgstr[2] "baitų"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5413,8 +5408,8 @@ msgstr[1] "baitai/s"
 msgstr[2] "baitų/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7694,8 +7689,8 @@ msgstr "Dabartinis IP filtro lygmuo %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Spartos apribojimai: išs: %u kB/s, ats: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8545,23 +8540,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8734,8 +8729,8 @@ msgid "Download: "
 msgstr "Atsiųsta: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Išsiųsta: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9041,6 +9036,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -736,12 +736,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑Augšup.: %.1f%s (%.1f) | ↓Lejup.: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1259,8 +1259,8 @@ msgstr "Atslēgts"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1844,8 +1844,8 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2394,7 +2394,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2492,11 +2492,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3143,8 +3143,8 @@ msgstr "Atlasīt visas"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3469,17 +3469,17 @@ msgstr "Minimālais izmērs"
 msgid "Bytes"
 msgstr "Baiti"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5229,12 +5229,8 @@ msgstr[1] "baits"
 msgstr[2] "baiti"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5260,8 +5256,8 @@ msgstr[1] "baits sekundē"
 msgstr[2] "baiti sekundē"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7455,8 +7451,8 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Datu pārraides ierobežojumi: ↑Augšup.: %u kB/s, ↓Lejup.: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8246,23 +8242,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8426,7 +8422,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
@@ -8738,6 +8734,21 @@ msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y.%m.%d %H:%M:%S"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -760,12 +760,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1290,8 +1290,8 @@ msgstr "Niet verbonden"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f KB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1879,8 +1879,8 @@ msgstr "Naam wijzigen"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2458,8 +2458,8 @@ msgstr "%.1f%% voltooid"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2558,11 +2558,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3216,8 +3216,8 @@ msgstr "Alles selecteren"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3552,17 +3552,17 @@ msgstr "Min grootte"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5342,12 +5342,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5372,8 +5368,8 @@ msgstr[0] "byte/sec"
 msgstr[1] "bytes/sec"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7624,8 +7620,8 @@ msgstr "Huidige IP-filter niveau is %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Bandbreedtegrenzen: Upload: %u kB/s, Download: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8460,23 +8456,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8649,8 +8645,8 @@ msgid "Download: "
 msgstr "Download: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upload: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8956,6 +8952,21 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -761,13 +761,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1298,8 +1297,8 @@ msgstr "Fråkopla"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f·kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1887,9 +1886,9 @@ msgstr "Døyp om fil"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f·kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2470,8 +2469,8 @@ msgstr "%.2f%%·ferdig"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f·kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2570,11 +2569,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3234,8 +3233,8 @@ msgstr "Vél alle"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3569,17 +3568,17 @@ msgstr "Min storleik"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5367,12 +5366,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5397,8 +5392,8 @@ msgstr[0] "byte/sek"
 msgstr[1] "bytes/sek"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7662,8 +7657,8 @@ msgstr "Novérande IPFilternivå er %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Bandbreiddegrenser: Opp: %u kB/s, Ned: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8515,23 +8510,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f·KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8704,8 +8699,8 @@ msgid "Download: "
 msgstr "Nedlasting: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, opplasting: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9011,6 +9006,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d·%H:%M:%S"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:40+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -761,13 +761,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1296,8 +1295,8 @@ msgstr "Rozłączony"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1885,9 +1884,9 @@ msgstr "Zmień nazwę"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2465,8 +2464,8 @@ msgstr "%.2f%% skończone"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2565,11 +2564,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3228,8 +3227,8 @@ msgstr "Zaznacz wszystko"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3563,17 +3562,17 @@ msgstr "Min rozmiar"
 msgid "Bytes"
 msgstr "Bajtów"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5361,12 +5360,8 @@ msgstr[1] "bajty"
 msgstr[2] "bajtów"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5392,8 +5387,8 @@ msgstr[1] "bajty/sek"
 msgstr[2] "bajtów/sek"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7666,8 +7661,8 @@ msgstr "Aktualny poziom filtra IP to %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Limity przepustowości: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8503,23 +8498,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8692,8 +8687,8 @@ msgid "Download: "
 msgstr "Pobranych: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Wysłanych: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8999,6 +8994,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -766,12 +766,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1295,8 +1295,8 @@ msgstr "Desconectado"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1871,8 +1871,8 @@ msgstr "Renomear"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2446,8 +2446,8 @@ msgstr "%.1f%% concluído"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2547,12 +2547,12 @@ msgid "Other / set manually"
 msgstr "Outra / configurar manualmente"
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
-msgstr "Limite de upload (kB/s, 0 = sem limite):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
-msgstr "Limite de download (kB/s, 0 = sem limite):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
 msgid "Networks & ports"
@@ -3210,8 +3210,8 @@ msgstr "Selecionar Tudo"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3536,17 +3536,17 @@ msgstr "Tamanho Mínimo"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5305,12 +5305,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5335,8 +5331,8 @@ msgstr[0] "byte/s"
 msgstr[1] "bytes/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7552,8 +7548,8 @@ msgstr "Nível atual do IPFilter é %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Limites de banda: Enviar: %u kB/s, Baixar: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8401,23 +8397,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8590,8 +8586,8 @@ msgid "Download: "
 msgstr "Download: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upload: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8901,6 +8897,21 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -765,13 +765,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1296,8 +1295,8 @@ msgstr "Desligado"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1884,9 +1883,9 @@ msgstr "Renomear ficheiro"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2462,8 +2461,8 @@ msgstr "%.2f%% terminado"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2562,11 +2561,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3220,8 +3219,8 @@ msgstr "Seleccionar tudo"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3555,17 +3554,17 @@ msgstr "Tamanho Mínimo"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "kB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5347,12 +5346,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5377,8 +5372,8 @@ msgstr[0] "byte/seg"
 msgstr[1] "bytes/seg"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7627,8 +7622,8 @@ msgstr "O nível actual do filtro de IPs é %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Limites de banda: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8463,23 +8458,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f kB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8652,8 +8647,8 @@ msgid "Download: "
 msgstr "Download: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upload: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8959,6 +8954,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:41+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -758,13 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MO/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1293,8 +1292,8 @@ msgstr "Deconectat"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1882,9 +1881,9 @@ msgstr "Redenumire fișier"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2460,8 +2459,8 @@ msgstr "%.1f%% realizat"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2560,11 +2559,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3223,8 +3222,8 @@ msgstr "Selectează tot"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3558,17 +3557,17 @@ msgstr "Dimensiune minimă"
 msgid "Bytes"
 msgstr "Baiți"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MO"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GO"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5349,12 +5348,8 @@ msgstr[1] "octeți"
 msgstr[2] "octeți"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kO"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TO"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5380,8 +5375,8 @@ msgstr[1] "octeți/secundă"
 msgstr[2] "octeți/secundă"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MO/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7648,8 +7643,8 @@ msgstr "Nivelul actual al filtrului IP este %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Limite lățime de bandă: În: %u kB/s, Desc: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8481,23 +8476,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8670,8 +8665,8 @@ msgid "Download: "
 msgstr "Descărcare:"
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Încărcare:"
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8977,6 +8972,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MO/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kO"
+
+#~ msgid "MB/s"
+#~ msgstr "MO/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -770,12 +770,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Отд: %.1f%s (%.1f) | Скач: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " МБ/с"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " КБ/с"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1303,8 +1303,8 @@ msgstr "Отключён"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f КБ/с"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1884,8 +1884,8 @@ msgstr "Переименовать файл"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f МБ/с"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2462,8 +2462,8 @@ msgstr "%.1f%% выполнено"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f КБ/с"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2563,12 +2563,12 @@ msgid "Other / set manually"
 msgstr "Другое / указать вручную"
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
-msgstr "Ограничение отдачи (КБ/с, 0 = без ограничений):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
-msgstr "Ограничение скачивания (КБ/с, 0 = без ограничений):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
 msgid "Networks & ports"
@@ -3232,8 +3232,8 @@ msgstr "Выделить все"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "КБ/с"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3562,17 +3562,17 @@ msgstr "Мин. размер"
 msgid "Bytes"
 msgstr "Байт"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "КБ"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "МБ"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "ГБ"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5340,12 +5340,8 @@ msgstr[1] "байта"
 msgstr[2] "байт"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "КБ"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "ТБ"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5371,8 +5367,8 @@ msgstr[1] "байт/с"
 msgstr[2] "байт/с"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "МБ/с"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7616,8 +7612,8 @@ msgstr "Текущий уровень IP-фильтра: %d.\n"
 # писать тут "вверх" и "вниз" по-моему глупо. да и не поймет никто
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Ограничения скорости передачи: Отд: %u КБ/с, Скач: %u КБ/с.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8465,23 +8461,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f МБ"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8655,8 +8651,8 @@ msgid "Download: "
 msgstr "Скачивание: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " КБ/с, отдача: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8967,6 +8963,21 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid " MB/s"
+#~ msgstr " МБ/с"
+
+#~ msgid " kB/s"
+#~ msgstr " КБ/с"
+
+#~ msgid "kB/s"
+#~ msgstr "КБ/с"
+
+#~ msgid "kB"
+#~ msgstr "КБ"
+
+#~ msgid "MB/s"
+#~ msgstr "МБ/с"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -764,12 +764,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MiB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1302,8 +1302,8 @@ msgstr "Ni povezave"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1893,8 +1893,8 @@ msgstr "Preimenuj datoteko"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MiB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2475,8 +2475,8 @@ msgstr "%.1f %% zaključeno"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2575,11 +2575,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3243,8 +3243,8 @@ msgstr "Izberi vse"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3578,17 +3578,17 @@ msgstr "Min. velikost"
 msgid "Bytes"
 msgstr "Bajtov"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KiB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MiB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GiB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5373,12 +5373,8 @@ msgstr[2] "bajta"
 msgstr[3] "bajti"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5405,8 +5401,8 @@ msgstr[2] "bajta/sek."
 msgstr[3] "bajti/sek."
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MiB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7691,8 +7687,8 @@ msgstr "Trenutna stopnja IP filtriranja je %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Omejitve prenosa: Gor: %u kB/s, Dol: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8520,23 +8516,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KiB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MiB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GiB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TiB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8709,8 +8705,8 @@ msgid "Download: "
 msgstr "Prejemanje: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Pošiljanje: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9016,6 +9012,21 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid " MB/s"
+#~ msgstr " MiB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MiB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%d.%m.%y %H:%M:%S"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:42+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -758,13 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1295,8 +1294,8 @@ msgstr "I shkeputur"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1882,9 +1881,9 @@ msgstr "Riemertim i failit"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2464,8 +2463,8 @@ msgstr "%.2f%% te mbaruara"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2564,11 +2563,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3228,8 +3227,8 @@ msgstr "Zgjidhi te gjitha"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3562,17 +3561,17 @@ msgstr "Madhesia Minimale"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5359,12 +5358,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5389,8 +5384,8 @@ msgstr[0] "byte/sec"
 msgstr[1] "bytes/sec"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7652,7 +7647,7 @@ msgstr "Niveli aktual i filtrimit te IP eshte %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8486,23 +8481,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8675,8 +8670,8 @@ msgid "Download: "
 msgstr "Shkarkim: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Ngarkim: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8982,6 +8977,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:43+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -757,13 +757,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1288,8 +1287,8 @@ msgstr "Frånkopplad"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1876,9 +1875,9 @@ msgstr "Byt namn på fil"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2454,8 +2453,8 @@ msgstr "%.1f%% färdig"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2554,11 +2553,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3212,8 +3211,8 @@ msgstr "Markera alla"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3547,17 +3546,17 @@ msgstr "Min storlek"
 msgid "Bytes"
 msgstr "Bytes"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5337,12 +5336,8 @@ msgstr[0] "byte"
 msgstr[1] "bytes"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5367,8 +5362,8 @@ msgstr[0] "byte/sek"
 msgstr[1] "bytes/sek"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7618,8 +7613,8 @@ msgstr "Aktuell IPFilternivå är %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Bandbreddsgränser: Upp: %u kB/s, Ner: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8451,23 +8446,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8640,8 +8635,8 @@ msgid "Download: "
 msgstr "Hämta: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Upp: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8947,6 +8942,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H.%M.%S"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -725,11 +725,11 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
+msgid " KiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp
@@ -1246,7 +1246,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1820,7 +1820,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2370,7 +2370,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2467,11 +2467,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3117,7 +3117,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
+msgid "KiB/s"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
@@ -3443,16 +3443,16 @@ msgstr ""
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
+msgid "MiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
+msgid "GiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5195,11 +5195,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
+msgid "TiB"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -5225,7 +5221,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7404,7 +7400,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8193,22 +8189,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f மெபை"
-
-#: src/utils/wxCas/src/onlinesig.cpp
-#, c-format
-msgid "%.2f GB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f GiB"
+msgstr ""
+
+#: src/utils/wxCas/src/onlinesig.cpp
+#, c-format
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8373,7 +8369,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -758,12 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/sn"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1287,8 +1287,8 @@ msgstr "Bağlantı kesildi"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1863,8 +1863,8 @@ msgstr "Dosya yeniden adlandır"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2438,8 +2438,8 @@ msgstr "%.1f%% tamamlandı"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2542,12 +2542,12 @@ msgid "Other / set manually"
 msgstr "Diğer / el ile ayarla"
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
-msgstr "Gönderme sınırı (kB/s, 0 = sınırsız):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
-msgstr "İndirme sınırı (kB/s, 0 = sınırsız):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
 #, fuzzy
@@ -3209,8 +3209,8 @@ msgstr "Tümünü Seç"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "kB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3535,17 +3535,17 @@ msgstr "En Az Boyut"
 msgid "Bytes"
 msgstr "Bayt"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5316,12 +5316,8 @@ msgstr[0] "bayt"
 msgstr[1] "bayt"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "kB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5346,8 +5342,8 @@ msgstr[0] "bayt/sn"
 msgstr[1] "bayt/sn"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7579,8 +7575,8 @@ msgstr "Şu anki IP Süzgeç seviyesi %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Bağlantı sınırları: Gön: %u kb/s, İnd: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8428,23 +8424,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8617,8 +8613,8 @@ msgid "Download: "
 msgstr "Aktarım: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " kB/s, Gönderme "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8928,6 +8924,21 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/sn"
+
+#~ msgid "kB/s"
+#~ msgstr "kB/s"
+
+#~ msgid "kB"
+#~ msgstr "kB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -758,13 +758,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "Мбайт/с"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " кбайт/с"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1295,8 +1294,8 @@ msgstr "Від'єднана"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f кбайт/с"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1890,9 +1889,9 @@ msgstr "Змінити назву файлу"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f кбайт/с"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2474,8 +2473,8 @@ msgstr "%.2f%% виконано"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f кбайт/с"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2574,11 +2573,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3244,8 +3243,8 @@ msgstr "Вибрати всі"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "кбайт/с"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3579,17 +3578,17 @@ msgstr "Найменший розмір"
 msgid "Bytes"
 msgstr "байт"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "кбайт"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "Мбайт"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "Гбайт"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5383,12 +5382,8 @@ msgstr[1] "байти"
 msgstr[2] "байт"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "кбайт"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "Тбайт"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5414,8 +5409,8 @@ msgstr[1] "байти/с"
 msgstr[2] "байт/с"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "Мбайт/с"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7695,8 +7690,8 @@ msgstr "Поточний рівень IP-фільтра %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "Обмеження смуги пропускання: вивантаження %u кб/с, звантаження: %u кб/с.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8550,23 +8545,23 @@ msgstr "%.0f байт"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.0f кбайт"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.0f Мбайт"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.0f Гбайт"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.0f Тбайт"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8739,8 +8734,8 @@ msgid "Download: "
 msgstr "Звантаження: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " кбайт/с, вивантаження: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -9046,6 +9041,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "Мбайт/с"
+
+#~ msgid " kB/s"
+#~ msgstr " кбайт/с"
+
+#~ msgid "kB/s"
+#~ msgstr "кбайт/с"
+
+#~ msgid "kB"
+#~ msgstr "кбайт"
+
+#~ msgid "MB/s"
+#~ msgstr "Мбайт/с"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y.%m.%d %H:%M:%S"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -724,11 +724,11 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
+msgid " MiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
+msgid " KiB/s"
 msgstr ""
 
 #: src/amuleDlg.cpp
@@ -1245,7 +1245,7 @@ msgstr ""
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
+msgid "%.1f KiB/s"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -1819,7 +1819,7 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
+msgid "%.1f MiB/s"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -2369,7 +2369,7 @@ msgstr ""
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
+msgid "%.2f KiB/s"
 msgstr ""
 
 #: src/FileLaunch.cpp
@@ -2466,11 +2466,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3116,7 +3116,7 @@ msgstr ""
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
+msgid "KiB/s"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp
@@ -3442,16 +3442,16 @@ msgstr ""
 msgid "Bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
+msgid "MiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
+msgid "GiB"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5194,11 +5194,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr ""
-
-#: src/OtherFunctions.cpp
-msgid "TB"
+msgid "TiB"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -5224,7 +5220,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
+msgid "MiB/s"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -7401,7 +7397,7 @@ msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
 msgstr ""
 
 #: src/TextClient.cpp
@@ -8190,22 +8186,22 @@ msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
+msgid "%.2f KiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
+msgid "%.2f MiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
+msgid "%.2f GiB"
 msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
+msgid "%.2f TiB"
 msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
@@ -8370,7 +8366,7 @@ msgid "Download: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
+msgid " KiB/s, Upload: "
 msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:44+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -762,12 +762,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-msgid " MB/s"
-msgstr " MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " kB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, c-format
@@ -1291,8 +1291,8 @@ msgstr "断开连接"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f kB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Name"
@@ -1867,8 +1867,8 @@ msgstr "重命名文件"
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f MB/s"
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2442,8 +2442,8 @@ msgstr "%.1f%% 已完成"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f kB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2543,12 +2543,12 @@ msgid "Other / set manually"
 msgstr "其他 /手动设置"
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
-msgstr "上传限制 （kB/s, 0 = 不限)："
+msgid "Upload limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
-msgstr "下载限制（kB/s,0 = 不限）："
+msgid "Download limit (KiB/s, 0 = unlimited):"
+msgstr ""
 
 #: src/FirstRunWizard.cpp
 msgid "Networks & ports"
@@ -3206,8 +3206,8 @@ msgstr "全选"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "KB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3532,17 +3532,17 @@ msgstr "大小下限"
 msgid "Bytes"
 msgstr "字节"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5301,12 +5301,8 @@ msgstr[0] "字节"
 msgstr[1] "字节"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "KB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5331,8 +5327,8 @@ msgstr[0] "字节/秒"
 msgstr[1] "字节/秒"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7548,8 +7544,8 @@ msgstr "当前IP过滤级别时 %d.\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "带宽限制：上传：%u kB/s，下载：%u kB/s。\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8394,23 +8390,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8583,8 +8579,8 @@ msgid "Download: "
 msgstr "下载: "
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " KB/s, 上传: "
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8894,6 +8890,21 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid " MB/s"
+#~ msgstr " MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " kB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "KB/s"
+
+#~ msgid "kB"
+#~ msgstr "KB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-15 23:10+0200\n"
+"POT-Creation-Date: 2026-08-16 10:27+0200\n"
 "PO-Revision-Date: 2026-08-14 21:45+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -762,13 +762,12 @@ msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp
-#, fuzzy
-msgid " MB/s"
-msgstr "MB/s"
+msgid " MiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp src/MuleTrayIcon.cpp src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s"
-msgstr " KB/s"
+msgid " KiB/s"
+msgstr ""
 
 #: src/amuleDlg.cpp
 #, fuzzy, c-format
@@ -1289,8 +1288,8 @@ msgstr "已中斷連線"
 #: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
 #: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
-msgid "%.1f kB/s"
-msgstr "%.1f KB/s"
+msgid "%.1f KiB/s"
+msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -1876,9 +1875,9 @@ msgstr "更改檔名"
 
 #: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
 #: src/SharedFilesCtrl.cpp
-#, fuzzy, c-format
-msgid "%.1f MB/s"
-msgstr "%.1f KB/s"
+#, c-format
+msgid "%.1f MiB/s"
+msgstr ""
 
 #: src/DownloadListCtrl.cpp
 #, c-format
@@ -2452,8 +2451,8 @@ msgstr "完成 %.1f%%"
 
 #: src/FileDetailDialog.cpp src/utils/wxCas/src/wxcasframe.cpp
 #, c-format
-msgid "%.2f kB/s"
-msgstr "%.2f KB/s"
+msgid "%.2f KiB/s"
+msgstr ""
 
 #: src/FileLaunch.cpp
 msgid "File preview"
@@ -2552,11 +2551,11 @@ msgid "Other / set manually"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Upload limit (kB/s, 0 = unlimited):"
+msgid "Upload limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
-msgid "Download limit (kB/s, 0 = unlimited):"
+msgid "Download limit (KiB/s, 0 = unlimited):"
 msgstr ""
 
 #: src/FirstRunWizard.cpp
@@ -3205,8 +3204,8 @@ msgstr "全選"
 
 #: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
 #: src/StatisticsDlg.cpp
-msgid "kB/s"
-msgstr "KB/s"
+msgid "KiB/s"
+msgstr ""
 
 #: src/MuleTrayIcon.cpp
 msgid "Unlimited"
@@ -3540,17 +3539,17 @@ msgstr "大小下限"
 msgid "Bytes"
 msgstr "B"
 
-#: src/muuli_wdr.cpp
-msgid "KB"
-msgstr "KB"
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+msgid "KiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "MB"
-msgstr "MB"
+msgid "MiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp src/OtherFunctions.cpp
-msgid "GB"
-msgstr "GB"
+msgid "GiB"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Max Size"
@@ -5330,12 +5329,8 @@ msgid_plural "bytes"
 msgstr[0] "B"
 
 #: src/OtherFunctions.cpp
-msgid "kB"
-msgstr "KB"
-
-#: src/OtherFunctions.cpp
-msgid "TB"
-msgstr "TB"
+msgid "TiB"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "k"
@@ -5359,8 +5354,8 @@ msgid_plural "bytes/sec"
 msgstr[0] "B/s"
 
 #: src/OtherFunctions.cpp
-msgid "MB/s"
-msgstr "MB/s"
+msgid "MiB/s"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "secs"
@@ -7592,8 +7587,8 @@ msgstr "目前的 IP 過濾等級：%d 。\n"
 
 #: src/TextClient.cpp
 #, c-format
-msgid "Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n"
-msgstr "頻寬限制：上傳 %u KB/s、下載 %u KB/s 。\n"
+msgid "Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n"
+msgstr ""
 
 #: src/TextClient.cpp
 #, c-format
@@ -8426,23 +8421,23 @@ msgstr "%.0f B"
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f KB"
-msgstr "%.2f KB"
+msgid "%.2f KiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f MB"
-msgstr "%.2f MB"
+msgid "%.2f MiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f GB"
-msgstr "%.2f GB"
+msgid "%.2f GiB"
+msgstr ""
 
 #: src/utils/wxCas/src/onlinesig.cpp
 #, c-format
-msgid "%.2f TB"
-msgstr "%.2f TB"
+msgid "%.2f TiB"
+msgstr ""
 
 #: src/utils/wxCas/src/wxcas.cpp
 msgid "wxCas, aMule Online Statistics"
@@ -8615,8 +8610,8 @@ msgid "Download: "
 msgstr "下載："
 
 #: src/utils/wxCas/src/wxcasframe.cpp
-msgid " kB/s, Upload: "
-msgstr " KB/s，上傳："
+msgid " KiB/s, Upload: "
+msgstr ""
 
 #: src/utils/wxCas/src/wxcasframe.cpp
 msgid "Sharing: "
@@ -8922,6 +8917,22 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid " MB/s"
+#~ msgstr "MB/s"
+
+#~ msgid " kB/s"
+#~ msgstr " KB/s"
+
+#~ msgid "kB/s"
+#~ msgstr "KB/s"
+
+#~ msgid "kB"
+#~ msgstr "KB"
+
+#~ msgid "MB/s"
+#~ msgstr "MB/s"
 
 #~ msgid "%y/%m/%d %H:%M:%S"
 #~ msgstr "%y/%m/%d %H:%M:%S"

--- a/src/ClientDetailDialog.cpp
+++ b/src/ClientDetailDialog.cpp
@@ -148,11 +148,11 @@ bool CClientDetailDialog::OnInitDialog()
 	CastChild(ID_DDOWN, wxStaticText)->SetLabel(CastItoXBytes(m_client.GetTransferredUp()));
 
 	// Average Upload Rate
-	CastChild(ID_DAVUR, wxStaticText)->SetLabel(CFormat(_("%.1f kB/s")) % m_client.GetKBpsDown());
+	CastChild(ID_DAVUR, wxStaticText)->SetLabel(CFormat(_("%.1f KiB/s")) % m_client.GetKBpsDown());
 
 	// Average Download Rate
 	CastChild(ID_DAVDR, wxStaticText)
-		->SetLabel(CFormat(_("%.1f kB/s")) % (m_client.GetUploadDatarate() / 1024.0f));
+		->SetLabel(CFormat(_("%.1f KiB/s")) % ((float)m_client.GetUploadDatarate() / 1024.0f));
 
 	// Total Upload
 	CastChild(ID_DUPTOTAL, wxStaticText)->SetLabel(CastItoXBytes(m_client.GetDownloadedTotal()));

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -872,9 +872,9 @@ wxString CDownloadListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) c
 	case COLUMN_DL_SPEED:
 		if (file->GetTransferingSrcCount()) {
 			if (file->GetKBpsDown() >= 1024) {
-				return CFormat(_("%.1f MB/s")) % (file->GetKBpsDown() / 1024.0);
+				return CFormat(_("%.1f MiB/s")) % (file->GetKBpsDown() / 1024.0);
 			}
-			return CFormat(_("%.1f kB/s")) % file->GetKBpsDown();
+			return CFormat(_("%.1f KiB/s")) % file->GetKBpsDown();
 		}
 		return wxEmptyString;
 

--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -194,7 +194,7 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 		CastChild(IDC_COMPLSIZE, wxControl)->SetLabel(CastItoXBytes(part->GetCompletedSize()));
 		bufferS = CFormat(_("%.1f%% done")) % part->GetPercentCompleted();
 		CastChild(IDC_PROCCOMPL, wxControl)->SetLabel(bufferS);
-		bufferS = CFormat(_("%.2f kB/s")) % part->GetKBpsDown();
+		bufferS = CFormat(_("%.2f KiB/s")) % part->GetKBpsDown();
 		CastChild(IDC_DATARATE, wxControl)->SetLabel(bufferS);
 		bufferS = CFormat("%i") % part->GetSourceCount();
 		CastChild(IDC_SOURCECOUNT, wxControl)->SetLabel(bufferS);
@@ -234,7 +234,7 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 	CastChild(IDC_FD_SHARE_ONQUEUE, wxControl)->SetLabel(CFormat("%u") % m_file->GetQueuedCount());
 	CastChild(IDC_FD_SHARE_UPPRIO, wxControl)
 		->SetLabel(PriorityToStr(m_file->GetUpPriority(), m_file->IsAutoUpPriority()));
-	bufferS = CFormat(_("%.2f kB/s")) % (m_file->GetUploadDatarate() / 1024.0);
+	bufferS = CFormat(_("%.2f KiB/s")) % (m_file->GetUploadDatarate() / 1024.0);
 	CastChild(IDC_FD_SHARE_UPSPEED, wxControl)->SetLabel(bufferS);
 	CastChild(IDC_FD_SHARE_UPCOUNT, wxControl)
 		->SetLabel(CFormat("%u") % m_file->GetTransferringClientCount());

--- a/src/FirstRunWizard.cpp
+++ b/src/FirstRunWizard.cpp
@@ -295,7 +295,7 @@ wxWizardPageSimple *CFirstRunWizard::BuildConnectionPage()
 	wxFlexGridSizer *grid = new wxFlexGridSizer(2, 2, 6, 8);
 	grid->AddGrowableCol(1);
 
-	grid->Add(new wxStaticText(page, wxID_ANY, _("Upload limit (kB/s, 0 = unlimited):")),
+	grid->Add(new wxStaticText(page, wxID_ANY, _("Upload limit (KiB/s, 0 = unlimited):")),
 		0,
 		wxALIGN_CENTER_VERTICAL);
 	m_uploadCtrl = new wxSpinCtrl(page, ID_FRW_UPLOAD);
@@ -303,7 +303,7 @@ wxWizardPageSimple *CFirstRunWizard::BuildConnectionPage()
 	m_uploadCtrl->SetValue(thePrefs::GetMaxUpload());
 	grid->Add(m_uploadCtrl, 0, wxEXPAND);
 
-	grid->Add(new wxStaticText(page, wxID_ANY, _("Download limit (kB/s, 0 = unlimited):")),
+	grid->Add(new wxStaticText(page, wxID_ANY, _("Download limit (KiB/s, 0 = unlimited):")),
 		0,
 		wxALIGN_CENTER_VERTICAL);
 	m_downloadCtrl = new wxSpinCtrl(page, wxID_ANY);

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -687,9 +687,9 @@ wxString CGenericClientListCtrl::GetItemColumnText(wxUIntPtr data, unsigned colu
 	case ColumnUserSpeedDown:
 		if (notA4AF && client.GetKBpsDown() > 0.001) {
 			if (client.GetKBpsDown() >= 1024) {
-				return CFormat(_("%.1f MB/s")) % (client.GetKBpsDown() / 1024.0);
+				return CFormat(_("%.1f MiB/s")) % (client.GetKBpsDown() / 1024.0);
 			}
-			return CFormat(_("%.1f kB/s")) % client.GetKBpsDown();
+			return CFormat(_("%.1f KiB/s")) % client.GetKBpsDown();
 		}
 		return wxEmptyString;
 
@@ -697,9 +697,9 @@ wxString CGenericClientListCtrl::GetItemColumnText(wxUIntPtr data, unsigned colu
 		// Datarate is in bytes.
 		if (notA4AF && client.GetUploadDatarate() >= 1024) {
 			if (client.GetUploadDatarate() >= 1048576) {
-				return CFormat(_("%.1f MB/s")) % (client.GetUploadDatarate() / 1048576.0);
+				return CFormat(_("%.1f MiB/s")) % (client.GetUploadDatarate() / 1048576.0);
 			}
-			return CFormat(_("%.1f kB/s")) % (client.GetUploadDatarate() / 1024.0);
+			return CFormat(_("%.1f KiB/s")) % (client.GetUploadDatarate() / 1024.0);
 		}
 		return wxEmptyString;
 

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -129,7 +129,7 @@ void CMuleTrayIcon::DoSetUploadLimit(long kBytesPerSec)
 {
 	// uint32, not uint16: the preference, its setter and its getter are all
 	// uint32, and a 16-bit cast here silently wrapped anything above 65535
-	// kB/s. A preset of 125000 applied as 59464 -- under half the figure on
+	// KiB/s. A preset of 125000 applied as 59464 -- under half the figure on
 	// the menu item the user clicked, with nothing logged either side.
 	thePrefs::SetMaxUpload(kBytesPerSec < 0 ? UNLIMITED : (uint32)kBytesPerSec);
 #ifdef CLIENT_GUI
@@ -151,12 +151,12 @@ void CMuleTrayIcon::DoSetDownloadLimit(long kBytesPerSec)
 // One ladder, one set of strings. The appindicator backend builds GtkWidgets
 // and the wx backend builds a wxMenu, but what goes in them is identical, and
 // it used to be written out twice -- which is how the GTK side ended up
-// showing "Unlimited" and "kB/s" untranslated while the wx side translated
+// showing "Unlimited" and "KiB/s" untranslated while the wx side translated
 // both.
 //
 // The presets are fractions of the configured line capacity rather than of the
 // current limit. Scaling from the limit would mean the menu could only ever
-// lower it: with a 50 kB/s cap in force, every entry would be at or below 50
+// lower it: with a 50 KiB/s cap in force, every entry would be at or below 50
 // and there would be no way back up. Capacity is what the line can do, so
 // fifths of it span throttled to full speed in both directions.
 namespace
@@ -180,7 +180,7 @@ void GetTraySpeedPresets(uint32 capacity, unsigned int (&speeds)[TRAY_SPEED_PRES
 	if (capacity == UNLIMITED) {
 		capacity = TRAY_FALLBACK_CAPACITY;
 	}
-	// Keep the smallest entry at 1 kB/s or more: a preset of 0 would read as
+	// Keep the smallest entry at 1 KiB/s or more: a preset of 0 would read as
 	// a limit and act as "unlimited", which is the opposite of what picking
 	// the bottom of the list means.
 	const uint32 smallest = TRAY_SPEED_DIVISORS[TRAY_SPEED_PRESETS - 1];
@@ -192,10 +192,10 @@ void GetTraySpeedPresets(uint32 capacity, unsigned int (&speeds)[TRAY_SPEED_PRES
 	}
 }
 
-/// The menu label for one preset, e.g. "2500 kB/s".
+/// The menu label for one preset, e.g. "2500 KiB/s".
 wxString TraySpeedLabel(unsigned int kBytesPerSec)
 {
-	return CFormat("%u %s") % kBytesPerSec % _("kB/s");
+	return CFormat("%u %s") % kBytesPerSec % _("KiB/s");
 }
 } // namespace
 
@@ -594,7 +594,7 @@ wxEND_EVENT_TABLE()
 static long GetSpeedFromString(wxString label)
 {
 	long temp;
-	label.Replace(_("kB/s"), "", TRUE);
+	label.Replace(_("KiB/s"), "", TRUE);
 	label.Trim(FALSE);
 	label.Trim(TRUE);
 	label.ToLong(&temp);
@@ -822,10 +822,10 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 
 	traymenu->Append(TRAY_MENU_INFO, label);
 	label = CFormat(_("Download speed: %.1f%s")) % (showMBpsDown ? MBpsDown : kBpsDown) %
-		(showMBpsDown ? _(" MB/s") : ((kBpsDown > 0) ? _(" kB/s") : ""));
+		(showMBpsDown ? _(" MiB/s") : ((kBpsDown > 0) ? _(" KiB/s") : ""));
 	traymenu->Append(TRAY_MENU_INFO, label);
 	label = CFormat(_("Upload speed: %.1f%s")) % (showMBpsUp ? MBpsUp : kBpsUp) %
-		(showMBpsUp ? _(" MB/s") : ((kBpsUp > 0) ? _(" kB/s") : ""));
+		(showMBpsUp ? _(" MiB/s") : ((kBpsUp > 0) ? _(" KiB/s") : ""));
 	traymenu->Append(TRAY_MENU_INFO, label);
 	traymenu->AppendSeparator();
 

--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -417,11 +417,11 @@ wxString COScopeCtrl::FormatValue(float value) const
 {
 	// The rate graphs hand their readout to CastItoSpeed so it picks the
 	// unit, the way every other speed in the GUI is shown -- a hover on a
-	// fast download reads "2.13 MB/s" rather than "2179.4 kB/s". It wants
-	// bytes per second; the graphs plot kB/s.
+	// fast download reads "2.13 MiB/s" rather than "2179.4 KiB/s". It wants
+	// bytes per second; the graphs plot KiB/s.
 	//
 	// Keyed on the graph rather than on m_strYUnits because those units
-	// are _("kB/s"), i.e. translated: comparing against the literal would
+	// are _("KiB/s"), i.e. translated: comparing against the literal would
 	// quietly stop matching in every locale but English.
 	if (graph_type == GRAPH_DOWN || graph_type == GRAPH_UP) {
 		return CastItoSpeed((uint32)(value * 1024.0f));

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -53,19 +53,24 @@
 #endif
 
 // Formats a filesize in bytes to make it suitable for displaying
+//
+// IEC units, because the arithmetic below is binary: every step divides by
+// 1024, so a figure labelled "GB" was really gibibytes and read about 7%
+// high against anything measuring in powers of 1000 (issue #930). Only the
+// label changed -- no displayed size moved.
 wxString CastItoXBytes(uint64 count)
 {
 
 	if (count < 1024)
 		return wxString(CFormat("%u ") % count) + wxPLURAL("byte", "bytes", count);
 	else if (count < 1048576)
-		return wxString(CFormat("%u ") % (count >> 10)) + _("kB");
+		return wxString(CFormat("%u ") % (count >> 10)) + _("KiB");
 	else if (count < 1073741824)
-		return wxString(CFormat("%.2f ") % ((float)(uint32)count / 1048576)) + _("MB");
+		return wxString(CFormat("%.2f ") % ((float)(uint32)count / 1048576)) + _("MiB");
 	else if (count < 1099511627776LL)
-		return wxString(CFormat("%.3f ") % ((float)((uint32)(count / 1024)) / 1048576)) + _("GB");
+		return wxString(CFormat("%.3f ") % ((float)((uint32)(count / 1024)) / 1048576)) + _("GiB");
 	else
-		return wxString(CFormat("%.3f ") % ((float)count / 1099511627776LL)) + _("TB");
+		return wxString(CFormat("%.3f ") % ((float)count / 1099511627776.0f)) + _("TiB");
 }
 
 wxString CastItoIShort(uint64 count)
@@ -88,9 +93,9 @@ wxString CastItoSpeed(uint32 bytes)
 	if (bytes < 1024)
 		return wxString(CFormat("%u ") % bytes) + wxPLURAL("byte/sec", "bytes/sec", bytes);
 	else if (bytes < 1048576)
-		return wxString(CFormat("%.2f ") % (bytes / 1024.0)) + _("kB/s");
+		return wxString(CFormat("%.2f ") % (bytes / 1024.0)) + _("KiB/s");
 	else
-		return wxString(CFormat("%.2f ") % (bytes / 1048576.0)) + _("MB/s");
+		return wxString(CFormat("%.2f ") % (bytes / 1048576.0)) + _("MiB/s");
 }
 
 // Make a time value in seconds suitable for displaying

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -2471,7 +2471,7 @@ void PrefsUnifiedDlg::UpdateGeoIPStatus()
 			const wxULongLong bytes = fn.GetSize();
 			if (bytes != wxInvalidSize) {
 				sizeLabel =
-					wxString::Format(" (%.1f MB)", bytes.ToDouble() / (1024.0 * 1024.0));
+					wxString::Format(" (%.1f MiB)", bytes.ToDouble() / (1024.0 * 1024.0));
 			}
 		}
 		if (attribution.IsEmpty()) {

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -390,14 +390,14 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 		}
 
 	case COLUMN_SHARED_SPEED:
-		// Live upload speed, adaptive kB/s / MB/s and blank below
-		// 1 kB/s — same formatting as the peers (client) list. Sorting
+		// Live upload speed, adaptive KiB/s / MiB/s and blank below
+		// 1 KiB/s — same formatting as the peers (client) list. Sorting
 		// uses the raw byte/s value (see CompareItemData), not this string.
 		if (file->GetUploadDatarate() >= 1024) {
 			if (file->GetUploadDatarate() >= 1048576) {
-				return CFormat(_("%.1f MB/s")) % (file->GetUploadDatarate() / 1048576.0);
+				return CFormat(_("%.1f MiB/s")) % (file->GetUploadDatarate() / 1048576.0);
 			}
-			return CFormat(_("%.1f kB/s")) % (file->GetUploadDatarate() / 1024.0);
+			return CFormat(_("%.1f KiB/s")) % (file->GetUploadDatarate() / 1024.0);
 		}
 		return wxEmptyString;
 

--- a/src/StatisticsDlg.cpp
+++ b/src/StatisticsDlg.cpp
@@ -90,9 +90,9 @@ void CStatisticsDlg::InitGraphs()
 	}
 
 	pscopeDL->SetRanges(0.0, (float)(thePrefs::GetMaxGraphDownloadRate() + 4));
-	pscopeDL->SetYUnits(_("kB/s"));
+	pscopeDL->SetYUnits(_("KiB/s"));
 	pscopeUL->SetRanges(0.0, (float)(thePrefs::GetMaxGraphUploadRate() + 4));
-	pscopeUL->SetYUnits(_("kB/s"));
+	pscopeUL->SetYUnits(_("KiB/s"));
 	pscopeConn->SetRanges(0.0, (float)(thePrefs::GetStatsMax()));
 	pscopeConn->SetYUnits("");
 

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -783,7 +783,7 @@ void CamulecmdApp::ShowResults(CResultMap results_map)
 	wxString output, name, sources, mb, kb;
 
 	printf("Nr.    Filename:                                                                        "
-	       "Size(MB):  Sources: \n");
+	       "Size(MiB):  Sources: \n");
 	printf("---------------------------------------------------------------------------------------------"
 	       "--------------\n");
 
@@ -867,7 +867,7 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 		const CECTag *connMaxUL = tab->GetTagByName(EC_TAG_CONN_MAX_UL);
 		const CECTag *connMaxDL = tab->GetTagByName(EC_TAG_CONN_MAX_DL);
 		if (connMaxUL && connMaxDL) {
-			s << CFormat(_("Bandwidth limits: Up: %u kB/s, Down: %u kB/s.\n")) %
+			s << CFormat(_("Bandwidth limits: Up: %u KiB/s, Down: %u KiB/s.\n")) %
 					connMaxUL->GetInt() % connMaxDL->GetInt();
 		}
 		tab = response->GetTagByNameSafe(EC_TAG_PREFS_FILES);

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1337,15 +1337,15 @@ void CamuleDlg::ShowTransferRate()
 	if (thePrefs::ShowOverhead()) {
 		buffer = CFormat(_("Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)")) %
 			 (showMBpsUp ? MBpsUp : kBpsUp) %
-			 (showMBpsUp ? _(" MB/s") : ((kBpsUp > 0) ? _(" kB/s") : "")) %
+			 (showMBpsUp ? _(" MiB/s") : ((kBpsUp > 0) ? _(" KiB/s") : "")) %
 			 (theStats::GetUpOverheadRate() / 1024.0) % (showMBpsDown ? MBpsDown : kBpsDown) %
-			 (showMBpsDown ? _(" MB/s") : ((kBpsDown > 0) ? _(" kB/s") : "")) %
+			 (showMBpsDown ? _(" MiB/s") : ((kBpsDown > 0) ? _(" KiB/s") : "")) %
 			 (theStats::GetDownOverheadRate() / 1024.0);
 	} else {
 		buffer = CFormat(_("Up: %.1f%s | Down: %.1f%s")) % (showMBpsUp ? MBpsUp : kBpsUp) %
-			 (showMBpsUp ? _(" MB/s") : ((kBpsUp > 0) ? _(" kB/s") : "")) %
+			 (showMBpsUp ? _(" MiB/s") : ((kBpsUp > 0) ? _(" KiB/s") : "")) %
 			 (showMBpsDown ? MBpsDown : kBpsDown) %
-			 (showMBpsDown ? _(" MB/s") : ((kBpsDown > 0) ? _(" kB/s") : ""));
+			 (showMBpsDown ? _(" MiB/s") : ((kBpsDown > 0) ? _(" KiB/s") : ""));
 	}
 	buffer.Truncate(50); // Max size 50
 
@@ -1359,9 +1359,9 @@ void CamuleDlg::ShowTransferRate()
 		// rather than asking translators for the string twice.
 		wxString UpDownSpeed = CFormat(_("Up: %.1f%s | Down: %.1f%s")) %
 				       (showMBpsUp ? MBpsUp : kBpsUp) %
-				       (showMBpsUp ? _(" MB/s") : ((kBpsUp > 0) ? _(" kB/s") : "")) %
+				       (showMBpsUp ? _(" MiB/s") : ((kBpsUp > 0) ? _(" KiB/s") : "")) %
 				       (showMBpsDown ? MBpsDown : kBpsDown) %
-				       (showMBpsDown ? _(" MB/s") : ((kBpsDown > 0) ? _(" kB/s") : ""));
+				       (showMBpsDown ? _(" MiB/s") : ((kBpsDown > 0) ? _(" KiB/s") : ""));
 		if (thePrefs::GetShowRatesOnTitle() == 1) {
 			SetTitle(theApp->m_FrameTitle + " -- " + UpDownSpeed);
 		} else {

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -273,9 +273,9 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxString strs25[] = 
     {
         _("Bytes"), 
-        _("KB"), 
-        _("MB"), 
-        _("GB")
+        _("KiB"), 
+        _("MiB"), 
+        _("GiB")
     };
     wxChoice *item25 = new wxChoice( parent, IDC_SEARCHMINSIZE, wxDefaultPosition, wxDefaultSize, 4, strs25, 0 );
     item23->Add( item25, wxSizerFlags().Center().Border(wxALL, 5) );
@@ -292,9 +292,9 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxString strs30[] = 
     {
         _("Bytes"), 
-        _("KB"), 
-        _("MB"), 
-        _("GB")
+        _("KiB"), 
+        _("MiB"), 
+        _("GiB")
     };
     wxChoice *item30 = new wxChoice( parent, IDC_SEARCHMAXSIZE, wxDefaultPosition, wxDefaultSize, 4, strs30, 0 );
     item28->Add( item30, wxSizerFlags().Center().Border(wxALL, 5) );
@@ -1463,7 +1463,7 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
     wxSpinCtrl *item5 = new wxSpinCtrl( parent, IDC_MAXDOWN, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000000, 0 );
     item3->Add( item5, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
-    wxStaticText *item6 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item6 = new wxStaticText( parent, -1, _("KiB/s"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item6, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *item7 = new wxStaticText( parent, -1, _("Upload"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item7, 0, wxALIGN_CENTER_VERTICAL, 0 );
@@ -1471,14 +1471,14 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
     wxSpinCtrl *item8 = new wxSpinCtrl( parent, IDC_MAXUP, "10", wxDefaultPosition, wxDefaultSize, 0, 0, 1000000, 10 );
     item3->Add( item8, wxSizerFlags().CenterVertical() );
 
-    wxStaticText *item9 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item9 = new wxStaticText( parent, -1, _("KiB/s"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item9, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *item10 = new wxStaticText( parent, -1, _("Slot Allocation"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item10, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
     wxSpinCtrl *item11 = new wxSpinCtrl( parent, IDC_SLOTALLOC, "10", wxDefaultPosition, wxDefaultSize, 0, 1, 100000, 10 );
     item3->Add( item11, wxSizerFlags().CenterVertical() );
 
-    wxStaticText *item12 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item12 = new wxStaticText( parent, -1, _("KiB/s"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item12, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     item1->Add( item3, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 0) );
     item0->Add( item1, wxSizerFlags().Expand().CenterHorizontal() );
@@ -1700,7 +1700,7 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
     item16->SetToolTip( _("Enter here the min disk space desired.") );
     item14->Add( item16, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
-    wxStaticText *item17 = new wxStaticText( parent, -1, _("MB"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item17 = new wxStaticText( parent, -1, _("MiB"), wxDefaultPosition, wxDefaultSize, 0 );
     item14->Add( item17, wxSizerFlags().Center().Border(wxLEFT, 5) );
     item5->Add( item14, wxSizerFlags().Expand().CenterVertical() );
     wxCheckBox *item18 = new wxCheckBox( parent, IDC_SRCSEEDS, _("Save 10 sources on rare files (< 20 sources)"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1976,13 +1976,13 @@ wxSizer *PreferencesStatisticsTab( wxWindow *parent, bool call_fit, bool set_siz
     wxSpinCtrl *item11 = new wxSpinCtrl( parent, IDC_DOWNLOAD_CAP, "3", wxDefaultPosition, wxDefaultSize, 0, 3, 1000000, 3 );
     item9->Add( item11, wxSizerFlags().CenterVertical() );
 
-    wxStaticText *item12 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item12 = new wxStaticText( parent, -1, _("KiB/s"), wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item12, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *item13 = new wxStaticText( parent, -1, _("Upload graph scale:"), wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item13, wxSizerFlags().CenterVertical().Border(wxTOP, 5) );
     wxSpinCtrl *item14 = new wxSpinCtrl( parent, IDC_UPLOAD_CAP, "3", wxDefaultPosition, wxDefaultSize, 0, 3, 1000000, 3 );
     item9->Add( item14, wxSizerFlags().CenterVertical().Border(wxTOP, 5) );
-    wxStaticText *item15 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item15 = new wxStaticText( parent, -1, _("KiB/s"), wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item15, wxSizerFlags().CenterVertical().Border(wxLEFT|wxTOP, 5) );
     item1->Add( item9, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
     wxFlexGridSizer *item16 = new wxFlexGridSizer( 3, 0, 0 );

--- a/src/utils/wxCas/src/onlinesig.cpp
+++ b/src/utils/wxCas/src/onlinesig.cpp
@@ -312,16 +312,16 @@ wxString OnLineSig::BytesConvertion(const wxString &bytes)
 		c_bytes = wxString::Format(_("%.0f B"), d_bytes);
 		break;
 	case 1:
-		c_bytes = wxString::Format(_("%.2f KB"), d_bytes);
+		c_bytes = wxString::Format(_("%.2f KiB"), d_bytes);
 		break;
 	case 2:
-		c_bytes = wxString::Format(_("%.2f MB"), d_bytes);
+		c_bytes = wxString::Format(_("%.2f MiB"), d_bytes);
 		break;
 	case 3:
-		c_bytes = wxString::Format(_("%.2f GB"), d_bytes);
+		c_bytes = wxString::Format(_("%.2f GiB"), d_bytes);
 		break;
 	default:
-		c_bytes = wxString::Format(_("%.2f TB"), d_bytes);
+		c_bytes = wxString::Format(_("%.2f TiB"), d_bytes);
 		break;
 	}
 	return c_bytes;

--- a/src/utils/wxCas/src/wxcasframe.cpp
+++ b/src/utils/wxCas/src/wxcasframe.cpp
@@ -1037,8 +1037,8 @@ wxString WxCasFrame::MakeStatLine_4() const
 
 wxString WxCasFrame::MakeStatLine_5() const
 {
-	wxString newline = _("Download: ") + m_aMuleSig->GetDLRate() + _(" kB/s, Upload: ") +
-			   m_aMuleSig->GetULRate() + _(" kB/s");
+	wxString newline = _("Download: ") + m_aMuleSig->GetDLRate() + _(" KiB/s, Upload: ") +
+			   m_aMuleSig->GetULRate() + _(" KiB/s");
 
 	return (newline);
 }
@@ -1061,7 +1061,7 @@ wxString WxCasFrame::MakeStatLine_7() const
 
 wxString WxCasFrame::MakeHitsLine_1() const
 {
-	wxString newline = wxString::Format(_("%.2f kB/s"), m_aMuleSig->GetSessionMaxDL()) + _(" on ") +
+	wxString newline = wxString::Format(_("%.2f KiB/s"), m_aMuleSig->GetSessionMaxDL()) + _(" on ") +
 			   m_aMuleSig->GetSessionMaxDlDate().Format("%c");
 
 	return (newline);
@@ -1069,7 +1069,7 @@ wxString WxCasFrame::MakeHitsLine_1() const
 
 wxString WxCasFrame::MakeHitsLine_2() const
 {
-	wxString newline = wxString::Format(_("%.2f kB/s"), m_aMuleSig->GetAbsoluteMaxDL()) + _(" on ") +
+	wxString newline = wxString::Format(_("%.2f KiB/s"), m_aMuleSig->GetAbsoluteMaxDL()) + _(" on ") +
 			   m_aMuleSig->GetAbsoluteMaxDlDate().Format("%c");
 
 	return (newline);

--- a/src/webapi/static/js/format.js
+++ b/src/webapi/static/js/format.js
@@ -3,7 +3,9 @@
 
 import { t } from "./i18n.js";
 
-const UNITS = ["B", "KB", "MB", "GB", "TB", "PB"];
+// IEC, because the scaling below is by 1024 -- same reasoning as
+// CastItoXBytes on the GUI side.
+const UNITS = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
 
 export function formatBytes(n) {
   n = Number(n) || 0;

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -17,7 +17,7 @@ import { formatBytes, formatDuration, formatInt } from "../format.js";
 import { Icon } from "../icons.js";
 import { t, tn, terr } from "../i18n.js";
 
-const SIZE_UNITS = { B: 1, KB: 1024, MB: 1048576, GB: 1073741824 };
+const SIZE_UNITS = { B: 1, KiB: 1024, MiB: 1048576, GiB: 1073741824 };
 // [API value, label key] — the value goes to the backend verbatim.
 const FILE_TYPES = [
   ["", "search_ftype_any"], ["Audio", "search_ftype_audio"], ["Video", "search_ftype_video"],
@@ -37,9 +37,9 @@ export default function Search({ isGuest }) {
   const [ext, setExt] = useState("");
   const [minAvail, setMinAvail] = useState("");
   const [minSize, setMinSize] = useState("");
-  const [minUnit, setMinUnit] = useState("MB");
+  const [minUnit, setMinUnit] = useState("MiB");
   const [maxSize, setMaxSize] = useState("");
-  const [maxUnit, setMaxUnit] = useState("MB");
+  const [maxUnit, setMaxUnit] = useState("MiB");
 
   const [results, setResults] = useState([]);
   const [filter, setFilter] = useState("");

--- a/src/webserver/default/amuleweb-main-dload.php
+++ b/src/webserver/default/amuleweb-main-dload.php
@@ -446,9 +446,9 @@ function formatBytes(value) {
 	var b = parseFloat(value);
 	if ( isNaN(b) ) return value;
 	if ( b < 1024 ) return b + " Bytes";
-	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KB";
-	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MB";
-	return (b / 1073741824).toFixed(2) + " GB";
+	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KiB";
+	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MiB";
+	return (b / 1073741824).toFixed(2) + " GiB";
 }
 (function() {
 	var els = document.getElementsByClassName("js-size");

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -102,9 +102,9 @@ function selectAll(check)
 <input name="minsize" type="text" id="minsize2" size="5"> 
                     <select name="minsizeu" id="select8">
                       <option>Byte</option>
-                      <option>KByte</option>
-                      <option selected>MByte</option>
-                      <option>GByte</option>
+                      <option>KiByte</option>
+                      <option selected>MiByte</option>
+                      <option>GiByte</option>
                     </select></td>
                 </tr>
                 <tr> 
@@ -121,9 +121,9 @@ function selectAll(check)
 <input name="maxsize" type="text" id="maxsize4" size="5"> 
                     <select name="maxsizeu" id="select10">
                       <option>Byte</option>
-                      <option>KByte</option>
-                      <option selected>MByte</option>
-                      <option>GByte</option>
+                      <option>KiByte</option>
+                      <option selected>MiByte</option>
+                      <option>GiByte</option>
                     </select></td>
                 </tr>
               </table>
@@ -184,9 +184,9 @@ function selectAll(check)
 			$result = 1;
 			switch($str) {
 				case "Byte":	$result = 1; break;
-				case "KByte":	$result = 1024; break;		
-				case "MByte":	$result = 1024*1024; break;
-				case "GByte":	$result = 1024*1024*1024; break;
+				case "KiByte":	$result = 1024; break;		
+				case "MiByte":	$result = 1024*1024; break;
+				case "GiByte":	$result = 1024*1024*1024; break;
 			}
 			return $result;
 		}
@@ -306,9 +306,9 @@ function formatBytes(value) {
 	var b = parseFloat(value);
 	if ( isNaN(b) ) return value;
 	if ( b < 1024 ) return b + " Bytes";
-	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KB";
-	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MB";
-	return (b / 1073741824).toFixed(2) + " GB";
+	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KiB";
+	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MiB";
+	return (b / 1073741824).toFixed(2) + " GiB";
 }
 (function() {
 	var els = document.getElementsByClassName("js-size");

--- a/src/webserver/default/amuleweb-main-shared.php
+++ b/src/webserver/default/amuleweb-main-shared.php
@@ -298,9 +298,9 @@ function formatBytes(value) {
 	var b = parseFloat(value);
 	if ( isNaN(b) ) return value;
 	if ( b < 1024 ) return b + " Bytes";
-	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KB";
-	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MB";
-	return (b / 1073741824).toFixed(2) + " GB";
+	if ( b < 1048576 ) return (b / 1024).toFixed(2) + " KiB";
+	if ( b < 1073741824 ) return (b / 1048576).toFixed(2) + " MiB";
+	return (b / 1073741824).toFixed(2) + " GiB";
 }
 (function() {
 	var els = document.getElementsByClassName("js-size");


### PR DESCRIPTION
Closes #930.

Every size and rate in aMule is computed in powers of 1024 and labelled kB/MB/GB/TB and kB/s. A figure shown as "2.2 TB" is 2.2 TiB, which reads about 10% high against anything measuring in powers of 1000. That is how #927 surfaced: the reporter compared aMule's shared-files total against `du --si`, and the two were never directly comparable.

### Relabel, not re-arithmetic

Nothing displayed changes value; only the unit stops being ambiguous. Switching the maths to powers of 1000 instead would silently restate every size in the GUI, which is a much worse thing to do to someone reading a share whose size they know. Nothing anywhere was actually decimal, so this is purely a labelling change.

### Wider than the scope list on the issue

The list I posted on #930 covered the two formatters and the input fields. It missed everything that formats its own units instead of calling `CastItoXBytes`, because I had grepped for bare `_("MB")` literals rather than for units embedded in larger format strings. The real surface:

| area | what |
|---|---|
| `CastItoXBytes` / `CastItoSpeed` | GUI, tray icon and `amulecmd` |
| download / shared-files / client lists | per-row rates formatting `_("%.1f kB/s")` themselves |
| file + client detail dialogs, main status line, first-run wizard | same |
| `amulecmd` | bandwidth summary, shared-files `Size(MB):` header |
| search Min/Max Size, Min disk space, speed limits | the fields you type into: `GetTypeSize()` is 1024-based, disk space ×1048576, limits ×1024 |
| IP2Country | formatted its own `" (%.1f MB)"` |
| tray icon | label built *and* parsed back with the same msgid, so the pair stays in step |
| rate graphs | Y-axis units |
| wxCas | its own online-signature and status formatters |
| amuleapi web UI | its own 1024-based table |
| amuleweb skin | dropdown labels double as the values its PHP switches on |

### Docs

Verified against the code before changing: `EC_TAG_CONN_MAX_UL` is the preference the throttler multiplies by 1024, `UL_CAP`/`DL_CAP` set the graph range whose axis is KiB/s, and amulesig writes `GetDownloadRate() / 1024.0`. All binary, so all three were mislabelled.

Relabelling exposed one figure that had been computed decimally: the note justifying the uint16 → uint32 widening of the speed tags said 65534 kB/s is "~524 Mbps". At 1024 bytes it is ~537 Mbps.

### Catalogs

The unit msgids are new strings, so msgmerge fuzzy-matched each to the label it replaces: `"%.1f KiB/s"` arrived carrying the old `"%.1f kB/s"` translation, Cyrillic `МиБ` carrying `МБ`. Fuzzy entries are not used at runtime, so behaviour is correct either way, but a translator accepting the suggestion in Weblate would put the old unit back in that locale, one language at a time and invisibly.

So those suggestions are cleared rather than left standing: 309 entries across 35 catalogs, every fuzzy whose msgid carries an IEC token and is therefore matched from the pre-IEC spelling. Each locale falls back to the IEC symbol until someone localises it deliberately. Verified as a fixpoint - re-running `scripts/update-po.sh` reproduces the cleared catalogs exactly, so the sync gate is satisfied and it will not drift back.

### Left alone

`CastItoIShort` is decimal and correctly labelled k/M/G/T, because it counts things rather than bytes. aLinkCreator's "files > 9.5 MB" is the ed2k part size (9500 KiB) written the way the protocol conventionally writes it, not a formatted figure.

### Testing

Builds clean on macOS arm64 and Ubuntu arm64 across monolithic, remote GUI, amulecmd, daemon, webserver, amuleapi, wxCas and aLinkCreator. clang-format clean, all 41 catalogs compile, the amuleapi web-UI dictionary check passes, and the new labels are present in the built `aMule` and `amulecmd` binaries.
