### PR TITLE
fix(windows): give the window the whole icon group, not one icon from it

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -83,6 +83,9 @@
 #include "CCtypeAsciiScope.h"  // Needed for locale-safe ASCII lowercasing of art ids
 
 #include <wx/artprov.h>
+#ifdef __WINDOWS__
+#include <wx/msw/private.h> // Needed for wxGetInstance
+#endif
 #include <wx/bmpbndl.h>  // Needed for wxBitmapBundle
 #include <wx/iconbndl.h> // Needed for wxIconBundle // Needed for wxArtProvider::GetIcon
 
@@ -283,7 +286,12 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	// resource bundle (see amule.rc), which already carries every size
 	// the window manager might ask for.
 #ifdef __WINDOWS__
-	SetIcon(wxICON(aMule));
+	// The whole group from amule.rc, not one icon out of it. SetIcon()
+	// gives the window a single image, and Windows then derives whichever
+	// of ICON_BIG / ICON_SMALL it was not handed by scaling that one --
+	// so one of the two is always resampled rather than read from the
+	// size the .ico already carries.
+	SetIcons(wxIconBundle("aMule", wxGetInstance()));
 #else
 	// Elsewhere the icon comes from CamuleArtProvider. A bundle, and a
 	// set of sizes rather than one: GetIcon() resolves through


### PR DESCRIPTION
`CamuleDlg` sets its window icon with `SetIcon(wxICON(aMule))` on Windows. That hands the window a single image, and Windows derives whichever of `ICON_BIG` / `ICON_SMALL` it was not given by scaling that one — so one of the two is always resampled, even though `amule.ico` already carries the size it wanted. `SetIcons(wxIconBundle(...))` passes the whole resource group and lets Windows pick per slot.

The non-Windows branch already does this, since #932 — this brings Windows in line rather than introducing a new approach.

### On the bug this came out of

This was investigated as a report of a soft taskbar icon on Windows 11 ARM at the current master. I could not establish that this call is the cause, and the PR does not claim to fix it:

- `amulegui.exe` uses the same `SetIcon` path and renders correctly, so the call is not broken by itself.
- A minimal wx app with the same `.ico`, the same manifest and the same `SetIcon` call renders sharply, so neither the icon file nor the DPI manifest is at fault. The `.ico` was also checked entry by entry and is well formed: 32bpp, `planes=1`, correct XOR+AND mask heights.
- The one build that looked right on the VM differs from the shipped one in two ways — this change *and* dynamic rather than static wx — so it is not a clean attribution.
- Flushing the Windows icon cache changed the observed rendering, which makes every visual comparison taken before that point unreliable.

What stands on its own is that supplying both icon sizes is more correct than supplying one and letting the shell scale, on a codebase that already ships every size in the `.ico` (#933).

### Testing

Compiled on Windows 11 ARM (CLANGARM64, wx 3.3.2) and run: banner prints, window icon present. Not reproducible on macOS or Linux, as the branch is `__WINDOWS__`-only.
