### PR TITLE
fix(gui): drop no-op wxALL flag causing a deprecated enum warning

### DIFF
--- a/src/ClientsWnd.cpp
+++ b/src/ClientsWnd.cpp
@@ -134,7 +134,7 @@ CClientsWnd::CClientsWnd(wxWindow *parent)
 	});
 
 	wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
-	sizer->Add(book, 1, wxEXPAND | wxALL, 0);
+	sizer->Add(book, 1, wxEXPAND);
 	SetSizer(sizer);
 	sizer->SetSizeHints(this);
 	sizer->Fit(this);


### PR DESCRIPTION
## Summary
- `CClientsWnd::CClientsWnd` called `sizer->Add(book, 1, wxEXPAND | wxALL, 0)` with a border of `0`, so `wxALL` never contributed anything.
- Newer wxWidgets/GCC flag the bitwise-OR between `wxStretch` (`wxEXPAND`) and `wxDirection` (`wxALL`) as deprecated, producing a `-Wdeprecated-enum-enum-conversion` compiler warning.
- Dropped the dead `wxALL`, matching the plain `wxEXPAND` already used for the sibling sizers in this file.

## Test plan
- [x] `./scripts/compile.sh` — clean build with all options, zero warnings, all 34 unit tests pass