### PR TITLE
fix(search): expand and collapse every selected folder, not just the clicked one

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -860,14 +860,61 @@ void CSearchListCtrl::SetSubtreeExpanded(const wxDataViewItem &item, bool expand
 	}
 }
 
+std::vector<wxDataViewItem> CSearchListCtrl::ContextFolders()
+{
+	std::vector<wxDataViewItem> folders;
+	if (!m_contextFolder.IsOk()) {
+		return folders;
+	}
+
+	wxDataViewItemArray selection;
+	GetSelections(selection);
+
+	// The whole selection, but only when the row clicked is part of it: the
+	// rule a file manager follows, since right-clicking outside a selection
+	// addresses the row under the pointer rather than whatever happens to be
+	// selected elsewhere. A right-click does not select on every platform,
+	// which is why m_contextFolder is remembered separately (see OnRightClick).
+	bool clicked_is_selected = false;
+	for (const wxDataViewItem &item : selection) {
+		if (item == m_contextFolder) {
+			clicked_is_selected = true;
+			break;
+		}
+	}
+	if (!clicked_is_selected) {
+		folders.push_back(m_contextFolder);
+		return folders;
+	}
+
+	for (const wxDataViewItem &item : selection) {
+		if (m_model->IsFolder(item)) {
+			folders.push_back(item);
+		}
+	}
+	// A selection of results with the click on a folder inside it: act on the
+	// folder, so the entry is never a no-op.
+	if (folders.empty()) {
+		folders.push_back(m_contextFolder);
+	}
+	return folders;
+}
+
 void CSearchListCtrl::OnExpandAll(wxCommandEvent &WXUNUSED(event))
 {
-	SetSubtreeExpanded(m_contextFolder, true);
+	// Every selected folder, not just the clicked one (issue #910 follow-up).
+	// Nesting needs no special case: a parent's subtree walk already covers a
+	// descendant that is also selected.
+	for (const wxDataViewItem &folder : ContextFolders()) {
+		SetSubtreeExpanded(folder, true);
+	}
 }
 
 void CSearchListCtrl::OnCollapseAll(wxCommandEvent &WXUNUSED(event))
 {
-	SetSubtreeExpanded(m_contextFolder, false);
+	for (const wxDataViewItem &folder : ContextFolders()) {
+		SetSubtreeExpanded(folder, false);
+	}
 }
 
 void CSearchListCtrl::OnGetComments(wxCommandEvent &WXUNUSED(event))

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -367,6 +367,9 @@ protected:
 	void OnRazorStatsCheck(wxCommandEvent &event);
 	void OnRelatedSearch(wxCommandEvent &event);
 	void OnGetComments(wxCommandEvent &event);
+	//! Folders the expand/collapse entries act on: the whole selection when the
+	//! clicked row belongs to it, otherwise just that row.
+	std::vector<wxDataViewItem> ContextFolders();
 	void OnExpandAll(wxCommandEvent &event);
 	void OnCollapseAll(wxCommandEvent &event);
 


### PR DESCRIPTION
Follow-up to #910, reported by @ghysler after testing the feature.

*Expand all* and *Collapse all* walked the row that was right-clicked and nothing else, so selecting several folders and asking to expand them opened one.

They now act on every selected folder, with the rule a file manager follows: the whole selection when the clicked row belongs to it, and that row alone when it does not. Right-clicking outside a selection addresses what is under the pointer rather than whatever happens to be selected elsewhere, which would otherwise expand rows the user is not looking at.

The selection cannot simply be read in the handler: a right-click does not select the row on every platform, which is why `m_contextFolder` is remembered when the menu is built. `ContextFolders()` combines the two.

Nesting needs no special case, since a parent's subtree walk already covers a descendant that is also selected, and a selection made of results with the click on a folder still acts on that folder, so the entry is never a no-op.

No new strings, so no catalog churn.

## Testing

Checked by hand on macOS: several folders selected and expanded together, then a right-click on a folder outside the selection expanding only that one. clang-format and both clang-tidy tiers clean.
