### PR TITLE
fix(gui): treat a tray restore as restored, instead of waiting for an event that never comes

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -753,6 +753,23 @@ void CamuleDlg::RestoreMainWindow()
 	// whatever the user is looking at.
 	mac_set_accessory_mode(false);
 #endif
+	// Restoring is a decision, not something to infer from events: this is
+	// the one place that knows the user asked for the window back, so the
+	// logical flag is cleared here rather than left to OnShow/OnMinimize.
+	//
+	// Those events do not arrive on the path that matters. On Windows, a
+	// window that is hidden *and* iconized -- which is what minimize-to-tray
+	// leaves behind -- gets neither wxEVT_SHOW nor wxEVT_ICONIZE from the
+	// sequence below: Iconize(false) restores and shows it, so the Show(true)
+	// after it sees an already-shown window and never reaches ShowWindow(),
+	// so no WM_SHOWWINDOW and no wxShowEvent. The flag then stays set for the
+	// rest of the session and IsVisibleToUser() never becomes true again,
+	// which stops the free-space refresh, keeps the tray toggle stuck on
+	// "restore", and leaves amulegui reconnecting quietly (#941, #817).
+	// Restoring a window that was only hidden does fire wxEVT_SHOW, which is
+	// why this looked intermittent.
+	m_iconized_logical = false;
+
 	// Clear the iconized bit on every platform — the window might be
 	// hidden (Show(false) via HideOnClose / minimize-to-tray) or just
 	// iconized to the OS Dock/taskbar; in either case the user wants a


### PR DESCRIPTION
Closes #941.

The "Free space" figure on the Downloads panel stops updating once the window has been minimised to the tray and restored, and never resumes until aMule is restarted.

`UpdateFreeSpaceLabels()` skips a panel nobody can see, which it decides with `IsVisibleToUser()` — `IsShown() && !m_iconized_logical`. That flag is only ever written from `wxEVT_ICONIZE` and `wxEVT_SHOW`, and on the tray-restore path **neither event arrives**.

`RestoreMainWindow()` does `Iconize(false); Show(true); Raise()`. On Windows, against a window that is hidden *and* iconized — exactly what minimize-to-tray leaves behind — `Iconize(false)` already restores and shows it, so the `Show(true)` after it sees an already-shown window, never reaches `ShowWindow()`, and no `WM_SHOWWINDOW` (hence no `wxShowEvent`) is generated. The flag stays set for the rest of the session.

Restoring a window that was merely *hidden* does fire `wxEVT_SHOW`, which is why the behaviour looks intermittent rather than broken.

### Fix

Clear the flag in `RestoreMainWindow()`. That function is the one place that knows the user asked for the window back, so the state is set from the decision rather than inferred from platform events. The existing comment there already intended this — it calls `Iconize(false)` to "clear the iconized bit on every platform" — but `m_iconized_logical` is a separate variable it never touched.

### Wider than free space

Everything gated on `IsVisibleToUser()` was stuck the same way:

- the free-space refresh (the reported symptom)
- `CMuleTrayIcon::DoShowHide()` — the tray toggle stops hiding the window and only ever re-raises it
- amulegui's quiet-reconnect suppression from #817

### Testing

Reproduced and verified on Windows 11 ARM with a standalone wx app replicating `CamuleDlg`'s handlers, `HideToTray()`, `RestoreMainWindow()` and `IsVisibleToUser()` line for line, logging every event.

Before — after the tray restore, no event fires at all and the flag stays set:

```
TRAY CLICK: IsVisibleToUser=0 -> RestoreMainWindow()
  RestoreMainWindow(): Iconize(false); Show(true); Raise()
TRAY CLICK: IsVisibleToUser=0 -> RestoreMainWindow()      <- still stuck
```

After:

```
TRAY CLICK: IsVisibleToUser=0 -> RestoreMainWindow()
  RestoreMainWindow() [FIXED]: clear flag, then Iconize/Show/Raise
TRAY CLICK: IsVisibleToUser=1 -> HideToTray()             <- toggle works
...
EVT_SHOW shown=1  -> m_iconized_logical=0
   state: ... => IsVisibleToUser=1 (updates would run)
```

Built on macOS; the changed line is platform-independent. The reproduction is on Windows — I have not verified the macOS or GTK tray paths behave the same way, though clearing the flag when the user explicitly restores the window is correct on any platform.
