### PR TITLE
fix(asio): stop shouting about a second Destroy() that is by design

### DIFF
--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -731,8 +731,21 @@ public:
 	void Destroy()
 	{
 		if (m_destroying.exchange(true, std::memory_order_acq_rel)) {
+			// Not an error: the guard is here so callers can be sloppy, and
+			// several deliberately are. CClientTCPSocket::Safe_Delete() says
+			// "Destroy may be called several times" and calls it regardless,
+			// and StopConnectionTry() destroys sockets whose connect is still
+			// in flight -- when that connect later fails, OnConnect() destroys
+			// the same socket again. The wrapper is notified once, by whichever
+			// call won the exchange, so the second is a no-op by design; the
+			// UDP twin below says the same and stays silent about it.
+			//
+			// Logged at 'F' rather than 'C' for that reason: AddDebugLogLineC
+			// survives a release build (see Logger.h -- only the N and F forms
+			// compile out), so a critical line here reached every user's log on
+			// an ordinary peer disconnect.
 			CLibSocket *w = m_libSocket.load(std::memory_order_acquire);
-			AddDebugLogLineC(logAsio,
+			AddDebugLogLineF(logAsio,
 				CFormat("Destroy() already dying socket %p %p %s") % w % this % m_IP);
 			return;
 		}


### PR DESCRIPTION
Reported by @ghysler on #887: `Destroy() already dying socket ...` appearing in an ordinary release build's log.

The line was emitted with `AddDebugLogLineC`, which is the one debug macro that survives a release build. `Logger.h` compiles out only the `N` and `F` forms when `__DEBUG__` is unset:

```c
// Macros for 'C'ritical logging
#define AddDebugLogLineC(type, string) theLogger.AddLogLine(__TFILE__, __LINE__, true, type, string)
```

It is not an error. The guard exists so callers can be sloppy about destroying, and several deliberately are:

- `CClientTCPSocket::Safe_Delete()` carries the comment *"Destroy may be called several times"* and calls it unconditionally, so **every peer disconnect** can reach it;
- `StopConnectionTry()` destroys sockets whose connect is still in flight, and when that connect later fails `OnConnect()` destroys the same socket again.

Whichever call wins the exchange does the teardown and notifies the wrapper exactly once; the loser returns having done nothing. The UDP implementation of the identical guard says as much, "Already destroying; no-op so callers can be sloppy about it", and stays silent.

Now logged at `F`, so a debug build keeps the trace in its logfile and a release build says nothing. The other seven critical sites in this file are genuine failures (cannot open socket, close error, accept error) and are left alone.

Since the peer path reaches this too, this removes noise from every release user's log on ordinary disconnects, not only during a server outage.
