### PR TITLE
fix(gui): stop repainting every notebook tab on every mouse move

### DIFF
--- a/src/MuleNotebook.cpp
+++ b/src/MuleNotebook.cpp
@@ -257,16 +257,22 @@ void CMuleNotebook::OnMouseMotion(wxMouseEvent &event)
 
 	long flags = 0;
 	int tab = HitTest(wxPoint(event.m_x, event.m_y), &flags);
+	const bool onIcon = (tab != -1) && (flags == wxNB_HITTEST_ONICON);
 
-	// Clear the highlight for all tabs.
+	// Write only the images that actually change. SetPageImage() is a
+	// TCM_SETITEM on MSW, which invalidates the tab it names, so setting
+	// every page on every motion event kept the whole tab bar repainting
+	// for as long as the pointer moved over it -- with enough tabs open
+	// that reads as flicker (issue #951). The highlight itself changes at
+	// most twice per crossing of a close icon.
 	for (int i = 0; i < (int)GetPageCount(); ++i) {
-		SetPageImage(i, 0);
+		const int image = (onIcon && i == tab) ? 1 : 0;
+		if (GetPageImage(i) != image) {
+			SetPageImage(i, image);
+		}
 	}
 
-	if ((tab != -1) && (flags == wxNB_HITTEST_ONICON)) {
-		// Mouse is over a 'x'
-		SetPageImage(tab, 1);
-	} else {
+	if (!onIcon) {
 		// Is not a 'x'. Send this event up.
 		event.Skip();
 	}


### PR DESCRIPTION
Addresses #951. Not marked as `Fixes`, so it does not auto-close — see Testing below.

`CMuleNotebook::OnMouseMotion()` cleared the hover highlight by writing image 0 to every page, then set image 1 on the tab under the pointer. Both writes went out on every motion event, so moving the pointer along the tab bar cost one write per open tab per event.

On MSW `SetPageImage()` is a `TCM_SETITEM` and invalidates the tab it names, so this repainted the whole bar continuously for as long as the pointer moved over it. With a handful of tabs it goes unnoticed; with a full search tab bar it becomes visible flicker.

Now only images that actually change are written. The highlight changes at most twice per crossing of a close icon, so in the common case the loop issues no writes at all. The behaviour is otherwise identical — and worth noting it has been invisible either way since #735 gave both image list entries the same `wxART_CLOSE` bitmap, where the plain and hover icons used to differ. The repaints were buying nothing.

## Testing

Built and gated on macOS. The flicker itself did **not** reproduce on our Windows 11 ARM64 VM, so this is not confirmed against the reported symptom. The change stands on the code path being unconditionally wasteful; @ghysler is best placed to say whether it clears what they saw, and the issue stays open until they do.
