### PR TITLE
fix(upload): stop reading a partfile whose handle has been closed

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -2460,7 +2460,15 @@ void CPartFile::PerformFileComplete()
 	FlushBuffer();
 
 	// close permanent handle
+	//
+	// Under m_hpartfileMutex: CUploadDiskIOThread reads this handle from a
+	// worker thread via ReadData, which holds the same mutex around its
+	// Seek+Read. Closing without it can land between that Seek and Read.
+	// Holding it also makes ReadData's IsOpened check decisive -- it runs
+	// under this same lock, so the handle cannot close between that check
+	// and the read it guards.
 	if (m_hpartfile.IsOpened()) {
+		std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 		m_hpartfile.Close();
 	}
 
@@ -2562,7 +2570,10 @@ void CPartFile::Delete()
 		}
 	}
 
+	// Same reasoning as PerformFileComplete: the upload reader holds
+	// m_hpartfileMutex around its Seek+Read, so the close takes it too.
 	if (m_hpartfile.IsOpened()) {
+		std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 		m_hpartfile.Close();
 	}
 
@@ -3815,8 +3826,12 @@ void CPartFile::OnAsyncHashComplete(uint16 partNumber, bool ok, bool fromAICHRec
 }
 
 // read data for upload, return false on error
-bool CPartFile::ReadData(CFileArea &area, uint64 offset, uint32 toread)
+bool CPartFile::ReadData(CFileArea &area, uint64 offset, uint32 toread, bool *handleClosed)
 {
+	if (handleClosed != nullptr) {
+		*handleClosed = false;
+	}
+
 	// Sanity check
 	if (offset + toread > GetFileSize()) {
 		AddDebugLogLineN(logPartFile,
@@ -3837,6 +3852,22 @@ bool CPartFile::ReadData(CFileArea &area, uint64 offset, uint32 toread)
 	// The write thread's Write then lands at the wrong offset, and
 	// the read returns bytes from the post-write position. See #586.
 	std::lock_guard<std::mutex> lock(m_hpartfileMutex);
+
+	// PerformFileComplete closes this handle under the same mutex once the
+	// file is finished, while the upload reader may still have block
+	// requests queued for it. Report that rather than seeking a closed
+	// handle: the throw would be indistinguishable from a real IO error,
+	// and the caller drops the client on those. Flagged separately from the
+	// bare false above, which is an asserted bug the caller must not treat
+	// as routine. Checked under the lock so the answer cannot change before
+	// the read.
+	if (!m_hpartfile.IsOpened()) {
+		if (handleClosed != nullptr) {
+			*handleClosed = true;
+		}
+		return false;
+	}
+
 	area.ReadAt(m_hpartfile, offset, toread);
 	// if it fails it throws (which the caller should catch)
 	return true;

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -599,7 +599,20 @@ public:
 	CUpDownClient *GetSlowerDownloadingClient(uint32 speed, CUpDownClient *caller);
 
 	// Read data for sharing
-	bool ReadData(class CFileArea &area, uint64 offset, uint32 toread);
+	/**
+	 * Reads part-file data into the given area.
+	 *
+	 * @param area Destination for the data.
+	 * @param offset Absolute offset to read from.
+	 * @param toread Number of bytes to read.
+	 * @param handleClosed Set when the read failed only because the
+	 *	completion path had already closed the file. That is the one
+	 *	recoverable failure; every other one is a real error and must
+	 *	not be silently swallowed by the caller.
+	 *
+	 * @return true on success, false on any failure.
+	 */
+	bool ReadData(class CFileArea &area, uint64 offset, uint32 toread, bool *handleClosed = nullptr);
 
 private:
 	/* downloading sources list */

--- a/src/UploadDiskIOThread.cpp
+++ b/src/UploadDiskIOThread.cpp
@@ -293,9 +293,31 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 						       currentblock->StartOffset %
 						       (currentblock->EndOffset - 1));
 				}
-				if (!srcPartFile->ReadData(
-					    req->area, currentblock->StartOffset, (uint32)togo)) {
+				bool handleClosed = false;
+				if (!srcPartFile->ReadData(req->area,
+					    currentblock->StartOffset,
+					    (uint32)togo,
+					    &handleClosed)) {
 					delete req;
+					// A closed handle means PerformFileComplete got there
+					// first: the download finished and the file is on its
+					// way to Incoming. That is not this client's fault, and
+					// throwing would set m_bIOError and have
+					// CUploadQueue::Process drop it -- undoing the graceful
+					// SuspendUpload(terminate == false) that parked it on
+					// the waiting list so it would survive the completion.
+					// Defer to the main thread, the same way the file-id
+					// switch at the top of this loop does; the client is
+					// resumed once the move is done.
+					//
+					// Only for that specific failure: any other false is a
+					// real error and must still be reported as one.
+					if (handleClosed && srcPartFile->GetStatus() == PS_COMPLETING) {
+						AddDebugLogLineN(logClient,
+							"CUploadDiskIOThread::StartCreateNextBlockPackage:"
+							" file completing, waiting for mainthread");
+						return;
+					}
 					throw wxString("Failed to read from requested partfile");
 				}
 			} else {


### PR DESCRIPTION
Fixes #952.

Finishing a download logs a burst of `SafeIO::IOFailure::SeekFailure: Cannot seek on closed file`, sandwiched between `Suspending upload of file` and `Resuming uploads of file` — one line per block request still queued for that file. The reporter saw about forty.

## What happens

`PerformFileComplete` suspends uploads, then closes `m_hpartfile` before handing the file to `CCompletionTask`:

```cpp
theApp->uploadqueue->SuspendUpload(GetFileHash(), false);
FlushBuffer();
if (m_hpartfile.IsOpened()) { m_hpartfile.Close(); }
CThreadScheduler::AddTask(new CCompletionTask(this));
```

`SuspendUpload` only touches the main-thread upload queue. `CUploadDiskIOThread` keeps servicing already-queued block requests on its worker thread and calls `CPartFile::ReadData`, which seeks the handle the main thread has just closed — so `CFile::Seek` throws on a closed file.

It is not only noise. The handler sets `m_bIOError`, and `CUploadQueue::Process` removes every client carrying that flag. So each completed download evicts the peers that were uploading it — precisely what `SuspendUpload(terminate == false)` exists to prevent, since it parks them on the waiting list so they survive the completion.

The download itself is unaffected: the file is complete and verified by then, which matches the reporter finding the result intact.

## The fix

`ReadData` now checks `IsOpened()` and reports a closed handle instead of seeking it, through an explicit `handleClosed` out-param. The check sits **under the `m_hpartfileMutex` it already holds**, so the handle cannot close between the check and the read it guards.

The upload reader treats that one failure as "defer to the main thread" when the file is `PS_COMPLETING`, the same way the file-id switch at the top of the same loop already does — the client stays parked and is resumed once the move is done. Any other failure still throws, so a genuine IO error is still reported as one.

The out-param is doing real work rather than decorating: `ReadData`'s other `false` is the past-eof `wxFAIL`, an asserted programming bug. Keying the defer on a bare `false` would conflate the two, so a past-eof arriving during completion would be logged as "file completing" and the client quietly parked — hiding exactly the kind of defect the assert exists to surface.

**Why the check is on the handle and not on `PS_COMPLETING` alone.** That status is also set at the *start* of the final hash: `CompleteFile`'s `!bIsHashingDone` branch sets it, spawns `CHashingTask` and returns without closing anything. Gating uploads on the status would starve them for the whole hash — minutes on a large file — even though the handle is open and the reads would succeed. The hazard is the close, not the completion.

Both closes also now take `m_hpartfileMutex`. `ReadData` holds it across its `Seek+Read` because `CFile`'s internal mutex serialises individual syscalls but not the composition; the closes ignored it and could land in the middle. Taking it is also what makes the `IsOpened` check decisive rather than racy. `Delete()` gets the same treatment — same unguarded composition, same worker.

## Deadlock analysis

- `CFile::Close()` takes only `CFile`'s own mutex, so the ordering stays `m_hpartfileMutex` → `CFile::m_mutex`, as at every existing lock site. Nothing takes them in the other order — `CFile` has no knowledge of `CPartFile`.
- `PerformFileComplete` has a single caller, and no lock site reaches it. `FlushBuffer` does call `CompleteFile`, but its lock is a closed inner scope released beforehand.
- In `Delete()` the lock is taken **after** the `m_pendingHashes` wait, never across it. Holding it there would block `CPartFileHashThread`, which needs the same mutex to finish the job being waited on.
- `Close()` can now block on an in-flight `ReadAt`, which is a bounded syscall and exactly the serialisation intended.

## Testing

Builds clean in Release and Debug on macOS; `clang-format` clean; unit suite 34/34.

The failure is a thread race on download completion and is not covered by the suite — I have not reproduced the original burst locally, so the reasoning above rests on the code paths rather than on an observed repro.
