### PR TITLE
fix(gui): raise the reconnect dialog when the window comes back from the tray

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -770,6 +770,20 @@ void CamuleDlg::RestoreMainWindow()
 	// why this looked intermittent.
 	m_iconized_logical = false;
 
+#ifdef CLIENT_GUI
+	// Same reasoning one step further: a reconnect that has been retrying
+	// quietly behind a tray-hidden window now has a window to explain itself
+	// in. OnMainWindowRestored() is otherwise reached only from OnShow() and
+	// OnMinimize(), i.e. from the two events the paragraph above explains do
+	// not arrive on this path -- so on Windows the dialog never appeared for
+	// a user who came back mid-outage, which is what issue #942 reports.
+	// Cheap to call unconditionally: it returns immediately unless a
+	// reconnect is running without a dialog, and defers the dialog itself to
+	// CallAfter, so the platforms that do deliver wxEVT_SHOW just no-op the
+	// second call.
+	theApp->OnMainWindowRestored();
+#endif
+
 	// Clear the iconized bit on every platform — the window might be
 	// hidden (Show(false) via HideOnClose / minimize-to-tray) or just
 	// iconized to the OS Dock/taskbar; in either case the user wants a


### PR DESCRIPTION
Addresses #942 — the part of it that #945 did not reach. Not marked as `Fixes`, so the issue stays open until @ghysler confirms.

Restoring amulegui from the tray during an outage left the reconnect running silently: the window came back, the log kept reporting attempts, and nothing explained why the interface was frozen.

`BeginReconnect()` skips the dialog while the window is not visible, and leaves it to `OnMainWindowRestored()` to put one up if the user returns while the retry loop is still going — its comment says exactly that. But that call is only reached from `OnShow()` and `OnMinimize()`, i.e. from `wxEVT_SHOW` and `wxEVT_ICONIZE`, and neither event arrives on the Windows tray-restore path — for the reason #945 documents a few lines above this change: against a window that is hidden *and* iconized, `Iconize(false)` restores and shows it, so the following `Show(true)` never reaches `ShowWindow()` and no `wxShowEvent` is generated.

#945 fixed the stale `m_iconized_logical` flag that same gap left behind, which is why a disconnect *after* a tray round-trip now shows the dialog. A reconnect already in progress when the user restores did not, because it depends on the notification rather than on the flag.

So notify from `RestoreMainWindow()` too, on the same grounds the flag is cleared there: it is the one place that knows the user asked for the window back, rather than an event that may never come. That covers every restore route — tray click, tray menu, un-hide after `HideOnClose`, and the remote GUI's own path — since all of them funnel through it.

Safe to call unconditionally: it returns immediately unless a reconnect is running without a dialog, and it defers the dialog itself to `CallAfter`, so platforms that *do* deliver `wxEVT_SHOW` just no-op the second call.

## Testing

Built on macOS for both targets, confirming the `#ifdef CLIENT_GUI` resolves per binary (`amule.dir` and `amulegui.dir` each build `amuleDlg.cpp`, so this is not shared through muleappgui). clang-format and Tier-2 clang-tidy clean.

The symptom itself is Windows-specific — it depends on `Iconize(false)` swallowing the show event — so the behavioural check has to come from @ghysler, who has the exact reproduction.
