### PR TITLE
fix(gui): compose the tray icon with real alpha, not a red colour key

### DIFF
--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -549,7 +549,9 @@ void CMuleTrayIcon::RebuildMenu()
 //  goes nowhere — build with libayatana-appindicator3 to fix that.
 // ---------------------------------------------------------------------
 
-#include <wx/artprov.h> // Needed for wxArtProvider::GetIcon
+#include <algorithm> // Needed for std::max / std::min
+
+#include <wx/artprov.h> // Needed for wxArtProvider::GetBitmap
 
 #include <wx/menu.h>
 
@@ -658,11 +660,6 @@ CMuleTrayIcon::CMuleTrayIcon()
 {
 	Old_Icon = -1;
 	Old_SpeedSize = 0xFFFF; // must be > any possible one.
-
-	// Create the background icons (speed improvement)
-	HighId_Icon_size = wxArtProvider::GetIcon("amule:tray_high").GetHeight();
-	LowId_Icon_size = wxArtProvider::GetIcon("amule:tray_low").GetHeight();
-	Disconnected_Icon_size = wxArtProvider::GetIcon("amule:tray_disconnected").GetHeight();
 }
 
 CMuleTrayIcon::~CMuleTrayIcon() {}
@@ -673,83 +670,71 @@ CMuleTrayIcon::~CMuleTrayIcon() {}
 
 void CMuleTrayIcon::SetTrayIcon(int Icon, uint32 percent)
 {
-	int Bar_ySize = 0;
+	wxASSERT(Icon >= 0 && Icon < (int)WXSIZEOF(BaseImage));
 
-	switch (Icon) {
-	case TRAY_ICON_HIGHID:
-		// Most likely case, test first
-		Bar_ySize = HighId_Icon_size;
-		break;
-	case TRAY_ICON_LOWID:
-		Bar_ySize = LowId_Icon_size;
-		break;
-	case TRAY_ICON_DISCONNECTED:
-		Bar_ySize = Disconnected_Icon_size;
-		break;
-	default:
-		wxFAIL;
+	if (!BaseImage[Icon].IsOk()) {
+		const char *artId = "amule:tray_disconnected";
+		switch (Icon) {
+		case TRAY_ICON_HIGHID:
+			artId = "amule:tray_high";
+			break;
+		case TRAY_ICON_LOWID:
+			artId = "amule:tray_low";
+			break;
+		default:
+			break;
+		}
+		wxImage image = wxArtProvider::GetBitmap(artId, wxART_OTHER).ConvertToImage();
+		if (!image.IsOk()) {
+			return;
+		}
+		// Artwork that predates alpha marks its transparency with pure red.
+		// Turn that into a real alpha channel once, here, so everything below
+		// this point works on one representation.
+		if (!image.HasAlpha()) {
+			image.SetMaskColour(255, 0, 0);
+			image.InitAlpha();
+		}
+		BaseImage[Icon] = image;
 	}
 
-	// Lookup this values for speed improvement: don't draw if not needed
-	int NewSize = (Bar_ySize * percent) / 100;
+	const wxImage &base = BaseImage[Icon];
+	const int width = base.GetWidth();
+	const int height = base.GetHeight();
+	const int barHeight = (height * (int)percent) / 100;
 
-	if ((Old_Icon != Icon) || (Old_SpeedSize != NewSize)) {
+	if ((Old_Icon == Icon) && (Old_SpeedSize == barHeight)) {
+		return;
+	}
+	Old_Icon = Icon;
+	Old_SpeedSize = barHeight;
 
-		if ((Old_SpeedSize > NewSize) || (Old_Icon != Icon)) {
-			// We have to rebuild the icon, because bar is lower now.
-			switch (Icon) {
-			case TRAY_ICON_HIGHID:
-				// Most likely case, test first
-				CurrentIcon = wxArtProvider::GetIcon("amule:tray_high");
-				break;
-			case TRAY_ICON_LOWID:
-				CurrentIcon = wxArtProvider::GetIcon("amule:tray_low");
-				break;
-			case TRAY_ICON_DISCONNECTED:
-				CurrentIcon = wxArtProvider::GetIcon("amule:tray_disconnected");
-				break;
-			default:
-				wxFAIL;
+	// Always compose onto a copy of the untouched artwork. Composing onto the
+	// icon we produced last time loses the transparency a little more each
+	// round: converting an icon back to a bitmap returns its transparent
+	// pixels as black, so a rising transfer rate -- which never takes the
+	// rebuild-from-scratch path -- ends up with a solid black background.
+	//
+	// The bar is written into the image rather than drawn with a wxDC because
+	// wxMSW's DC writes the colour channels and leaves alpha alone: a bar
+	// drawn over transparent pixels keeps alpha 0 and never appears, which is
+	// what happens to any artwork that carries its own alpha channel.
+	wxImage composed = base.Copy();
+	if (barHeight > 0) {
+		const wxColour barColour = CStatisticsDlg::getColors(11);
+		// Two pixels wide, in from the right edge, growing from the bottom.
+		const int barLeft = std::max(0, width - 4);
+		const int barRight = std::min(width, barLeft + 2);
+		for (int y = height - barHeight; y < height; ++y) {
+			for (int x = barLeft; x < barRight; ++x) {
+				composed.SetRGB(x, y, barColour.Red(), barColour.Green(), barColour.Blue());
+				composed.SetAlpha(x, y, wxALPHA_OPAQUE);
 			}
 		}
-
-		Old_Icon = Icon;
-		Old_SpeedSize = NewSize;
-
-		// Do whatever to the icon before drawing it (percent)
-
-		wxBitmap TempBMP;
-		TempBMP.CopyFromIcon(CurrentIcon);
-
-		TempBMP.SetMask(NULL);
-
-		IconWithSpeed.SelectObject(TempBMP);
-
-		// Speed bar is: centered, taking 80% of the icon height, and
-		// right-justified taking a 10% of the icon width.
-
-		// X
-		int Bar_xSize = 4;
-		int Bar_xPos = CurrentIcon.GetWidth() - 5;
-
-		IconWithSpeed.SetBrush(*(wxTheBrushList->FindOrCreateBrush(CStatisticsDlg::getColors(11))));
-		IconWithSpeed.SetPen(*wxTRANSPARENT_PEN);
-
-		IconWithSpeed.DrawRectangle(Bar_xPos + 1, Bar_ySize - NewSize, Bar_xSize - 2, NewSize);
-
-		// Unselect the icon.
-		IconWithSpeed.SelectObject(wxNullBitmap);
-
-		// Do transparency
-
-		// Set a new mask with transparency set to red.
-		wxMask *new_mask = new wxMask(TempBMP, wxColour(0xFF, 0x00, 0x00));
-
-		TempBMP.SetMask(new_mask);
-		CurrentIcon.CopyFromBitmap(TempBMP);
-
-		UpdateTray();
 	}
+
+	CurrentIcon.CopyFromBitmap(wxBitmap(composed));
+	UpdateTray();
 }
 
 void CMuleTrayIcon::SetTrayToolTip(const wxString &Tip)

--- a/src/MuleTrayIcon.h
+++ b/src/MuleTrayIcon.h
@@ -71,7 +71,7 @@ typedef struct _GtkWidget GtkWidget;
 #else
 #include <wx/taskbar.h>
 #include <wx/icon.h>
-#include <wx/dcmemory.h>
+#include <wx/image.h>
 class wxMenu;
 #endif
 
@@ -143,12 +143,12 @@ private:
 	int Old_Icon;
 	int Old_SpeedSize;
 
-	int Disconnected_Icon_size;
-	int LowId_Icon_size;
-	int HighId_Icon_size;
+	// The unmodified artwork for each state, indexed by TRAY_ICON_*, loaded
+	// once. SetTrayIcon() composes the speed bar onto a copy of one of these
+	// rather than onto the icon it drew last time -- see the comment there.
+	wxImage BaseImage[3];
 
 	wxIcon CurrentIcon;
-	wxMemoryDC IconWithSpeed;
 	wxString CurrentTip;
 
 	wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
The tray icon turns into a black square while a download is running, and the speed bar cannot work at all with artwork that carries an alpha channel. Both come from the same place.

`SetTrayIcon()` composed the speed bar onto the icon it produced last time, and expressed transparency as a `wxMask` keyed on pure red. The pristine artwork is only re-fetched when the bar *shrinks*, so while a transfer ramps up each update composes onto the previous result — and that round-trip is lossy: converting an icon back to a bitmap returns its transparent pixels as **black**, `SetMask(NULL)` then drops the mask that made them transparent, and the freshly built red key finds no red left to key on. The background stays black for as long as the rate keeps climbing, and repairs itself when it falls. Idle is one composite from a clean base, which is why it only misbehaves during transfers.

The `wxDC` is the second half. wxMSW writes the colour channels and leaves alpha untouched, so a bar drawn over transparent pixels keeps alpha 0 and never appears — which is what happens to any artwork with a real alpha channel, such as the icons proposed in #957. macOS composites through CoreGraphics, which does write alpha, so the same code behaved differently on the two platforms and the fault stayed hidden.

Compose through a `wxImage` instead, from artwork cached once per state and never drawn over: write the bar's colour *and* its alpha, then build the icon from that. Artwork without an alpha channel is converted once on load by keying its red, so the old convention still works where it is needed without constraining anything downstream — new tray artwork is free to contain red.

## Testing

Built on macOS and Windows 11 ARM64, and compared four builds — current artwork and #957's alpha artwork, each with and without this change:

| artwork | this fix | result |
|---|---|---|
| current | no | black background while downloading |
| alpha (#957) | no | clean at rest, no speed bar at all |
| alpha (#957) | yes | correct on both platforms |
| current | yes | correct on both platforms |

Checked at rest and during transfers, with the bar in its default black and in a custom colour, on light and dark taskbars.
