### PR TITLE
fix(log): stop reporting a tag-read failure without saying where

### DIFF
--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -466,11 +466,26 @@ CTag *CFileDataIO::ReadTag(bool bOptACP) const
 				       EscapeForLog(name));
 		}
 	} catch (const CMuleException &e) {
-		AddLogLineN(e.what());
+		// Debug, not standard: this says only what went wrong, never which
+		// file or packet it went wrong in, and it is rethrown for a caller
+		// that does know. A truncated tag off the network therefore put a
+		// bare "SafeIO::EOF: Attempt to read past end of file." in the
+		// daemon log with nothing around it, while the line naming the peer
+		// and opcode sat at debug level and was compiled out (issue #961).
+		//
+		// Every caller reports the failure itself: CIndexed::ReadFile and
+		// ~CIndexed through AddDebugLogLineC, which survives a release
+		// build, and fileview on cerr. The Kad UDP handlers report through
+		// CClientUDPSocket's AddDebugLogLineN, so a malformed packet is now
+		// silent in release -- which is the right answer for a packet that
+		// was dropped and cost nothing.
+		AddDebugLogLineN(logGeneral, e.what());
 		delete retVal;
 		throw;
 	} catch (const wxString &e) {
-		AddLogLineN(e);
+		// Same reasoning: the throw just above carries the type and name,
+		// and the caller names the source.
+		AddDebugLogLineN(logGeneral, e);
 		throw;
 	}
 


### PR DESCRIPTION
Fixes #961.

`CFileDataIO::ReadTag()` logged the exception at standard level and then rethrew it. The message says *what* went wrong and never *where*, so a truncated tag arriving off the network put

```
SafeIO::EOF: Attempt to read past end of file.
```

in the daemon log with nothing around it, at irregular intervals. The line that *does* name the peer and opcode sits in `CClientUDPSocket`'s catch at debug level, which a release build compiles out - so the user was shown the useless half and never the useful one.

### Every caller already reports with context

I traced all ten `ReadTag`/`ReadTagPtrList` call sites:

| path | caller's report | in release? |
|---|---|---|
| `CIndexed::ReadFile`, `~CIndexed` | `AddDebugLogLineC(logKadIndex, …)` | yes - that macro is always compiled in |
| `fileview` | `cerr` + non-zero exit | yes |
| Kad UDP (`AddContact2`, `Process2Publish{Key,Source,Notes}Request`, `ProcessSearchResponse`) | `AddDebugLogLineN(logClientUDP, …)` | **no** |

The last row is deliberate, not an oversight: a malformed Kad packet becomes silent in a release build. It is dropped either way, a peer sending bad bytes is not something an operator can act on, and it was the entirety of the reported noise.

The write path keeps standard-level logging - a tag that fails to *serialise* is our own bug, not a remote one.

### Testing

Builds clean in Release and Debug. Debug matters here specifically: `AddDebugLogLineN` expands to `do{}while(false)` in Release, so only the Debug build type-checks the changed lines.
