### PR TITLE
fix(gui): move the tray speed bar to the icon's outermost columns

### DIFF
--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -722,8 +722,12 @@ void CMuleTrayIcon::SetTrayIcon(int Icon, uint32 percent)
 	wxImage composed = base.Copy();
 	if (barHeight > 0) {
 		const wxColour barColour = CStatisticsDlg::getColors(11);
-		// Two pixels wide, in from the right edge, growing from the bottom.
-		const int barLeft = std::max(0, width - 4);
+		// Two pixels wide, in the last two columns, growing from the bottom.
+		// It used to sit two columns further in, which the artwork of the day
+		// left clear. Newer artwork fills more of its canvas, so the bar landed
+		// on the drawing instead of beside it; the outermost columns are the
+		// ones an icon is least likely to use.
+		const int barLeft = std::max(0, width - 2);
 		const int barRight = std::min(width, barLeft + 2);
 		for (int y = height - barHeight; y < height; ++y) {
 			for (int x = barLeft; x < barRight; ++x) {


### PR DESCRIPTION
The speed bar was drawn two columns in from the right edge, in space that the tray artwork of the day happened to leave clear — the current icons stop at x=15 of 22.

Artwork that fills more of its canvas puts the drawing underneath the bar instead of beside it. The icons proposed in #957 reach x=19, so the bar lands on the mule's body, and a dark bar over dark artwork is not much of an indicator.

Move it to the last two columns, which an icon is least likely to use. It stays two pixels wide and still grows from the bottom, so nothing else about it changes.

## Testing

Checked on Windows 11 and macOS with #957's artwork and a live download, at both bar positions. In the last two columns the bar reads as separate from the mule; two columns further in it sits on top of it. Also confirmed the current artwork is unaffected — it stops well clear of either position.
