### PR TITLE
fix(gui): use the translations these strings already have

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:30+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3503,7 +3503,7 @@ msgstr "بايت"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:31+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3562,7 +3562,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:31+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3495,7 +3495,7 @@ msgstr "Байта"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:32+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3551,7 +3551,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-20 09:19+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3547,7 +3547,7 @@ msgstr "bajtů"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:34+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3514,7 +3514,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:35+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3549,7 +3549,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:36+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3573,7 +3573,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-20 09:19+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3540,7 +3540,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "MiB"
 

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3551,7 +3551,7 @@ msgstr "Baiti"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:39+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3552,7 +3552,7 @@ msgstr "Byte"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:40+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3552,7 +3552,7 @@ msgstr "Tavua"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 18:18+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3539,7 +3539,7 @@ msgstr "Octets"
 msgid "KiB"
 msgstr "Kio"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "Mio"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:42+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3562,7 +3562,7 @@ msgstr "Octetos"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:42+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3527,7 +3527,7 @@ msgstr "בתים"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:43+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3523,7 +3523,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:44+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3531,7 +3531,7 @@ msgstr "bájt"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:45+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3546,7 +3546,7 @@ msgstr "Byte"
 msgid "KiB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "MiB"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3552,7 +3552,7 @@ msgstr "B"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:46+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3572,7 +3572,7 @@ msgstr "바이트"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:47+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3586,7 +3586,7 @@ msgstr "Baitai"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-20 09:19+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3473,7 +3473,7 @@ msgstr "Baiti"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-20 09:19+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3554,7 +3554,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:49+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3572,7 +3572,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:50+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3566,7 +3566,7 @@ msgstr "Bajtów"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-18 18:56+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3540,7 +3540,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "MiB"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:52+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3558,7 +3558,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:53+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3561,7 +3561,7 @@ msgstr "Baiți"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-20 09:19+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3566,7 +3566,7 @@ msgstr "Байт"
 msgid "KiB"
 msgstr "КиБ"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "МиБ"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:55+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3582,7 +3582,7 @@ msgstr "Bajtov"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:56+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3565,7 +3565,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 08:57+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3550,7 +3550,7 @@ msgstr "Bytes"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 09:04+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-18 18:56+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3532,7 +3532,7 @@ msgstr "Bayt"
 msgid "KiB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "MiB"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 09:00+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3582,7 +3582,7 @@ msgstr "байт"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 09:01+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3536,7 +3536,7 @@ msgstr "字节"
 msgid "KiB"
 msgstr "KiB"
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr "MiB"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-16 10:27+0200\n"
+"POT-Creation-Date: 2026-08-20 11:35+0200\n"
 "PO-Revision-Date: 2026-08-17 09:02+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3543,7 +3543,7 @@ msgstr "B"
 msgid "KiB"
 msgstr ""
 
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
 msgstr ""
 

--- a/src/ClientHistoryListCtrl.cpp
+++ b/src/ClientHistoryListCtrl.cpp
@@ -354,7 +354,9 @@ wxString CClientHistoryListCtrl::GetItemColumnText(wxUIntPtr item, unsigned colu
 		return CFormat(wxT("%s:%u")) % Uint32toStringIP(row->ip) % row->port;
 
 	case COLUMN_HISTORY_ORIGIN:
-		return row->identityKnown ? OriginToText(row->sourceFrom) : wxString();
+		// Translated here, not by OriginToText(): see CClientsListCtrl, which
+		// shares this column and had the same gap.
+		return row->identityKnown ? wxGetTranslation(OriginToText(row->sourceFrom)) : wxString();
 
 	case COLUMN_HISTORY_FIRST_SEEN:
 		return row->firstSeen == 0

--- a/src/ClientsListCtrl.cpp
+++ b/src/ClientsListCtrl.cpp
@@ -233,7 +233,10 @@ wxString CClientsListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 		return CFormat(wxT("%s:%u")) % Uint32toStringIP(row->ip) % row->port;
 
 	case COLUMN_CLIENTS_ORIGIN:
-		return OriginToText(row->sourceFrom);
+		// OriginToText() hands back the wxTRANSLATE() marker, which is only an
+		// extraction hint -- the lookup has to happen here, the way the download
+		// list's source column already does it.
+		return wxGetTranslation(OriginToText(row->sourceFrom));
 
 	case COLUMN_CLIENTS_FILES:
 		return row->files;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -2470,8 +2470,10 @@ void PrefsUnifiedDlg::UpdateGeoIPStatus()
 		if (fn.FileExists()) {
 			const wxULongLong bytes = fn.GetSize();
 			if (bytes != wxInvalidSize) {
-				sizeLabel =
-					wxString::Format(" (%.1f MiB)", bytes.ToDouble() / (1024.0 * 1024.0));
+				// The unit is a separate argument so it picks up the "MiB"
+				// translation the rest of the dialog already uses.
+				sizeLabel = wxString::Format(
+					" (%.1f %s)", bytes.ToDouble() / (1024.0 * 1024.0), _("MiB"));
 			}
 		}
 		if (attribution.IsEmpty()) {


### PR DESCRIPTION
Closes #958. Closes #959.

Two places show English to a translated user, both because the translation exists and simply isn't looked up.

### Origin column in the Clients tab (#958)

`OriginToText()` returns `wxTRANSLATE(...)`, which marks a string for extraction and does nothing at runtime — the caller has to do the lookup. The download list's source column does (`GenericClientListCtrl.cpp`); the Clients tab did not, so `Passive`, `Local Server`, `Remote Server` and `Source Exchange` stayed English while the same values were translated one tab over.

Fixed in both lists that share the column: the active list and the history list. The reporter saw the active one; the history list had the identical gap.

### MiB in the IP2Country status line (#959)

The unit was inside the format string — `" (%.1f MiB)"` — so it could never be translated. It is a separate argument now and picks up the `"MiB"` msgid the rest of the Preferences dialog already uses (`МиБ` in Russian, and so on).

### Catalogs

No new strings: both fixes reuse msgids that exist and are already translated. The catalogs are regenerated only because `_("MiB")` now appears in a second source file, so that entry's source references change:

```
-#: src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/muuli_wdr.cpp src/OtherFunctions.cpp src/PrefsUnifiedDlg.cpp
 msgid "MiB"
```

No msgid added or removed, no translation touched.

### Testing

Built on macOS. Both changes are lookups against existing catalog entries, so there is nothing platform-specific here.

Thanks to @adem4ik for both reports — found by running a non-English build, which is also how the history-list instance surfaced.
