### PR TITLE
feat(amuleapi): expose the friends list over REST, and fix the unreadable friend slot

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -37,6 +37,7 @@ const EVENT_TYPES = [
   "shared_added",   "shared_updated",   "shared_removed",
   "client_added",   "client_updated",   "client_removed",
   "server_added",   "server_updated",   "server_removed",
+  "friend_added",   "friend_updated",   "friend_removed",
   "status_changed", "log_appended",
   "search_result_added", "search_progress",
   "comments_updated",
@@ -156,6 +157,7 @@ Every event belongs to a single channel. The full set, prefix-mapped from the ev
 | `shared` | `shared_*` | Shared file list |
 | `servers` | `server_*` | Known ed2k servers |
 | `clients` | `client_*` | Peers we're exchanging with |
+| `friends` | `friend_*` | The friends list, and whether each one is online |
 | `status` | `status_*` | Connection state + headline counters |
 | `logs` | `log_*` | amuled log buffer (live tail; serverinfo is poll-only) |
 | `search` | `search_*` | Result deltas + completion of an active `POST /search` |
@@ -218,7 +220,7 @@ Both `since_id` and `newest_id` are uint64. The client never has to compute them
 
 ## Event catalog
 
-Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`), `client_ecid` for `client_removed`, `ecid` for `server_removed` — so the client can drop the cache entry without needing the old object. Two events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge) and `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace). Branch on the event type in your dispatcher accordingly.
+Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`), `client_ecid` for `client_removed`, `friend_ecid` for `friend_removed`, `ecid` for `server_removed` — so the client can drop the cache entry without needing the old object. Two events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge) and `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace). Branch on the event type in your dispatcher accordingly.
 
 ### `downloads` channel
 
@@ -331,6 +333,35 @@ Identical to the REST [`/api/v0/servers`](REFERENCE.md#get-apiv0servers) list-it
 ```
 
 Servers are ECID-keyed (not hash-keyed) so the removed payload carries the integer ECID.
+
+### `friends` channel
+
+#### `friend_added` / `friend_updated`
+
+Identical to the REST [`/api/v0/friends`](REFERENCE.md#get-apiv0friends) list-item shape.
+
+```json
+{
+  "friend_ecid":  12,
+  "name":         "alice",
+  "user_hash":    "a1b2c3d4e5060e708090a0b0c0d06f00",
+  "ip":           "203.0.113.42",
+  "port":         4662,
+  "client_ecid":  4382,
+  "online":       true,
+  "friend_slot":  false
+}
+```
+
+`friend_updated` fires on any observable change, including a friend coming online or going offline — that transition is `client_ecid` moving between a live peer's ECID and `0`, which is what drives the connected indicator in the desktop client.
+
+One `PATCH /api/v0/friends/{ecid}` can produce **two** `friend_updated` events. Only one friend may hold the friend slot, so granting it to one clears it on whoever held it before, and both records change.
+
+#### `friend_removed`
+
+```json
+{ "friend_ecid": 12 }
+```
 
 ### `clients` channel
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -64,6 +64,11 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`DELETE /api/v0/servers/{ecid}`](#delete-apiv0serversecid--delete-apiv0serversipport) — remove server (ECID or `ip:port`)
 - [`PATCH /api/v0/servers/{ecid}`](#patch-apiv0serversecid--patch-apiv0serversipport) — set server priority / static flag (ECID or `ip:port`)
 - [`POST /api/v0/servers/update`](#post-apiv0serversupdate) — refresh from `server.met` URL
+- [`GET /api/v0/friends`](#get-apiv0friends) — list the friends list
+- [`POST /api/v0/friends`](#post-apiv0friends) — add a friend, by connected peer or by address
+- [`DELETE /api/v0/friends/{ecid}`](#delete-apiv0friendsecid) — remove a friend
+- [`PATCH /api/v0/friends/{ecid}`](#patch-apiv0friendsecid) — grant or clear the friend slot
+- [`POST /api/v0/friends/{ecid}/shared_files`](#post-apiv0friendsecidshared_files) — browse a friend's shared files
 
 **Categories**
 - [`GET /api/v0/categories`](#get-apiv0categories) — list categories
@@ -188,7 +193,7 @@ Each endpoint documents its own response shape under the endpoint section. List 
 
 ### List pagination and sorting
 
-The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, and `/search/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
+The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, and `/search/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
@@ -218,6 +223,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 | `GET /known_clients`  | `name`, `software`, `first_seen`, `last_seen`, `sessions`, `total_uploaded`, `total_downloaded` |
 | `GET /shared`         | `name`, `size` |
 | `GET /servers`        | `name`, `users`, `ping`, `files` |
+| `GET /friends`        | `name`, `online` |
 | `GET /search/results` | `name`, `size`, `sources`, `rating` |
 
 ### Bulk mutations and the `results` envelope
@@ -1574,6 +1580,98 @@ The URL must start with `http://` or `https://`; anything else is rejected `400 
 **Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
+
+### Friends
+
+The friends list amuled persists to `emfriends.met`. The daemon ships the whole list inside the update every client already receives, so `GET /friends` costs no roundtrip of its own.
+
+`{ecid}` is the friend's own id, distinct from the peer ECIDs on `/clients`. Like every ECID it does **not** survive an `amuled` restart — use `user_hash` as the durable reference where a friend has one. A friend added by address alone has no hash.
+
+#### `GET /api/v0/friends`
+
+**Auth:** `GUEST`
+
+```json
+{
+  "friends": [
+    {
+      "friend_ecid": 12,
+      "name": "alice",
+      "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00",
+      "ip": "203.0.113.42",
+      "port": 4662,
+      "client_ecid": 4382,
+      "online": true,
+      "friend_slot": false
+    }
+  ],
+  "total": 7,
+  "offset": 0,
+  "limit": 7
+}
+```
+
+`client_ecid` is the live peer this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `0` when the friend is offline — `online` is the convenience form of that test. `user_hash` is `""` for a friend added by address only, and `ip` is `""` for a zero address.
+
+`friend_slot` reads `false` against a daemon predating the tag that carries it, the same way `is_friend` and `dl_up_modifier` degrade on `/clients`.
+
+**Errors:** `503 ec_unavailable`.
+
+#### `POST /api/v0/friends`
+
+**Auth:** `ADMIN`
+
+Two mutually exclusive body forms.
+
+Promote a connected peer:
+
+```json
+{ "client_ecid": 4382 }
+```
+
+Or add by address, where `ip` and `port` are required and non-zero, `user_hash` must be 32 hexadecimal characters when given, and `name` defaults to the address:
+
+```json
+{ "ip": "203.0.113.42", "port": 4662, "name": "alice", "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00" }
+```
+
+Sending `client_ecid` together with any address field is a `400`.
+
+**Response:** `201 Created` → the new friend object.
+
+**Errors:** `400 bad_request`, `404 not_found` (no connected client with that `client_ecid`), `400 amuled_rejected`, `503 ec_unavailable`.
+
+#### `DELETE /api/v0/friends/{ecid}`
+
+**Auth:** `ADMIN`
+
+**Response:** `200 OK` → `{ "ok": true, "friend_ecid": 12 }`.
+
+Removing the friend that currently holds the friend slot clears it.
+
+**Errors:** `404 not_found`, `400 amuled_rejected`, `503 ec_unavailable`.
+
+#### `PATCH /api/v0/friends/{ecid}`
+
+**Auth:** `ADMIN`
+
+**Body:** `{ "friend_slot": true }` — the only mutable field.
+
+**Response:** `200 OK` → the updated friend object.
+
+Only one friend can hold the slot at a time, so granting it clears it on whoever held it before. A single call therefore changes two records and emits two `friend_updated` events; the response body describes only the friend named in the URL.
+
+**Errors:** `400 bad_request`, `404 not_found`, `400 amuled_rejected`, `503 ec_unavailable`.
+
+#### `POST /api/v0/friends/{ecid}/shared_files`
+
+**Auth:** `ADMIN`
+
+Browse a friend's shared files. The friend-addressed twin of [`POST /api/v0/clients/{ecid}/shared_files`](#post-apiv0clientsecidshared_files), and more capable: a friend record carries a stored address, so the daemon can browse a friend who is **not currently connected**, which the clients route cannot do.
+
+**Response:** `202 Accepted` → `{ "ok": true, "search_id": 17 }`. Poll [`GET /api/v0/search/results`](#get-apiv0searchresults) with that `search_id`.
+
+**Errors:** `403 forbidden`, `404 not_found`, `502 amuled_rejected`, `503 ec_unavailable`.
 
 ### Categories
 

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -599,6 +599,11 @@ CEC_Friend_Tag::CEC_Friend_Tag(const CFriend *Friend, CValueMap *valuemap)
 	AddTag(EC_TAG_FRIEND_PORT, Friend->GetPort(), valuemap);
 	const CClientRef &linkedClient = Friend->GetLinkedClient();
 	AddTag(EC_TAG_FRIEND_CLIENT, linkedClient.IsLinked() ? linkedClient.ECID() : 0, valuemap);
+	// The slot is settable over EC (EC_TAG_FRIEND_FRIENDSLOT on the request
+	// side) but was never reported back, so every EC client read it as false
+	// -- amulegui's "Establish Friend Slot" check mark could not follow the
+	// state it had just set. Same tag id in both directions.
+	AddTag(EC_TAG_FRIEND_FRIENDSLOT, Friend->HasFriendSlot(), valuemap);
 }
 
 // File_checked_for_headers

--- a/src/Friend.cpp
+++ b/src/Friend.cpp
@@ -172,7 +172,7 @@ void CFriend::WriteToFile(CFileDataIO *file)
 	}
 }
 
-bool CFriend::HasFriendSlot()
+bool CFriend::HasFriendSlot() const
 {
 	return m_HasFriendSlot;
 }

--- a/src/Friend.h
+++ b/src/Friend.h
@@ -67,7 +67,7 @@ public:
 	const CClientRef &GetLinkedClient() const { return m_LinkedClient; }
 	void UnLinkClient(bool notify = true);
 
-	bool HasFriendSlot();
+	bool HasFriendSlot() const;
 	void SetPersistentFriendSlot(bool v) { m_HasFriendSlot = v; }
 
 	const wxString &GetName() const { return m_strName; }

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3220,6 +3220,14 @@ void CFriendListRem::ProcessItemUpdate(const CEC_Friend_Tag *tag, CFriend *Frien
 	tag->UserHash(Friend->m_UserHash);
 	tag->IP(Friend->m_dwLastUsedIP);
 	tag->Port(Friend->m_nLastUsedPort);
+	// Read the slot back rather than leaving it at its constructor false: the
+	// context menu's check mark is drawn from it, so without this it never
+	// showed which friend actually holds the slot -- not even right after
+	// this GUI set it.
+	bool friendSlot = false;
+	if (tag->FriendSlot(friendSlot)) {
+		Friend->SetPersistentFriendSlot(friendSlot);
+	}
 	uint32 clientID;
 	bool notified = false;
 	if (tag->Client(clientID)) {

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -747,6 +747,7 @@ public:
 	bool IP(uint32 &target) const { return AssignIfExist(EC_TAG_FRIEND_IP, target); }
 	bool Port(uint16 &target) const { return AssignIfExist(EC_TAG_FRIEND_PORT, target); }
 	bool Client(uint32 &target) const { return AssignIfExist(EC_TAG_FRIEND_CLIENT, target); }
+	bool FriendSlot(bool &target) const { return AssignIfExist(EC_TAG_FRIEND_FRIENDSLOT, target); }
 };
 
 #endif /* ECSPECIALTAGS_H */

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -869,6 +869,45 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / POST on /servers");
 	}
 
+	if (path == "/api/v0/friends") {
+		if (req.method == "GET" || req.method == "HEAD") {
+			return HandleFriends(req);
+		}
+		if (req.method == "POST") {
+			return HandleFriendAdd(req);
+		}
+		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / POST on /friends");
+	}
+
+	// One friend by ECID: remove, set the friend slot, or browse their shared
+	// files. The browse form is checked first, same ordering rationale as the
+	// server routes above.
+	{
+		static const auto friend_browse =
+			web_api_path::ParsePattern("/api/v0/friends/{ecid}/shared_files");
+		static const auto friend_one = web_api_path::ParsePattern("/api/v0/friends/{ecid}");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(friend_browse, path_segs, caps)) {
+			if (req.method != "POST") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only POST on /friends/{ecid}/shared_files");
+			}
+			return HandleFriendBrowse(req, caps["ecid"]);
+		}
+		if (web_api_path::Match(friend_one, path_segs, caps)) {
+			if (req.method == "DELETE") {
+				return HandleFriendRemove(req, caps["ecid"]);
+			}
+			if (req.method == "PATCH") {
+				return HandleFriendPatch(req, caps["ecid"]);
+			}
+			return ErrorResponse(
+				405, "method_not_allowed", "only DELETE / PATCH on /friends/{ecid}");
+		}
+	}
+
 	if (path == "/api/v0/servers/update") {
 		if (req.method != "POST") {
 			return ErrorResponse(405, "method_not_allowed", "only POST on /servers/update");
@@ -4249,6 +4288,20 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 namespace
 {
 
+// Dotted-quad IPv4 -> host-order uint32, the encoding EC_TAG_*_IP uses.
+// Three call sites parsed this inline with the same sscanf; the friends add
+// path made it four.
+bool ParseIpv4Dotted(const std::string &text, std::uint32_t &out_he)
+{
+	unsigned a = 0, b = 0, c = 0, d = 0;
+	if (std::sscanf(text.c_str(), "%u.%u.%u.%u", &a, &b, &c, &d) != 4)
+		return false;
+	if (a > 255 || b > 255 || c > 255 || d > 255)
+		return false;
+	out_he = (a) | (b << 8) | (c << 16) | (d << 24);
+	return true;
+}
+
 void WriteServerObject(CJsonWriter &w, const webapi::ServerSnapshot &s)
 {
 	w.BeginObject();
@@ -4306,6 +4359,33 @@ void WriteCategoryObject(CJsonWriter &w, const webapi::CategorySnapshot &c)
 }
 
 } // namespace
+
+void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
+{
+	w.BeginObject();
+	// The URL key for /friends/{ecid} and its sub-routes. Like every ECID it
+	// does not survive an amuled restart -- `user_hash` is the durable
+	// reference, when the friend has one.
+	w.Key("friend_ecid");
+	w.ValueInt(static_cast<int64_t>(f.ecid));
+	w.Key("name");
+	w.ValueString(wxString::FromUTF8(f.name.c_str()));
+	w.Key("user_hash");
+	w.ValueString(wxString::FromUTF8(f.user_hash.c_str()));
+	w.Key("ip");
+	w.ValueString(wxString::FromUTF8(f.ip.c_str()));
+	w.Key("port");
+	w.ValueInt(static_cast<int64_t>(f.port));
+	// The live peer this friend is linked to, joinable against /clients. 0
+	// when the friend is not connected, which is what `online` reports.
+	w.Key("client_ecid");
+	w.ValueInt(static_cast<int64_t>(f.client_ecid));
+	w.Key("online");
+	w.ValueBool(f.client_ecid != 0);
+	w.Key("friend_slot");
+	w.ValueBool(f.friend_slot);
+	w.EndObject();
+}
 
 CHttpServer::Response CApiDispatcher::HandleServers(const CHttpServer::Request &req)
 {
@@ -4388,6 +4468,21 @@ bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::C
 	for (const auto &c : all) {
 		if (c.ecid == ecid) {
 			out = c;
+			return true;
+		}
+	}
+	return false;
+}
+
+// Same shape again for friends. The EC remove/slot ops are idempotent about
+// unknown ids, but a REST caller who mistypes one should get a 404 rather than
+// a cheerful 200, so every /friends/{ecid} handler looks the id up first.
+bool FindFriendByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::FriendSnapshot &out)
+{
+	const auto all = state.Friends();
+	for (const auto &f : all) {
+		if (f.ecid == ecid) {
+			out = f;
 			return true;
 		}
 	}
@@ -4553,6 +4648,300 @@ CHttpServer::Response CApiDispatcher::HandleClientDetail(
 	r.content_type = "application/json";
 	CJsonWriter w;
 	WriteClientDetailObject(w, cli);
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleFriends(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+	static const ListComparators<webapi::FriendSnapshot> kComps = {
+		{ "name",
+			[](const webapi::FriendSnapshot &a, const webapi::FriendSnapshot &b) {
+				return a.name < b.name;
+			} },
+		{ "online",
+			[](const webapi::FriendSnapshot &a, const webapi::FriendSnapshot &b) {
+				return (a.client_ecid != 0) < (b.client_ecid != 0);
+			} },
+	};
+	// Served from the refresher snapshot: the friends list rides along with
+	// every GET_UPDATE, so this costs no EC roundtrip of its own.
+	return ListResponse(m_state, "friends", m_state.Friends(), WriteFriendObject, params, kComps);
+}
+
+CHttpServer::Response CApiDispatcher::HandleFriendAdd(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+
+	const bool has_client = obj.find("client_ecid") != obj.end();
+	const bool has_manual = obj.find("ip") != obj.end() || obj.find("port") != obj.end() ||
+				obj.find("user_hash") != obj.end();
+	if (has_client && has_manual) {
+		return ErrorResponse(400,
+			"bad_request",
+			"`client_ecid` and the ip/port/user_hash form are mutually exclusive");
+	}
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_FRIEND));
+	CECEmptyTag addtag(EC_TAG_FRIEND_ADD);
+
+	if (has_client) {
+		// Promote a connected peer, the desktop's "Add to Friends" item.
+		const auto &v = obj.at("client_ecid");
+		if (!v.is<double>() || v.get<double>() < 0) {
+			return ErrorResponse(
+				400, "bad_request", "`client_ecid` must be a non-negative integer");
+		}
+		const std::uint32_t client_ecid = static_cast<std::uint32_t>(v.get<double>());
+		webapi::ClientSnapshot peer;
+		if (!FindClientByEcid(m_state, client_ecid, peer)) {
+			return ErrorResponse(404, "not_found", "no connected client with that `client_ecid`");
+		}
+		addtag.AddTag(CECTag(EC_TAG_CLIENT, client_ecid));
+	} else {
+		// Manual add, the desktop's "Add a Friend" dialog. The EC handler
+		// wants all four tags present, so an omitted hash is sent empty and
+		// an omitted name defaults to the address -- same as the dialog.
+		std::string ip_str;
+		{
+			const auto it = obj.find("ip");
+			if (it == obj.end() || !it->second.is<std::string>()) {
+				return ErrorResponse(
+					400, "bad_request", "required string field `ip` is missing");
+			}
+			ip_str = it->second.get<std::string>();
+		}
+		std::uint32_t ip_he = 0;
+		if (!ParseIpv4Dotted(ip_str, ip_he) || ip_he == 0) {
+			return ErrorResponse(
+				400, "bad_request", "`ip` must be a non-zero dotted IPv4 address");
+		}
+		std::uint16_t port = 0;
+		{
+			const auto it = obj.find("port");
+			if (it == obj.end() || !it->second.is<double>()) {
+				return ErrorResponse(
+					400, "bad_request", "required integer field `port` is missing");
+			}
+			const double d = it->second.get<double>();
+			if (d <= 0 || d > 65535) {
+				return ErrorResponse(400, "bad_request", "`port` must be in 1..65535");
+			}
+			port = static_cast<std::uint16_t>(d);
+		}
+		CMD4Hash hash;
+		{
+			const auto it = obj.find("user_hash");
+			if (it != obj.end()) {
+				if (!it->second.is<std::string>()) {
+					return ErrorResponse(
+						400, "bad_request", "`user_hash` must be a string");
+				}
+				const std::string h = it->second.get<std::string>();
+				if (!h.empty() && !hash.Decode(wxString::FromUTF8(h.c_str()))) {
+					return ErrorResponse(400,
+						"bad_request",
+						"`user_hash` must be 32 hexadecimal characters");
+				}
+			}
+		}
+		std::string name;
+		{
+			const auto it = obj.find("name");
+			if (it != obj.end()) {
+				if (!it->second.is<std::string>()) {
+					return ErrorResponse(400, "bad_request", "`name` must be a string");
+				}
+				name = it->second.get<std::string>();
+			}
+		}
+		if (name.empty()) {
+			name = ip_str;
+		}
+		addtag.AddTag(CECTag(EC_TAG_FRIEND_HASH, hash));
+		addtag.AddTag(CECTag(EC_TAG_FRIEND_IP, ip_he));
+		addtag.AddTag(CECTag(EC_TAG_FRIEND_PORT, port));
+		addtag.AddTag(CECTag(EC_TAG_FRIEND_NAME, wxString::FromUTF8(name.c_str())));
+	}
+	ec_req->AddTag(addtag);
+
+	std::set<std::uint32_t> before;
+	for (const auto &f : m_state.Friends())
+		before.insert(f.ecid);
+
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for FRIEND add");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	// The daemon applies the add synchronously but the record only reaches us
+	// on a GET_UPDATE, so tick before answering and return the real object.
+	(void)RefresherTick(m_app, m_state);
+
+	CHttpServer::Response r;
+	r.status = 201;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	// The daemon does not echo the new friend's ECID, so identify it as the
+	// one the pre-add snapshot did not have. Diffing beats picking the
+	// highest id: nothing promises ECIDs are handed out in ascending order,
+	// and a concurrent removal could free a lower one for reuse.
+	webapi::FriendSnapshot added;
+	bool found = false;
+	for (const auto &f : m_state.Friends()) {
+		if (before.find(f.ecid) == before.end()) {
+			added = f;
+			found = true;
+			break;
+		}
+	}
+	if (found) {
+		WriteFriendObject(w, added);
+	} else {
+		w.BeginObject();
+		w.Key("ok");
+		w.ValueBool(true);
+		w.EndObject();
+	}
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleFriendRemove(
+	const CHttpServer::Request &req, const std::string &ecid_str)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	std::uint32_t ecid = 0;
+	if (!ParseEcidPath(ecid_str, ecid)) {
+		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
+	}
+	webapi::FriendSnapshot existing;
+	if (!FindFriendByEcid(m_state, ecid, existing)) {
+		return ErrorResponse(404, "not_found", "no friend with that ecid");
+	}
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_FRIEND));
+	CECEmptyTag removetag(EC_TAG_FRIEND_REMOVE);
+	removetag.AddTag(CECTag(EC_TAG_FRIEND, ecid));
+	ec_req->AddTag(removetag);
+
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for FRIEND remove");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	(void)RefresherTick(m_app, m_state);
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.Key("friend_ecid");
+	w.ValueInt(static_cast<int64_t>(ecid));
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleFriendPatch(
+	const CHttpServer::Request &req, const std::string &ecid_str)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	std::uint32_t ecid = 0;
+	if (!ParseEcidPath(ecid_str, ecid)) {
+		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
+	}
+	webapi::FriendSnapshot existing;
+	if (!FindFriendByEcid(m_state, ecid, existing)) {
+		return ErrorResponse(404, "not_found", "no friend with that ecid");
+	}
+
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+	const auto it = obj.find("friend_slot");
+	if (it == obj.end() || !it->second.is<bool>()) {
+		return ErrorResponse(400, "bad_request", "required boolean field `friend_slot` is missing");
+	}
+	const bool slot = it->second.get<bool>();
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_FRIEND));
+	CECTag slottag(EC_TAG_FRIEND_FRIENDSLOT, slot);
+	slottag.AddTag(CECTag(EC_TAG_FRIEND, ecid));
+	ec_req->AddTag(slottag);
+
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for FRIEND slot");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	// Only one friend can hold the slot, so granting it here clears whoever
+	// held it before -- the tick picks up both changes and both emit an SSE
+	// event, not just the friend named in the URL.
+	(void)RefresherTick(m_app, m_state);
+
+	webapi::FriendSnapshot updated;
+	if (!FindFriendByEcid(m_state, ecid, updated)) {
+		return ErrorResponse(404, "not_found", "friend disappeared while setting the slot");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	WriteFriendObject(w, updated);
 	FinalizeJsonBody(w, r);
 	return r;
 }
@@ -4826,13 +5215,7 @@ static std::uint32_t ResolveServerEcidByAddress(const webapi::CState &state, con
 	// number that matches ServerSnapshot::ip. We compute both so we
 	// can match either against what the cache holds.
 	std::uint32_t ip_he = 0;
-	{
-		unsigned a_, b_, c_, d_;
-		if (std::sscanf(ip_str.c_str(), "%u.%u.%u.%u", &a_, &b_, &c_, &d_) == 4 && a_ <= 255 &&
-			b_ <= 255 && c_ <= 255 && d_ <= 255) {
-			ip_he = (a_) | (b_ << 8) | (c_ << 16) | (d_ << 24);
-		}
-	}
+	(void)ParseIpv4Dotted(ip_str, ip_he);
 	// Require an IPv4-shaped address: drop the s.address string
 	// fallback. The fallback was a convenience for hostname-form
 	// URLs (e.g. `/api/v0/servers/donkey.example.com:4242/connect`),
@@ -6752,15 +7135,12 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 		if (it->second.is<std::string>()) {
 			// Dotted-quad string. Parse with strtoul on each octet.
 			const std::string &s = it->second.get<std::string>();
-			unsigned a_, b_, c_, d_;
-			if (std::sscanf(s.c_str(), "%u.%u.%u.%u", &a_, &b_, &c_, &d_) != 4 || a_ > 255 ||
-				b_ > 255 || c_ > 255 || d_ > 255) {
+			if (!ParseIpv4Dotted(s, ip_he)) {
 				return ErrorResponse(400,
 					"bad_request",
 					"`ip` must be a dotted-quad IPv4 address or a "
 					"host-order uint32");
 			}
-			ip_he = (a_) | (b_ << 8) | (c_ << 16) | (d_ << 24);
 		} else if (it->second.is<double>()) {
 			const double v = it->second.get<double>();
 			if (v < 0 || v > 4294967295.0) {
@@ -8076,6 +8456,24 @@ bool SearchTypeFromString(const std::string &s, std::uint8_t &out)
 CHttpServer::Response CApiDispatcher::HandleClientBrowse(
 	const CHttpServer::Request &req, const std::string &ecid_str)
 {
+	return HandleBrowse(req, ecid_str, /*by_friend=*/false);
+}
+
+CHttpServer::Response CApiDispatcher::HandleFriendBrowse(
+	const CHttpServer::Request &req, const std::string &ecid_str)
+{
+	return HandleBrowse(req, ecid_str, /*by_friend=*/true);
+}
+
+// Shared by /clients/{ecid}/shared_files and /friends/{ecid}/shared_files.
+// Same opcode and reply shape either way; only the sub-tag differs, which is
+// what tells the daemon whether the id names a live peer or a friend record.
+// The friend form is the more capable of the two: a friend carries a stored
+// ip:port, so the daemon can build a client for it and browse a friend that is
+// not currently connected.
+CHttpServer::Response CApiDispatcher::HandleBrowse(
+	const CHttpServer::Request &req, const std::string &ecid_str, bool by_friend)
+{
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
@@ -8094,7 +8492,7 @@ CHttpServer::Response CApiDispatcher::HandleClientBrowse(
 	// then drives the refresher's per-id polling.
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_FRIEND));
 	CECEmptyTag sharedtag(EC_TAG_FRIEND_SHARED);
-	sharedtag.AddTag(CECTag(EC_TAG_CLIENT, ecid));
+	sharedtag.AddTag(CECTag(by_friend ? EC_TAG_FRIEND : EC_TAG_CLIENT, ecid));
 	ec_req->AddTag(sharedtag);
 
 	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
@@ -8773,6 +9171,8 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 			return "servers";
 		if (prefix == "client")
 			return "clients";
+		if (prefix == "friend")
+			return "friends";
 		if (prefix == "status")
 			return "status";
 		if (prefix == "log")

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -145,6 +145,11 @@ private:
 	CHttpServer::Response HandleDownloadsBulkDelete(const CHttpServer::Request &);
 	// server lifecycle.
 	CHttpServer::Response HandleServerAdd(const CHttpServer::Request &);
+	CHttpServer::Response HandleFriends(const CHttpServer::Request &);
+	CHttpServer::Response HandleFriendAdd(const CHttpServer::Request &);
+	CHttpServer::Response HandleFriendRemove(const CHttpServer::Request &, const std::string &ecid_str);
+	CHttpServer::Response HandleFriendPatch(const CHttpServer::Request &, const std::string &ecid_str);
+	CHttpServer::Response HandleFriendBrowse(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleServerConnect(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleServerDelete(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleServerPatch(const CHttpServer::Request &, const std::string &ecid_str);
@@ -243,6 +248,10 @@ private:
 	// results via GET /search/results?search_id=, progress + SSE via the
 	// standard search machinery.
 	CHttpServer::Response HandleClientBrowse(const CHttpServer::Request &, const std::string &ecid_str);
+	// Shared by the /clients and /friends browse routes; `by_friend` selects
+	// which sub-tag addresses the target.
+	CHttpServer::Response HandleBrowse(
+		const CHttpServer::Request &, const std::string &ecid_str, bool by_friend);
 	CHttpServer::Response HandleSharedList(const CHttpServer::Request &);
 	CHttpServer::Response HandleServers(const CHttpServer::Request &);
 	CHttpServer::Response HandleKad(const CHttpServer::Request &);

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -180,6 +180,19 @@ std::string ToJson(const ServerSnapshot &s)
 	return o.str();
 }
 
+std::string ToJson(const FriendSnapshot &f)
+{
+	std::ostringstream o;
+	o << "{"
+	  << "\"friend_ecid\":" << f.ecid << ",\"name\":\"" << EscJson(f.name) << "\""
+	  << ",\"user_hash\":\"" << EscJson(f.user_hash) << "\""
+	  << ",\"ip\":\"" << EscJson(f.ip) << "\""
+	  << ",\"port\":" << f.port << ",\"client_ecid\":" << f.client_ecid
+	  << ",\"online\":" << (f.client_ecid != 0 ? "true" : "false")
+	  << ",\"friend_slot\":" << (f.friend_slot ? "true" : "false") << "}";
+	return o.str();
+}
+
 std::string ToJson(const ClientSnapshot &c)
 {
 	std::ostringstream o;
@@ -312,6 +325,14 @@ bool Equal(const ServerSnapshot &a, const ServerSnapshot &b)
 	       a.priority == b.priority && a.ping_ms == b.ping_ms && a.failed == b.failed &&
 	       a.is_static == b.is_static;
 }
+bool Equal(const FriendSnapshot &a, const FriendSnapshot &b)
+{
+	// client_ecid is part of the identity here on purpose: it going to 0 is
+	// the friend going offline, which is exactly what a subscriber watching
+	// the connected indicator needs to hear about.
+	return a.name == b.name && a.user_hash == b.user_hash && a.ip == b.ip && a.port == b.port &&
+	       a.client_ecid == b.client_ecid && a.friend_slot == b.friend_slot;
+}
 bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 {
 	return a.client_name == b.client_name && a.user_hash == b.user_hash && a.ip == b.ip &&
@@ -396,6 +417,12 @@ std::string RemovedEcidPayload(const ServerSnapshot &s)
 	o << "{\"ecid\":" << s.ecid << "}";
 	return o.str();
 }
+std::string RemovedEcidPayload(const FriendSnapshot &f)
+{
+	std::ostringstream o;
+	o << "{\"friend_ecid\":" << f.ecid << "}";
+	return o.str();
+}
 std::string RemovedEcidPayload(const ClientSnapshot &c)
 {
 	std::ostringstream o;
@@ -460,6 +487,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	// map all along.
 	auto new_files = ByEcid(state.Files());
 	auto new_servers = ByEcid(state.Servers());
+	auto new_friends = ByEcid(state.Friends());
 	auto new_clients = ByEcid(state.Clients());
 	// Read the full dashboard for status_changed — the event payload
 	// mirrors the REST /status nested envelope which pulls from
@@ -541,6 +569,12 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	DiffMap(bus, "client", prev.clients, new_clients, [](const ClientSnapshot &c) {
 		return RemovedEcidPayload(c);
 	});
+	// Note for consumers: a single PATCH of the friend slot can produce two
+	// friend_updated events, because granting it to one friend clears it on
+	// whoever held it before.
+	DiffMap(bus, "friend", prev.friends, new_friends, [](const FriendSnapshot &f) {
+		return RemovedEcidPayload(f);
+	});
 
 	// /status: one event when anything in the dashboard envelope
 	// changes (StatusSnapshot fields OR Kad network rollup OR
@@ -560,6 +594,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	prev.files = std::move(new_files);
 	prev.servers = std::move(new_servers);
 	prev.clients = std::move(new_clients);
+	prev.friends = std::move(new_friends);
 	prev.status = new_status;
 	prev.kad = new_kad;
 	prev.ec_connected = new_ec;

--- a/src/webapi/EventDiff.h
+++ b/src/webapi/EventDiff.h
@@ -49,6 +49,7 @@ struct LastSeenState
 	std::map<std::uint32_t, FileSnapshot> files;
 	std::map<std::uint32_t, ServerSnapshot> servers;
 	std::map<std::uint32_t, ClientSnapshot> clients;
+	std::map<std::uint32_t, FriendSnapshot> friends;
 	// Status event payload mirrors the REST /status envelope, which
 	// pulls from THREE sources (StatusSnapshot + KadSnapshot +
 	// ec_connected flag). All three must be diffed against the prior

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1612,6 +1612,89 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 
 } // namespace
 
+// Same container shape as the servers walker above: GET_UPDATE wraps every
+// friend in one EC_TAG_FRIEND container, per-field values are CValueMap-
+// suppressed when unchanged, and the container is always the complete list --
+// so "not seen this tick" means the friend was removed on the daemon side.
+static void MergeFriendTag(const CEC_Friend_Tag *ft, FriendSnapshot &f, bool is_new)
+{
+	f.ecid = ft->ID();
+	{
+		wxString tmp;
+		if (ft->Name(tmp) || is_new)
+			f.name = std::string(tmp.utf8_str());
+	}
+	{
+		CMD4Hash hash;
+		if (ft->UserHash(hash)) {
+			// A friend added by ip:port carries an empty hash; keep it empty
+			// rather than writing out 32 zeroes, which would read as a real
+			// hash to a client.
+			f.user_hash = hash.IsEmpty() ? std::string()
+						     : std::string(hash.Encode().Lower().utf8_str());
+		}
+	}
+	{
+		std::uint32_t ip = 0;
+		if (ft->IP(ip))
+			f.ip = FormatClientIpv4(ip);
+	}
+	{
+		std::uint16_t port = 0;
+		if (ft->Port(port))
+			f.port = port;
+	}
+	{
+		// 0 means the friend is not linked to a live client right now. The
+		// daemon does send the transition, so an absent tag means unchanged.
+		std::uint32_t client = 0;
+		if (ft->Client(client))
+			f.client_ecid = client;
+	}
+	{
+		// Absent on daemons that predate the tag being serialized; the
+		// snapshot then keeps its default false.
+		bool slot = false;
+		if (ft->FriendSlot(slot))
+			f.friend_slot = slot;
+	}
+}
+
+void ApplyGetUpdateToFriends(const CECPacket *resp, std::map<std::uint32_t, FriendSnapshot> &cache)
+{
+	if (!resp)
+		return;
+	const CECTag *container = resp->GetTagByName(EC_TAG_FRIEND);
+	if (!container)
+		return;
+
+	std::set<std::uint32_t> seen;
+	for (const CECTag &child : *container) {
+		if (child.GetTagName() != EC_TAG_FRIEND)
+			continue;
+		const CEC_Friend_Tag *ft = static_cast<const CEC_Friend_Tag *>(&child);
+		const std::uint32_t ecid = ft->ID();
+		seen.insert(ecid);
+
+		auto map_it = cache.find(ecid);
+		if (map_it == cache.end()) {
+			FriendSnapshot fresh;
+			MergeFriendTag(ft, fresh, /*is_new=*/true);
+			cache.emplace(ecid, std::move(fresh));
+		} else {
+			MergeFriendTag(ft, map_it->second, /*is_new=*/false);
+		}
+	}
+
+	for (auto it = cache.begin(); it != cache.end();) {
+		if (seen.find(it->first) == seen.end()) {
+			it = cache.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
 void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, ServerSnapshot> &cache)
 {
 	if (!resp)

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -72,6 +72,7 @@ void EmitDiffsForEventBus(CamuleapiApp &app, const CState &state);
 struct StatusSnapshot;
 struct FileSnapshot;
 struct ClientSnapshot;
+struct FriendSnapshot;
 struct ServerSnapshot;
 struct KadSnapshot;
 struct CategorySnapshot;
@@ -168,6 +169,11 @@ void ApplyGetUpdateToDownloads(
 void ApplyGetUpdateToShared(const CECPacket *resp, FileMap &cache);
 
 void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, ServerSnapshot> &cache);
+
+// Consumes the EC_TAG_FRIEND container the daemon appends to every
+// EC_OP_GET_UPDATE reply (ExternalConn.cpp, "Add friends"), so /friends is
+// served from the tick we already run rather than a roundtrip of its own.
+void ApplyGetUpdateToFriends(const CECPacket *resp, std::map<std::uint32_t, FriendSnapshot> &cache);
 
 // ed2k server priority, both directions. The SRV_PR_* wire values are not
 // monotone (NORMAL=0, HIGH=1, LOW=2), so callers must never assume a name's

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -90,10 +90,10 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// (identity short-circuit at EC_DETAIL_UPDATE only) are documented
 	// next to ApplyGetUpdateToDownloads in Refresher.h.
 	//
-	// The response also carries EC_TAG_CLIENT (filtered server-side
-	// by `TransmitOnlyUploadingClients`) and EC_TAG_FRIEND containers,
-	// both of which we ignore — /uploads stays bound to the upload-
-	// queue semantic via EC_OP_GET_ULOAD_QUEUE below.
+	// The response also carries EC_TAG_CLIENT (filtered server-side by
+	// `TransmitOnlyUploadingClients`) and EC_TAG_FRIEND containers. Both are
+	// consumed below, into /clients and /friends respectively — /uploads
+	// stays bound to the upload-queue semantic via EC_OP_GET_ULOAD_QUEUE.
 	//
 	// Three Mutate calls under three separate lock acquisitions —
 	// snapshot_at is set after the whole tick succeeds; per-substruct
@@ -138,6 +138,10 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 
 		state.MutateServers([&](std::map<std::uint32_t, ServerSnapshot> &cache) {
 			ApplyGetUpdateToServers(resp, cache);
+		});
+
+		state.MutateFriends([&](std::map<std::uint32_t, FriendSnapshot> &cache) {
+			ApplyGetUpdateToFriends(resp, cache);
 		});
 
 		// /clients — every alive peer in theApp->clientlist (download

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -362,6 +362,20 @@ void CState::MutateServers(const std::function<void(std::map<std::uint32_t, Serv
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_servers);
 }
+std::vector<FriendSnapshot> CState::Friends() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	std::vector<FriendSnapshot> out;
+	out.reserve(m_friends.size());
+	for (const auto &kv : m_friends)
+		out.push_back(kv.second);
+	return out;
+}
+void CState::MutateFriends(const std::function<void(std::map<std::uint32_t, FriendSnapshot> &)> &fn)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	fn(m_friends);
+}
 
 std::vector<FileSnapshot> CState::Downloads() const
 {

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -417,6 +417,25 @@ struct ServerSnapshot
 	bool is_static = false;
 };
 
+// /friends endpoint. The daemon ships the whole friends list inside every
+// EC_OP_GET_UPDATE reply, so this is filled from the tick we already run and
+// no endpoint here costs an extra roundtrip.
+struct FriendSnapshot
+{
+	std::uint32_t ecid = 0;
+	std::string name;
+	std::string user_hash; // 32-char lowercase MD4, "" when added by ip:port
+	// Dotted quad, "" for a zero IP -- rendered in the walker like
+	// ClientSnapshot::ip, so nothing downstream has to know the wire encoding.
+	std::string ip;
+	std::uint16_t port = 0;
+	std::uint32_t client_ecid = 0; // live peer this friend is linked to, 0 = offline
+	// Reported by cores that serialize EC_TAG_FRIEND_FRIENDSLOT. An older
+	// daemon omits the tag and this stays false, the same way is_friend and
+	// dl_up_modifier degrade on /clients.
+	bool friend_slot = false;
+};
+
 // /kad endpoint. Single composite snapshot pulled from the STAT_REQ
 // response we're already fetching for /status — saves a roundtrip
 // since amuled's `EC_OP_STAT_REQ` at `EC_DETAIL_CMD` ships every
@@ -1182,6 +1201,7 @@ public:
 	}
 
 	std::vector<ServerSnapshot> Servers() const;
+	std::vector<FriendSnapshot> Friends() const;
 	// Results / progress for one search. search_id == 0 resolves to the
 	// current (most-recently-started) search; an unknown id yields an empty
 	// list / idle progress. HasSearch distinguishes "unknown id" (404) from
@@ -1240,6 +1260,7 @@ public:
 	void MutateShared(const std::function<void(FileMap &)> &fn);
 	void MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn);
 	void MutateServers(const std::function<void(std::map<std::uint32_t, ServerSnapshot> &)> &fn);
+	void MutateFriends(const std::function<void(std::map<std::uint32_t, FriendSnapshot> &)> &fn);
 	// Mutate one search's result map (the refresher's per-tick full-fetch
 	// overwrite). No-op if the id names no live slot.
 	void MutateSearch(std::uint32_t search_id,
@@ -1338,6 +1359,7 @@ private:
 	//! MUST be called with m_mu held for writing.
 	void ReconcileKnownClientsLocked();
 	std::map<std::uint32_t, ServerSnapshot> m_servers;
+	std::map<std::uint32_t, FriendSnapshot> m_friends;
 	std::vector<std::string> m_amule_log_lines;
 	ServerInfoLog m_server_info;
 	StatsTreeNode m_stats_tree;

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# amuleapi 34-friends — the /friends resource.
+#
+# The friends list is the one the desktop client keeps in emfriends.met.
+# amuleapi serves it from the snapshot the refresher already builds: the
+# daemon appends the whole list to every GET_UPDATE reply, so reading it
+# costs no EC roundtrip of its own.
+#
+# What is asserted here:
+#
+#   * the envelope is the standard list shape — a `friends` array plus
+#     `total` / `offset` / `limit` — and paginates through the shared
+#     helpers rather than a private implementation,
+#   * `limit` is clamped and a bad `limit` / `offset` / `order` is a 400,
+#     the same contract as every other list endpoint,
+#   * both advertised sort keys are accepted and an unknown one is a 400,
+#   * a friend added by address round-trips: it appears in the list with
+#     the address given, and `online` is false while nothing is linked,
+#   * `user_hash` is either empty or a 32-char lowercase MD4, so it
+#     correlates with /clients `user_hash` directly,
+#   * `friend_slot` toggles through PATCH and reads back, which is the
+#     part that needed the daemon to serialize the flag at all,
+#   * DELETE removes it and a second DELETE is a 404 — the EC op is
+#     idempotent but a mistyped id must not answer 200,
+#   * the mutations require ADMIN and the read does not,
+#   * malformed bodies are rejected before any EC traffic,
+#   * HEAD is routed like GET, and non-routed methods are 405.
+#
+# Usage:
+#   amuleapi --config-dir=/tmp/amuleapi-regtest &
+#   ./34-friends.sh
+#
+# Exits 0 on success, 1 on any failed assertion, 2 on bring-up error.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+GUEST_PASS=${GUEST_PASS:-guestpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+AUTH=()
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -D /tmp/amuleapi_34_head -o /tmp/amuleapi_34_body \
+		-w '%{http_code}' "${AUTH[@]}" "$@") || _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat /tmp/amuleapi_34_body)
+	CURL_HEAD=$(cat /tmp/amuleapi_34_head)
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" "body: ${CURL_BODY:0:200}"
+	fi
+}
+
+_jq() { echo "$CURL_BODY" | jq -r "$1" 2>/dev/null; }
+
+trap 'rm -f /tmp/amuleapi_34_head /tmp/amuleapi_34_body' EXIT
+
+command -v jq >/dev/null 2>&1 || _die "jq is required"
+
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
+fi
+
+echo "amuleapi 34-friends @ $HOST"
+
+# --- 0. Log in. ----------------------------------------------------
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "could not log in for friends tests"
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# --- 1. The envelope. ---------------------------------------------
+_curl "$HOST/api/v0/friends"
+_assert_status 200 "GET /friends"
+
+if [ "$(_jq 'has("friends")')" = "true" ]; then
+	_pass "envelope has a friends array"
+else
+	_fail "envelope" "no friends key in: ${CURL_BODY:0:200}"
+fi
+
+for k in total offset limit; do
+	if [ "$(_jq "has(\"$k\")")" = "true" ]; then
+		_pass "envelope has $k"
+	else
+		_fail "envelope" "missing pagination key: $k"
+	fi
+done
+
+BEFORE=$(_jq '.total')
+echo "        (list holds $BEFORE friend(s) before this run)"
+
+# --- 2. Shared list-parameter contract. ----------------------------
+_curl "$HOST/api/v0/friends?limit=1&offset=0"
+_assert_status 200 "GET /friends?limit=1"
+[ "$(_jq '.limit')" = "1" ] && _pass "limit is echoed" || _fail "limit echo" "got $(_jq '.limit')"
+
+_curl "$HOST/api/v0/friends?limit=99999"
+_assert_status 200 "GET /friends?limit=99999 (clamped, not rejected)"
+CLAMPED=$(_jq '.limit')
+if [ "$CLAMPED" -le 500 ] 2>/dev/null; then
+	_pass "limit clamped to $CLAMPED"
+else
+	_fail "limit clamp" "expected <= 500, got $CLAMPED"
+fi
+
+for bad in "limit=abc" "limit=-1" "offset=-1" "order=sideways"; do
+	_curl "$HOST/api/v0/friends?$bad"
+	_assert_status 400 "GET /friends?$bad is rejected"
+done
+
+for key in name online; do
+	_curl "$HOST/api/v0/friends?sort=$key&order=desc"
+	_assert_status 200 "sort=$key is accepted"
+done
+_curl "$HOST/api/v0/friends?sort=nonsuch"
+_assert_status 400 "unknown sort key is rejected"
+
+# --- 3. Add by address, then read it back. -------------------------
+# 203.0.113.x is TEST-NET-3 (RFC 5737) — never routable, so this cannot
+# reach a real peer no matter where the regtest daemon runs.
+TEST_IP="203.0.113.42"
+TEST_PORT=4662
+_curl -X POST -H "Content-Type: application/json" \
+	-d "{\"ip\":\"$TEST_IP\",\"port\":$TEST_PORT,\"name\":\"curltest-friend\"}" \
+	"$HOST/api/v0/friends"
+_assert_status 201 "POST /friends (address form)"
+
+NEW_ECID=$(_jq '.friend_ecid')
+if [ -n "$NEW_ECID" ] && [ "$NEW_ECID" != "null" ]; then
+	_pass "response carries friend_ecid ($NEW_ECID)"
+else
+	_fail "POST response" "no friend_ecid in: ${CURL_BODY:0:200}"
+fi
+[ "$(_jq '.ip')" = "$TEST_IP" ] && _pass "ip round-trips" || _fail "ip" "got $(_jq '.ip')"
+[ "$(_jq '.port')" = "$TEST_PORT" ] && _pass "port round-trips" || _fail "port" "got $(_jq '.port')"
+[ "$(_jq '.online')" = "false" ] && _pass "a friend with no linked peer is offline" \
+	|| _fail "online" "expected false, got $(_jq '.online')"
+
+_curl "$HOST/api/v0/friends"
+AFTER=$(_jq '.total')
+if [ "$AFTER" -gt "$BEFORE" ] 2>/dev/null; then
+	_pass "the list grew ($BEFORE -> $AFTER)"
+else
+	_fail "list growth" "expected > $BEFORE, got $AFTER"
+fi
+
+# every record's hash is either absent-as-empty or a real MD4
+BADHASH=$(echo "$CURL_BODY" | jq -r '[.friends[] | select(.user_hash != "" and (.user_hash | test("^[0-9a-f]{32}$") | not))] | length')
+[ "$BADHASH" = "0" ] && _pass "user_hash is empty or 32-char lowercase MD4" \
+	|| _fail "user_hash shape" "$BADHASH record(s) with a malformed hash"
+
+# --- 4. The friend slot, the flag that needed the core change. -----
+_curl -X PATCH -H "Content-Type: application/json" \
+	-d '{"friend_slot":true}' "$HOST/api/v0/friends/$NEW_ECID"
+_assert_status 200 "PATCH friend_slot=true"
+[ "$(_jq '.friend_slot')" = "true" ] && _pass "friend_slot reads back true" \
+	|| _fail "friend_slot" "expected true, got $(_jq '.friend_slot') — is the daemon serializing the tag?"
+
+_curl "$HOST/api/v0/friends?limit=500"
+STILL=$(echo "$CURL_BODY" | jq -r --arg e "$NEW_ECID" '[.friends[] | select(.friend_ecid == ($e|tonumber)) | .friend_slot] | first')
+[ "$STILL" = "true" ] && _pass "the slot survives into the list view" \
+	|| _fail "friend_slot in list" "expected true, got $STILL"
+
+_curl -X PATCH -H "Content-Type: application/json" \
+	-d '{"friend_slot":false}' "$HOST/api/v0/friends/$NEW_ECID"
+_assert_status 200 "PATCH friend_slot=false"
+[ "$(_jq '.friend_slot')" = "false" ] && _pass "the slot clears again" \
+	|| _fail "friend_slot" "expected false, got $(_jq '.friend_slot')"
+
+_curl -X PATCH -H "Content-Type: application/json" -d '{}' "$HOST/api/v0/friends/$NEW_ECID"
+_assert_status 400 "PATCH with no recognized field is rejected"
+
+# --- 5. Bad input is rejected before any EC traffic. ---------------
+_curl -X POST -H "Content-Type: application/json" \
+	-d '{"client_ecid":1,"ip":"203.0.113.9","port":4662}' "$HOST/api/v0/friends"
+_assert_status 400 "POST with both body forms is rejected"
+
+_curl -X POST -H "Content-Type: application/json" \
+	-d '{"ip":"not-an-ip","port":4662}' "$HOST/api/v0/friends"
+_assert_status 400 "POST with a malformed ip is rejected"
+
+_curl -X POST -H "Content-Type: application/json" \
+	-d "{\"ip\":\"$TEST_IP\",\"port\":0}" "$HOST/api/v0/friends"
+_assert_status 400 "POST with a zero port is rejected"
+
+_curl -X POST -H "Content-Type: application/json" \
+	-d "{\"ip\":\"$TEST_IP\",\"port\":4662,\"user_hash\":\"nothex\"}" "$HOST/api/v0/friends"
+_assert_status 400 "POST with a malformed user_hash is rejected"
+
+_curl -X POST -H "Content-Type: application/json" \
+	-d '{"client_ecid":4294967290}' "$HOST/api/v0/friends"
+_assert_status 404 "POST naming an unknown client_ecid is a 404"
+
+# --- 6. HEAD and method routing. -----------------------------------
+# Status only, as the other phases do: `curl -I` prints the response headers
+# on stdout, so the -o capture holds those rather than a body, and asserting
+# emptiness here would be testing curl instead of the endpoint.
+_curl -I "$HOST/api/v0/friends"
+_assert_status 200 "HEAD /friends"
+
+_curl -X PUT "$HOST/api/v0/friends"
+_assert_status 405 "PUT /friends is 405"
+_curl -X POST "$HOST/api/v0/friends/$NEW_ECID"
+_assert_status 405 "POST /friends/{ecid} is 405"
+
+# --- 7. Guests read but cannot mutate. ------------------------------
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$GUEST_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
+	SAVED=("${AUTH[@]}")
+	AUTH=(-H "Authorization: Bearer $GUEST_TOKEN")
+	_curl "$HOST/api/v0/friends"
+	_assert_status 200 "guest may GET /friends"
+	_curl -X DELETE "$HOST/api/v0/friends/$NEW_ECID"
+	_assert_status 403 "guest may not DELETE a friend"
+	_curl -X POST -H "Content-Type: application/json" \
+		-d "{\"ip\":\"$TEST_IP\",\"port\":4662}" "$HOST/api/v0/friends"
+	_assert_status 403 "guest may not POST a friend"
+	AUTH=("${SAVED[@]}")
+else
+	echo "        (no guest account configured — skipping the guest assertions)"
+fi
+
+# --- 8. Remove, and prove a stale id does not answer 200. ----------
+_curl -X DELETE "$HOST/api/v0/friends/$NEW_ECID"
+_assert_status 200 "DELETE /friends/$NEW_ECID"
+[ "$(_jq '.friend_ecid')" = "$NEW_ECID" ] && _pass "DELETE echoes the id" \
+	|| _fail "DELETE echo" "got $(_jq '.friend_ecid')"
+
+_curl -X DELETE "$HOST/api/v0/friends/$NEW_ECID"
+_assert_status 404 "a second DELETE of the same id is a 404"
+
+_curl "$HOST/api/v0/friends"
+FINAL=$(_jq '.total')
+[ "$FINAL" = "$BEFORE" ] && _pass "the list is back to its starting size ($BEFORE)" \
+	|| _fail "cleanup" "expected $BEFORE, got $FINAL"
+
+# --- Summary -------------------------------------------------------
+echo
+echo "34-friends: $((TEST_COUNT-FAIL_COUNT))/$TEST_COUNT assertions passed"
+[ "$FAIL_COUNT" -eq 0 ] || exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -213,6 +213,7 @@ PHASES=(
 	31-shared-directories.sh
 	32-country-flags.sh
 	33-known-clients.sh
+	34-friends.sh
 )
 
 # Override list from the command line if given.

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -797,6 +797,118 @@ TEST(Refresher, ServersNoContainerLeavesCacheAlone)
 }
 
 // ----------------------------------------------------------------------
+// Friends — same container shape as servers: full list every tick, per-field
+// CValueMap suppression, eviction by "not seen".
+// ----------------------------------------------------------------------
+
+TEST(Refresher, FriendsFromContainerMergesByEcid)
+{
+	std::map<std::uint32_t, FriendSnapshot> cache;
+	{
+		// A friend removed on the daemon side between ticks.
+		FriendSnapshot f;
+		f.ecid = 9999;
+		f.name = "removed";
+		cache.emplace(9999, f);
+	}
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	{
+		CECTag container(EC_TAG_FRIEND, static_cast<std::uint32_t>(0));
+		CECTag fr(EC_TAG_FRIEND, static_cast<std::uint32_t>(12));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_NAME, wxString::FromUTF8("alice")));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_IP, static_cast<std::uint32_t>(0x2A7100CB)));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_PORT, static_cast<std::uint16_t>(4662)));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_CLIENT, static_cast<std::uint32_t>(4382)));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_FRIENDSLOT, true));
+		container.AddTag(fr);
+		resp.AddTag(container);
+	}
+
+	ApplyGetUpdateToFriends(&resp, cache);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	ASSERT_TRUE(cache.find(12) != cache.end());
+	ASSERT_TRUE(cache.find(9999) == cache.end()); // evicted
+	ASSERT_EQUALS(std::string("alice"), cache[12].name);
+	ASSERT_EQUALS(std::string("203.0.113.42"), cache[12].ip);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(4662), cache[12].port);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(4382), cache[12].client_ecid);
+	ASSERT_TRUE(cache[12].friend_slot);
+}
+
+TEST(Refresher, FriendsSuppressedFieldsKeepCachedValues)
+{
+	// CValueMap omits unchanged fields, so a tick carrying only the changed
+	// one must not blank the rest. The friend goes offline (CLIENT -> 0) and
+	// nothing else is sent.
+	std::map<std::uint32_t, FriendSnapshot> cache;
+	{
+		FriendSnapshot f;
+		f.ecid = 12;
+		f.name = "alice";
+		f.ip = "203.0.113.42";
+		f.port = 4662;
+		f.client_ecid = 4382;
+		f.friend_slot = true;
+		cache.emplace(12, f);
+	}
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	{
+		CECTag container(EC_TAG_FRIEND, static_cast<std::uint32_t>(0));
+		CECTag fr(EC_TAG_FRIEND, static_cast<std::uint32_t>(12));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_CLIENT, static_cast<std::uint32_t>(0)));
+		container.AddTag(fr);
+		resp.AddTag(container);
+	}
+
+	ApplyGetUpdateToFriends(&resp, cache);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), cache[12].client_ecid); // went offline
+	ASSERT_EQUALS(std::string("alice"), cache[12].name);                 // preserved
+	ASSERT_EQUALS(std::string("203.0.113.42"), cache[12].ip);            // preserved
+	ASSERT_TRUE(cache[12].friend_slot);                                  // preserved
+}
+
+TEST(Refresher, FriendsWithoutSlotTagReadFalse)
+{
+	// An older daemon does not serialize EC_TAG_FRIEND_FRIENDSLOT at all.
+	// The snapshot must degrade to false rather than carrying junk.
+	std::map<std::uint32_t, FriendSnapshot> cache;
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	{
+		CECTag container(EC_TAG_FRIEND, static_cast<std::uint32_t>(0));
+		CECTag fr(EC_TAG_FRIEND, static_cast<std::uint32_t>(5));
+		fr.AddTag(CECTag(EC_TAG_FRIEND_NAME, wxString::FromUTF8("bob")));
+		container.AddTag(fr);
+		resp.AddTag(container);
+	}
+
+	ApplyGetUpdateToFriends(&resp, cache);
+
+	ASSERT_TRUE(cache.find(5) != cache.end());
+	ASSERT_TRUE(!cache[5].friend_slot);
+	ASSERT_EQUALS(std::string(""), cache[5].ip); // zero IP renders empty
+}
+
+TEST(Refresher, FriendsNoContainerLeavesCacheAlone)
+{
+	std::map<std::uint32_t, FriendSnapshot> cache;
+	cache.emplace(7, FriendSnapshot{});
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	// No EC_TAG_FRIEND container at all.
+
+	ApplyGetUpdateToFriends(&resp, cache);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	ASSERT_TRUE(cache.find(7) != cache.end());
+}
+
+// ----------------------------------------------------------------------
 // RLE state map — cleaned up alongside the cache when a partfile
 // gets evicted via FILE_REMOVED. Without the cleanup, the decoder's
 // internal buffer (~200 KB per partfile on TB-class files) would


### PR DESCRIPTION
Closes #970.

Messages → Friends was the last major desktop surface with no REST equivalent: a client could see that a connected peer happened to be a friend, but could not read the list, add to it, remove from it, or grant the friend slot.

Everything needed was already on the wire. The daemon appends the whole friends list to every `EC_OP_GET_UPDATE` reply — the tick amuleapi already runs once a second — and the refresher threw it away with a comment saying so. The mutations are branches of `EC_OP_FRIEND`, which amuleapi already sends for the "View Files" browse.

**One thing genuinely was missing, and it's a desktop bug in its own right.** `CEC_Friend_Tag` never serialized the friend-slot flag, so no EC client could read it back — amulegui's "Establish Friend Slot" check mark has been permanently unchecked, even for the friend that holds the slot, and even immediately after that GUI set it. Writing worked; reading never did. This serializes the flag, adds the accessor, and reads it in the remote GUI's item update, which fixes that independently of the REST work.

## The REST surface

| Route | Auth | |
|---|---|---|
| `GET /api/v0/friends` | GUEST | list, standard envelope, sortable by `name` / `online` |
| `POST /api/v0/friends` | ADMIN | add by connected peer, or by address |
| `DELETE /api/v0/friends/{ecid}` | ADMIN | remove |
| `PATCH /api/v0/friends/{ecid}` | ADMIN | grant / clear the friend slot |
| `POST /api/v0/friends/{ecid}/shared_files` | ADMIN | browse their shared files |

Plus `friend_added` / `friend_updated` / `friend_removed` on the events stream under a `friends` channel. `friend_updated` fires on the online↔offline transition too, since that's what drives the desktop's connected indicator. Note one `PATCH` can emit **two** events: only one friend may hold the slot, so granting it clears whoever held it before.

The browse route is the more capable twin of the `/clients` one — a friend record carries a stored address, so the daemon can browse a friend who is **not currently connected**, which the clients route cannot do.

## Reuse

The list endpoint goes through the shared `ParseListParams` / `ListResponse` helpers, so pagination, the limit clamp and sort validation behave exactly as on `/servers` rather than being reimplemented. `FindFriendByEcid` sits beside its server and client siblings with the same signature. The two browse routes now share one handler differing only in which sub-tag addresses the target. And the dotted-quad IPv4 parse existed inline **twice** in `Api.cpp` — this would have been the third, so it is now one helper with both old call sites converted.

## Testing

- **4 new walker unit tests** in `RefresherTest` — merge by ECID, eviction, `CValueMap`-suppressed fields preserved across a tick, and an older daemon's missing slot tag degrading to `false`. All 55 pass.
- **New `34-friends.sh` curl phase**, 44 assertions, registered in `run-all.sh`. Run against a live amuled: **44/44 pass**, covering the envelope and shared list-param contract, add-by-address round-trip, the slot toggling and reading back, malformed-body rejection, guest vs admin, and a second DELETE returning 404 rather than a cheerful 200.
- **SSE verified live** — added a friend, patched the slot, removed it, and observed exactly `friend_added` / `friend_updated` / `friend_removed` on `?channels=friends` with the documented payloads.
- Docs updated: `REFERENCE.md` index + a Friends section, `EVENTS.md` catalog + channel table.

Deliberately deferred, as #970 allows: the optional `last_seen` / `last_chatted` sub-tags, and the web UI view.
