### PR TITLE
feat(amuleapi): complete the stats surface and fix what it reported wrong

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -90,7 +90,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 
 **Statistics**
 - [`GET /api/v0/stats/tree`](#get-apiv0statstree) — full statistics tree
-- [`GET /api/v0/stats/graphs/{graph}`](#get-apiv0statsgraphsgraph) — time-series points (`download`, `upload`, `connections`, `kad`)
+- [`GET /api/v0/stats/graphs/{graph}`](#get-apiv0statsgraphsgraph) — time-series points (`download_speed`, `upload_speed`, `connections`, `kad_nodes`)
 
 **Search**
 - [`GET /api/v0/search`](#get-apiv0search) — enumerate every search amuled currently holds, including ones this session never started
@@ -1937,30 +1937,32 @@ The ed2k server-info log buffer. Unlike `/logs/amule`, amuled ships this one as 
 
 **Auth:** `GUEST`
 
+**Query parameters:** `max_client_versions=N` (`0`–`255`, default `0` = unlimited) — caps how many per-software **version** rows the daemon serializes. Only the version lists are affected; the OS breakdown and the fixed skeleton nodes are always complete. A long-lived node accumulates hundreds of version rows, so a dashboard showing a top-10 should pass this rather than discard the rest client-side.
+
 A tree mirroring amuled's "Statistics" tree (transfers, connections, clients, servers, downloads). Cached with a 1 s TTL.
 
-The envelope is `{ "nodes": [...] }`. Each node is `{ "key": "<id>", "raw": "<value>", "label": "<template>", "values": [...], "children": [...] }`. A leaf is a node whose `children` array is empty. `key` and `raw` are optional (see below).
+The envelope is `{ "nodes": [...] }`. Each node is `{ "key": "<id>", "label_value": "<value>", "label": "<template>", "values": [...], "children": [...] }`. A leaf is a node whose `children` array is empty. `key` and `label_value` are optional (see below).
 
 `label` is the **untranslated English template** (e.g. `"Total uploaded: %s"`), and `values` are the **typed, raw** values that fill its `%s` placeholders in order — the client formats and localizes them. This keeps the response identical regardless of the amuleapi/amuled `--locale` (see [Response model](#response-model)). A container node (one that only groups children) has an empty `values` array.
 
 `key` is a **stable, machine-readable identifier** for the node (e.g. `"upload_data"`, `"ul_dl_ratio"`, `"servers_working"`). Unlike `label`, it does not change when the label is reworded, and it is never translated — use it to locate a specific field instead of matching on the label string. The `key` is optional: it is present only for nodes the daemon assigns one to, and it is omitted entirely when absent (older daemons that predate this field emit no `key` at all). Keys are unique among the fixed skeleton nodes; the dynamic per-client-software rows share a key by kind (see below).
 
-`raw` is the **raw, untranslated machine value** for nodes whose `label` is itself data — the per-client-software breakdown rows, where the label is a version or OS string (`"v0.70b: %s"`, `"Linux: %s"`). It carries just that value (`"v0.70b"`, `"Linux"`) so a client reads it directly instead of parsing it out of the `label`. Present only on those rows; omitted otherwise and on daemons that predate the field. These rows are grouped under the `client_versions` / `client_operating_system` container nodes and each row carries `key: "client_version"` / `key: "client_os"` — so the `key` tells you the kind and `raw` gives the value.
+`label_value` is the **raw, untranslated machine value** for nodes whose `label` is itself data — the per-client-software breakdown rows, where the label is a version or OS string (`"v0.70b: %s"`, `"Linux: %s"`). It carries just that value (`"v0.70b"`, `"Linux"`) so a client reads it directly instead of parsing it out of the `label`. Present only on those rows; omitted otherwise and on daemons that predate the field. These rows are grouped under the `client_versions` / `client_operating_system` container nodes and each row carries `key: "client_version"` / `key: "client_os"` — so the `key` tells you the kind and `label_value` gives the value.
 
 Each value is `{ "type": "<type>", "value": <raw> }`:
 
 | `type` | `value` JSON | meaning |
 | --- | --- | --- |
-| `integer`, `istring`, `ishort` | number | plain count |
+| `integer` | number | plain count |
 | `bytes` | number | raw bytes |
 | `speed` | number | raw bytes/second |
 | `time` | number | raw seconds |
 | `double` | number | raw double |
 | `string` | string | opaque English string (e.g. a ratio, or `"Not available"`) |
 
-A `string` value that is a **well-known sentinel** additionally carries an `enum` field with a stable, locale-independent token — currently `"never"` (a "Never" timestamp, e.g. max-connection-limit-reached) and `"not_available"` (a ratio with no data yet). The English `value` is left in place unchanged, so this is purely additive: prefer `enum` when present and fall back to `value` otherwise. It is absent on non-sentinel values and on daemons that predate the field.
+A `string` value that is a **well-known sentinel** additionally carries a `token` field with a stable, locale-independent token — currently `"never"` (a "Never" timestamp, e.g. max-connection-limit-reached) and `"not_available"` (a ratio with no data yet). The English `value` is left in place unchanged, so this is purely additive: prefer `token` when present and fall back to `value` otherwise. It is absent on non-sentinel values and on daemons that predate the field.
 
-A value may carry a nested `extra` value of the same shape — the parenthetical "(total …)" some nodes append (e.g. session vs. total transfer).
+A value may carry a nested `extra` value of the same shape — whatever the desktop prints in parentheses. It is **three different quantities** depending on the node, so format it from its own `type` rather than assuming: a **percentage of the parent** on counter nodes that show one, a **packet count** beside a byte total on the packet nodes, and the **all-time total** beside a session figure on the transfer counters.
 
 The UL:DL ratio node (`key: "ul_dl_ratio"`) additionally carries a `ratio` object with numeric `session` and `total` fields, so clients don't have to parse its composite string value. Both are **download-per-upload** doubles (received ÷ sent bytes): `session` for the current session, `total` for all time. Each field appears only when the daemon can compute it (both sides greater than zero); the whole `ratio` object is omitted when neither is available and on daemons that predate this field. No other node type carries `ratio`.
 
@@ -1998,14 +2000,14 @@ The UL:DL ratio node (`key: "ul_dl_ratio"`) additionally carries a `ratio` objec
 }
 ```
 
-A per-client-software version row (note `raw`), and a sentinel value (note the additive `enum`):
+A per-client-software version row (note `label_value`, and an `extra` that is a percentage of the parent here), and a sentinel value (note the additive `token`):
 
 ```json
 {
   "key": "client_version",
-  "raw": "v0.70b",
+  "label_value": "v0.70b",
   "label": "v0.70b: %s",
-  "values": [ { "type": "istring", "value": 42, "extra": { "type": "double", "value": 12.5 } } ],
+  "values": [ { "type": "integer", "value": 42, "extra": { "type": "double", "value": 12.5 } } ],
   "children": []
 }
 ```
@@ -2013,7 +2015,7 @@ A per-client-software version row (note `raw`), and a sentinel value (note the a
 ```json
 {
   "label": "Max Connection Limit Reached: %s",
-  "values": [ { "type": "string", "value": "Never", "enum": "never" } ],
+  "values": [ { "type": "string", "value": "Never", "token": "never" } ],
   "children": []
 }
 ```
@@ -2026,26 +2028,49 @@ A per-client-software version row (note `raw`), and a sentinel value (note the a
 
 Time-series points behind the desktop Statistics graphs.
 
-`{graph}` is one of `download`, `upload`, `connections`, `kad`.
+`{graph}` is one of `download_speed`, `upload_speed`, `connections`, `kad_nodes`.
 
-**Query parameters:** `width=N` — clamp the response to the last `N` samples (default/`0` returns the full ~1800-sample window).
+**Query parameters:**
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `interval` | int, `1`–`3600` | `1` | Seconds between samples. Changes what amuled is asked for, so it changes the reach of the window: `interval=10` covers ten times as long at a tenth the resolution. |
+| `width` | int, `1`–`1800` | full window | Tails the response to the last `N` samples. Applied after the fetch — it does not change what is requested, so it never changes the time span each sample covers. |
 
 ```json
 {
-  "graph": "download",
-  "unit": "bps",
+  "graph": "connections",
+  "unit": "count",
   "interval_seconds": 1,
+  "max_points": 1800,
   "points": [
-    { "t": "2026-06-19T11:00:00Z", "t_unix": 1781430000, "value": 4500000 },
-    { "t": "2026-06-19T11:00:10Z", "t_unix": 1781430010, "value": 4800000 }
+    { "t": "2026-06-19T11:00:00Z", "t_unix": 1781430000, "value": 42, "active_downloads": 7, "active_uploads": 4 },
+    { "t": "2026-06-19T11:00:01Z", "t_unix": 1781430001, "value": 44, "active_downloads": 8, "active_uploads": 4 }
   ],
-  "session": { "download_bytes": 12400000000, "upload_bytes": 980000000, "kad_bytes": 5400000 }
+  "session": {
+    "download_bytes": 12400000000,
+    "upload_bytes": 980000000,
+    "kad_node_seconds": 5400000,
+    "duration_seconds": 86400
+  }
 }
 ```
 
-Each point is an object with `t` (ISO-8601 UTC), `t_unix` (unix seconds), and `value`. `unit` is `"bps"` for download/upload and `"count"` for connections/kad. `session` carries this-session byte totals so a client doesn't need a separate roundtrip.
+Each point has `t` (ISO-8601 UTC), `t_unix` (unix seconds) and `value`, spaced by `interval_seconds`. `unit` is `"bytes_per_second"` for the two speed graphs and `"count"` for the other two.
 
-**Errors:** `404 not_found` (unknown graph name), `503 ec_unavailable`.
+`max_points` is how many points this daemon can answer with before it starts repeating records; `points` is never longer than it. It is not a constant across daemons, so a client that wants the deepest window available should read it rather than assume 1800.
+
+**`connections` only:** each point also carries `active_downloads` (peers being pulled from) and `active_uploads` (peers being pushed to), alongside `value`, which stays the total connection count. Against an amuled that does not report them the two keys are **omitted entirely** rather than sent as `0`, so "not reported" is distinguishable from "nothing was transferring". They are all-or-nothing: either every point in a response has them or none does.
+
+**`session`** carries this-session figures so a client doesn't need a separate roundtrip:
+
+| Field | Meaning |
+|---|---|
+| `download_bytes` / `upload_bytes` | Bytes transferred this session. Granularity is 1 KiB — amuled tracks these in kibibytes and truncates before sending. |
+| `kad_node_seconds` | **Not a transfer figure.** The running per-second sum of the Kad node count, i.e. node·seconds. Divide by `duration_seconds` for the session-average node count, which is its only use. |
+| `duration_seconds` | Daemon uptime at the newest point. `0` if the daemon does not report it. Divide any of the three figures above by it to get the session average the desktop plots. |
+
+**Errors:** `400 bad_request` (`interval` outside `1`–`3600` or non-numeric), `404 not_found` (unknown graph name), `503 ec_unavailable`.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5219,10 +5219,15 @@ void WriteStatsValue(CJsonWriter &w, const webapi::StatsTreeValue &v)
 	// ("never"/"not_available"); the English "value" above is kept so old
 	// clients keep working. Omitted when the value is not a sentinel.
 	if (!v.enum_token.empty()) {
-		w.Key("enum");
+		// `token`, not `enum`: `enum` is a reserved word in C++, C#, Java,
+		// Rust, PHP and Swift, so a generated client cannot name a field
+		// after the key. Matches the internal enum_token.
+		w.Key("token");
 		w.ValueString(wxString::FromUTF8(v.enum_token.c_str()));
 	}
-	// Optional nested sub-value (the parenthetical "(total …)" some nodes carry).
+	// Optional nested sub-value. Three different quantities depending on
+	// the node -- percentage of parent, packet count, or all-time total --
+	// so a client formats it from its `type`, not from its position.
 	if (!v.extra.empty()) {
 		w.Key("extra");
 		WriteStatsValue(w, v.extra.front());
@@ -5242,7 +5247,11 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 	// Raw machine value (client version / OS string) for data-labelled
 	// nodes; omitted when absent so clients read it without parsing `label`.
 	if (!n.raw.empty()) {
-		w.Key("raw");
+		// `label_value`, not `raw`: for a row whose label is itself data
+		// ("v0.70b: %s") this carries the datum. "raw" says unprocessed
+		// without saying of what, and sits next to values[] where a reader
+		// would look for a raw value.
+		w.Key("label_value");
 		w.ValueString(wxString::FromUTF8(n.raw.c_str()));
 	}
 	w.Key("label");
@@ -5280,17 +5289,28 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 // snapshot_at. Earliest sample sits at points[start] and corresponds
 // to `snapshot_at - (samples.size()-1)*interval`; most recent sits
 // at `snapshot_at`.
+// `extra_a` / `extra_b` are optional series point-aligned with `samples`,
+// emitted under `key_a` / `key_b` beside each `value`. Used by the
+// connections graph for its active-uploads / active-downloads lines; null or
+// short (an amuled predating the tag reports neither) leaves the keys off
+// entirely, so a consumer can tell "not reported" from "zero".
 void WritePointArray(CJsonWriter &w,
 	const std::vector<std::uint32_t> &samples,
 	std::time_t snapshot_at,
 	std::uint32_t interval,
-	std::size_t max_width)
+	std::size_t max_width,
+	const std::vector<std::uint32_t> *extra_a = nullptr,
+	const char *key_a = nullptr,
+	const std::vector<std::uint32_t> *extra_b = nullptr,
+	const char *key_b = nullptr)
 {
 	w.BeginArray();
 	if (samples.empty()) {
 		w.EndArray();
 		return;
 	}
+	const bool has_a = (extra_a != nullptr && extra_a->size() == samples.size() && key_a != nullptr);
+	const bool has_b = (extra_b != nullptr && extra_b->size() == samples.size() && key_b != nullptr);
 	const std::size_t start =
 		(max_width > 0 && samples.size() > max_width) ? samples.size() - max_width : 0;
 	for (std::size_t i = start; i < samples.size(); ++i) {
@@ -5303,6 +5323,14 @@ void WritePointArray(CJsonWriter &w,
 		w.ValueInt(static_cast<int64_t>(t));
 		w.Key("value");
 		w.ValueInt(static_cast<int64_t>(samples[i]));
+		if (has_a) {
+			w.Key(key_a);
+			w.ValueInt(static_cast<int64_t>((*extra_a)[i]));
+		}
+		if (has_b) {
+			w.Key(key_b);
+			w.ValueInt(static_cast<int64_t>((*extra_b)[i]));
+		}
 		w.EndObject();
 	}
 	w.EndArray();
@@ -5454,23 +5482,55 @@ CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request
 	if (!a.ok)
 		return a.rejection;
 
+	// ?max_client_versions=N — caps how many per-software version rows the
+	// daemon serializes (EC_TAG_STATTREE_CAPPING). 0 is unlimited, which
+	// stays the default so a caller that never passes it sees today's tree.
+	// Only the version lists are affected; the OS breakdown and the fixed
+	// skeleton nodes are not.
+	std::uint8_t max_client_versions = 0;
+	{
+		std::string query;
+		const std::size_t q = req.target.find('?');
+		if (q != std::string::npos)
+			query = req.target.substr(q + 1);
+		const auto qmap = web_api_path::ParseQuery(query);
+		const auto it = qmap.find("max_client_versions");
+		if (it != qmap.end()) {
+			char *end = nullptr;
+			const long n = std::strtol(it->second.c_str(), &end, 10);
+			if (end == it->second.c_str() || *end != '\0' || n < 0 || n > 255) {
+				return ErrorResponse(400,
+					"bad_request",
+					"max_client_versions must be an integer between 0 and 255");
+			}
+			max_client_versions = static_cast<std::uint8_t>(n);
+		}
+	}
+
 	// lazy-fetch with 1 s TTL coalescing. The fetcher runs
 	// the EC roundtrip under m_app's m_ec_mtx (SendRecvSerialized);
 	// concurrent burst reads serialize on m_stats_tree_cache's mutex
-	// and the second waiter reads the just-stored value.
-	auto pair =
-		m_stats_tree_cache.GetOrFetch(std::chrono::milliseconds(1000), [this]() -> TtlPair_StatsTree {
+	// and the second waiter reads the just-stored value. As with the graph
+	// bundle, the cache is unkeyed, so an entry fetched at a different cap
+	// counts as a miss.
+	auto pair = m_stats_tree_cache.GetOrFetch(
+		std::chrono::milliseconds(1000),
+		[this, max_client_versions]() -> TtlPair_StatsTree {
 			std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_STATSTREE, EC_DETAIL_WEB));
-			req_ec->AddTag(CECTag(EC_TAG_STATTREE_CAPPING, static_cast<std::uint8_t>(0)));
+			req_ec->AddTag(CECTag(EC_TAG_STATTREE_CAPPING, max_client_versions));
 			const CECPacket *resp = m_app.SendRecvSerialized(req_ec.get());
 			webapi::StatsTreeNode tree;
 			std::time_t ts = 0;
 			if (resp) {
 				webapi::ParseStatsTreeFromPacket(resp, tree);
+				tree.max_client_versions = max_client_versions;
 				ts = std::time(nullptr);
 				delete resp;
 			}
 			return TtlPair_StatsTree(std::move(tree), ts);
+		},
+		[max_client_versions](const TtlPair_StatsTree &c) {
+			return c.first.max_client_versions == max_client_versions;
 		});
 
 	if (pair.second == 0) {
@@ -5511,38 +5571,69 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	// Validate the graph name BEFORE fetching — saves an EC roundtrip
 	// on tab-complete typos hitting /stats/graphs/<bogus>.
 	const char *unit = nullptr;
-	if (graph == "download") {
-		unit = "bps";
-	} else if (graph == "upload") {
-		unit = "bps";
+	if (graph == "download_speed") {
+		unit = "bytes_per_second";
+	} else if (graph == "upload_speed") {
+		unit = "bytes_per_second";
 	} else if (graph == "connections") {
 		unit = "count";
-	} else if (graph == "kad") {
+	} else if (graph == "kad_nodes") {
 		unit = "count";
 	} else {
 		return ErrorResponse(404,
 			"not_found",
-			"unknown graph; expected one of: download, upload, connections, kad");
+			"unknown graph; expected one of: download_speed, upload_speed, "
+			"connections, kad_nodes");
 	}
 
-	// Lazy-fetch the full 4-series graph bundle (one EC call serves
-	// all 4 named graphs, so the cache shares across concurrent
-	// requests for different graph names).
+	std::string query;
+	const std::size_t q = req.target.find('?');
+	if (q != std::string::npos)
+		query = req.target.substr(q + 1);
+	const auto qmap = web_api_path::ParseQuery(query);
+
+	// ?interval=N — seconds between samples, passed through as
+	// EC_TAG_STATSGRAPH_SCALE. Rejected rather than clamped: 0 makes the
+	// daemon answer EC_OP_FAILED, which would reach the caller as an
+	// unexplained empty graph, and past an hour almost every point falls
+	// off the start of the session (the daemon's ranges hold ~63 h in
+	// total) — besides, SCALE is a uint16 on the wire.
+	std::uint32_t interval = 1;
+	{
+		const auto it = qmap.find("interval");
+		if (it != qmap.end()) {
+			char *end = nullptr;
+			const long n = std::strtol(it->second.c_str(), &end, 10);
+			if (end == it->second.c_str() || *end != '\0' || n < 1 || n > 3600) {
+				return ErrorResponse(
+					400, "bad_request", "interval must be an integer between 1 and 3600");
+			}
+			interval = static_cast<std::uint32_t>(n);
+		}
+	}
+
+	// Lazy-fetch the full graph bundle (one EC call serves all four named
+	// graphs, so the cache shares across concurrent requests for different
+	// graph names). The cache is unkeyed, so an entry fetched at another
+	// interval has to count as a miss — see CTtlCache's validated overload.
 	auto pair = m_stats_graphs_cache.GetOrFetch(
-		std::chrono::milliseconds(1000), [this]() -> TtlPair_StatsGraphs {
+		std::chrono::milliseconds(1000),
+		[this, interval]() -> TtlPair_StatsGraphs {
 			std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_STATSGRAPHS));
-			req_ec->AddTag(CECTag(EC_TAG_STATSGRAPH_SCALE, static_cast<std::uint16_t>(1)));
+			req_ec->AddTag(CECTag(EC_TAG_STATSGRAPH_SCALE, static_cast<std::uint16_t>(interval)));
 			req_ec->AddTag(CECTag(EC_TAG_STATSGRAPH_WIDTH, static_cast<std::uint16_t>(1800)));
 			const CECPacket *resp = m_app.SendRecvSerialized(req_ec.get());
 			webapi::StatsGraphs g;
 			std::time_t ts = 0;
 			if (resp) {
 				webapi::ParseGraphsFromPacket(resp, g);
+				g.interval_seconds = interval;
 				ts = std::time(nullptr);
 				delete resp;
 			}
 			return TtlPair_StatsGraphs(std::move(g), ts);
-		});
+		},
+		[interval](const TtlPair_StatsGraphs &c) { return c.first.interval_seconds == interval; });
 
 	if (pair.second == 0) {
 		return ErrorResponse(503,
@@ -5552,25 +5643,22 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 
 	const webapi::StatsGraphs &g = pair.first;
 	const std::vector<std::uint32_t> *series = nullptr;
-	if (graph == "download") {
+	if (graph == "download_speed") {
 		series = &g.download_bps;
-	} else if (graph == "upload") {
+	} else if (graph == "upload_speed") {
 		series = &g.upload_bps;
 	} else if (graph == "connections") {
 		series = &g.connections;
-	} else /* kad */ {
+	} else /* kad_nodes */ {
 		series = &g.kad_nodes;
 	}
 
-	// ?width=N — clamp the sample count returned. 0 / absent means
-	// "everything we have" (up to the 1800-sample window we ask for).
-	std::string query;
-	const std::size_t q = req.target.find('?');
-	if (q != std::string::npos)
-		query = req.target.substr(q + 1);
+	// ?width=N — tail the sample count returned. 0 / absent means
+	// "everything we have". Applied after the fetch, deliberately: the EC
+	// request always asks for the full window, so one cached bundle still
+	// answers every (graph, width) combination.
 	std::size_t width = 0;
 	{
-		const auto qmap = web_api_path::ParseQuery(query);
 		const auto it = qmap.find("width");
 		if (it != qmap.end()) {
 			const long n = std::atol(it->second.c_str());
@@ -5591,21 +5679,43 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	w.ValueString(wxString::FromUTF8(unit));
 	w.Key("interval_seconds");
 	w.ValueInt(static_cast<int64_t>(g.interval_seconds));
+	// How many points this daemon can answer with before it starts
+	// repeating records. `points` is never longer than this.
+	w.Key("max_points");
+	w.ValueInt(static_cast<int64_t>(g.max_points));
 	// snapshot_at retired from the response. WritePointArray
 	// still consumes `ts` to compute per-point timestamps (anchoring
 	// the time-series backwards from the fetch wall-clock).
+	//
+	// The two extra series exist only on the connections graph, and only
+	// when the daemon sent the second data blob.
 	w.Key("points");
-	WritePointArray(w, *series, ts, g.interval_seconds, width);
+	if (graph == "connections") {
+		WritePointArray(w,
+			*series,
+			ts,
+			g.interval_seconds,
+			width,
+			&g.active_downloads,
+			"active_downloads",
+			&g.active_uploads,
+			"active_uploads");
+	} else {
+		WritePointArray(w, *series, ts, g.interval_seconds, width);
+	}
 	// Session totals tag along — clients showing "this session: X GB
-	// down" don't need a separate roundtrip.
+	// down" don't need a separate roundtrip. Divide any of the three by
+	// duration_seconds for the session average the desktop plots.
 	w.Key("session");
 	w.BeginObject();
 	w.Key("download_bytes");
 	w.ValueInt(static_cast<int64_t>(g.session_download_bytes));
 	w.Key("upload_bytes");
 	w.ValueInt(static_cast<int64_t>(g.session_upload_bytes));
-	w.Key("kad_bytes");
-	w.ValueInt(static_cast<int64_t>(g.session_kad_bytes));
+	w.Key("kad_node_seconds");
+	w.ValueInt(static_cast<int64_t>(g.session_kad_node_seconds));
+	w.Key("duration_seconds");
+	w.ValueInt(static_cast<int64_t>(g.session_duration_seconds));
 	w.EndObject();
 	w.EndObject();
 	FinalizeJsonBody(w, r);

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1679,11 +1679,15 @@ const char *ECStatValueTypeName(int type)
 	case EC_VALUE_INTEGER:
 		return "integer";
 	case EC_VALUE_ISTRING:
-		return "istring";
+		// Both ISTRING and ISHORT are plain integers that the desktop
+		// happens to render abbreviated ("12.5k"). The distinction is a
+		// wx formatter choice with nothing a REST client can act on, so
+		// they collapse onto the token an untyped value already resolves to.
+		return "integer";
 	case EC_VALUE_BYTES:
 		return "bytes";
 	case EC_VALUE_ISHORT:
-		return "ishort";
+		return "integer";
 	case EC_VALUE_TIME:
 		return "time";
 	case EC_VALUE_SPEED:
@@ -1845,6 +1849,15 @@ void UnpackInterleavedUint32(const std::uint8_t *bytes,
 	}
 }
 
+// Keep only the newest `keep` samples. The series arrive oldest-first, so
+// the tail is what survives.
+void TruncateToLast(std::vector<std::uint32_t> &v, std::uint32_t keep)
+{
+	if (keep > 0 && v.size() > static_cast<std::size_t>(keep)) {
+		v.erase(v.begin(), v.end() - keep);
+	}
+}
+
 } // namespace
 
 void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
@@ -1872,20 +1885,60 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 			out.kad_nodes = std::move(channels[3]);
 		}
 	}
-	// EC_TAG_STATSGRAPH_DATA_CONN carries the upload-slot / download-
-	// slot counts (2 interleaved channels) — useful for the dashboard
-	// graph but not in StatsGraphs surface yet. Skipping until a
-	// concrete client asks; the EC bytes still travel for free since
-	// they're in the same response.
-	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATSGRAPH_SESSION_DL)) {
-		out.session_download_bytes = static_cast<std::uint64_t>(t->GetInt());
+	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATSGRAPH_DATA_CONN)) {
+		// 2 interleaved channels, filled by the same amuled loop and from
+		// the same records as EC_TAG_STATSGRAPH_DATA, so index i lines up
+		// across both blobs (Statistics.cpp, GetHistoryForGui):
+		//  ch0 = cntUploads   (peers we are pushing to)
+		//  ch1 = cntDownloads (peers we are pulling from)
+		std::vector<std::vector<std::uint32_t>> channels;
+		UnpackInterleavedUint32(static_cast<const std::uint8_t *>(t->GetTagData()),
+			t->GetTagDataLen(),
+			/*num_channels=*/2,
+			channels);
+		if (channels.size() >= 2) {
+			out.active_uploads = std::move(channels[0]);
+			out.active_downloads = std::move(channels[1]);
+		}
 	}
-	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATSGRAPH_SESSION_UL)) {
-		out.session_upload_bytes = static_cast<std::uint64_t>(t->GetInt());
+
+	// How many records a resolution range holds. Ask for more and the
+	// daemon repeats records instead of failing, which the caller cannot
+	// detect since no timestamps are on the wire -- so this bounds every
+	// series below. Absent on daemons predating the tag; the default in
+	// StatsGraphs matches what current builds report.
+	{
+		std::uint16_t depth = 0;
+		if (resp->AssignIfExist(EC_TAG_STATSGRAPH_DEPTH, depth) && depth > 0) {
+			out.max_points = depth;
+		}
 	}
-	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATSGRAPH_SESSION_KAD)) {
-		out.session_kad_bytes = static_cast<std::uint64_t>(t->GetInt());
+
+	// The daemon divides both byte counters by 1024 before sending
+	// (Statistics.cpp, RecordHistory: kBytesSent / kBytesReceived), so
+	// scale back to make the reported unit true.
+	if (resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_DL, out.session_download_bytes)) {
+		out.session_download_bytes *= 1024;
 	}
+	if (resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_UL, out.session_upload_bytes)) {
+		out.session_upload_bytes *= 1024;
+	}
+	// Not bytes: the time-integral of the Kad node count. Passed through
+	// unscaled -- it is only meaningful divided by the session duration.
+	resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_KAD, out.session_kad_node_seconds);
+	resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_TIMESPAN, out.session_duration_seconds);
+
+	// Drop anything past the daemon's per-range depth. Beyond it the walk
+	// hands back repeated records, and reconstructing a time axis over
+	// those draws them as distinct samples -- silently compressing time
+	// across the older part of the plot. A no-op where the request width
+	// and the reported depth agree, which is the current-build case.
+	TruncateToLast(out.download_bps, out.max_points);
+	TruncateToLast(out.upload_bps, out.max_points);
+	TruncateToLast(out.connections, out.max_points);
+	TruncateToLast(out.kad_nodes, out.max_points);
+	TruncateToLast(out.active_uploads, out.max_points);
+	TruncateToLast(out.active_downloads, out.max_points);
 }
 
 // --- /search/results (full fetch per tick) -----------------------------

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -464,8 +464,13 @@ struct CategorySnapshot
 // flattening through GetDisplayString() (which translates and locale-formats
 // in the amuleapi process). `type` is the EC value type as a stable lowercase
 // string; the raw value lands in exactly one of num/dbl/str per `kind`.
-// `extra` holds the optional nested sub-value (the parenthetical "(total …)"
-// some nodes carry) — at most one level deep, matching the EC encoding.
+// `extra` holds the optional nested sub-value — at most one level deep,
+// matching the EC encoding. It is whatever the desktop prints in
+// parentheses, which is three different quantities depending on the node:
+// a percentage of the parent (CStatTreeItemCounterTmpl with stShowPercent),
+// a packet count beside a byte total (CStatTreeItemPackets), or the all-time
+// total beside a session figure (CStatTreeItemUlDlCounter). It is `type`-
+// tagged, so a client formats it from `type` rather than from its position.
 struct StatsTreeValue
 {
 	enum Kind
@@ -496,6 +501,11 @@ struct StatsTreeValue
 // text + C-locale numbers, independent of the amuleapi/amuled --locale.
 struct StatsTreeNode
 {
+	// The EC_TAG_STATTREE_CAPPING value this tree was fetched at. Only
+	// meaningful on the root; carried so the unkeyed TTL cache can reject
+	// an entry fetched at a different cap.
+	std::uint8_t max_client_versions = 0;
+
 	// Stable, untranslated machine key (EC_TAG_STAT_NODE_KEY). Empty when
 	// the node carries no key; omitted from JSON in that case.
 	std::string key;
@@ -529,8 +539,11 @@ struct StatsTreeNode
 // in the `{graph}` path segment.
 struct StatsGraphs
 {
-	// Sample cadence in seconds. amuled's CStatsCollection uses 1s.
-	// Used as the `interval` field in the response.
+	// Seconds between samples, as actually requested of amuled via
+	// EC_TAG_STATSGRAPH_SCALE. Reported as `interval_seconds` and used to
+	// space the reconstructed timestamps, so it has to be the value that
+	// was asked for rather than an assumption. Also the cache key: an
+	// entry fetched at one interval must not answer a request for another.
 	std::uint32_t interval_seconds = 1;
 
 	std::vector<std::uint32_t> download_bps;
@@ -538,12 +551,38 @@ struct StatsGraphs
 	std::vector<std::uint32_t> connections;
 	std::vector<std::uint32_t> kad_nodes;
 
-	// Session running totals — single uint64 per series, reported
-	// alongside the time-series so the panel can show "this session
-	// total" without needing a separate roundtrip.
+	// Second data blob (EC_TAG_STATSGRAPH_DATA_CONN), point-aligned with
+	// the four above and only meaningful on the connections graph. Empty
+	// when the daemon predates the tag -- which is why these are reported
+	// as absent rather than as zeros: "not reported" and "nothing was
+	// transferring" are different answers.
+	std::vector<std::uint32_t> active_uploads;
+	std::vector<std::uint32_t> active_downloads;
+
+	// Records amuled holds per resolution range (EC_TAG_STATSGRAPH_DEPTH).
+	// Asking for more points than this makes the daemon repeat records
+	// rather than fail, and no timestamps travel on the wire, so the
+	// caller cannot spot it -- every series is truncated to this.
+	std::uint32_t max_points = 1800;
+
+	// Session running totals — reported alongside the time-series so the
+	// panel can show "this session total" without a separate roundtrip.
+	//
+	// The daemon divides the two byte counters by 1024 before sending
+	// (Statistics.cpp, RecordHistory), so these are scaled back on parse
+	// and really are bytes, to 1 KiB granularity.
 	std::uint64_t session_download_bytes = 0;
 	std::uint64_t session_upload_bytes = 0;
-	std::uint64_t session_kad_bytes = 0;
+
+	// NOT a transfer figure: the running per-second sum of the Kad node
+	// count, i.e. node·seconds. Divided by session_duration_seconds it
+	// gives the session-average node count, which is its only use.
+	std::uint64_t session_kad_node_seconds = 0;
+
+	// Daemon uptime in seconds at the newest point
+	// (EC_TAG_STATSGRAPH_SESSION_TIMESPAN). Without it the three totals
+	// above cannot be turned into averages. 0 when not reported.
+	double session_duration_seconds = 0.0;
 };
 
 // One result from a /search/results poll. Identity is the file's

--- a/src/webapi/TtlCache.h
+++ b/src/webapi/TtlCache.h
@@ -70,11 +70,28 @@ public:
 	// and then read the stored value.
 	template <class Fetcher> T GetOrFetch(std::chrono::milliseconds ttl, Fetcher fetch)
 	{
+		return GetOrFetch(ttl, fetch, [](const T &) { return true; });
+	}
+
+	// As above, plus a validity predicate on the cached value. A fresh
+	// entry that fails it counts as a miss and is refetched.
+	//
+	// This is for endpoints whose EC request is parameterised by the
+	// caller: the cache is unkeyed, so an entry fetched at one parameter
+	// must not be served to a request asking for another. Storing the
+	// parameter inside the cached value and rejecting a mismatch keeps
+	// the single-entry cache -- a caller with a fixed parameter (every
+	// real one) still pays one round trip per TTL, while callers
+	// alternating parameters each pay their own. The alternative, a map
+	// keyed by a caller-supplied value, is unbounded by construction.
+	template <class Fetcher, class Validator>
+	T GetOrFetch(std::chrono::milliseconds ttl, Fetcher fetch, Validator is_valid)
+	{
 		std::unique_lock<std::mutex> lk(m_mu);
 		while (true) {
 			const auto now = clock_t::now();
 			const bool unset = (m_fetched_at == clock_t::time_point{});
-			if (!unset && (now - m_fetched_at) <= ttl) {
+			if (!unset && (now - m_fetched_at) <= ttl && is_valid(m_value)) {
 				return m_value;
 			}
 			if (m_inflight) {

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -244,7 +244,7 @@ function KadPanel() {
     let alive = true;
     const tick = async () => {
       try {
-        const r = await api.get("stats/graphs/kad?width=" + GRAPH_WIDTH);
+        const r = await api.get("stats/graphs/kad_nodes?width=" + GRAPH_WIDTH);
         const pts = r.points || [];
         if (alive) setGraphData([pts.map((p) => p.t_unix), pts.map((p) => p.value)]);
       } catch (_) { /* leave previous data */ }

--- a/src/webapi/static/js/views/stats.js
+++ b/src/webapi/static/js/views/stats.js
@@ -18,8 +18,8 @@ const SMA_WINDOW = 50; // ponytail: SMA over ~5 min of samples; amulegui makes t
 
 const speedAxis = (max) => bytesAxis(max, true);
 const GRAPHS = [
-  { name: "download", title: t("stats_download_speed"), color: "#3aaf5d", avgColor: "#1fb5ad", fmt: formatSpeed, axis: speedAxis },
-  { name: "upload", title: t("stats_upload_speed"), color: "#3b86e0", avgColor: "#8a5cd6", fmt: formatSpeed, axis: speedAxis },
+  { name: "download_speed", title: t("stats_download_speed"), color: "#3aaf5d", avgColor: "#1fb5ad", fmt: formatSpeed, axis: speedAxis },
+  { name: "upload_speed", title: t("stats_upload_speed"), color: "#3b86e0", avgColor: "#8a5cd6", fmt: formatSpeed, axis: speedAxis },
   { name: "connections", title: t("stats_connections"), color: "#d68a0c", avgColor: "#c94f7c", fmt: formatInt },
 ];
 
@@ -130,7 +130,7 @@ function tNodeLabel(node) {
   // tail so nodeText still fills the count/percent. ponytail: heads have no ":".
   if (node.key === "client_version" || node.key === "client_os") {
     const tail = node.label.slice(node.label.indexOf(":"));
-    if (node.raw) return node.raw + tail;
+    if (node.label_value) return node.label_value + tail;
     return tOr("stats_tree_" + node.key + "_unknown", node.label) + tail;
   }
   return tOr("stats_tree_" + node.key, tLabel(node.label));
@@ -145,7 +145,7 @@ function fmtValue(v, spec) {
     case "speed": s = formatBytes(v.value) + "/s"; break;
     case "time": s = formatDuration(v.value); break;
     case "double": s = /f/.test(spec || "") ? Number(v.value).toFixed(2) : String(v.value); break;
-    case "string": s = v.enum ? tEnum(v.enum) : tLabel(String(v.value)); break;
+    case "string": s = v.token ? tEnum(v.token) : tLabel(String(v.value)); break;
     default: s = formatInt(v.value); break; // integer/istring/ishort
   }
   if (v.extra) {

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -97,7 +97,7 @@ _assert_json_eq '.nodes[0].children | type' array '/stats/tree first node has a 
 _assert_json_eq '[.. | .values? // empty | .[]?] | length > 0' true \
 	'/stats/tree carries at least one typed value'
 _assert_json_eq '([.. | .values? // empty | .[]? | .type] | unique)
-	- ["integer","istring","bytes","ishort","time","speed","string","double"]
+	- ["integer","bytes","time","speed","string","double"]
 	| length == 0' true '/stats/tree value types are all from the known set'
 # Stable machine keys: locale-independent identifiers on the fixed skeleton
 # nodes, safe to pin (unlike labels). Uptime is always the first node.
@@ -127,41 +127,85 @@ _assert_json_eq '[.. | objects | select(has("raw")) | .raw | type] | all(. == "s
 # enum: additive locale-independent token on well-known sentinel string values
 # ("never"/"not_available"). Assert the tokens are from the known set and always
 # accompany a string value (the English value is kept alongside).
-_assert_json_eq '([.. | objects | .values? // empty | .[]? | select(has("enum")) | .enum]
+_assert_json_eq '([.. | objects | .values? // empty | .[]? | select(has("token")) | .token]
 	| unique) - ["never","not_available"] | length == 0' \
-	true '/stats/tree enum tokens are from the known set'
-_assert_json_eq '[.. | objects | .values? // empty | .[]? | select(has("enum"))
+	true '/stats/tree value tokens are from the known set'
+_assert_json_eq '[.. | objects | .values? // empty | .[]? | select(has("token"))
 	| (.type == "string" and (.value | type) == "string")] | all(.)' \
-	true '/stats/tree enum tokens ride on a string value (kept for legacy clients)'
+	true '/stats/tree value tokens ride on a string value (kept for legacy clients)'
 
 # --- 3. /stats/graphs/{graph} — all four named graphs. -------------
-for g in download upload connections kad; do
+for g in download_speed upload_speed connections kad_nodes; do
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/$g"
 	_assert_status 200 "GET /stats/graphs/$g → 200"
 	_assert_json_eq '.graph'                    "$g"  "/stats/graphs/$g reports graph=$g"
 	_assert_json_eq '.interval_seconds | type'  number "/stats/graphs/$g interval_seconds is numeric"
 	_assert_json_eq '.points | type'            array  "/stats/graphs/$g .points is array"
 	_assert_json_eq '.session | type'           object "/stats/graphs/$g .session is object"
+	_assert_json_eq '.max_points | type'        number "/stats/graphs/$g max_points is numeric"
+	_assert_json_eq '.points | length <= .max_points' true \
+		"/stats/graphs/$g never returns more points than max_points"
 done
 # Per-graph unit mapping.
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download"
-_assert_json_eq '.unit' bps   '/stats/graphs/download reports unit=bps'
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_speed"
+_assert_json_eq '.unit' bytes_per_second '/stats/graphs/download_speed reports unit=bytes_per_second'
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/connections"
 _assert_json_eq '.unit' count '/stats/graphs/connections reports unit=count'
 
+# Session object: the two byte counters are scaled back from the KiB the
+# daemon sends, kad is node-seconds rather than bytes, and duration is what
+# turns any of them into an average.
+_assert_json_eq '.session | has("download_bytes") and has("upload_bytes")
+	and has("kad_node_seconds") and has("duration_seconds")' true \
+	'/stats/graphs session carries the four corrected fields'
+_assert_json_eq '.session | has("kad_bytes")' false \
+	'/stats/graphs session no longer reports the misnamed kad_bytes'
+
+# The connections graph carries the second data blob's two series when the
+# daemon reports it; the other graphs never do.
+if [ "$(printf '%s' "$CURL_BODY" | jq '.points | length')" -gt 0 ]; then
+	_assert_json_eq '[.points[] | has("active_uploads")] | (all(.) or (any(.) | not))' true \
+		'/stats/graphs/connections active_uploads is present on all points or none'
+fi
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_speed"
+_assert_json_eq '[.points[]? | has("active_uploads")] | any(.) | not' true \
+	'/stats/graphs/download_speed never carries the connections-only series'
+
+# --- 3b. ?interval=N and its validation. ---------------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_speed?interval=10"
+_assert_status 200 "GET /stats/graphs/download_speed?interval=10 → 200"
+_assert_json_eq '.interval_seconds' 10 \
+	'/stats/graphs?interval=10 reports the interval it applied'
+for bad in 0 3601 abc; do
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_speed?interval=$bad"
+	_assert_status 400 "GET /stats/graphs/download_speed?interval=$bad → 400"
+	_assert_json_eq '.error.code' bad_request \
+		"/stats/graphs?interval=$bad carries error.code=bad_request"
+done
+
+# --- 3c. /stats/tree ?max_client_versions=N and its validation. ----
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/tree?max_client_versions=3"
+_assert_status 200 "GET /stats/tree?max_client_versions=3 → 200"
+for bad in -1 256 abc; do
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/tree?max_client_versions=$bad"
+	_assert_status 400 "GET /stats/tree?max_client_versions=$bad → 400"
+	_assert_json_eq '.error.code' bad_request \
+		"/stats/tree?max_client_versions=$bad carries error.code=bad_request"
+done
+
 # --- 4. /stats/graphs/{graph} ?width=N tailing. --------------------
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download?width=5"
-_assert_status 200 "GET /stats/graphs/download?width=5 → 200"
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_speed?width=5"
+_assert_status 200 "GET /stats/graphs/download_speed?width=5 → 200"
 _assert_json_eq '.points | length <= 5' true \
-	'/stats/graphs/download?width=5 returns ≤5 points'
+	'/stats/graphs/download_speed?width=5 returns ≤5 points'
 # When a point exists, it must carry both t (ISO-8601) and t_unix.
 if [ "$(printf '%s' "$CURL_BODY" | jq '.points | length')" -gt 0 ]; then
 	_assert_json_eq '.points[0].t | length' 20 \
-		'/stats/graphs/download point.t is 20-char ISO-8601'
+		'/stats/graphs/download_speed point.t is 20-char ISO-8601'
 	_assert_json_eq '.points[0].t_unix | type' number \
-		'/stats/graphs/download point.t_unix is numeric'
+		'/stats/graphs/download_speed point.t_unix is numeric'
 	_assert_json_eq '.points[0].value | type' number \
-		'/stats/graphs/download point.value is numeric'
+		'/stats/graphs/download_speed point.value is numeric'
 fi
 
 # --- 5. Unknown graph name → 404. ----------------------------------

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -405,9 +405,13 @@ TEST(State, WriteGraphsRoundtripAllSeries)
 	g.upload_bps = { 10, 20, 30 };
 	g.connections = { 1, 2, 3 };
 	g.kad_nodes = { 500, 600, 700 };
+	g.active_uploads = { 4, 5, 6 };
+	g.active_downloads = { 7, 8, 9 };
+	g.max_points = 1800;
 	g.session_download_bytes = 1024;
 	g.session_upload_bytes = 256;
-	g.session_kad_bytes = 4096;
+	g.session_kad_node_seconds = 4096;
+	g.session_duration_seconds = 3600.0;
 	s.WriteGraphs(g);
 
 	const StatsGraphs out = s.Graphs();
@@ -415,8 +419,32 @@ TEST(State, WriteGraphsRoundtripAllSeries)
 	ASSERT_EQUALS(static_cast<size_t>(3), out.download_bps.size());
 	ASSERT_EQUALS(static_cast<std::uint32_t>(300), out.download_bps[2]);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(700), out.kad_nodes[2]);
+	// The second data blob rides along point-aligned with the first.
+	ASSERT_EQUALS(static_cast<size_t>(3), out.active_uploads.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(6), out.active_uploads[2]);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(9), out.active_downloads[2]);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1800), out.max_points);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(1024), out.session_download_bytes);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(4096), out.session_kad_bytes);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(4096), out.session_kad_node_seconds);
+	ASSERT_EQUALS(3600.0, out.session_duration_seconds);
+}
+
+// An amuled predating EC_TAG_STATSGRAPH_DATA_CONN sends the first blob and
+// not the second. The two extra series must come back empty rather than
+// zero-filled: the handler keys "omit the JSON fields" off exactly that, so
+// a consumer can tell "not reported" from "nothing was transferring".
+TEST(State, WriteGraphsWithoutConnBlobLeavesExtraSeriesEmpty)
+{
+	CState s;
+	StatsGraphs g;
+	g.download_bps = { 100, 200, 300 };
+	g.connections = { 1, 2, 3 };
+	s.WriteGraphs(g);
+
+	const StatsGraphs out = s.Graphs();
+	ASSERT_EQUALS(static_cast<size_t>(3), out.connections.size());
+	ASSERT_TRUE(out.active_uploads.empty());
+	ASSERT_TRUE(out.active_downloads.empty());
 }
 
 TEST(State, SearchResultsRoundtripAndOrderByEcid)


### PR DESCRIPTION
Closes #981.

The Statistics tab and `GET /api/v0/stats/*` are fed by the same two EC operations, but the REST side hardcoded every knob the protocol offers, dropped one of the two data blobs the daemon sends, and mislabelled part of what it did return. **No core change and no EC protocol change** — every tag involved was already on the wire.

## Correctness fixes

| Field | Was | Now |
|---|---|---|
| `session.download_bytes` / `upload_bytes` | kibibytes under a `_bytes` name — off by 1024 | scaled back; granularity stays 1 KiB, which is what the daemon sends |
| `session.kad_bytes` | not bytes, and not a transfer figure — the running per-second sum of the Kad node count | `session.kad_node_seconds` |
| — | no way to turn those totals into averages | `session.duration_seconds`, from the ignored `TIMESPAN` tag |
| `unit: "bps"` | bytes/s labelled with the notation that means bits | `unit: "bytes_per_second"` |

The time axis could also be **silently wrong**. Asking for more points than a resolution range holds makes the daemon repeat records rather than fail; it says so via `EC_TAG_STATSGRAPH_DEPTH`, which we ignored while spacing timestamps at a fixed interval — drawing repeats as distinct samples and compressing time across the older part of the plot. Now read, truncated to, and reported as `max_points`.

## New capability

**Connections graph** carries `active_downloads` / `active_uploads` per point, from the `DATA_CONN` blob the parser previously skipped. Omitted rather than zeroed against an amuled that doesn't report them, so "not reported" stays distinguishable from "nothing was transferring".

**`?interval=N`** (1–3600) on the graphs, replacing the pinned `SCALE=1` that capped every graph at 30 minutes. Rejected rather than clamped outside the range: `0` makes the daemon answer `EC_OP_FAILED`, which would surface as an unexplained empty graph.

**`?max_client_versions=N`** on the tree, replacing the hardcoded `CAPPING=0` — which the core reads as unlimited, since `max_children - 1` underflows a `uint32_t`.

## Renames

`/api/v0/` is experimental, so these land now rather than waiting for a `v1`: graph names describe the quantity plotted (`download_speed`, `upload_speed`, `connections`, `kad_nodes`); `raw` → `label_value`; `enum` → `token`, since `enum` is reserved in most languages a generated client is written in; `istring`/`ishort` → `integer`, a distinction that was only ever which wx formatter the desktop calls.

**The bundled web UI reads all of these, so it moves in the same commit** — `stats.js` and `networks.js` are updated, not left to break.

## On the cache

Both handlers now take a caller-supplied EC parameter, which the unkeyed TTL cache cannot serve blindly. Rather than duplicate a bypass in each handler, `CTtlCache` grows a validated `GetOrFetch` overload — a fresh entry failing the predicate counts as a miss — with the parameter carried inside the cached value. A caller with a fixed parameter, which is every real one, keeps today's single round trip per TTL. Rejected a map keyed by a caller-supplied value: unbounded by construction.

## Testing

Release and Debug build clean; `clang-format` clean; **34/34** unit tests, including a new case asserting the two extra series stay *empty* rather than zero-filled when the daemon omits the blob — that is what the omit-the-keys behaviour keys off.

Tier-2 `clang-tidy` clean on the changed lines, verified against a live check rather than a silent no-op. Curl smoke test extended for the new parameters, their `400` cases, `max_points`, the corrected `session` object, and a negative assertion that `kad_bytes` is gone.

Not verified against a running daemon: I have no amuled with a deep enough history to exercise the `DEPTH` truncation path, so that one rests on the code rather than on an observed repro.
