### PR TITLE
fix(amuleapi): gate the comment lookups, guard downloads add, and split ip:port parsing

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -748,7 +748,7 @@ A per-source `rating` of `-1` means the source left a comment but no rating. Rat
 
 #### `POST /api/v0/downloads/{hash}/comments`
 
-**Auth:** `USER`
+**Auth:** `ADMIN`
 
 Trigger an on-demand **Kad notes** lookup for this download (the desktop "Get from Kad" button). aMule asks the Kad network for community ratings/comments keyed on the file hash. The lookup is **asynchronous** on the daemon (it can take up to ~45 s); this call returns immediately with `202 Accepted`, and the retrieved notes then show up in the `GET` list above. Poll the `GET` endpoint to observe them arrive.
 
@@ -761,7 +761,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 { "status": "kad_search_started" }
 ```
 
-**Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`, `400 amuled_rejected` (daemon refused, e.g. Kad not connected).
+**Errors:** `403 forbidden` (guest token — the lookup makes the daemon do network work, so it is `ADMIN`-only), `404 not_found` (no download with that hash), `503 ec_unavailable`, `400 amuled_rejected` (daemon refused, e.g. Kad not connected).
 
 #### `GET /api/v0/downloads/{hash}/filenames`
 
@@ -1534,7 +1534,7 @@ Removes the server from amuled's list.
 
 **Response:** `200 OK` → `{ "ok": true, "ecid": 1 }`.
 
-**Errors:** `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer, or an `ip:port` selector that is not a dotted quad with a port in 1–65535), `400 amuled_rejected`, `404 not_found` (well-formed but no such server), `503 ec_unavailable`.
 
 #### `PATCH /api/v0/servers/{ecid}` / `PATCH /api/v0/servers/{ip}:{port}`
 
@@ -2333,13 +2333,13 @@ Community ratings/comments for a single search result — the Kad notes retrieve
 
 #### `POST /api/v0/search/results/{hash}/comments`
 
-**Auth:** `GUEST`
+**Auth:** `ADMIN`
 
 Trigger an on-demand Kad notes lookup for a search result you have not downloaded. This is the search-side equivalent of [`POST /downloads/{hash}/comments`](#post-apiv0downloadshashcomments): the lookup is asynchronous on amuled (up to ~45 s), and retrieved ratings/comments then appear via the `GET` above and on the result's `comments` in the search list.
 
 **Response:** `202 Accepted` → `{ "status": "kad_search_started" }`.
 
-**Errors:** `400 bad_request` (malformed hash), `404 not_found` (no current search result with that hash), `400 amuled_rejected` (Kad down, or a search is already using this hash — retry shortly), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (malformed hash), `403 forbidden` (guest token — the lookup makes the daemon do network work, so it is `ADMIN`-only), `404 not_found` (no current search result with that hash), `400 amuled_rejected` (Kad down, or a search is already using this hash — retry shortly), `503 ec_unavailable`.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -221,6 +221,22 @@ std::unique_ptr<CHttpServer::Response> RequireAdmin(const AuthOutcome &a)
 	return nullptr;
 }
 
+// First-snapshot gate, the counterpart to RequireAdmin above and used the
+// same way: ` if (auto r = RequireSnapshot(m_state)) return *r;`.
+//
+// Until the first EC snapshot lands there is nothing to answer from, and
+// every handler that touches cached state has to say so identically -- the
+// status, the code and the sentence are part of the API contract, not local
+// wording. Thirty handlers had spelled the same four lines out by hand.
+std::unique_ptr<CHttpServer::Response> RequireSnapshot(const webapi::CState &state)
+{
+	if (!state.HasFirstSnapshot()) {
+		return std::make_unique<CHttpServer::Response>(ErrorResponse(
+			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet"));
+	}
+	return nullptr;
+}
+
 // Wrapper that pipes AuthenticateRequest through a per-IP failure
 // counter. Every 401 (missing token / bad sig / expired / revoked)
 // counts against the calling IP; once the bucket fills the IP gets
@@ -1936,10 +1952,8 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	// is empty. Return 503 with a structured code so clients can
 	// retry rather than guessing — saves a round of confused log-
 	// reading when the daemon just came up.
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	// Single shared_lock for the whole composite read. Dashboard()
 	// returns a (status, kad, snapshot_at, ec_connected) tuple in
@@ -2790,10 +2804,8 @@ CHttpServer::Response ListResponse(const webapi::CState &state,
 	const ListParams &params = ListParams(),
 	const ListComparators<T> &comparators = ListComparators<T>())
 {
-	if (!state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(state))
+		return *r;
 	std::vector<const T *> window;
 	std::size_t total = 0;
 	if (auto err = BuildListWindow(items, params, comparators, window, total))
@@ -3102,10 +3114,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	// {hash} is the 32-char lowercase-hex MD4. URL is case-tolerant;
 	// State writes lowercase, so we down-case the capture before the
@@ -3143,10 +3153,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedDetail(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	// {hash} is the 32-char MD4; URL is case-tolerant, State keys are
 	// lowercase — down-case before the O(1) lookup (mirrors the download
@@ -3179,10 +3187,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadComments(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -3235,10 +3241,13 @@ CHttpServer::Response CApiDispatcher::HandleDownloadCommentsKadSearch(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	// Admin-only, like every other mutation. This drives an unbounded Kad
+	// NOTES lookup on the daemon, so a guest session must not reach it.
+	if (auto r = RequireAdmin(a))
+		return *r;
+
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -3286,10 +3295,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadFilenames(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -3347,10 +3354,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4af(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -3379,10 +3384,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -3619,6 +3622,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
+
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	// Body shape (two forms — both accepted, exactly one required):
 	//  {"ed2k_link": "ed2k://|file|...|/", "category": 0}    — singular
@@ -3884,10 +3890,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -4074,10 +4078,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDelete(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot d;
 	std::string needle = key;
@@ -4153,10 +4155,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	// Two shapes share this endpoint:
 	//  * no body (or all-whitespace body) → bulk clear every
@@ -4510,10 +4510,8 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 			503, "ec_unsupported", "the connected amuled does not serve the client history");
 	}
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	ListParams params;
 	if (auto err = ParseListParams(QueryOf(req), params))
@@ -4616,10 +4614,8 @@ CHttpServer::Response CApiDispatcher::HandleClientDetail(
 	if (!ParseEcidPath(ecid_str, ecid)) {
 		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
 	}
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 	webapi::ClientSnapshot cli;
 	if (!FindClientByEcid(m_state, ecid, cli)) {
 		return ErrorResponse(404, "not_found", "no client with that ECID in the current snapshot");
@@ -5034,10 +5030,8 @@ CHttpServer::Response CApiDispatcher::HandleServerConnect(
 	if (!ParseEcidPath(ecid_str, ecid)) {
 		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
 	}
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 	webapi::ServerSnapshot srv;
 	if (!FindServerByEcid(m_state, ecid, srv)) {
 		return ErrorResponse(404, "not_found", "no server with that ECID in the current snapshot");
@@ -5092,10 +5086,8 @@ CHttpServer::Response CApiDispatcher::HandleServerDelete(
 	if (!ParseEcidPath(ecid_str, ecid)) {
 		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
 	}
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 	webapi::ServerSnapshot srv;
 	if (!FindServerByEcid(m_state, ecid, srv)) {
 		return ErrorResponse(404, "not_found", "no server with that ECID in the current snapshot");
@@ -5195,43 +5187,79 @@ CHttpServer::Response CApiDispatcher::HandleServerUpdateFromUrl(const CHttpServe
 	return r;
 }
 
-// Resolve "<ip>:<port>" from the URL into an ECID by walking the
-// servers cache. Returns 0 on miss; the caller 404s.
-static std::uint32_t ResolveServerEcidByAddress(const webapi::CState &state, const std::string &ip_port)
+// One "<ip>:<port>" selector, parsed. Split out from the lookup so a
+// selector that cannot be parsed is distinguishable from one that parses
+// but names no server we know -- those are a 400 and a 404, and the old
+// single-uint32 return collapsed them, and every other failure, onto 0.
+// Separate also so the parsing is testable without a populated cache.
+struct IpPortSelector
+{
+	std::uint32_t ip_he; // host order, as ServerSnapshot::ip holds it
+	std::uint16_t port;
+};
+
+// Accepts a dotted quad and a port in 1..65535, nothing else.
+//
+// Hostname forms are deliberately rejected: an earlier version fell back to
+// matching ServerSnapshot::address, which amuled fills from the wire "name"
+// tag -- that can be a hostname OR a synthetic display string ("Eserver
+// No.1"), so a DELETE by address could match a colliding label and remove
+// the wrong row. An exact IP + port has no such ambiguity.
+// boost::optional, not std::optional: the tree builds as C++14 and this file
+// already uses the boost form (PreflightEvents), so it is the house spelling
+// as well as the available one.
+boost::optional<IpPortSelector> ParseIpPortSelector(const std::string &ip_port)
 {
 	const auto colon = ip_port.rfind(':');
 	if (colon == std::string::npos)
-		return 0;
+		return boost::none;
+
 	const std::string ip_str = ip_port.substr(0, colon);
 	const std::string port_str = ip_port.substr(colon + 1);
 	if (ip_str.empty() || port_str.empty())
-		return 0;
+		return boost::none;
+
 	char *end = nullptr;
 	const unsigned long port = std::strtoul(port_str.c_str(), &end, 10);
-	if (end == port_str.c_str() || *end != '\0' || port == 0 || port > 0xFFFF) {
-		return 0;
+	if (end == port_str.c_str() || *end != '\0' || port == 0 || port > 0xFFFF)
+		return boost::none;
+
+	// ParseIpv4Dotted rather than a second sscanf of our own: it landed on
+	// master while this was in review and does exactly this job, with three
+	// other callers already relying on it.
+	IpPortSelector sel;
+	sel.ip_he = 0;
+	if (!ParseIpv4Dotted(ip_str, sel.ip_he) || sel.ip_he == 0)
+		return boost::none;
+
+	sel.port = static_cast<std::uint16_t>(port);
+	return sel;
+}
+
+// Resolve a selector to a server ECID, in the same shape as RequireAdmin
+// and RequireSnapshot: nullptr means @a ecid is set and the caller may
+// proceed, otherwise it is the response to return. Mapping the outcomes
+// here rather than at each call site is what keeps the three
+// /servers/{ip:port} routes from drifting apart, and no caller compares an
+// ECID against a magic value any more.
+std::unique_ptr<CHttpServer::Response> ResolveServerEcid(
+	const webapi::CState &state, const std::string &ip_port, std::uint32_t &ecid)
+{
+	const auto sel = ParseIpPortSelector(ip_port);
+	if (!sel) {
+		return std::make_unique<CHttpServer::Response>(ErrorResponse(400,
+			"bad_request",
+			"malformed ip:port selector: expected a dotted quad and a port in 1..65535"));
 	}
-	// Parse the IP — accept dotted-quad form OR a uint32 host-order
-	// number that matches ServerSnapshot::ip. We compute both so we
-	// can match either against what the cache holds.
-	std::uint32_t ip_he = 0;
-	(void)ParseIpv4Dotted(ip_str, ip_he);
-	// Require an IPv4-shaped address: drop the s.address string
-	// fallback. The fallback was a convenience for hostname-form
-	// URLs (e.g. `/api/v0/servers/donkey.example.com:4242/connect`),
-	// but it admits an UNINTENDED match too — `s.address` is
-	// populated from amuled's wire-form "name" tag, which can be
-	// a hostname OR a synthetic display string ("Eserver No.1");
-	// a DELETE-by-address with a colliding label could remove the
-	// wrong row. IP+port exact match has no such ambiguity.
-	if (ip_he == 0)
-		return 0;
+
 	for (const auto &s : state.Servers()) {
-		if (s.port == static_cast<std::uint16_t>(port) && s.ip == ip_he) {
-			return s.ecid;
+		if (s.port == sel->port && s.ip == sel->ip_he) {
+			ecid = s.ecid;
+			return nullptr;
 		}
 	}
-	return 0;
+	return std::make_unique<CHttpServer::Response>(
+		ErrorResponse(404, "not_found", "no server matches that ip:port"));
 }
 
 CHttpServer::Response CApiDispatcher::HandleServerConnectByAddress(
@@ -5242,14 +5270,11 @@ CHttpServer::Response CApiDispatcher::HandleServerConnectByAddress(
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
-	const std::uint32_t ecid = ResolveServerEcidByAddress(m_state, ip_port);
-	if (ecid == 0) {
-		return ErrorResponse(404, "not_found", "no server matches that ip:port");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+	std::uint32_t ecid = 0;
+	if (auto r = ResolveServerEcid(m_state, ip_port, ecid))
+		return *r;
 	// Delegate to the ECID-keyed handler; passing the resolved ECID as
 	// a decimal string keeps the contract uniform.
 	std::ostringstream os;
@@ -5317,10 +5342,8 @@ CHttpServer::Response CApiDispatcher::HandleServerPatch(
 			400, "bad_request", "body must include at least one of `priority`, `static`");
 	}
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 	webapi::ServerSnapshot srv;
 	if (!FindServerByEcid(m_state, ecid, srv)) {
 		return ErrorResponse(404, "not_found", "no server with that ECID in the current snapshot");
@@ -5373,14 +5396,11 @@ CHttpServer::Response CApiDispatcher::HandleServerPatchByAddress(
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
-	const std::uint32_t ecid = ResolveServerEcidByAddress(m_state, ip_port);
-	if (ecid == 0) {
-		return ErrorResponse(404, "not_found", "no server matches that ip:port");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+	std::uint32_t ecid = 0;
+	if (auto r = ResolveServerEcid(m_state, ip_port, ecid))
+		return *r;
 	std::ostringstream os;
 	os << ecid;
 	return HandleServerPatch(req, os.str());
@@ -5394,14 +5414,11 @@ CHttpServer::Response CApiDispatcher::HandleServerDeleteByAddress(
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
-	const std::uint32_t ecid = ResolveServerEcidByAddress(m_state, ip_port);
-	if (ecid == 0) {
-		return ErrorResponse(404, "not_found", "no server matches that ip:port");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+	std::uint32_t ecid = 0;
+	if (auto r = ResolveServerEcid(m_state, ip_port, ecid))
+		return *r;
 	std::ostringstream os;
 	os << ecid;
 	return HandleServerDelete(req, os.str());
@@ -5445,10 +5462,8 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	const webapi::KadSnapshot k = m_state.Kad();
 	CHttpServer::Response r;
@@ -6545,10 +6560,8 @@ CHttpServer::Response CApiDispatcher::HandlePreferences(const CHttpServer::Reque
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	const webapi::PreferencesSnapshot p = m_state.Preferences();
 	CHttpServer::Response r;
@@ -7353,10 +7366,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot s;
 	std::string needle = key;
@@ -7470,10 +7481,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	picojson::value root;
 	std::string parse_err;
@@ -7609,10 +7618,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkDelete(const CHttpServe
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	picojson::value root;
 	std::string parse_err;
@@ -7681,10 +7688,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedBulkPatch(const CHttpServer::R
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	picojson::value root;
 	std::string parse_err;
@@ -7758,10 +7763,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedVerify(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	webapi::FileSnapshot s;
 	std::string needle = key;
@@ -8378,10 +8381,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 	if (!ParseCategoryIndex(index_str, idx)) {
 		return ErrorResponse(400, "bad_request", "path `{index}` must be a uint8 in [0, 255]");
 	}
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	// Find the existing category — we need its current values for any
 	// field the PATCH body doesn't override (CEC_Category_Tag is
@@ -8464,10 +8465,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryDelete(
 	if (!ParseCategoryIndex(index_str, idx)) {
 		return ErrorResponse(400, "bad_request", "path `{index}` must be a uint8 in [0, 255]");
 	}
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 	// Index 0 is the implicit "All" category — amuled treats deleting
 	// it as illegal. Reject before the EC roundtrip.
 	if (idx == 0) {
@@ -9029,10 +9028,8 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	std::string needle = hash;
 	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
@@ -9088,10 +9085,13 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 	if (!a.ok)
 		return a.rejection;
 
-	if (!m_state.HasFirstSnapshot()) {
-		return ErrorResponse(
-			503, "ec_unavailable", "amuleapi has not received its first EC snapshot yet");
-	}
+	// Admin-only, like every other mutation. This drives an unbounded Kad
+	// NOTES lookup on the daemon, so a guest session must not reach it.
+	if (auto r = RequireAdmin(a))
+		return *r;
+
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	std::string needle = hash;
 	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -135,6 +135,16 @@ if [ "$HAVE_GUEST" = "1" ]; then
 		-H "Content-Type: application/json" \
 		-d '{"status":"paused"}' "$HOST/api/v0/downloads/$TEST_HASH"
 	_assert_status 403 "PATCH /downloads/{hash} (guest token) → 403"
+
+	# The comments POST drives an unbounded Kad NOTES lookup on the daemon
+	# (EC_OP_SHARED_FILE_SEARCH_KAD_NOTES), so it is a mutation for gating
+	# purposes even though it writes nothing locally. The matching GET is a
+	# plain read and stays open to guests.
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
+		"$HOST/api/v0/downloads/$TEST_HASH/comments"
+	_assert_status 403 "POST /downloads/{hash}/comments (guest token) → 403"
+	_assert_json_eq '.error.code' forbidden \
+		'POST downloads comments guest carries error.code=forbidden'
 else
 	echo "    info: no guest password set on daemon; admin-gate test skipped"
 fi

--- a/unittests/curl-tests/amuleapi/14-servers-mutations.sh
+++ b/unittests/curl-tests/amuleapi/14-servers-mutations.sh
@@ -338,6 +338,43 @@ _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/servers/not-a-number"
 _assert_status 400 "DELETE /servers/not-a-number → 400"
 
+# --- 8. ip:port selector: malformed is 400, unknown is 404. --------
+# The routes also accept "<ip>:<port>" in place of an ECID. Parsing and
+# lookup are separate outcomes: a selector that cannot be parsed is the
+# caller's mistake (400), one that parses but names no server we hold is
+# simply absent (404). They used to collapse onto the same 404 because the
+# resolver signalled every failure by returning ECID 0.
+# Every case carries a colon on purpose: the dispatcher only routes to the
+# by-address handler when the capture contains one, so a colon-less value
+# would be read as an ECID and 400 for an unrelated reason.
+for bad in "not-an-ip:4242" "1.2.3.4:" ":4242" "1.2.3.4:0" "1.2.3.4:70000" \
+	"1.2.3.4:abc" "999.1.1.1:4242"; do
+	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/servers/$bad"
+	_assert_status 400 "DELETE /servers/$bad (malformed selector) → 400"
+done
+
+# Well-formed but absent: TEST-NET-1 (RFC 5737), never a real server.
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/servers/192.0.2.1:4242"
+_assert_status 404 "DELETE /servers/192.0.2.1:4242 (unknown server) → 404"
+_assert_json_eq '.error.code' not_found \
+	'unknown ip:port carries error.code=not_found'
+
+# Same split on the other two routes that take the selector.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/servers/not-an-ip:4242/connect"
+_assert_status 400 "POST /servers/{malformed}/connect → 400"
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/servers/192.0.2.1:4242/connect"
+_assert_status 404 "POST /servers/{unknown ip:port}/connect → 404"
+
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" -d '{"static":true}' \
+	"$HOST/api/v0/servers/not-an-ip:4242"
+_assert_status 400 "PATCH /servers/{malformed} → 400"
+
 # --- Summary. -----------------------------------------------------
 echo
 if [ "$FAIL_COUNT" -eq 0 ]; then

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -472,6 +472,19 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/search/results/not-32-hex-chars/comments"
 _assert_status 400 "POST search comments (bad hash format) → 400"
 
+# Admin gate. The POST drives an unbounded Kad NOTES lookup on the daemon
+# (EC_OP_SHARED_FILE_SEARCH_KAD_NOTES), so a guest session must not reach
+# it; the GET is a plain read and stays open to guests.
+if [ "$HAVE_GUEST" = "1" ]; then
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
+		"$HOST/api/v0/search/results/$BOGUS/comments"
+	_assert_status 403 "POST /search/results/{hash}/comments (guest token) → 403"
+	_assert_json_eq '.error.code' forbidden \
+		'POST search comments guest carries error.code=forbidden'
+else
+	echo "    info: no guest password set on daemon; admin-gate test skipped"
+fi
+
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/search/results/$BOGUS/comments"
 _assert_status 404 "POST search comments (well-formed unknown hash) → 404"


### PR DESCRIPTION
Fixes #985.

Three independent behaviour bugs in the REST layer, each verified against the code and covered by a curl test.

### 1. `RequireAdmin` missing on both comment POSTs

`POST /downloads/{hash}/comments` and `POST /search/results/{hash}/comments` were the only mutating POSTs outside `/auth` without an admin check, and both drive an unbounded Kad NOTES lookup (`EC_OP_SHARED_FILE_SEARCH_KAD_NOTES`) - a guest session could make the daemon do real network work. Both now gate right after `Authenticate`, the position every other mutation uses.

This is a **documented** behaviour change, not only a code fix: the reference had these as `**Auth:** USER` (the only `USER` in the whole document) and `**Auth:** GUEST`. Both are now `ADMIN`, with `403 forbidden` added to their error lists.

### 2. Missing snapshot guard on `POST /downloads`

`HandleDownloadAdd` returned `202` before the first EC snapshot while every sibling returned `503`. Here the *docs were already right* - `POST /downloads` has always listed `503 ec_unavailable`; only the code diverged. No doc change needed.

### 3. `ResolveServerEcidByAddress` collapsed five outcomes onto `0`

No colon, empty half, bad port, non-dotted-quad, and genuine no-match all returned `0`, and all three callers mapped `0` to `404`. Split into:

- `ParseIpPortSelector` - parse only, independently testable
- `ResolveServerEcid` - maps outcomes to `400` / `404`, in the same shape as `RequireAdmin` (`nullptr` means proceed)

No caller compares an ECID against a magic value any more. The docs were *already right* here too - `POST /servers/{ip:port}/connect` has always listed `400 bad_request` (unparseable address); only `DELETE`'s error list had omitted it, and that is now added.

Two notes on the issue text:

- **`std::optional` is not available.** The tree builds as C++14 (`__cplusplus == 201402`, no `-std=` flag) and uses no C++17 library types anywhere. Used `boost::optional`, which `Api.cpp` already uses for `PreflightEvents`.
- **The "ECID 0" consequence is not reachable.** `CECID` assigns `m_ID = ++s_IDCounter` from `s_IDCounter = 0`, so the first ECID is 1. The `400`/`404` conflation alone justifies the redesign.

### Dedup rather than a 31st copy

The issue asked for the missing snapshot block to be pasted verbatim. That block was already written out **31 times**, all byte-identical. Added `RequireSnapshot` beside the existing `RequireAdmin` and converted every copy - 30 handlers plus one in the `ListResponse` template that takes `state` by parameter. The 503 contract now exists once. Likewise the three `/servers/{ip:port}` callers collapse to one `if (auto r = ResolveServerEcid(...)) return *r;`.

Net effect on `Api.cpp`: **+160 / -166**.

### Testing

Release and Debug build clean, `clang-format` clean, unit suite **34/34**.

Curl tests added to files that already had the fixtures, rather than new files: `12-downloads-add-patch.sh` (guest-403, its admin-gate section), `19-search.sh` (guest-403, its comments section), `14-servers-mutations.sh` (7 malformed → 400, unknown → 404, across all three routes).

Run against a live daemon: **all 13 new assertions pass**, `12-downloads-add-patch.sh` 42/42. Also run as a **positive control against a master-built `amuleapi`**, where 11 of the 13 fail - so the tests detect the bugs rather than passing vacuously. The two that pass on master (`unknown → 404`) are there to pin that the correct case survives.

**One acceptance criterion has no harness.** Asserting `POST /downloads` → `503` needs amuleapi *before* its first snapshot, and the suite does the opposite - `03-read-status.sh` polls up to 15 s waiting for that window to close. Nothing constructs `CApiDispatcher`/`CState` directly either, so there is no unit seam. The fix is verified by parity with its siblings and by the documented contract; building a pre-snapshot harness would be its own change.
