### PR TITLE
feat(amuleapi): expose server file limits and TCP/UDP capability flags

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -319,12 +319,22 @@ Identical to the REST [`/api/v0/servers`](REFERENCE.md#get-apiv0servers) list-it
   "users":       312000,
   "max_users":   500000,
   "files":       75000000,
+  "soft_file_limit": 1000,
+  "hard_file_limit": 5000,
   "priority":    "normal",
   "ping_ms":     42,
-  "failed":      0,
-  "static":      false
+  "failed_count": 0,
+  "static":      false,
+  "tcp_flags":   { "bitmask": 1497, "compression": true, "new_tags": true, "unicode": true,
+                   "related_search": true, "type_tag_integer": true, "large_files": true,
+                   "tcp_obfuscation": true },
+  "udp_flags":   { "bitmask": 1851, "get_sources": true, "get_files": true, "new_tags": true,
+                   "unicode": true, "get_sources_v2": true, "large_files": true,
+                   "udp_obfuscation": true, "tcp_obfuscation": true }
 }
 ```
+
+A server announces its capabilities and publishing limits only after it answers a UDP status request, which is usually a tick or two after it is added. Until then it reports `0` / all-`false`, and the reply produces one `server_updated`. Every bit is documented in [`GET /api/v0/servers`](REFERENCE.md#get-apiv0servers).
 
 #### `server_removed`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1480,16 +1480,72 @@ Send a bare priority level to pin it (the file's `priority_auto` becomes `false`
       "users": 312000,
       "max_users": 500000,
       "files": 75000000,
+      "soft_file_limit": 1000,
+      "hard_file_limit": 5000,
       "priority": "normal",
       "ping_ms": 42,
-      "failed": 0,
-      "static": false
+      "failed_count": 0,
+      "static": false,
+      "tcp_flags": {
+        "bitmask": 1497,
+        "compression": true,
+        "new_tags": true,
+        "unicode": true,
+        "related_search": true,
+        "type_tag_integer": true,
+        "large_files": true,
+        "tcp_obfuscation": true
+      },
+      "udp_flags": {
+        "bitmask": 1851,
+        "get_sources": true,
+        "get_files": true,
+        "new_tags": true,
+        "unicode": true,
+        "get_sources_v2": true,
+        "large_files": true,
+        "udp_obfuscation": true,
+        "tcp_obfuscation": true
+      }
     }
   ]
 }
 ```
 
 `country_code` is the ISO 3166-1 alpha-2 code (lowercase, e.g. `"de"`) of the server host, resolved server-side from the server IP by the daemon's GeoIP database — same semantics and empty-string fallback as the peer `country_code` on `/clients`, and the same artwork route, [`GET /flags/{code}.png`](#get-flagscodepng).
+
+`files` is how many files the server indexes. `soft_file_limit` and `hard_file_limit` are something else entirely: the per-user publishing limits the server advertises. Below the soft limit a client may publish every file it shares, between soft and hard only its rarest, above the hard limit nothing. Both arrive only once the server has answered a UDP status request, so **`0` means "not reported yet", not "the limit is zero"** — render it blank rather than as a number, the way the desktop's Soft Files / Hard Files columns do. `users`, `max_users` and `files` share that sentinel.
+
+`failed_count` is the number of consecutive failed connection attempts, not a boolean.
+
+`tcp_flags` and `udp_flags` are the eD2k wire capabilities the server announced, decoded server-side so a consumer never needs the protocol tables. Every key below is always present — `false` when the bit is clear — so there is no need to branch on key existence. `bitmask` carries the raw value alongside, both for diagnostics and so a bit a newer server announces that this build does not name yet is still visible. A server that has announced nothing yet reports `bitmask: 0` with every boolean `false`.
+
+`tcp_flags`:
+
+| Key | Bit | Meaning |
+|---|---|---|
+| `compression` | `0x0001` | zlib-compressed packets |
+| `new_tags` | `0x0008` | compact tag encoding |
+| `unicode` | `0x0010` | Unicode strings |
+| `related_search` | `0x0040` | related-files search — whether a `related::<hash>` local search will work against this server |
+| `type_tag_integer` | `0x0080` | integer file-type tags |
+| `large_files` | `0x0100` | files larger than 4 GiB |
+| `tcp_obfuscation` | `0x0400` | TCP protocol obfuscation |
+
+`udp_flags`:
+
+| Key | Bit | Meaning |
+|---|---|---|
+| `get_sources` | `0x0001` | extended GetSources request |
+| `get_files` | `0x0002` | extended GetFiles request |
+| `new_tags` | `0x0008` | compact tag encoding |
+| `unicode` | `0x0010` | Unicode strings |
+| `get_sources_v2` | `0x0020` | GetSources v2 |
+| `large_files` | `0x0100` | files larger than 4 GiB |
+| `udp_obfuscation` | `0x0200` | UDP obfuscation |
+| `tcp_obfuscation` | `0x0400` | TCP obfuscation, announced over UDP |
+
+Both objects spell out the transport on their obfuscation keys because `udp_flags` legitimately carries both bits; a key means exactly one wire capability in either object.
 
 **Errors:** `503 ec_unavailable`.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -25,6 +25,8 @@
 #include "Api.h"
 
 #include "ClientTagNames.h" // Needed for the shared client-tag token decoders
+// Shared server capability-bit tables, decoded to JSON
+#include "ServerFlagNames.h"
 
 #include "config.h" // AMULEAPI_STATIC_DIR (compile-time install path)
 #include "AmuleApiConfig.h"
@@ -4329,14 +4331,28 @@ void WriteServerObject(CJsonWriter &w, const webapi::ServerSnapshot &s)
 	w.ValueInt(static_cast<int64_t>(s.max_users));
 	w.Key("files");
 	w.ValueInt(static_cast<int64_t>(s.files));
+	// 0 means the server has not reported a limit yet, not a limit of zero;
+	// the sentinel is documented so a UI can render it blank the way the
+	// desktop's Soft/Hard Files columns do.
+	w.Key("soft_file_limit");
+	w.ValueInt(static_cast<int64_t>(s.soft_file_limit));
+	w.Key("hard_file_limit");
+	w.ValueInt(static_cast<int64_t>(s.hard_file_limit));
 	w.Key("priority");
 	w.ValueString(wxString::FromUTF8(s.priority.c_str()));
 	w.Key("ping_ms");
 	w.ValueInt(static_cast<int64_t>(s.ping_ms));
-	w.Key("failed");
-	w.ValueInt(static_cast<int64_t>(s.failed));
+	w.Key("failed_count");
+	w.ValueInt(static_cast<int64_t>(s.failed_count));
 	w.Key("static");
 	w.ValueBool(s.is_static);
+	// Decoded capability bits. Written as a pre-built fragment from the shared
+	// tables so this object and the SSE payload in EventDiff.cpp -- two
+	// different writers, one documented shape -- cannot drift apart.
+	w.Key("tcp_flags");
+	w.ValueRaw(wxString::FromAscii(webapi::ServerTcpFlagsJson(s.tcp_flags).c_str()));
+	w.Key("udp_flags");
+	w.ValueRaw(wxString::FromAscii(webapi::ServerUdpFlagsJson(s.udp_flags).c_str()));
 	w.EndObject();
 }
 

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -25,6 +25,7 @@
 #include "EventDiff.h"
 
 #include "EventBus.h"
+#include "ServerFlagNames.h" // Shared server capability-bit tables, decoded to JSON
 
 #include <algorithm>
 #include <atomic>
@@ -174,9 +175,14 @@ std::string ToJson(const ServerSnapshot &s)
 	  << ",\"address\":\"" << EscJson(s.address) << "\""
 	  << ",\"country_code\":\"" << EscJson(s.country_code) << "\""
 	  << ",\"port\":" << s.port << ",\"users\":" << s.users << ",\"max_users\":" << s.max_users
-	  << ",\"files\":" << s.files << ",\"priority\":\"" << EscJson(s.priority) << "\""
-	  << ",\"ping_ms\":" << s.ping_ms << ",\"failed\":" << s.failed
-	  << ",\"static\":" << (s.is_static ? "true" : "false") << "}";
+	  << ",\"files\":" << s.files << ",\"soft_file_limit\":" << s.soft_file_limit
+	  << ",\"hard_file_limit\":" << s.hard_file_limit << ",\"priority\":\"" << EscJson(s.priority) << "\""
+	  << ",\"ping_ms\":" << s.ping_ms << ",\"failed_count\":" << s.failed_count << ",\"static\":"
+	  << (s.is_static ? "true" : "false")
+	  // Same fragment builder WriteServerObject uses, so the event payload and
+	  // the REST object stay byte-identical here by construction.
+	  << ",\"tcp_flags\":" << ServerTcpFlagsJson(s.tcp_flags)
+	  << ",\"udp_flags\":" << ServerUdpFlagsJson(s.udp_flags) << "}";
 	return o.str();
 }
 
@@ -322,8 +328,9 @@ bool Equal(const ServerSnapshot &a, const ServerSnapshot &b)
 	return a.name == b.name && a.description == b.description && a.version == b.version &&
 	       a.address == b.address && a.country_code == b.country_code && a.port == b.port &&
 	       a.users == b.users && a.max_users == b.max_users && a.files == b.files &&
-	       a.priority == b.priority && a.ping_ms == b.ping_ms && a.failed == b.failed &&
-	       a.is_static == b.is_static;
+	       a.soft_file_limit == b.soft_file_limit && a.hard_file_limit == b.hard_file_limit &&
+	       a.tcp_flags == b.tcp_flags && a.udp_flags == b.udp_flags && a.priority == b.priority &&
+	       a.ping_ms == b.ping_ms && a.failed_count == b.failed_count && a.is_static == b.is_static;
 }
 bool Equal(const FriendSnapshot &a, const FriendSnapshot &b)
 {

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1578,7 +1578,7 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 	{
 		std::uint32_t v = 0;
 		if (st->AssignIfExist(EC_TAG_SERVER_FAILED, v))
-			s.failed = v;
+			s.failed_count = v;
 	}
 	{
 		std::uint32_t v = 0;
@@ -1594,6 +1594,30 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 		std::uint32_t v = 0;
 		if (st->AssignIfExist(EC_TAG_SERVER_FILES, v))
 			s.files = v;
+	}
+	// Publishing limits and wire capability flags. Both server-tag builders
+	// emit all four (ECSpecialCoreTags.cpp), so the initial list and the
+	// incremental updates carry them alike; a tick where CValueMap suppresses
+	// an unchanged tag leaves the cached value intact, as above.
+	{
+		std::uint32_t v = 0;
+		if (st->AssignIfExist(EC_TAG_SERVER_FILES_SOFT, v))
+			s.soft_file_limit = v;
+	}
+	{
+		std::uint32_t v = 0;
+		if (st->AssignIfExist(EC_TAG_SERVER_FILES_HARD, v))
+			s.hard_file_limit = v;
+	}
+	{
+		std::uint32_t v = 0;
+		if (st->AssignIfExist(EC_TAG_SERVER_TCP_FLAGS, v))
+			s.tcp_flags = v;
+	}
+	{
+		std::uint32_t v = 0;
+		if (st->AssignIfExist(EC_TAG_SERVER_UDP_FLAGS, v))
+			s.udp_flags = v;
 	}
 	{
 		std::uint32_t v = 0;

--- a/src/webapi/ServerFlagNames.h
+++ b/src/webapi/ServerFlagNames.h
@@ -1,0 +1,136 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef WEBAPI_SERVERFLAGNAMES_H
+#define WEBAPI_SERVERFLAGNAMES_H
+
+#include <protocol/ed2k/Client2Server/TCP.h>
+#include <protocol/ed2k/Client2Server/UDP.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace webapi
+{
+
+/**
+ * The eD2k server capability bitmasks, decoded to stable JSON keys.
+ *
+ * A server announces what it supports as two bitmasks; the API decodes them
+ * server-side so a consumer never has to carry a copy of the aMule protocol
+ * headers, the same rule /clients already follows for its numeric enums (see
+ * ClientTagNames.h).
+ *
+ * Header-only, and deliberately built around a string-returning helper rather
+ * than a per-writer emit loop: the REST object (Api.cpp, via CJsonWriter) and
+ * the SSE payload (EventDiff.cpp, via ostringstream) use different writers but
+ * are documented as carrying the identical object, so they call the same
+ * function and emit the same bytes. Only the two tables below decide what a flags
+ * object contains; adding a bit is a one-line change that both paths pick up.
+ *
+ * EventDiff.cpp is compiled into EventDiffTest, which is stdlib-only by
+ * design, so nothing here may reach for wxWidgets or EC.
+ *
+ * These are protocol tokens, not display text: untranslated and stable. The
+ * desktop's TCP/UDP Flags columns render the same bits as single letters
+ * (ServerListCtrl.cpp), which is a separate presentation of the same data.
+ */
+
+struct ServerFlagBit
+{
+	std::uint32_t mask;
+	const char *key;
+};
+
+/**
+ * One flags object: `{"bitmask":N,"compression":true,...}`.
+ *
+ * Every key in the table is always present, false when its bit is clear, so a
+ * consumer never branches on key existence. `bitmask` rides along for the
+ * diagnostic case and for any bit a future server announces that this build
+ * does not name yet -- decoding it to booleans alone would silently drop it.
+ *
+ * All keys are ASCII literals from the tables, so no JSON escaping is needed.
+ */
+inline std::string ServerFlagsJson(std::uint32_t bits, const ServerFlagBit *table, std::size_t count)
+{
+	std::string out = "{\"bitmask\":";
+	out += std::to_string(bits);
+	for (std::size_t i = 0; i < count; ++i) {
+		out += ",\"";
+		out += table[i].key;
+		out += "\":";
+		out += (bits & table[i].mask) != 0 ? "true" : "false";
+	}
+	out += "}";
+	return out;
+}
+
+/**
+ * The TCP capability object for `tcp_flags`.
+ *
+ * Bits from include/protocol/ed2k/Client2Server/TCP.h, in wire-bit order.
+ * The table is a function-local static rather than a namespace-scope one so
+ * every translation unit including this header shares a single instance.
+ */
+inline std::string ServerTcpFlagsJson(std::uint32_t bits)
+{
+	static const ServerFlagBit kBits[] = {
+		{ SRV_TCPFLG_COMPRESSION, "compression" },
+		{ SRV_TCPFLG_NEWTAGS, "new_tags" },
+		{ SRV_TCPFLG_UNICODE, "unicode" },
+		{ SRV_TCPFLG_RELATEDSEARCH, "related_search" },
+		{ SRV_TCPFLG_TYPETAGINTEGER, "type_tag_integer" },
+		{ SRV_TCPFLG_LARGEFILES, "large_files" },
+		// Spelled out rather than plain "obfuscation" because the UDP
+		// object below carries both a UDP- and a TCP-obfuscation bit;
+		// one key means one wire constant in either object.
+		{ SRV_TCPFLG_TCPOBFUSCATION, "tcp_obfuscation" },
+	};
+	return ServerFlagsJson(bits, kBits, sizeof(kBits) / sizeof(kBits[0]));
+}
+
+//! The UDP capability object for `udp_flags`. Bits from
+//! include/protocol/ed2k/Client2Server/UDP.h, in wire-bit order.
+inline std::string ServerUdpFlagsJson(std::uint32_t bits)
+{
+	static const ServerFlagBit kBits[] = {
+		{ SRV_UDPFLG_EXT_GETSOURCES, "get_sources" },
+		{ SRV_UDPFLG_EXT_GETFILES, "get_files" },
+		{ SRV_UDPFLG_NEWTAGS, "new_tags" },
+		{ SRV_UDPFLG_UNICODE, "unicode" },
+		// "_v2" not "2": a bare digit glued to the name reads like a count.
+		{ SRV_UDPFLG_EXT_GETSOURCES2, "get_sources_v2" },
+		{ SRV_UDPFLG_LARGEFILES, "large_files" },
+		{ SRV_UDPFLG_UDPOBFUSCATION, "udp_obfuscation" },
+		{ SRV_UDPFLG_TCPOBFUSCATION, "tcp_obfuscation" },
+	};
+	return ServerFlagsJson(bits, kBits, sizeof(kBits) / sizeof(kBits[0]));
+}
+
+} // namespace webapi
+
+#endif // WEBAPI_SERVERFLAGNAMES_H
+// File_checked_for_headers

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -409,10 +409,23 @@ struct ServerSnapshot
 	// resolved by the daemon's GeoIP (#440). "" when GeoIP is off/unresolved.
 	std::string country_code;
 	std::uint32_t ping_ms = 0;
-	std::uint32_t failed = 0;
+	std::uint32_t failed_count = 0;
 	std::uint32_t users = 0;
 	std::uint32_t max_users = 0;
 	std::uint32_t files = 0;
+	// Per-user publishing limits the server advertises: below the soft limit a
+	// client may publish every file, between soft and hard only its rarest,
+	// above the hard limit nothing. Both arrive only once a UDP status reply
+	// has come back, so 0 means "the server has not told us", not "the limit
+	// is zero" -- the desktop renders that as a blank cell, as it does for
+	// Users and Files.
+	std::uint32_t soft_file_limit = 0;
+	std::uint32_t hard_file_limit = 0;
+	// Bitmasks of the eD2k wire capabilities the server announced, decoded to
+	// booleans on the way out (ServerFlagNames.h). 0 likewise means "nothing
+	// announced yet" rather than "supports nothing".
+	std::uint32_t tcp_flags = 0;
+	std::uint32_t udp_flags = 0;
 	std::string priority; // "low" | "normal" | "high"
 	bool is_static = false;
 };

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -103,6 +103,30 @@ if [ "$COUNT" -gt 0 ]; then
 	# #440 server country: always-present ISO 3166-1 alpha-2 string,
 	# empty when GeoIP is off/unresolved (never absent/null).
 	_assert_json_eq '.servers[0].country_code | type' string '/servers[0].country_code is string (#440)'
+	# Consecutive failed connection attempts -- a counter, not a boolean,
+	# which is why the key is not just "failed".
+	_assert_json_eq '.servers[0].failed_count | type' number '/servers[0].failed_count is numeric'
+	# Per-user publishing limits. Always present; 0 until the server has
+	# answered a UDP status request, so a value is not guaranteed here.
+	_assert_json_eq '.servers[0].soft_file_limit | type' number '/servers[0].soft_file_limit is numeric'
+	_assert_json_eq '.servers[0].hard_file_limit | type' number '/servers[0].hard_file_limit is numeric'
+	# Decoded capability bits: an object carrying the raw bitmask plus one
+	# always-present boolean per named bit, so a consumer never has to test
+	# for a key or carry the eD2k protocol tables.
+	_assert_json_eq '.servers[0].tcp_flags | type'                 object  '/servers[0].tcp_flags is an object'
+	_assert_json_eq '.servers[0].tcp_flags.bitmask | type'         number  '/servers[0].tcp_flags.bitmask is numeric'
+	_assert_json_eq '.servers[0].tcp_flags.related_search | type'  boolean '/servers[0].tcp_flags.related_search is boolean'
+	_assert_json_eq '.servers[0].tcp_flags.tcp_obfuscation | type' boolean '/servers[0].tcp_flags.tcp_obfuscation is boolean'
+	_assert_json_eq '.servers[0].udp_flags | type'                 object  '/servers[0].udp_flags is an object'
+	_assert_json_eq '.servers[0].udp_flags.bitmask | type'         number  '/servers[0].udp_flags.bitmask is numeric'
+	_assert_json_eq '.servers[0].udp_flags.get_sources_v2 | type'  boolean '/servers[0].udp_flags.get_sources_v2 is boolean'
+	# The two obfuscation bits are distinct keys in the UDP object; the
+	# TCP object spells its own out for the same reason.
+	_assert_json_eq '.servers[0].udp_flags.udp_obfuscation | type' boolean '/servers[0].udp_flags.udp_obfuscation is boolean'
+	_assert_json_eq '.servers[0].udp_flags.tcp_obfuscation | type' boolean '/servers[0].udp_flags.tcp_obfuscation is boolean'
+	# Each decoded boolean must agree with the bitmask it came from.
+	_assert_json_eq '.servers[0].tcp_flags | (.bitmask / 64 | floor | . % 2 == 1) == .related_search' \
+		true '/servers[0].tcp_flags.related_search matches bit 0x0040 of the bitmask'
 fi
 
 # --- 2. /kad -------------------------------------------------------

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -551,6 +551,9 @@ add_executable (EventDiffTest
 )
 target_include_directories (EventDiffTest
 	PRIVATE ${CMAKE_SOURCE_DIR}/src/webapi
+	# ServerFlagNames.h reads the SRV_*FLG_* masks straight from the eD2k
+	# protocol headers rather than restating them.
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
 )
 add_test (NAME EventDiffTest COMMAND EventDiffTest)
 target_link_libraries (EventDiffTest

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -26,6 +26,7 @@
 
 #include "EventBus.h"
 #include "EventDiff.h"
+#include "ServerFlagNames.h"
 #include "State.h"
 
 #include <chrono>
@@ -284,4 +285,103 @@ TEST(EventDiff, ClientUpdatedFiresOnUploadFileNameChange)
 	}
 	ASSERT_EQUALS(1, updated);
 	ASSERT_TRUE(payload.find("b.iso") != std::string::npos);
+}
+
+// Same contract as the client test above, for the capability bitmasks issue
+// #974 added: a server announcing its flags after the first UDP status reply
+// has to fire exactly one server_updated, and the payload has to carry the
+// decoded object -- not just the raw bitmask.
+TEST(EventDiff, ServerUpdatedFiresOnTcpFlagsChange)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	// A freshly added server, before any UDP status reply came back:
+	// nothing announced, so every bit is clear.
+	state.MutateServers([](std::map<std::uint32_t, ServerSnapshot> &cache) {
+		ServerSnapshot s;
+		s.ecid = 5;
+		s.name = "srv";
+		cache.emplace(s.ecid, s);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	// The reply lands and the server announces what it supports.
+	state.MutateServers([](std::map<std::uint32_t, ServerSnapshot> &cache) {
+		cache.at(5).tcp_flags = SRV_TCPFLG_COMPRESSION | SRV_TCPFLG_RELATEDSEARCH;
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	const auto drained = DrainAll(bus);
+	int updated = 0;
+	std::string payload;
+	for (const auto &ev : drained) {
+		if (ev.name == "server_updated") {
+			++updated;
+			payload = ev.data;
+		}
+	}
+	ASSERT_EQUALS(1, updated);
+	ASSERT_TRUE(payload.find("\"related_search\":true") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"compression\":true") != std::string::npos);
+	// A bit that was not announced is present and false, never absent:
+	// consumers are documented as never having to test for the key.
+	ASSERT_TRUE(payload.find("\"unicode\":false") != std::string::npos);
+}
+
+// The publishing limits move independently of the flags and are likewise
+// carried in the payload rather than requiring a re-GET.
+TEST(EventDiff, ServerUpdatedFiresOnFileLimitChange)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	state.MutateServers([](std::map<std::uint32_t, ServerSnapshot> &cache) {
+		ServerSnapshot s;
+		s.ecid = 6;
+		s.name = "srv";
+		cache.emplace(s.ecid, s);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	state.MutateServers([](std::map<std::uint32_t, ServerSnapshot> &cache) {
+		cache.at(6).soft_file_limit = 1000;
+		cache.at(6).hard_file_limit = 5000;
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	const auto drained = DrainAll(bus);
+	int updated = 0;
+	std::string payload;
+	for (const auto &ev : drained) {
+		if (ev.name == "server_updated") {
+			++updated;
+			payload = ev.data;
+		}
+	}
+	ASSERT_EQUALS(1, updated);
+	ASSERT_TRUE(payload.find("\"soft_file_limit\":1000") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"hard_file_limit\":5000") != std::string::npos);
+}
+
+// The flags object is built by one shared helper so the REST writer
+// (Api.cpp, CJsonWriter) and this SSE writer emit the same bytes. Pin the
+// exact shape: key order follows the wire-bit order, bitmask leads.
+TEST(EventDiff, ServerFlagsJsonShape)
+{
+	ASSERT_EQUALS(std::string("{\"bitmask\":0,\"compression\":false,\"new_tags\":false,"
+				  "\"unicode\":false,\"related_search\":false,"
+				  "\"type_tag_integer\":false,\"large_files\":false,"
+				  "\"tcp_obfuscation\":false}"),
+		webapi::ServerTcpFlagsJson(0));
+
+	// An unnamed bit survives in `bitmask` even though no boolean
+	// describes it -- that is what the field is there for.
+	ASSERT_TRUE(webapi::ServerUdpFlagsJson(0x8000u).find("\"bitmask\":32768") != std::string::npos);
 }

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -761,6 +761,87 @@ TEST(Refresher, ServersFromContainerMergesByEcid)
 	ASSERT_EQUALS(std::string("de"), cache[42].country_code);
 }
 
+// The four fields issue #974 added: publishing limits + capability
+// bitmasks. They ride the same GET_UPDATE response the rest of the
+// server snapshot comes from, so the only thing to prove is that
+// MergeServerTag reads them and that a tag CValueMap suppressed on an
+// unchanged tick does not clobber the cached value.
+TEST(Refresher, ServerLimitsAndFlagsReachTheSnapshot)
+{
+	std::map<std::uint32_t, ServerSnapshot> cache;
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	{
+		CECTag container(EC_TAG_SERVER, static_cast<std::uint32_t>(0));
+		CECTag srv(EC_TAG_SERVER, static_cast<std::uint32_t>(7));
+		srv.AddTag(CECTag(EC_TAG_SERVER_FILES_SOFT, static_cast<std::uint32_t>(1000)));
+		srv.AddTag(CECTag(EC_TAG_SERVER_FILES_HARD, static_cast<std::uint32_t>(5000)));
+		srv.AddTag(CECTag(EC_TAG_SERVER_TCP_FLAGS,
+			static_cast<std::uint32_t>(SRV_TCPFLG_COMPRESSION | SRV_TCPFLG_RELATEDSEARCH)));
+		srv.AddTag(CECTag(EC_TAG_SERVER_UDP_FLAGS,
+			static_cast<std::uint32_t>(SRV_UDPFLG_EXT_GETSOURCES | SRV_UDPFLG_LARGEFILES)));
+		container.AddTag(srv);
+		resp.AddTag(container);
+	}
+
+	ApplyGetUpdateToServers(&resp, cache);
+
+	ASSERT_TRUE(cache.find(7) != cache.end());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1000), cache[7].soft_file_limit);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(5000), cache[7].hard_file_limit);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_TCPFLG_COMPRESSION | SRV_TCPFLG_RELATEDSEARCH),
+		cache[7].tcp_flags);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_UDPFLG_EXT_GETSOURCES | SRV_UDPFLG_LARGEFILES),
+		cache[7].udp_flags);
+
+	// Next tick: the server is still in the list but nothing it
+	// announced changed, so CValueMap suppresses all four tags. The
+	// cached values have to survive -- dropping to 0 here would read
+	// as "the server stopped supporting everything".
+	CECPacket quiet(EC_OP_SHARED_FILES);
+	{
+		CECTag container(EC_TAG_SERVER, static_cast<std::uint32_t>(0));
+		CECTag srv(EC_TAG_SERVER, static_cast<std::uint32_t>(7));
+		srv.AddTag(CECTag(EC_TAG_SERVER_USERS, static_cast<std::uint32_t>(42)));
+		container.AddTag(srv);
+		quiet.AddTag(container);
+	}
+
+	ApplyGetUpdateToServers(&quiet, cache);
+
+	ASSERT_EQUALS(static_cast<std::uint32_t>(42), cache[7].users);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1000), cache[7].soft_file_limit);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(5000), cache[7].hard_file_limit);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_TCPFLG_COMPRESSION | SRV_TCPFLG_RELATEDSEARCH),
+		cache[7].tcp_flags);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(SRV_UDPFLG_EXT_GETSOURCES | SRV_UDPFLG_LARGEFILES),
+		cache[7].udp_flags);
+}
+
+// A server old enough not to send the tags at all leaves the defaults
+// in place: 0 / 0 / no bits, which the API documents as "not reported".
+TEST(Refresher, ServerWithoutLimitOrFlagTagsKeepsZeroDefaults)
+{
+	std::map<std::uint32_t, ServerSnapshot> cache;
+
+	CECPacket resp(EC_OP_SHARED_FILES);
+	{
+		CECTag container(EC_TAG_SERVER, static_cast<std::uint32_t>(0));
+		CECTag srv(EC_TAG_SERVER, static_cast<std::uint32_t>(3));
+		srv.AddTag(CECTag(EC_TAG_SERVER_USERS, static_cast<std::uint32_t>(9)));
+		container.AddTag(srv);
+		resp.AddTag(container);
+	}
+
+	ApplyGetUpdateToServers(&resp, cache);
+
+	ASSERT_TRUE(cache.find(3) != cache.end());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), cache[3].soft_file_limit);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), cache[3].hard_file_limit);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), cache[3].tcp_flags);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), cache[3].udp_flags);
+}
+
 TEST(Refresher, ServersEmptyContainerEmptiesCache)
 {
 	std::map<std::uint32_t, ServerSnapshot> cache;


### PR DESCRIPTION
Closes #974.

`GET /api/v0/servers` covered 12 of the desktop server list's 16 columns. The four missing ones — Soft Files, Hard Files, TCP Flags and UDP Flags — were already on the wire: both `CEC_Server_Tag` constructors emit them and libec has typed accessors for all four, but `MergeServerTag` never looked at them. This is amuleapi-side only — no core change, no EC protocol change, no extra round-trip.

One of the fields is functionally load-bearing rather than cosmetic. The `related_search` TCP flag is what the desktop gates its *"Search related files (eD2k, local server)"* action on, so without it a REST client cannot tell whether a `related::<hash>` local search will work against the currently connected server.

## The new fields

| Field | Type | Meaning |
|---|---|---|
| `soft_file_limit` | int | Per-user *soft* publishing limit the server advertises. `0` = not reported yet. |
| `hard_file_limit` | int | Per-user *hard* publishing limit. `0` = not reported yet. |
| `tcp_flags` | object | Decoded TCP capability bits, plus `bitmask`. |
| `udp_flags` | object | Decoded UDP capability bits, plus `bitmask`. |
| `failed_count` | int | **Renamed** from `failed`. Consecutive failed connection attempts. |

The bitmasks are decoded server-side into objects of named booleans rather than shipped as bare integers, which is the rule `/clients` already follows for its numeric enums — a bare `tcp_flags: 1497` would force every consumer to carry a copy of two `#define` blocks out of the aMule tree. Every boolean is always present (`false` when the bit is clear), so consumers never branch on key existence. The raw value rides along as `bitmask` for diagnostics and so a bit a newer server announces that this build does not name yet is still visible rather than silently dropped.

Both limits and both bitmasks are `0` until the server answers a UDP status request. That means "not reported yet", not a real zero, and the docs say so, so a UI can render it blank the way the desktop's columns do.

`failed` became `failed_count` because `"failed": 0` reads as a boolean that happens to be serialized as a number, when it is a counter of consecutive failures. `/api/v0/` is experimental and the key has no consumer — not the bundled web UI, not the curl tests, only the two doc files — so the rename lands in place rather than waiting for a `v1`.

## One decode, two writers

The obvious dedup — having the SSE writer call the REST writer — does not work here: `EventDiff.cpp` is compiled into `EventDiffTest`, which is deliberately stdlib-only, while `WriteServerObject` takes a `CJsonWriter` and so pulls in wxWidgets.

What is shared instead is the finished JSON fragment. `ServerFlagNames.h` owns the bit tables and returns the object as a string; `Api.cpp` hands it to `CJsonWriter::ValueRaw()` (which exists for exactly this) and `EventDiff.cpp` streams it. The REST object and the SSE payload are documented as identical, and this makes them identical by construction rather than by two hand-maintained copies of the bit list. Adding a future flag is a one-line change both paths pick up.

The tables are function-local statics rather than namespace-scope `static const`, so the inline functions in the header do not reference an internal-linkage object across translation units.

The desktop's TCP/UDP Flags columns render the same bits as single letters. That rendering is deliberately left alone: it is presentation, not a protocol token, and the sibling `ClientTagNames.h` already draws that line explicitly.

## Verification

Checked against a live `amuled` connected to real ed2k servers, on an isolated config dir and ports:

- **90 bit assertions across 6 real servers, 0 mismatches.** The connected server reports `tcp=0x17f9`, which decodes to the letters `cnurtlo` the desktop renders for the same value; servers not currently connected report `0`, since TCP flags arrive with the login handshake and only UDP flags persist in `server.met`. Real limits came through (`soft=10000 hard=12000`), and a never-contacted server exercised the all-zero path.
- **The SSE `server_updated` payload is identical to the REST object** — same keys, same values, same key order.
- New unit tests cover the merge path, the `CValueMap` suppression path (an unchanged tag must not clobber a cached value), the zero defaults against an `amuled` that never sends the tags, `server_updated` firing on a flags-only and a limits-only change, and the exact JSON shape of a flags object.
- The curl-test additions assert the new keys, that each flags object is an object with a numeric `bitmask`, and that a decoded boolean agrees with the bit it came from.

No new translatable strings, so no catalog regeneration.

## Not included

The optional web-UI columns for the two limits. The flag objects are diagnostics — the desktop hides those two columns by default — and the limits can ship as a separate front-end change.
