### PR TITLE
feat(amuleapi): swap a single A4AF source onto a file, and report whether it worked

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -810,7 +810,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 Force A4AF source-swapping for this download. Downloads-only.
 
-**Body:** `{ "action": "<action>" }`
+**Body:** `{ "action": "<action>", "client_ecid": 1234 }`
 
 | action | Effect |
 |---|---|
@@ -818,9 +818,15 @@ Force A4AF source-swapping for this download. Downloads-only.
 | `swap_this_auto` | Toggle automatic A4AF swapping for this file. |
 | `swap_others` | Release this file's sources to the other files that want them. |
 
+`client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-peer "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_this_auto` or `swap_others` is a `400`, because the core has no per-source form of those.
+
+A successful single-source swap shows up as that `client_ecid` having left `sources` in the response.
+
+The swap moves the peer between two files' source lists, so an SSE subscriber sees `download_updated` for **both** the peer's former download and this one, plus `client_updated` for the peer itself.
+
 **Response:** `200 OK` — the post-action A4AF view (same shape as the `GET`).
 
-**Errors:** `400 bad_request` (missing or unknown `action`), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (missing or unknown `action`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads`
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2121,6 +2121,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:06+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2160,6 +2160,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:07+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2187,6 +2187,10 @@ msgstr "Nome de ficheru incorreutu"
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nun ye dable renomar ficheru"
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:09+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2154,6 +2154,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2120,6 +2120,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2180,6 +2180,10 @@ msgstr "Nom de fitxer invàlid."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "No s'ha pogut canviar el nom del fitxer."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:10+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2173,6 +2173,10 @@ msgstr "Neplatný název souboru."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nelze přejmenovat soubor."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:12+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2165,6 +2165,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:13+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2185,6 +2185,10 @@ msgstr "Ungültiger Dateiname."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Datei kann nicht umbenannt werden."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:14+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2197,6 +2197,10 @@ msgstr "Άκυρο όνομα αρχείου."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Αποτυχία μετονομασίας αρχείου."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2121,6 +2121,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:14+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2172,6 +2172,10 @@ msgstr "Nombre de archivo incorrecto."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "No se puede renombrar el archivo."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2180,6 +2180,10 @@ msgstr "Vigane failinimi."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ei suuda faili ringinimetada."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:16+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2181,6 +2181,10 @@ msgstr "Fitxategi izen baliogabea."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ezinda fitxategia berrizendatu."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:16+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2181,6 +2181,10 @@ msgstr "Epäkelpo tiedostonimi."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Tiedostoa ei voitu uudelleennimetä."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:17+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2171,6 +2171,10 @@ msgstr "Nom de fichier invalide."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Impossible de renommer le fichier."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:17+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2198,6 +2198,10 @@ msgstr "Nome de ficheiro inválido."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Imposible cambiarlle o nome ao ficheiro."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:19+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2176,6 +2176,10 @@ msgstr "שם קובץ לא תכף."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "לא מצליח לשנות את השם של הקובץ."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2173,6 +2173,10 @@ msgstr "Nepravilan naziv datoteke."
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:20+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2172,6 +2172,10 @@ msgstr "Érvénytelen fájl név."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nem tudom átnevezni a fájlt."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:20+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2178,6 +2178,10 @@ msgstr "Nome file non valido."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Impossibile rinominare il file."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2183,6 +2183,10 @@ msgstr "不正なファイル名。"
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "ファイルを改名できません。"
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:23+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2194,6 +2194,10 @@ msgstr "유효하지 않은 파일 이름입니다."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "파일이름을 변경할 수 없습니다."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:24+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2204,6 +2204,10 @@ msgstr "Klaidingas failo pavadinimas."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nepavyko pervadinti failo."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:39+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2144,6 +2144,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:27+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2168,6 +2168,10 @@ msgstr "Ongeldige bestandsnaam."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Kon naam van bestand niet wijzigen."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:28+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2195,6 +2195,10 @@ msgstr "Ikkje gangbart filnamn."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ikkje i stand til å døype om fila."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:29+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2190,6 +2190,10 @@ msgstr "Nieprawidłowa nazwa pliku."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nie udało się zmienić nazwy pliku."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:29+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2172,6 +2172,10 @@ msgstr "Nome de arquivo inválido."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Não foi possível renomear o arquivo."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:30+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2187,6 +2187,10 @@ msgstr "Nome de ficheiro inválido."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Não é possível renomear o ficheiro."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:31+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2187,6 +2187,10 @@ msgstr "Nume fișier nevalid."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Nu se poate redenumii fișierul."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:32+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2188,6 +2188,10 @@ msgstr "Неверное имя файла."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Невозможно переименовать файл."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:32+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2201,6 +2201,10 @@ msgstr "Neveljavno ime datoteke."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Ni mogoče preimenovati datoteke."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:34+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2190,6 +2190,10 @@ msgstr "Emri i failit i pavlere."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "E pamundur te riemeroje failin."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:34+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2179,6 +2179,10 @@ msgstr "Ogiltigt filnamn."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Kunde inte byta namn på fil."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:42+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2120,6 +2120,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2164,6 +2164,10 @@ msgstr "Geçersiz dosya adı."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Dosya yeniden adlandırılamıyor."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:36+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2200,6 +2200,10 @@ msgstr "Недопустима назва файлу."
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "Неможливо змінити назву файлу."
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2119,6 +2119,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:36+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2168,6 +2168,10 @@ msgstr "无效的文件名。"
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "无法重命名文件。"
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-20 11:35+0200\n"
+"POT-Creation-Date: 2026-08-21 11:21+0200\n"
 "PO-Revision-Date: 2026-08-20 14:37+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2177,6 +2177,10 @@ msgstr "無效的檔名。"
 #: src/ExternalConn.cpp
 msgid "Unable to rename file."
 msgstr "無法重新命名。"
+
+#: src/ExternalConn.cpp
+msgid "Client could not be swapped to that file."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, c-format

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -3712,14 +3712,30 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	}
 	case EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE: {
+		// Report what happened rather than answering NOOP either way. The swap
+		// is best-effort in the core -- it refuses a peer that is actively
+		// sending, and a peer that is not an A4AF source of the target has
+		// nowhere to go -- and a caller that cannot tell those apart from
+		// success can only guess. amulegui registers a null handler for this
+		// op and discards the reply whatever its opcode, so nothing on that
+		// side needs to change.
 		uint32 idClient = request->GetTagByNameSafe(EC_TAG_CLIENT)->GetInt();
 		CUpDownClient *client = theApp->clientlist->FindClientByECID(idClient);
 		CMD4Hash idFile = request->GetTagByNameSafe(EC_TAG_PARTFILE)->GetMD4Data();
 		CPartFile *file = theApp->downloadqueue->GetFileByID(idFile);
-		if (client && file) {
-			client->SwapToAnotherFile(true, false, false, file);
+		if (!client) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Client not found.")));
+		} else if (!file) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("File not found.")));
+		} else if (!client->SwapToAnotherFile(true, false, false, file)) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(
+				EC_TAG_STRING, wxTRANSLATE("Client could not be swapped to that file.")));
+		} else {
+			response = new CECPacket(EC_OP_NOOP);
 		}
-		response = new CECPacket(EC_OP_NOOP);
 		break;
 	}
 	case EC_OP_SHARED_FILE_SET_COMMENT: {

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3325,6 +3325,11 @@ CHttpServer::Response CApiDispatcher::HandleDownloadFilenames(
 // resolved download snapshot.
 namespace
 {
+// Defined further down beside its FindServerByEcid / FindFriendByEcid
+// siblings; declared here so the per-source A4AF swap can validate its
+// `client_ecid` without moving the helper away from its family or copying it.
+bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::ClientSnapshot &out);
+
 void WriteA4afObject(CJsonWriter &w, const webapi::FileSnapshot &d)
 {
 	w.BeginObject();
@@ -3416,11 +3421,45 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 			400, "bad_request", "`action` must be one of swap_this, swap_this_auto, swap_others");
 	}
 
+	// `client_ecid` narrows swap_this from "every A4AF source of this file" to
+	// one named source, which is what the desktop's per-peer "Swap to this
+	// file" does. The core has no per-source form of the other two actions, so
+	// pairing it with them is a request that cannot be honoured rather than one
+	// that quietly does something else.
+	bool per_source = false;
+	std::uint32_t client_ecid = 0;
+	if (const auto cit = obj.find("client_ecid"); cit != obj.end()) {
+		if (!cit->second.is<double>() || cit->second.get<double>() < 0) {
+			return ErrorResponse(
+				400, "bad_request", "`client_ecid` must be a non-negative integer");
+		}
+		if (op != EC_OP_PARTFILE_SWAP_A4AF_THIS) {
+			return ErrorResponse(
+				400, "bad_request", "`client_ecid` is only valid with action `swap_this`");
+		}
+		per_source = true;
+		client_ecid = static_cast<std::uint32_t>(cit->second.get<double>());
+
+		webapi::ClientSnapshot peer;
+		if (!FindClientByEcid(m_state, client_ecid, peer)) {
+			return ErrorResponse(
+				404, "not_found", "no client with that ECID in the current snapshot");
+		}
+		const auto &srcs = d.download.a4af_sources;
+		if (std::find(srcs.begin(), srcs.end(), client_ecid) == srcs.end()) {
+			return ErrorResponse(
+				409, "conflict", "that client is not an A4AF source of this download");
+		}
+	}
+
 	CMD4Hash file_hash;
 	if (!HashFromHex(d.hash, file_hash)) {
 		return ErrorResponse(500, "internal_error", "failed to decode partfile hash");
 	}
-	std::unique_ptr<CECPacket> ec_req(new CECPacket(op));
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(per_source ? EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE : op));
+	if (per_source) {
+		ec_req->AddTag(CECTag(EC_TAG_CLIENT, client_ecid));
+	}
 	ec_req->AddTag(CECTag(EC_TAG_PARTFILE, file_hash));
 	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
 	if (!ec_resp) {

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -211,6 +211,48 @@ if [ "$COUNT" -gt 0 ]; then
 		-d '{"action":"bogus"}' "$HOST/api/v0/downloads/$HASH/a4af"
 	_assert_status 400 "POST /downloads/{hash}/a4af unknown action → 400"
 
+	# Per-source swap (issue #983): `client_ecid` narrows swap_this to one
+	# source. Validation is asserted here rather than the swap itself — a
+	# regtest daemon has no A4AF source to move, and the conflict/not-found
+	# paths are the ones that must never silently succeed.
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"swap_this","client_ecid":"nope"}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 400 "POST a4af with a non-integer client_ecid → 400"
+
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"swap_others","client_ecid":1}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 400 "POST a4af with client_ecid on swap_others → 400"
+
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"swap_this_auto","client_ecid":1}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 400 "POST a4af with client_ecid on swap_this_auto → 400"
+
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"swap_this","client_ecid":4294967290}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 404 "POST a4af naming an unknown client_ecid → 404"
+
+	# A live peer that is not an A4AF source of this file is a conflict, not a
+	# no-op: pick any client from /clients and ensure it is absent from the
+	# A4AF list before asserting.
+	OTHER_ECID=$(curl -s -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/clients?limit=1" \
+		| jq -r '.clients[0].client_ecid // empty')
+	if [ -n "$OTHER_ECID" ]; then
+		IN_A4AF=$(curl -s -H "Authorization: Bearer $TOKEN" \
+			"$HOST/api/v0/downloads/$HASH/a4af" \
+			| jq -r --argjson e "$OTHER_ECID" '[.sources[] | select(. == $e)] | length')
+		if [ "$IN_A4AF" = "0" ]; then
+			_curl -X POST -H "Authorization: Bearer $TOKEN" \
+				-H "Content-Type: application/json" \
+				-d "{\"action\":\"swap_this\",\"client_ecid\":$OTHER_ECID}" \
+				"$HOST/api/v0/downloads/$HASH/a4af"
+			_assert_status 409 "POST a4af for a non-A4AF client → 409"
+		fi
+	fi
+
 	# Valid action → 200 (no-op on a download with no A4AF sources, but
 	# exercises the EC op path). Response echoes the A4AF view.
 	_curl -X POST -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
Closes #983.

The peer context menu's **Swap to this file** takes one A4AF source — a peer holding this file while serving another — and moves it onto this file now. amuleapi could only do the three *file-wide* A4AF actions, which move every source at once. There was no way to move one.

The daemon has implemented `EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE` for years and amulegui already sends it, so this is the REST half plus the core fix @ngosang recommended.

## REST

The existing action endpoint takes an optional `client_ecid`, valid only with `swap_this`:

```json
{ "action": "swap_this", "client_ecid": 1234 }
```

No new route, per the issue's own reasoning: the action is a (source, file) pair either way, so it belongs on the file that already owns the A4AF resource. A success shows up as that ECID having left `sources` in the reply.

Validation refuses what the core would otherwise swallow — an ECID absent from the snapshot is `404`, and a live peer that is not an A4AF source of *this* download is `409` rather than a request the daemon quietly drops. `client_ecid` with `swap_this_auto` / `swap_others` is `400`, since the core has no per-source form of those.

## Core

The EC handler stops answering `EC_OP_NOOP` unconditionally. `SwapToAnotherFile()` returns a bool and the handler discarded it, so an unknown ECID, an unknown hash, a peer that is actively sending — which the core refuses to swap away — and a real swap were all indistinguishable. It now reports each, which is what lets the endpoint distinguish a refusal from a success instead of reporting "delivered". amulegui registers a null handler for this op and discards the reply whatever its opcode, so that side needs no change.

## Reuse

`FindClientByEcid` is *declared* above the A4AF handlers rather than moved. Every unnamed-namespace block in a TU is the same namespace, so the definition below resolves — and its `FindServerByEcid` / `FindFriendByEcid` siblings stay together where a reader expects them, instead of one being exiled 1000 lines up.

## Testing

New assertions in the existing `04-read-downloads-shared.sh` phase, run against a live amuled with a real download and a real connected peer — **all pass**: non-integer `client_ecid` → 400, `client_ecid` on either wrong action → 400, unknown ECID → 404, and a live non-A4AF peer → 409.

Unit suite 34/34, clang-format and both clang-tidy tiers clean, catalogs regenerated for the one new translatable string.

**Not verified locally: the successful swap itself.** It needs a peer that is an A4AF source of a second download, which a test daemon has no way to arrange on demand — and the REST validation correctly rejects before reaching the daemon in every synthetic case. The wire format matches what amulegui sends, and every rejection path is covered, but the happy path is verified by construction rather than observation.
