### PR TITLE
feat(amuleapi): report the status counters and identity /status was dropping

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -415,14 +415,18 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
 
 #### `status_changed`
 
-Identical to the REST [`/api/v0/status`](REFERENCE.md#get-apiv0status) envelope. The payload is the post-change snapshot, not a diff. Fires when any field anywhere in the envelope changes — ed2k state, Kad state, Kad network counters, headline speeds, queue length, or `ec_connected`.
+Identical to the REST [`/api/v0/status`](REFERENCE.md#get-apiv0status) envelope, including the `null` rule on the two disk figures. The payload is the post-change snapshot, not a diff. Fires when any field anywhere in the envelope changes — ed2k state and identity, Kad state, Kad network counters, headline speeds, the overhead rates, the free-space figures, the queue counters, or `ec_connected`.
+
+Rate impact is small: the overhead rates move about as often as the speeds already in that comparison, so they add no wakeups, and the disk figures are resampled only every 10 s by the daemon, so at worst they add one event per 10 s and only when the number actually moved. An idle daemon still emits nothing.
 
 ```json
 {
   "ec_connected": true,
   "ed2k": {
     "state":       "connected",
-    "low_id":      false,
+    "high_id":     true,
+    "id":          3523226697,
+    "public_ip":   "210.2.150.73",
     "server_name": "eMule Server",
     "server_ip":   "203.0.113.5",
     "server_port": 4242
@@ -432,8 +436,12 @@ Identical to the REST [`/api/v0/status`](REFERENCE.md#get-apiv0status) envelope.
     "firewalled": false,
     "network":    { "users": 5400000, "files": 1400000000, "nodes": 2400 }
   },
-  "speeds": { "download_bps": 4500000, "upload_bps": 50000 },
-  "queue":  { "upload_queue_length": 12, "total_source_count": 1843 }
+  "speeds": {
+    "download_bps": 4500000, "upload_bps": 50000,
+    "download_overhead_bps": 8700, "upload_overhead_bps": 1100
+  },
+  "disk":   { "temp_free_bytes": 48318382080, "incoming_free_bytes": 48318382080 },
+  "queue":  { "upload_clients_waiting": 12, "download_sources_total": 1843 }
 }
 ```
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -406,7 +406,9 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
   "ec_connected": true,
   "ed2k": {
     "state": "connected",
-    "low_id": false,
+    "high_id": true,
+    "id": 3523226697,
+    "public_ip": "210.2.150.73",
     "connected_since": 1751000000,
     "server_name": "eMule Server",
     "server_ip": "203.0.113.5",
@@ -418,14 +420,32 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
     "connected_since": 1751000000,
     "network": { "users": 5400000, "files": 1400000000, "nodes": 2400 }
   },
-  "speeds": { "download_bps": 4500000, "upload_bps": 50000 },
-  "queue": { "upload_queue_length": 12, "total_source_count": 1843 }
+  "speeds": {
+    "download_bps": 4500000,
+    "upload_bps": 50000,
+    "download_overhead_bps": 8700,
+    "upload_overhead_bps": 1100
+  },
+  "disk": { "temp_free_bytes": 48318382080, "incoming_free_bytes": 48318382080 },
+  "queue": { "upload_clients_waiting": 12, "download_sources_total": 1843 }
 }
 ```
 
 `ec_connected` is `false` while amuleapi can't reach the underlying amuled. Most other endpoints return `503 ec_unavailable` in that state.
 
 `ed2k.connected_since` / `kad.connected_since` are unix timestamps of the most recent connect, `0` while not connected — gate on `ed2k.state` / `kad.state` rather than trust a `0` timestamp alone.
+
+**Our eD2k identity.** `ed2k.id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the peer-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `""` there.
+
+While disconnected `id` is `0`, `public_ip` is `""` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
+
+**Overhead is additive.** `speeds.download_overhead_bps` / `upload_overhead_bps` are protocol and control traffic, counted **separately** from `download_bps` / `upload_bps` rather than being part of them — the desktop shows them as a second figure in parentheses. Both are `0` when the daemon reports nothing.
+
+**Disk figures may be `null`.** `disk.temp_free_bytes` is free space on the filesystem holding the part files, `disk.incoming_free_bytes` where finished downloads land. Either is `null` when the daemon has no figure — the first seconds after startup, or a directory it cannot stat, such as an unreachable network mount. `null` rather than `0`, because `0` would read as a full disk.
+
+The two are **equal whenever Temp and Incoming share a filesystem**, which is the default layout — that is correct, not a bug. `incoming_free_bytes` describes the **default category's** incoming directory; a category pointed at another filesystem is not covered, because the daemon publishes no per-category figure.
+
+To reproduce the desktop's low-space warning, compare `temp_free_bytes` against the bytes still to write across the queue (`size - size_done` summed over [`GET /downloads`](#get-apiv0downloads)), or against the `files.min_free_space_mb` preference when `files.stop_on_low_disk_space` is on. Note that preference is in **MiB** while these fields are bytes.
 
 **Errors:** `503 ec_unavailable` if amuleapi hasn't received its first EC snapshot yet.
 
@@ -1099,7 +1119,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-The detail fields mirror the desktop "Client Details" modal. `user_id_hybrid` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `0x1000000`) and `false` for LowID. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `available_parts` is the count of parts the peer holds of the linked file; `mod_version` is the peer's client-mod string (often `""`); `view_shared_disabled` is `true` when the peer forbids browsing its shared files. `is_friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `dl_up_modifier` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`available_parts` over that file's part count) and is **omitted** when there is no linked download or the part count is unknown.
+The detail fields mirror the desktop "Client Details" modal. `user_id_hybrid` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `available_parts` is the count of parts the peer holds of the linked file; `mod_version` is the peer's client-mod string (often `""`); `view_shared_disabled` is `true` when the peer forbids browsing its shared files. `is_friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `dl_up_modifier` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`available_parts` over that file's part count) and is **omitted** when there is no linked download or the part count is unknown.
 
 > `is_friend` and `dl_up_modifier` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `is_friend` reads `false` and `dl_up_modifier` reads `0`.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1974,8 +1974,18 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.BeginObject();
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(s.ed2k_state.c_str()));
-	w.Key("low_id");
-	w.ValueBool(s.ed2k_lowid);
+	// Positive sense, matching the peer-side high_id on /clients/{ecid}.
+	// False for a LowID and while disconnected alike, so read it together
+	// with `state` before treating it as a firewall verdict.
+	w.Key("high_id");
+	w.ValueBool(s.ed2k_high_id);
+	// Our server-assigned id; a HighID (>= 16777216) is our public address
+	// packed LSB-first, which is where public_ip comes from. Both are 0 /
+	// empty while disconnected.
+	w.Key("id");
+	w.ValueInt(static_cast<int64_t>(s.ed2k_id));
+	w.Key("public_ip");
+	w.ValueString(wxString::FromUTF8(s.ed2k_public_ip.c_str()));
 	// 0 when not connected -- gate on ed2k.state, not on this being nonzero.
 	w.Key("connected_since");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_connected_since));
@@ -2033,13 +2043,39 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.ValueInt(static_cast<int64_t>(s.download_bps));
 	w.Key("upload_bps");
 	w.ValueInt(static_cast<int64_t>(s.upload_bps));
+	// Additive to the two above, not a subset: amuled counts protocol
+	// overhead separately from payload.
+	w.Key("download_overhead_bps");
+	w.ValueInt(static_cast<int64_t>(s.download_overhead_bps));
+	w.Key("upload_overhead_bps");
+	w.ValueInt(static_cast<int64_t>(s.upload_overhead_bps));
+	w.EndObject();
+
+	// null rather than a number when the daemon has no figure. Emitting the
+	// -1 sentinel as an unsigned value would read as 17 exabytes free, and
+	// 0 would read as a full disk -- the desktop hides the label for the
+	// same reason.
+	w.Key("disk");
+	w.BeginObject();
+	w.Key("temp_free_bytes");
+	if (s.temp_free_bytes < 0) {
+		w.ValueNull();
+	} else {
+		w.ValueInt(static_cast<int64_t>(s.temp_free_bytes));
+	}
+	w.Key("incoming_free_bytes");
+	if (s.incoming_free_bytes < 0) {
+		w.ValueNull();
+	} else {
+		w.ValueInt(static_cast<int64_t>(s.incoming_free_bytes));
+	}
 	w.EndObject();
 
 	w.Key("queue");
 	w.BeginObject();
-	w.Key("upload_queue_length");
+	w.Key("upload_clients_waiting");
 	w.ValueInt(static_cast<int64_t>(s.ul_queue_len));
-	w.Key("total_source_count");
+	w.Key("download_sources_total");
 	w.ValueInt(static_cast<int64_t>(s.total_src_count));
 	w.EndObject();
 	// Nickname is a /preferences field, not a /status one.

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -229,14 +229,23 @@ std::string ToJson(const ClientSnapshot &c)
 // REST nesting groups data from StatusSnapshot AND KadSnapshot AND
 // the dashboard's ec_connected bit — all three are read in one
 // shared_lock by state.Dashboard() at the call site.
+// A free-space figure renders as a JSON number, or as null when the daemon
+// has none (-1). Kept beside the REST handler's identical rule so the SSE
+// payload and the REST body cannot drift apart.
+std::string JsonFreeSpace(std::int64_t v)
+{
+	return v < 0 ? std::string("null") : std::to_string(v);
+}
+
 std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, bool ec_connected)
 {
 	std::ostringstream o;
 	o << "{"
 	  << "\"ec_connected\":" << (ec_connected ? "true" : "false") << ",\"ed2k\":{"
 	  << "\"state\":\"" << EscJson(s.ed2k_state) << "\""
-	  << ",\"low_id\":" << (s.ed2k_lowid ? "true" : "false") << ",\"server_name\":\""
-	  << EscJson(s.server_name) << "\""
+	  << ",\"high_id\":" << (s.ed2k_high_id ? "true" : "false") << ",\"id\":" << s.ed2k_id
+	  << ",\"public_ip\":\"" << EscJson(s.ed2k_public_ip) << "\""
+	  << ",\"server_name\":\"" << EscJson(s.server_name) << "\""
 	  << ",\"server_ip\":\"" << EscJson(s.server_ip) << "\""
 	  << ",\"server_port\":" << s.server_port << ",\"network\":{"
 	  << "\"users\":" << s.ed2k_users << ",\"files\":" << s.ed2k_files << "}}"
@@ -246,10 +255,16 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << "\"users\":" << k.users << ",\"files\":" << k.files << ",\"nodes\":" << k.nodes << "}"
 	  << "}"
 	  << ",\"speeds\":{"
-	  << "\"download_bps\":" << s.download_bps << ",\"upload_bps\":" << s.upload_bps << "}"
+	  << "\"download_bps\":" << s.download_bps << ",\"upload_bps\":" << s.upload_bps
+	  << ",\"download_overhead_bps\":" << s.download_overhead_bps
+	  << ",\"upload_overhead_bps\":" << s.upload_overhead_bps << "}"
+	  << ",\"disk\":{"
+	  // null, not the -1 sentinel and not 0 -- same reasoning as the REST body.
+	  << "\"temp_free_bytes\":" << JsonFreeSpace(s.temp_free_bytes)
+	  << ",\"incoming_free_bytes\":" << JsonFreeSpace(s.incoming_free_bytes) << "}"
 	  << ",\"queue\":{"
-	  << "\"upload_queue_length\":" << s.ul_queue_len << ",\"total_source_count\":" << s.total_src_count
-	  << "}"
+	  << "\"upload_clients_waiting\":" << s.ul_queue_len
+	  << ",\"download_sources_total\":" << s.total_src_count << "}"
 	  << "}";
 	return o.str();
 }
@@ -351,12 +366,17 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 }
 bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 {
-	return a.ed2k_state == b.ed2k_state && a.kad_state == b.kad_state && a.ed2k_lowid == b.ed2k_lowid &&
+	// public_ip is derived from ed2k_id, so comparing the id covers it.
+	return a.ed2k_state == b.ed2k_state && a.kad_state == b.kad_state &&
+	       a.ed2k_high_id == b.ed2k_high_id && a.ed2k_id == b.ed2k_id &&
 	       a.kad_firewalled == b.kad_firewalled && a.server_name == b.server_name &&
 	       a.server_ip == b.server_ip && a.server_port == b.server_port &&
 	       a.download_bps == b.download_bps && a.upload_bps == b.upload_bps &&
-	       a.ul_queue_len == b.ul_queue_len && a.total_src_count == b.total_src_count &&
-	       a.ed2k_users == b.ed2k_users && a.ed2k_files == b.ed2k_files;
+	       a.download_overhead_bps == b.download_overhead_bps &&
+	       a.upload_overhead_bps == b.upload_overhead_bps && a.temp_free_bytes == b.temp_free_bytes &&
+	       a.incoming_free_bytes == b.incoming_free_bytes && a.ul_queue_len == b.ul_queue_len &&
+	       a.total_src_count == b.total_src_count && a.ed2k_users == b.ed2k_users &&
+	       a.ed2k_files == b.ed2k_files;
 }
 bool Equal(const KadSnapshot &a, const KadSnapshot &b)
 {

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -170,6 +170,32 @@ const char *KadStateString(const CEC_ConnState_Tag *conn)
 	return "connecting";
 }
 
+// Renders an IPv4 address that arrives LSB-first — the layout
+// EC_TAG_CLIENT_USER_IP, the Kad address tags and the eD2k id all share,
+// and what Uint32toStringIP() renders on the desktop side.
+std::string IPv4ToDotted(std::uint32_t ip_lsb_first)
+{
+	char buf[16];
+	std::snprintf(buf,
+		sizeof(buf),
+		"%u.%u.%u.%u",
+		static_cast<unsigned>((ip_lsb_first) & 0xFFu),
+		static_cast<unsigned>((ip_lsb_first >> 8) & 0xFFu),
+		static_cast<unsigned>((ip_lsb_first >> 16) & 0xFFu),
+		static_cast<unsigned>((ip_lsb_first >> 24) & 0xFFu));
+	return std::string(buf);
+}
+
+// As above, but an unset address formats as empty rather than "0.0.0.0".
+// The peer and server fields use 0 for "not known" and omit the key on it,
+// whereas the Kad fields report the quad verbatim — which is the only
+// difference there has ever been between these two, and the reason the
+// distinction is a wrapper rather than a second formatter.
+std::string FormatClientIpv4(std::uint32_t ip_lsb_first)
+{
+	return ip_lsb_first == 0 ? std::string() : IPv4ToDotted(ip_lsb_first);
+}
+
 } // namespace
 
 void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
@@ -184,9 +210,24 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 	out.kad_state = KadStateString(conn);
 
 	if (conn) {
-		out.ed2k_lowid = conn->HasLowID();
+		// Only meaningful while connected: with no EC_TAG_ED2K_ID the id
+		// reads 0, and HasLowID() is "id < HIGHEST_LOWID_ED2K_KAD", so a
+		// disconnected daemon would otherwise be reported as a LowID.
+		out.ed2k_high_id = conn->IsConnectedED2K() && !conn->HasLowID();
 		out.kad_firewalled = conn->IsKadFirewalled();
 		if (conn->IsConnectedED2K()) {
+			// 0xffffffff is the "connect in flight, no id yet" sentinel
+			// (ECSpecialCoreTags.cpp) and must not reach a consumer.
+			const std::uint32_t id = static_cast<std::uint32_t>(conn->GetEd2kId());
+			if (id != 0xffffffffu) {
+				out.ed2k_id = id;
+				// A HighID *is* our public address, LSB-first, the same
+				// layout EC_TAG_CLIENT_USER_IP uses. A LowID is a small
+				// number the server picked and carries no address.
+				if (out.ed2k_high_id) {
+					out.ed2k_public_ip = IPv4ToDotted(id);
+				}
+			}
 			const CECTag *server = conn->GetTagByName(EC_TAG_SERVER);
 			if (server) {
 				const CECTag *name = server->GetTagByName(EC_TAG_SERVER_NAME);
@@ -214,6 +255,22 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UL_SPEED)) {
 		out.upload_bps = static_cast<std::uint64_t>(t->GetInt());
+	}
+	// Overhead rates and free space ride the same EC_DETAIL_FULL response.
+	// The two disk figures are cast through int64 on purpose: amuled's
+	// FREE_SPACE_UNKNOWN is -1 and the serializer casts it to uint64, so an
+	// unsigned read would turn "unknown" into 18446744073709551615.
+	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UP_OVERHEAD)) {
+		out.upload_overhead_bps = static_cast<std::uint64_t>(t->GetInt());
+	}
+	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_DOWN_OVERHEAD)) {
+		out.download_overhead_bps = static_cast<std::uint64_t>(t->GetInt());
+	}
+	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_TEMP_FREE_SPACE)) {
+		out.temp_free_bytes = static_cast<std::int64_t>(t->GetInt());
+	}
+	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_INCOMING_FREE_SPACE)) {
+		out.incoming_free_bytes = static_cast<std::int64_t>(t->GetInt());
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UL_QUEUE_LEN)) {
 		out.ul_queue_len = static_cast<std::uint32_t>(t->GetInt());
@@ -706,21 +763,6 @@ const char *ClientIdentStateName(std::uint8_t code)
 // Format an IP from EC_TAG_CLIENT_USER_IP. The EC tag holds a
 // 32-bit host-order IPv4; we render it dotted-quad. Returns "" for
 // zero IPs (commonly the case for clients we've never confirmed).
-std::string FormatClientIpv4(std::uint32_t ip_he)
-{
-	if (ip_he == 0)
-		return std::string();
-	char buf[16];
-	std::snprintf(buf,
-		sizeof(buf),
-		"%u.%u.%u.%u",
-		static_cast<unsigned>((ip_he) & 0xFFu),
-		static_cast<unsigned>((ip_he >> 8) & 0xFFu),
-		static_cast<unsigned>((ip_he >> 16) & 0xFFu),
-		static_cast<unsigned>((ip_he >> 24) & 0xFFu));
-	return std::string(buf);
-}
-
 // Merge a `CEC_UpDownClient_Tag` into an existing ClientSnapshot.
 // On a cache-miss the caller pre-populates ecid + hashes; on a hit
 // the AssignIfExist pattern leaves cached values intact when the
@@ -1334,18 +1376,6 @@ const char *KadBuddyStatusName(std::uint32_t status_code)
 // Render a host-byte-order uint32 IP as dotted-quad. amuled emits the
 // Kad address with network bytes already swapped (see
 // `ExternalConn.cpp:761` — `wxUINT32_SWAP_ALWAYS`).
-std::string IPv4ToDotted(std::uint32_t ip_host_order)
-{
-	char buf[24];
-	std::snprintf(buf,
-		sizeof(buf),
-		"%u.%u.%u.%u",
-		(ip_host_order) & 0xFF,
-		(ip_host_order >> 8) & 0xFF,
-		(ip_host_order >> 16) & 0xFF,
-		(ip_host_order >> 24) & 0xFF);
-	return std::string(buf);
-}
 
 } // namespace
 

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -58,11 +58,13 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	//
 	// Detail level CMD → FULL because amuled only piggybacks
 	// `EC_TAG_STATS_LOGGER_MESSAGE` (the incremental-log channel) at
-	// FULL or INC_UPDATE (ExternalConn.cpp:722-730). FULL also adds
-	// a few stat-overhead extras (STATS_UP_OVERHEAD,
-	// STATS_DOWN_OVERHEAD, STATS_BANNED_COUNT, STATS_TOTAL_*_BYTES,
-	// STATS_SHARED_FILE_COUNT) that StatusSnapshot doesn't yet
-	// surface — harmless overhead.
+	// FULL or INC_UPDATE (ExternalConn.cpp:722-730). FULL is also what
+	// carries STATS_UP_OVERHEAD / STATS_DOWN_OVERHEAD and the two
+	// free-space tags, which /status reports — so this is load-bearing
+	// now, not a harmless over-request: dropping it to CMD would silently
+	// empty those fields along with the log channel. STATS_BANNED_COUNT,
+	// STATS_TOTAL_*_BYTES and STATS_SHARED_FILE_COUNT still arrive
+	// unconsumed.
 	{
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_STAT_REQ, EC_DETAIL_FULL));
 		const CECPacket *resp = app.SendRecvSerialized(req.get());

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1017,7 +1017,24 @@ struct StatusSnapshot
 	// (NAT'd, can't accept incoming). adds NAT-T affordances
 	// that change this calculus; until then the field maps 1:1 to the
 	// EC CONNSTATE bit.
-	bool ed2k_lowid = false;
+	// True when our eD2k id is a HighID (>= HIGHEST_LOWID_ED2K_KAD). False
+	// for a LowID *and* whenever we are not connected at all -- there is no
+	// id then, so gate on ed2k_state == "connected" before reading this as
+	// a firewall verdict. Positive sense so it matches the peer-side
+	// high_id on /clients/{ecid}, and so the disconnected case does not
+	// read as an alarming "low id".
+	bool ed2k_high_id = false;
+
+	// Our eD2k id as assigned by the connected server. 0 when not
+	// connected; the 0xffffffff "connect in flight" sentinel is normalized
+	// to 0 rather than surfaced.
+	std::uint32_t ed2k_id = 0;
+
+	// Our public IPv4 in dotted-quad form, derived from ed2k_id when that
+	// is a HighID -- a HighID *is* the address. Empty for a LowID or while
+	// disconnected, where no address exists. Formatted here rather than in
+	// the handler, matching every other address in these snapshots.
+	std::string ed2k_public_ip;
 	// True when Kad is running but firewalled.
 	bool kad_firewalled = false;
 
@@ -1033,9 +1050,29 @@ struct StatusSnapshot
 	std::uint64_t download_bps = 0;
 	std::uint64_t upload_bps = 0;
 
+	// Protocol/control-traffic overhead, bytes/second. ADDITIVE to the two
+	// rates above rather than a subset of them -- amuled keeps them as
+	// separate counters and the desktop renders them as a second figure in
+	// parentheses. 0 when the daemon reports nothing.
+	std::uint64_t download_overhead_bps = 0;
+	std::uint64_t upload_overhead_bps = 0;
+
 	// Aggregate counts pulled by the same EC_OP_STATS round-trip.
 	std::uint32_t ul_queue_len = 0;
 	std::uint32_t total_src_count = 0;
+
+	// Free bytes on the filesystems holding the part files and the finished
+	// downloads. SIGNED, with -1 meaning "the daemon has no figure" -- the
+	// state before CFreeSpaceThread publishes its first sample, and the
+	// permanent state of a directory it cannot stat.
+	//
+	// amuled's FREE_SPACE_UNKNOWN is -1 and the EC serializer casts it
+	// straight to uint64, so the wire carries 0xFFFFFFFFFFFFFFFF. Storing
+	// that unsigned and emitting it would report 17 exabytes free -- the
+	// exact opposite of the truth -- so it is read back as a signed -1 and
+	// serialised as JSON null.
+	std::int64_t temp_free_bytes = -1;
+	std::int64_t incoming_free_bytes = -1;
 
 	// ed2k network-wide totals (all connected servers). Surfaced in
 	// /status as ed2k.network.{users,files} — symmetric with

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -306,9 +306,9 @@ function ConnectionStatus({ status }) {
   let e2Text = t("app_not_connected"), e2Cls = "off";
   if (ed2k) {
     if (ed2k.state === "connected") {
-      e2Cls = ed2k.low_id ? "low" : "ok";
+      e2Cls = ed2k.high_id ? "ok" : "low";
       e2Text = (ed2k.server_name || ed2k.server_ip || t("app_connected")) +
-        " · " + (ed2k.low_id ? t("app_low_id") : t("app_high_id"));
+        " · " + (ed2k.high_id ? t("app_high_id") : t("app_low_id"));
     } else if (ed2k.state === "connecting") {
       e2Cls = "warn"; e2Text = t("app_connecting");
     }

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -380,7 +380,7 @@ function Ed2kInfoPanel() {
             ${connected ? t("networks_ed2k_connected") : t("networks_ed2k_not_connected")}
           </span>`)}
         ${stat(t("networks_ed2k_connection_type"),
-          connected ? (ed2k.low_id ? t("networks_ed2k_low_id") : t("networks_ed2k_high_id")) : "—")}
+          connected ? (ed2k.high_id ? t("networks_ed2k_high_id") : t("networks_ed2k_low_id")) : "—")}
       </div>
     </div>`;
 }

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -124,8 +124,19 @@ _assert_json_eq '.ec_connected | type' boolean \
 # ed2k subtree.
 _assert_json_eq '.ed2k.state | test("^(connected|connecting|disconnected)$")' \
 	true 'ed2k.state is a known enum value'
-_assert_json_eq '.ed2k.low_id | type' boolean \
-	'ed2k.low_id is boolean'
+_assert_json_eq '.ed2k.high_id | type' boolean \
+	'ed2k.high_id is boolean'
+_assert_json_eq '.ed2k.id | type' number \
+	'ed2k.id is numeric'
+_assert_json_eq '.ed2k.public_ip | type' string \
+	'ed2k.public_ip is string'
+# A public address exists exactly when we hold a HighID on a live connection;
+# a LowID carries none, and neither does a disconnected daemon.
+_assert_json_eq '(.ed2k.public_ip != "") == (.ed2k.high_id and .ed2k.state == "connected")' \
+	true 'ed2k.public_ip is non-empty exactly when high_id and connected'
+# The 0xffffffff "connect in flight" sentinel must never surface.
+_assert_json_eq '.ed2k.id != 4294967295' true \
+	'ed2k.id never reports the connecting sentinel'
 _assert_json_eq '.ed2k.server_name | type' string \
 	'ed2k.server_name is string'
 
@@ -140,10 +151,28 @@ _assert_json_eq '.speeds.download_bps | type' number \
 	'speeds.download_bps is numeric'
 _assert_json_eq '.speeds.upload_bps | type' number \
 	'speeds.upload_bps is numeric'
-_assert_json_eq '.queue.upload_queue_length | type' number \
-	'queue.upload_queue_length is numeric'
-_assert_json_eq '.queue.total_source_count | type' number \
-	'queue.total_source_count is numeric'
+_assert_json_eq '.speeds.download_overhead_bps | type' number \
+	'speeds.download_overhead_bps is numeric'
+_assert_json_eq '.speeds.upload_overhead_bps | type' number \
+	'speeds.upload_overhead_bps is numeric'
+_assert_json_eq '.queue.upload_clients_waiting | type' number \
+	'queue.upload_clients_waiting is numeric'
+_assert_json_eq '.queue.download_sources_total | type' number \
+	'queue.download_sources_total is numeric'
+
+# disk subtree: a number, or null when the daemon has no figure. Never the
+# unsigned reading of the -1 sentinel, and never 0 (which would read as a
+# full disk).
+_assert_json_eq '.disk.temp_free_bytes | type | . == "number" or . == "null"' true \
+	'disk.temp_free_bytes is a number or null'
+_assert_json_eq '.disk.incoming_free_bytes | type | . == "number" or . == "null"' true \
+	'disk.incoming_free_bytes is a number or null'
+_assert_json_eq '[.disk[]] | map(select(. == 18446744073709551615)) | length == 0' true \
+	'disk figures never report the unsigned free-space sentinel'
+
+# Retired spellings must be gone from the whole body, not merely unused.
+_assert_json_eq '[paths | join(".")] | map(select(test("low_id|upload_queue_length|total_source_count"))) | length == 0' \
+	true '/status no longer carries the retired field names'
 
 # --- 4. /status with guest bearer also works (any-role read gate). --
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -208,6 +208,83 @@ TEST(EventDiff, LogAppendedSilentOnTruncation)
 // FROM us) is part of the base client field set, so it must ride the
 // client_added SSE payload — otherwise the WebUI clients table has no way to
 // fill the File column for an upload-only peer (it shows a blank "—").
+// Drives one status change through the real emit path and returns the
+// status_changed payload, so these assert what a subscriber actually sees
+// rather than reaching into EventDiff's internals.
+namespace
+{
+std::string EmitStatusAndGetPayload(const StatusSnapshot &next)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // baseline tick
+	state.WriteStatus(next);
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &ev : DrainAll(bus)) {
+		if (ev.name == "status_changed")
+			payload = ev.data;
+	}
+	return payload;
+}
+} // namespace
+
+// The free-space sentinel must reach the SSE payload as JSON null, never as
+// a number. amuled's FREE_SPACE_UNKNOWN is -1 and its EC serializer casts it
+// to uint64, so the wire carries 0xFFFFFFFFFFFFFFFF; emitting that unsigned
+// would tell a consumer 17 exabytes are free, and 0 would read as a full
+// disk. Same rule as the REST body, asserted so the two cannot drift apart.
+TEST(EventDiff, StatusEventSerialisesUnknownFreeSpaceAsNull)
+{
+	StatusSnapshot s;
+	s.temp_free_bytes = -1;
+	s.incoming_free_bytes = 48318382080LL;
+
+	const std::string payload = EmitStatusAndGetPayload(s);
+
+	ASSERT_TRUE(payload.find("\"temp_free_bytes\":null") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"incoming_free_bytes\":48318382080") != std::string::npos);
+	// The unsigned reading of the sentinel must appear nowhere.
+	ASSERT_TRUE(payload.find("18446744073709551615") == std::string::npos);
+}
+
+// high_id is positive-sense precisely so the disconnected case does not read
+// as a firewall verdict, and the id/public_ip pair rides the same payload.
+TEST(EventDiff, StatusEventCarriesIdentityFields)
+{
+	StatusSnapshot s;
+	s.ed2k_state = "connected";
+	s.ed2k_high_id = true;
+	s.ed2k_id = 3523226697u;
+	s.ed2k_public_ip = "210.2.150.73";
+	s.download_overhead_bps = 8700;
+
+	const std::string payload = EmitStatusAndGetPayload(s);
+
+	ASSERT_TRUE(payload.find("\"high_id\":true") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"id\":3523226697") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"public_ip\":\"210.2.150.73\"") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
+	// The retired spelling must not linger anywhere in the payload.
+	ASSERT_TRUE(payload.find("low_id") == std::string::npos);
+}
+
+// A tick where only the overhead moved still has to fire: the field is in the
+// REST body, so if the SSE twin stays silent the two diverge until something
+// else happens to move.
+TEST(EventDiff, StatusEventFiresWhenOnlyOverheadMoved)
+{
+	StatusSnapshot s;
+	s.download_overhead_bps = 8700;
+
+	const std::string payload = EmitStatusAndGetPayload(s);
+
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
+}
+
 TEST(EventDiff, ClientAddedCarriesUploadFileName)
 {
 	CState state;

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -82,7 +82,13 @@ TEST(State, WriteStatusRoundtrip)
 	StatusSnapshot in;
 	in.ed2k_state = "connected";
 	in.kad_state = "connecting";
-	in.ed2k_lowid = true;
+	in.ed2k_high_id = true;
+	in.ed2k_id = 3523226697u; // 210.2.150.73 packed LSB-first
+	in.ed2k_public_ip = "210.2.150.73";
+	in.download_overhead_bps = 8700;
+	in.upload_overhead_bps = 1100;
+	in.temp_free_bytes = 48318382080LL;
+	in.incoming_free_bytes = -1; // unknown
 	in.kad_firewalled = false;
 	in.server_name = "Some Server";
 	in.server_ip = "192.0.2.42";
@@ -96,7 +102,15 @@ TEST(State, WriteStatusRoundtrip)
 	const StatusSnapshot out = s.Status();
 	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
 	ASSERT_EQUALS(std::string("connecting"), out.kad_state);
-	ASSERT_TRUE(out.ed2k_lowid);
+	ASSERT_TRUE(out.ed2k_high_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(3523226697u), out.ed2k_id);
+	ASSERT_EQUALS(std::string("210.2.150.73"), out.ed2k_public_ip);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::int64_t>(48318382080LL), out.temp_free_bytes);
+	// -1 must survive the round trip as -1: it is what the handler turns
+	// into JSON null, and an unsigned slot would make it 1.8e19.
+	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.incoming_free_bytes);
 	ASSERT_FALSE(out.kad_firewalled);
 	ASSERT_EQUALS(std::string("Some Server"), out.server_name);
 	ASSERT_EQUALS(std::string("192.0.2.42"), out.server_ip);


### PR DESCRIPTION
Closes #973.

The refresher already asks amuled for stats at `EC_DETAIL_FULL`, and that response carries the protocol overhead rates and the free disk space for Temp and Incoming. `StatusSnapshot` read none of them — `RefresherTick` even said so in a comment. Our own eD2k id rides `EC_TAG_CONNSTATE` too, and the parser called into that tag object for `HasLowID()` while discarding the id that answer is derived from.

Everything here comes from data already on the wire: **no core change, no EC protocol change, no extra round trip.**

## New fields

| Field | Meaning |
|---|---|
| `ed2k.id` | Our server-assigned id. `0` when disconnected; the `0xffffffff` mid-connect sentinel is normalized away. |
| `ed2k.public_ip` | Our public IPv4. A HighID **is** the address packed LSB-first, so the dotted quad falls straight out of the id. `""` for a LowID or while disconnected. |
| `speeds.download_overhead_bps` / `upload_overhead_bps` | Protocol traffic, **additive** to the payload rates rather than a subset — amuled counts them separately and the desktop renders them in parentheses. |
| `disk.temp_free_bytes` / `incoming_free_bytes` | Free space, or `null` when the daemon has no figure. |

With these, the desktop's ED2K Info panel is reproducible from `/status` plus `/preferences` alone.

## Three corrections

**`low_id` → `high_id`.** `HasLowID()` is `id < 16777216` and an absent tag reads `0`, so `/status` reported `low_id: true` whenever we were **not connected at all** — a firewall diagnosis for a daemon that simply has no id yet. The positive spelling reads correctly in all three states and matches the peer-side `high_id` on `/clients/{ecid}`, which until now answered the same question with opposite polarity.

**The free-space sentinel.** `FREE_SPACE_UNKNOWN` is `-1` and amuled's serializer casts it to `uint64`, so the wire carries `0xFFFFFFFFFFFFFFFF`. Stored signed and emitted as JSON `null`: unsigned it would report 17 exabytes free, and `0` would read as a full disk.

**`queue` keys** become `upload_clients_waiting` and `download_sources_total`, which say what they count and which side they belong to.

## Deduplication

`Refresher.cpp` carried **two identical dotted-quad formatters** in separate anonymous namespaces, differing only in whether `0` renders as `""` or `"0.0.0.0"`. Rather than add a third call site to one of them, they are now one implementation with that policy as a thin wrapper, hoisted to the first anonymous block so all three call regions share it. The `"0.0.0.0"` behaviour the Kad fields rely on is preserved exactly.

## Kept in step

The **web UI** reads `ed2k.low_id` in two places and would have silently inverted its badge, so `app.js` and `networks.js` move in the same commit. No i18n changes needed — both strings already exist, only the branch flips.

The **SSE twin** carries every new field with the same names and compares them, so a subscriber and a poller cannot disagree. `RefresherTick`'s comment now records that `EC_DETAIL_FULL` is load-bearing rather than a harmless over-request.

## Testing

Release and Debug build clean; `clang-format` clean; Tier-2 `clang-tidy` clean on the changed lines. 34/34 binaries pass, with new cases asserting the `-1` survives the snapshot round trip as `-1`, that the SSE payload renders unknown free space as `null` and never `18446744073709551615`, and that an overhead-only tick still fires. Curl test asserts `public_ip` is non-empty *exactly* when `high_id` and connected, and that the retired names appear nowhere in the body.

Not verified against a live daemon: I have no amuled on a LowID connection to hand, so the LowID branch rests on the code path rather than an observed run.
