### PR TITLE
feat(amuleapi): per-file client routes, per-part bitmaps, and peer fields on the list row

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -412,6 +412,8 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "friend_slot":            false
 }
 ```
+Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `available_parts`, `mod_version` and `view_shared_disabled`. It never carries a `parts` bitmap — those are opt-in on the per-file client routes only, being one boolean per chunk per peer.
+
 
 `upload_file_hash` (file we're uploading TO this peer) and `download_file_hash` (file we're downloading FROM this peer) are 32-char MD4 hex hashes — directly resolvable against [`/api/v0/downloads/{hash}`](REFERENCE.md#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised while we download from them; `upload_file_name` is the partfile they're downloading from us, resolved locally — see [`GET /clients`](REFERENCE.md#get-apiv0clients) for details.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -31,7 +31,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/downloads/{hash}/comments`](#get-apiv0downloadshashcomments) — per-source comments/ratings list (incl. retrieved Kad notes)
 - [`POST /api/v0/downloads/{hash}/comments`](#post-apiv0downloadshashcomments) — trigger an on-demand Kad notes lookup
 - [`GET /api/v0/downloads/{hash}/filenames`](#get-apiv0downloadshashfilenames) — source-reported filenames + counts
-- [`GET /api/v0/downloads/{hash}/a4af`](#get-apiv0downloadshasha4af) — A4AF source list + auto flag
+- [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients) — sources and A4AF rows of one partfile
 - [`POST /api/v0/downloads/{hash}/a4af`](#post-apiv0downloadshasha4af) — force A4AF source-swapping
 - [`POST /api/v0/downloads`](#post-apiv0downloads) — add ed2k link(s)
 - [`PATCH /api/v0/downloads`](#patch-apiv0downloads) — bulk pause / resume / priority / category
@@ -48,6 +48,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Shared files**
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
+- [`GET /api/v0/shared/{hash}/clients`](#get-apiv0sharedhashclients) — peers of one shared file
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
 - [`GET /api/v0/shared/directories`](#get-apiv0shareddirectories) — the configured share roots
 - [`PUT /api/v0/shared/directories`](#put-apiv0shareddirectories) — replace the configured share roots
@@ -197,7 +198,7 @@ Each endpoint documents its own response shape under the endpoint section. List 
 
 ### List pagination and sorting
 
-The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, and `/search/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
+The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, the two per-file client routes, and `/search/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
@@ -224,6 +225,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 |-----------------------|---------------|
 | `GET /downloads`      | `name`, `size`, `progress`, `speed`, `status` |
 | `GET /clients`        | `name`, `software` |
+| `GET /downloads/{hash}/clients`<br>`GET /shared/{hash}/clients` | same keys as `/clients` |
 | `GET /known_clients`  | `name`, `software`, `first_seen`, `last_seen`, `sessions`, `total_uploaded`, `total_downloaded` |
 | `GET /shared`         | `name`, `size` |
 | `GET /servers`        | `name`, `users`, `ping`, `files` |
@@ -789,28 +791,40 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 **Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
 
-#### `GET /api/v0/downloads/{hash}/a4af`
+#### `GET /api/v0/downloads/{hash}/clients` / `GET /api/v0/shared/{hash}/clients`
 
 **Auth:** `GUEST`
 
-The download's **A4AF** (asked-for-another-file) sources — peers that hold this file but are currently serving another. Downloads-only.
+The peers of one file: sources serving it to us, peers pulling it from us, and — on the downloads side — A4AF sources parked on another file. Replaces the client-side join of the global `/clients` list against `download_file_hash` / `upload_file_hash`, which could never produce the A4AF rows.
+
+Each entry is the [`/clients`](#get-apiv0clients) list object plus three keys:
+
+| Key | Meaning |
+|---|---|
+| `role` | this peer's live relation to **this** file: `"source"` (serves it to us, including queued), `"peer"` (pulls it from us), `"both"`, `"none"` |
+| `a4af` | `true` for a source parked on another file — the desktop's A4AF row |
+| `parts` | the peer's per-part bitmap, **only** when `?include_parts=true` |
+
+`role` and `a4af` are orthogonal: a pure A4AF row is `role: "none"`, `a4af: true`, but a peer can be parked on another file *and* be pulling this one from us (`role: "peer"`, `a4af: true`).
+
+`parts` is opt-in because it is one boolean per chunk per peer — a multi-TiB file is 100k+ entries each. It is exactly `part_count` entries, and it describes the file this row is about: the download bitmap for a `source`, the upload bitmap for a `peer`. A peer the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
+
+The file's own five-state part view is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap to render the desktop's per-source bar.
+
+Both routes accept `limit` / `offset` / `sort` / `order` exactly as `/clients` does. A partfile with at least one completed chunk is both a download and a shared file, and then **both routes return the same body** — they differ only in which collection the hash must belong to, which is what the `404` checks.
 
 ```sh
-curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/downloads/8b54a3c2…/a4af"
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/downloads/8b54a3c2…/clients?include_parts=true"
 ```
 
-```json
-{ "a4af_auto": false, "sources": [ 1234, 5678 ] }
-```
-
-`sources` are client ECIDs, joinable against [`GET /clients`](#get-apiv0clients)'s `client_ecid`. The scalar `sources.a4af` count on the download object is unchanged.
-
-**Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
+**Errors:** `404 not_found` (no download / no shared file with that hash), `400 bad_request` (bad list params, or `include_parts` other than `true` / `false`), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads/{hash}/a4af`
 
 **Auth:** `ADMIN`
+
+> The `GET` on this path was retired: A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients) now, carrying the whole peer object rather than a bare ECID, and `a4af_auto` is already on the download detail object. `GET` answers `405`.
 
 Force A4AF source-swapping for this download. Downloads-only.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1047,6 +1047,23 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
+	// peers of one shared file. Same rows as /clients, selected by hash and
+	// carrying their relation to the file; matched before `/shared/{hash}`.
+	{
+		static const auto shared_clients =
+			web_api_path::ParsePattern("/api/v0/shared/{hash}/clients");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(shared_clients, path_segs, caps)) {
+			if (req.method != "GET" && req.method != "HEAD") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only GET / HEAD on /shared/{hash}/clients");
+			}
+			return HandleFileClients(req, caps["hash"], /*require_downloading=*/false);
+		}
+	}
+
 	// shared file priority PATCH. `{hash}` is the lowercase 32-char hex
 	// MD4 hash.
 	{
@@ -1257,15 +1274,32 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(dl_a4af, path_segs, caps)) {
-			if (req.method == "GET" || req.method == "HEAD") {
-				return HandleDownloadA4af(req, caps["hash"]);
-			}
 			if (req.method == "POST") {
 				return HandleDownloadA4afAction(req, caps["hash"]);
 			}
-			return ErrorResponse(405,
-				"method_not_allowed",
-				"only GET / HEAD / POST on /downloads/{hash}/a4af");
+			// The read half is retired (issue #984): A4AF sources are rows of
+			// /downloads/{hash}/clients now, carrying the whole peer object
+			// rather than a bare ECID, and `a4af_auto` is already on the
+			// download detail object. The POST stays -- the swap actions have
+			// no equivalent there, and its reply is still the A4AF view.
+			return ErrorResponse(
+				405, "method_not_allowed", "only POST on /downloads/{hash}/a4af");
+		}
+	}
+
+	// sources and A4AF rows of one partfile. Matched before the bare
+	// `/downloads/{hash}` pattern, which accepts any single segment.
+	{
+		static const auto dl_clients = web_api_path::ParsePattern("/api/v0/downloads/{hash}/clients");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(dl_clients, path_segs, caps)) {
+			if (req.method != "GET" && req.method != "HEAD") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only GET / HEAD on /downloads/{hash}/clients");
+			}
+			return HandleFileClients(req, caps["hash"], /*require_downloading=*/true);
 		}
 	}
 
@@ -2359,6 +2393,25 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueString(wxString::FromUTF8(c.obfuscation_status.c_str()));
 	w.Key("friend_slot");
 	w.ValueBool(c.friend_slot);
+	// Promoted out of the detail object (issue #984): the desktop's per-file
+	// peer panels render Origin and "Shares File List" as list columns, so a
+	// caller should not have to fetch each peer individually to draw a table.
+	// Anything added here also reaches the SSE payload -- see ToJson AND Equal
+	// in EventDiff.cpp; a field in one but not the other never updates.
+	w.Key("source_origin");
+	w.ValueString(wxString::FromUTF8(c.source_origin.c_str()));
+	w.Key("available_parts");
+	w.ValueInt(static_cast<int64_t>(c.available_parts));
+	w.Key("mod_version");
+	w.ValueString(wxString::FromUTF8(c.mod_version.c_str()));
+	w.Key("view_shared_disabled");
+	w.ValueBool(c.view_shared_disabled);
+	// Omitted rather than sent negative when not computable (no linked
+	// download / unknown part count).
+	if (c.part_progress_percent >= 0.0) {
+		w.Key("part_progress_percent");
+		w.ValueDouble(c.part_progress_percent);
+	}
 }
 
 // List-level client object (GET /clients).
@@ -2494,14 +2547,6 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueString(wxString::FromUTF8(c.server_name.c_str()));
 	w.Key("kad_port");
 	w.ValueInt(static_cast<int64_t>(c.kad_port));
-	w.Key("source_origin");
-	w.ValueString(wxString::FromUTF8(c.source_origin.c_str()));
-	w.Key("available_parts");
-	w.ValueInt(static_cast<int64_t>(c.available_parts));
-	w.Key("mod_version");
-	w.ValueString(wxString::FromUTF8(c.mod_version.c_str()));
-	w.Key("view_shared_disabled");
-	w.ValueBool(c.view_shared_disabled);
 	// Friend status + DL/UP modifier (issue #423). is_friend is
 	// friends-list membership, distinct from the friend_slot reserved
 	// upload slot above.
@@ -2509,12 +2554,6 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueBool(c.is_friend);
 	w.Key("dl_up_modifier");
 	w.ValueDouble(c.dl_up_modifier);
-	// Completeness of the linked download for this peer; omitted when
-	// not computable (no linked file / unknown part count).
-	if (c.part_progress_percent >= 0.0) {
-		w.Key("part_progress_percent");
-		w.ValueDouble(c.part_progress_percent);
-	}
 	w.EndObject();
 }
 
@@ -2651,6 +2690,25 @@ struct ListParams
 // and an unknown `sort` value is simply a lookup miss -> 400.
 template <class T>
 using ListComparators = std::vector<std::pair<std::string, std::function<bool(const T &, const T &)>>>;
+
+// Sort keys for peer rows, shared by /clients and by the per-file client
+// routes -- the latter derive theirs from this set, so a key added here shows
+// up on every peer list rather than only the one it was added to.
+const ListComparators<webapi::ClientSnapshot> &ClientComparators()
+{
+	static const ListComparators<webapi::ClientSnapshot> kComps = {
+		{ "name",
+			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
+				return a.client_name < b.client_name;
+			} },
+		{ "software",
+			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
+				return a.software < b.software;
+			} },
+	};
+	;
+	return kComps;
+}
 
 std::unique_ptr<CHttpServer::Response> BadRequestPtr(const char *message)
 {
@@ -3176,6 +3234,203 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 		kComps);
 }
 
+namespace
+{
+// Completeness of the file we download FROM this peer: parts the peer has over
+// that file's part count. Only the download link carries a meaningful
+// denominator -- a peer that merely downloads from us has no percent. Left at
+// its < 0 sentinel when not computable, which is how the writers know to omit
+// the field. Used by the detail endpoint and by the per-file client rows.
+void ComputePartProgressPercent(const webapi::CState &state, webapi::ClientSnapshot &cli)
+{
+	if (!cli.has_available_parts || cli.download_file_hash.empty()) {
+		return;
+	}
+	webapi::FileSnapshot f;
+	if (!state.FindDownload(cli.download_file_hash, f) || f.size == 0) {
+		return;
+	}
+	const std::uint64_t part_count = (f.size + kPartSize - 1) / kPartSize;
+	if (part_count == 0) {
+		return;
+	}
+	double pct = 100.0 * static_cast<double>(cli.available_parts) / static_cast<double>(part_count);
+	if (pct > 100.0)
+		pct = 100.0;
+	cli.part_progress_percent = pct;
+}
+
+// One peer row of a per-file client list: the ordinary /clients object plus the
+// three things that only make sense relative to a file.
+struct FileClientRow
+{
+	webapi::ClientSnapshot client;
+	std::string role; // "source" | "peer" | "both" | "none"
+	bool a4af = false;
+	std::vector<bool> parts;
+	bool has_parts = false;
+};
+
+// Sort keys, derived from the /clients set rather than restated, so the two
+// surfaces cannot drift apart.
+const ListComparators<FileClientRow> &FileClientComparators()
+{
+	static const ListComparators<FileClientRow> kComps = [] {
+		ListComparators<FileClientRow> out;
+		for (const auto &kv : ClientComparators()) {
+			auto fn = kv.second;
+			out.emplace_back(kv.first, [fn](const FileClientRow &a, const FileClientRow &b) {
+				return fn(a.client, b.client);
+			});
+		}
+		return out;
+	}();
+	return kComps;
+}
+
+void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row)
+{
+	w.BeginObject();
+	WriteClientBaseFields(w, row.client);
+	// The peer's relation to THIS file, which the global /clients row cannot
+	// express: "source" serves it to us, "peer" pulls it from us, "both" does
+	// each way, "none" is a row that exists only because it is parked here as
+	// an A4AF source.
+	w.Key("role");
+	w.ValueString(wxString::FromUTF8(row.role.c_str()));
+	// Orthogonal to role on purpose: a peer can be parked on another file and
+	// still be pulling this one from us, which a fourth role value could not
+	// represent.
+	w.Key("a4af");
+	w.ValueBool(row.a4af);
+	if (row.has_parts) {
+		w.Key("parts");
+		w.BeginArray();
+		for (const bool b : row.parts) {
+			w.ValueBool(b);
+		}
+		w.EndArray();
+	}
+	w.EndObject();
+}
+
+// Resolve one peer's bitmap for `part_count` chunks of the file this row is
+// about, following the two wire conventions: an "all" flag means the core sent
+// an empty tag for a full source, and a decoded bitmap that cannot cover the
+// file is dropped rather than padded (its tail beyond part_count is the
+// buffer's byte padding, which is fine to trim).
+bool ResolvePartBitmap(const std::vector<bool> &bits,
+	bool all,
+	bool present,
+	std::uint64_t part_count,
+	std::vector<bool> &out)
+{
+	if (!present || part_count == 0) {
+		return false;
+	}
+	if (all) {
+		out.assign(static_cast<std::size_t>(part_count), true);
+		return true;
+	}
+	if (bits.size() < part_count) {
+		return false;
+	}
+	out.assign(bits.begin(), bits.begin() + static_cast<std::ptrdiff_t>(part_count));
+	return true;
+}
+} // namespace
+
+// Serves both /downloads/{hash}/clients and /shared/{hash}/clients. The rows
+// are the same object out of the same cache either way -- the relation to the
+// file is a field, not a path -- so the two routes differ only in which role
+// the hash must already have, which is what makes each a sub-resource of its
+// own collection. A partfile with at least one completed chunk is in both
+// collections at once and answers identically on both.
+CHttpServer::Response CApiDispatcher::HandleFileClients(
+	const CHttpServer::Request &req, const std::string &key, bool require_downloading)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
+	std::string needle = key;
+	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
+		return std::tolower(c);
+	});
+
+	webapi::FileSnapshot file;
+	const bool found =
+		require_downloading ? m_state.FindDownload(needle, file) : m_state.FindShared(needle, file);
+	if (!found) {
+		return ErrorResponse(404,
+			"not_found",
+			require_downloading ? "no download with that hash" : "no shared file with that hash");
+	}
+
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+
+	bool include_parts = false;
+	{
+		const auto qmap = web_api_path::ParseQuery(QueryOf(req));
+		const auto it = qmap.find("include_parts");
+		if (it != qmap.end()) {
+			if (it->second != "true" && it->second != "false") {
+				return ErrorResponse(
+					400, "bad_request", "`include_parts` must be \"true\" or \"false\"");
+			}
+			include_parts = (it->second == "true");
+		}
+	}
+
+	const std::uint64_t part_count = file.size > 0 ? (file.size + kPartSize - 1) / kPartSize : 0;
+	const auto &a4af_sources = file.download.a4af_sources;
+
+	std::vector<FileClientRow> rows;
+	for (auto client : m_state.Clients()) {
+		const bool is_source = (client.download_file_hash == needle);
+		const bool is_peer = (client.upload_file_hash == needle);
+		const bool is_a4af = std::find(a4af_sources.begin(), a4af_sources.end(), client.ecid) !=
+				     a4af_sources.end();
+		if (!is_source && !is_peer && !is_a4af) {
+			continue;
+		}
+
+		FileClientRow row;
+		row.role =
+			is_source && is_peer ? "both" : (is_source ? "source" : (is_peer ? "peer" : "none"));
+		row.a4af = is_a4af;
+		ComputePartProgressPercent(m_state, client);
+		if (include_parts) {
+			// Which bitmap belongs to this row follows its direction: the
+			// download map describes the file we pull from the peer, the
+			// upload map the file it pulls from us, and for a "both" row
+			// those are this same file seen from each side. A pure A4AF row
+			// has no bitmap for this file at all.
+			if (is_source) {
+				row.has_parts = ResolvePartBitmap(client.part_status,
+					client.part_status_all,
+					client.has_part_status,
+					part_count,
+					row.parts);
+			} else if (is_peer) {
+				row.has_parts = ResolvePartBitmap(client.upload_part_status,
+					client.upload_part_status_all,
+					client.has_upload_part_status,
+					part_count,
+					row.parts);
+			}
+		}
+		row.client = std::move(client);
+		rows.push_back(std::move(row));
+	}
+
+	return ListResponse(m_state, "clients", rows, WriteFileClientRow, params, FileClientComparators());
+}
+
 CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -3228,17 +3483,7 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 	ListParams params;
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
-	static const ListComparators<webapi::ClientSnapshot> kComps = {
-		{ "name",
-			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
-				return a.client_name < b.client_name;
-			} },
-		{ "software",
-			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
-				return a.software < b.software;
-			} },
-	};
-	return ListResponse(m_state, "clients", clients, WriteClientObject, params, kComps);
+	return ListResponse(m_state, "clients", clients, WriteClientObject, params, ClientComparators());
 }
 
 CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Request &req)
@@ -3488,8 +3733,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadFilenames(
 // resolved download snapshot.
 namespace
 {
+
 // Defined further down beside its FindServerByEcid / FindFriendByEcid
-// siblings; declared here so the per-source A4AF swap can validate its
+// siblings; declared here so the A4AF handlers below can validate a
 // `client_ecid` without moving the helper away from its family or copying it.
 bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::ClientSnapshot &out);
 
@@ -3507,34 +3753,6 @@ void WriteA4afObject(CJsonWriter &w, const webapi::FileSnapshot &d)
 	w.EndObject();
 }
 } // namespace
-
-CHttpServer::Response CApiDispatcher::HandleDownloadA4af(
-	const CHttpServer::Request &req, const std::string &key)
-{
-	auto a = Authenticate(req);
-	if (!a.ok)
-		return a.rejection;
-
-	if (auto r = RequireSnapshot(m_state))
-		return *r;
-
-	webapi::FileSnapshot d;
-	std::string needle = key;
-	std::transform(needle.begin(), needle.end(), needle.begin(), [](unsigned char c) {
-		return std::tolower(c);
-	});
-	if (!m_state.FindDownload(needle, d)) {
-		return ErrorResponse(404, "not_found", "no download with that hash");
-	}
-
-	CHttpServer::Response r;
-	r.status = 200;
-	r.content_type = "application/json";
-	CJsonWriter w;
-	WriteA4afObject(w, d);
-	FinalizeJsonBody(w, r);
-	return r;
-}
 
 CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 	const CHttpServer::Request &req, const std::string &key)
@@ -4830,23 +5048,7 @@ CHttpServer::Response CApiDispatcher::HandleClientDetail(
 		return ErrorResponse(404, "not_found", "no client with that ECID in the current snapshot");
 	}
 
-	// Completeness of the file we download FROM this peer = parts the
-	// peer has (available_parts) over that file's part count. Only the
-	// download link carries a meaningful denominator; a peer that is
-	// only downloading from us has no percent (available_parts stays).
-	if (cli.has_available_parts && !cli.download_file_hash.empty()) {
-		webapi::FileSnapshot f;
-		if (m_state.FindDownload(cli.download_file_hash, f) && f.size > 0) {
-			const std::uint64_t part_count = (f.size + kPartSize - 1) / kPartSize;
-			if (part_count > 0) {
-				double pct = 100.0 * static_cast<double>(cli.available_parts) /
-					     static_cast<double>(part_count);
-				if (pct > 100.0)
-					pct = 100.0;
-				cli.part_progress_percent = pct;
-			}
-		}
-	}
+	ComputePartProgressPercent(m_state, cli);
 
 	CHttpServer::Response r;
 	r.status = 200;

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -132,7 +132,6 @@ private:
 	// source-reported filenames + counts. `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleDownloadFilenames(const CHttpServer::Request &, const std::string &key);
 	// A4AF source list (GET) + swap actions (POST). `key` = 32-char MD4 hash.
-	CHttpServer::Response HandleDownloadA4af(const CHttpServer::Request &, const std::string &key);
 	CHttpServer::Response HandleDownloadA4afAction(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);
@@ -247,6 +246,10 @@ private:
 	CHttpServer::Response HandleSearchCommentsKadSearch(
 		const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleClients(const CHttpServer::Request &);
+	// Both per-file peer routes; `require_downloading` picks which collection
+	// the hash must belong to (downloads vs shared).
+	CHttpServer::Response HandleFileClients(
+		const CHttpServer::Request &, const std::string &key, bool require_downloading);
 	CHttpServer::Response HandleClientDetail(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleKnownClients(const CHttpServer::Request &);
 	// POST /clients/{ecid}/shared_files — browse a peer's shared file list

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -225,7 +225,11 @@ std::string ToJson(const ClientSnapshot &c)
 	  << ",\"queue_waiting_position\":" << c.queue_waiting_position
 	  << ",\"remote_queue_rank\":" << c.remote_queue_rank << ",\"score\":" << c.score
 	  << ",\"obfuscation_status\":\"" << EscJson(c.obfuscation_status) << "\""
-	  << ",\"friend_slot\":" << (c.friend_slot ? "true" : "false") << "}";
+	  << ",\"friend_slot\":" << (c.friend_slot ? "true" : "false") << ",\"source_origin\":\""
+	  << EscJson(c.source_origin) << "\""
+	  << ",\"available_parts\":" << c.available_parts << ",\"mod_version\":\"" << EscJson(c.mod_version)
+	  << "\""
+	  << ",\"view_shared_disabled\":" << (c.view_shared_disabled ? "true" : "false") << "}";
 	return o.str();
 }
 
@@ -354,7 +358,9 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 	       a.download_speed_bps == b.download_speed_bps &&
 	       a.queue_waiting_position == b.queue_waiting_position &&
 	       a.remote_queue_rank == b.remote_queue_rank && a.score == b.score &&
-	       a.obfuscation_status == b.obfuscation_status && a.friend_slot == b.friend_slot;
+	       a.obfuscation_status == b.obfuscation_status && a.friend_slot == b.friend_slot &&
+	       a.source_origin == b.source_origin && a.available_parts == b.available_parts &&
+	       a.mod_version == b.mod_version && a.view_shared_disabled == b.view_shared_disabled;
 }
 bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 {

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -703,6 +703,43 @@ const char *ClientIdentStateName(std::uint8_t code)
 	}
 }
 
+// Decode one per-part BitVector tag into a bool vector.
+//
+// Two shapes on the wire, and the empty one is the trap: the core sends a tag
+// with no payload when the peer holds EVERY part (ECSpecialCoreTags.cpp), so an
+// empty tag means "full", not "unknown". The caller learns that through
+// `out_all` because the true length is the file's part count, which is known
+// only where the row is rendered.
+//
+// The buffer holds ceil(bits/8) bytes, so decoding yields a multiple of 8 and
+// the tail beyond the file's part count is padding to be trimmed by the
+// renderer -- which also rejects a bitmap too short for the file rather than
+// padding it out.
+void DecodePartStatusTag(const CECTag *client_tag,
+	ec_tagname_t tag_name,
+	std::vector<bool> &out_bits,
+	bool &out_all,
+	bool &out_present)
+{
+	const CECTag *t = client_tag->GetTagByName(tag_name);
+	if (!t) {
+		return; // absent => unchanged
+	}
+	out_present = true;
+	if (!t->IsCustom() || t->GetTagDataLen() == 0) {
+		out_all = true;
+		out_bits.clear();
+		return;
+	}
+	out_all = false;
+	const auto *buf = static_cast<const std::uint8_t *>(t->GetTagData());
+	const std::size_t len = t->GetTagDataLen();
+	out_bits.assign(len * 8, false);
+	for (std::size_t i = 0; i < len * 8; ++i) {
+		out_bits[i] = (buf[i / 8] & (1u << (i & 7))) != 0;
+	}
+}
+
 // Format an IP from EC_TAG_CLIENT_USER_IP. The EC tag holds a
 // 32-bit host-order IPv4; we render it dotted-quad. Returns "" for
 // zero IPs (commonly the case for clients we've never confirmed).
@@ -933,6 +970,32 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 	// value when absent.
 	if (const CECTag *t = c->GetTagByName(EC_TAG_PARTFILE_NAME)) {
 		cs.upload_file_name = std::string(t->GetStringData().utf8_str());
+	}
+	// Per-part bitmaps. Both tags carry a raw BitVector buffer, bit i at
+	// buffer[i / 8] & (1 << (i & 7)) -- LSB-first within each byte -- and an
+	// EMPTY tag is the core's shorthand for "has every part", not for "no
+	// data". Absent means unchanged, per the tagmap convention the rest of
+	// this decoder follows, so the has_ flags only ever go from false to true.
+	DecodePartStatusTag(
+		c, EC_TAG_CLIENT_PART_STATUS, cs.part_status, cs.part_status_all, cs.has_part_status);
+	DecodePartStatusTag(c,
+		EC_TAG_CLIENT_UPLOAD_PART_STATUS,
+		cs.upload_part_status,
+		cs.upload_part_status_all,
+		cs.has_upload_part_status);
+	{
+		std::uint32_t v = 0;
+		if (c->AssignIfExist(EC_TAG_CLIENT_NEXT_REQUESTED_PART, v)) {
+			cs.next_requested_part = static_cast<std::uint16_t>(v);
+			cs.has_next_requested_part = true;
+		}
+	}
+	{
+		std::uint32_t v = 0;
+		if (c->AssignIfExist(EC_TAG_CLIENT_LAST_DOWNLOADING_PART, v)) {
+			cs.last_downloading_part = static_cast<std::uint16_t>(v);
+			cs.has_last_downloading_part = true;
+		}
 	}
 	{
 		std::uint32_t v = 0;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -256,8 +256,10 @@ struct FileSnapshot
 // by role:
 //  * /uploads → filter by upload_state == US_UPLOADING
 //  * /clients → no filter, full set surfaced
-// (/downloads/{hash}/sources can filter by
-// upload_file_hash matching the partfile.)
+//  * /downloads/{hash}/clients and /shared/{hash}/clients → the peers
+//    related to one file, selected by download_file_hash /
+//    upload_file_hash (plus that download's A4AF sources), each row
+//    carrying the direction as a `role` field.
 /**
  * One peer from the daemon's credit store — GET /known_clients.
  *
@@ -385,6 +387,30 @@ struct ClientSnapshot
 	// (available_parts / file part count). < 0 => not computable (no
 	// linked file / no part count); populated by the detail handler.
 	double part_progress_percent = -1.0;
+
+	// Per-part bitmaps, one bit per chunk of the file the relation names:
+	// `part_status` is what the peer holds of the file WE PULL FROM IT,
+	// `upload_part_status` what it holds of the file IT PULLS FROM US. A peer
+	// doing both at once has two different files' bitmaps here, so a consumer
+	// must pick by direction rather than assume they describe the same file.
+	//
+	// The core sends an EMPTY tag to mean "has every part" rather than
+	// spending bytes on an all-ones buffer, and omits the tag entirely when
+	// its length would disagree with the file's part count. `*_all` carries
+	// the first case; the vector is then left empty and sized by whoever
+	// renders it, which is the only place the part count is known.
+	std::vector<bool> part_status;
+	std::vector<bool> upload_part_status;
+	bool part_status_all = false;
+	bool upload_part_status_all = false;
+	bool has_part_status = false;
+	bool has_upload_part_status = false;
+	// Indices into the download bitmap; absent from the wire means unchanged,
+	// so the has_ flags distinguish "never reported" from "reported as 0".
+	std::uint16_t next_requested_part = 0;
+	std::uint16_t last_downloading_part = 0;
+	bool has_next_requested_part = false;
+	bool has_last_downloading_part = false;
 
 	// --- Detail-only fields (issue #423, new EC tags) ----------------
 	bool is_friend = false;      // CUpDownClient::IsFriend(); distinct from friend_slot

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -197,19 +197,65 @@ if [ "$COUNT" -gt 0 ]; then
 	_assert_json_eq '.media | type' null \
 		'/downloads/{hash} omits media when unprobed'
 
-	# A4AF source list sub-resource (issue #421).
-	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/a4af"
-	_assert_status 200 "GET /downloads/{hash}/a4af → 200"
-	_assert_json_eq '.a4af_auto | type' boolean \
-		'/downloads/{hash}/a4af carries a4af_auto'
-	_assert_json_eq '.sources | type' array \
-		'/downloads/{hash}/a4af.sources is an array'
+	# The A4AF read sub-resource (issue #421) was retired in favour of the
+	# per-file client rows below (issue #984), which carry the whole peer
+	# object per A4AF source rather than a bare ECID. `a4af_auto` lives on the
+	# download detail object, asserted above. The POST half is unaffected.
 
 	# Unknown action → 400 (mutation validation; admin token).
 	_curl -X POST -H "Authorization: Bearer $TOKEN" \
 		-H "Content-Type: application/json" \
 		-d '{"action":"bogus"}' "$HOST/api/v0/downloads/$HASH/a4af"
 	_assert_status 400 "POST /downloads/{hash}/a4af unknown action → 400"
+
+	# Per-file client rows (issue #984): the peers of one file, with their
+	# relation to it, replacing a client-side join against the global list.
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients"
+	_assert_status 200 "GET /downloads/{hash}/clients → 200"
+	_assert_json_eq '.clients | type' array '/downloads/{hash}/clients returns a clients array'
+	for k in total offset limit; do
+		_assert_json_eq "has(\"$k\")" true "/downloads/{hash}/clients envelope has $k"
+	done
+
+	# Every row carries its relation to this file, and no row carries a parts
+	# bitmap unless it was asked for.
+	_assert_json_eq '[.clients[] | select(.role as $r | ($r == null) or ((["source","peer","both","none"] | index($r)) == null))] | length' \
+		0 "every row has a valid role"
+	_assert_json_eq '[.clients[] | select(.a4af == null)] | length' 0 "every row has an a4af flag"
+	_assert_json_eq '[.clients[] | select(has("parts"))] | length' 0 "no parts bitmap without include_parts"
+
+	# Opt-in bitmaps are exactly part_count long for a row that has one.
+	PARTCOUNT=$(curl -s -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH" | jq -r '.progress.parts | length')
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?include_parts=true"
+	_assert_status 200 "GET /downloads/{hash}/clients?include_parts=true → 200"
+	_assert_json_eq "[.clients[] | select(has(\"parts\")) | select((.parts | length) != $PARTCOUNT)] | length" \
+		0 "every parts bitmap is exactly part_count entries"
+
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?include_parts=maybe"
+	_assert_status 400 "include_parts must be true/false"
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?sort=nonsuch"
+	_assert_status 400 "unknown sort key on the per-file route → 400"
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?sort=name&order=desc"
+	_assert_status 200 "the /clients sort keys work on the per-file route"
+	_curl -X POST -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients"
+	_assert_status 405 "POST /downloads/{hash}/clients → 405"
+	_curl -H "Authorization: Bearer $TOKEN" \
+		"$HOST/api/v0/downloads/ffffffffffffffffffffffffffffffff/clients"
+	_assert_status 404 "unknown hash on the per-file route → 404"
+
+	# The promoted client fields (issue #984) must be on the LIST row, not
+	# just the detail object — the desktop renders them as table columns.
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/clients?limit=1"
+	if [ "$(echo "$CURL_BODY" | jq -r '.clients | length')" != "0" ]; then
+		for k in source_origin available_parts mod_version view_shared_disabled; do
+			_assert_json_eq ".clients[0] | has(\"$k\")" true "/clients row carries $k"
+		done
+	fi
+
+	# The A4AF read route is retired in favour of the rows above; its POST
+	# stays, so the path must answer 405 rather than 404.
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 405 "GET /downloads/{hash}/a4af is retired → 405"
 
 	# Per-source swap (issue #983): `client_ecid` narrows swap_this to one
 	# source. Validation is asserted here rather than the swap itself — a

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1422,6 +1422,87 @@ static void PutOneClient(CECPacket &resp,
 	resp.AddTag(container);
 }
 
+// Per-part bitmaps (issue #984). Three wire conventions have to survive the
+// decoder: an EMPTY tag means "holds every part", the buffer is LSB-first
+// within each byte, and an absent tag means unchanged rather than zero.
+static void PutClientWithPartStatus(CECPacket &resp,
+	std::uint32_t ecid,
+	const std::uint8_t *buf /* nullptr = empty tag */,
+	std::size_t len)
+{
+	CECTag container(EC_TAG_CLIENT, static_cast<std::uint32_t>(0));
+	CECTag cli(EC_TAG_CLIENT, ecid);
+	if (buf) {
+		cli.AddTag(CECTag(EC_TAG_CLIENT_PART_STATUS, len, buf));
+	} else {
+		cli.AddTag(CECEmptyTag(EC_TAG_CLIENT_PART_STATUS));
+	}
+	container.AddTag(cli);
+	resp.AddTag(container);
+}
+
+TEST(Refresher, ClientEmptyPartStatusMeansFullSource)
+{
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> no_files;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	PutClientWithPartStatus(resp, 11, nullptr, 0);
+
+	ApplyGetUpdateToClients(&resp, cache, no_files);
+
+	ASSERT_TRUE(cache.find(11) != cache.end());
+	ASSERT_TRUE(cache[11].has_part_status);
+	// "all" rather than an empty bitmap: the true length is the file's part
+	// count, which only the renderer knows.
+	ASSERT_TRUE(cache[11].part_status_all);
+	ASSERT_TRUE(cache[11].part_status.empty());
+}
+
+TEST(Refresher, ClientPartStatusIsDecodedLsbFirst)
+{
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> no_files;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	// 0x05 = bits 0 and 2 set, LSB-first (BitVector::s_posMask).
+	const std::uint8_t buf[] = { 0x05 };
+	PutClientWithPartStatus(resp, 12, buf, sizeof(buf));
+
+	ApplyGetUpdateToClients(&resp, cache, no_files);
+
+	ASSERT_TRUE(cache.find(12) != cache.end());
+	ASSERT_TRUE(cache[12].has_part_status);
+	ASSERT_TRUE(!cache[12].part_status_all);
+	ASSERT_EQUALS(static_cast<size_t>(8), cache[12].part_status.size());
+	ASSERT_TRUE(cache[12].part_status[0]);
+	ASSERT_TRUE(!cache[12].part_status[1]);
+	ASSERT_TRUE(cache[12].part_status[2]);
+	ASSERT_TRUE(!cache[12].part_status[7]);
+}
+
+TEST(Refresher, ClientAbsentPartStatusLeavesCachedBitmap)
+{
+	// Tagmap convention: a tick that does not carry the tag says nothing
+	// about it, so a previously decoded bitmap must survive.
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	{
+		ClientSnapshot c;
+		c.ecid = 13;
+		c.part_status = { true, false, true };
+		c.has_part_status = true;
+		cache.emplace(13, c);
+	}
+	std::map<std::uint32_t, std::string> no_files;
+	CECPacket resp(EC_OP_SHARED_FILES);
+	PutOneClient(resp, 13, static_cast<std::uint32_t>(SO_AMULE), nullptr);
+
+	ApplyGetUpdateToClients(&resp, cache, no_files);
+
+	ASSERT_TRUE(cache[13].has_part_status);
+	ASSERT_EQUALS(static_cast<size_t>(3), cache[13].part_status.size());
+	ASSERT_TRUE(cache[13].part_status[0]);
+	ASSERT_TRUE(cache[13].part_status[2]);
+}
+
 TEST(Refresher, ClientVersionUnknownYieldsLocaleIndependentSentinel)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;


### PR DESCRIPTION
Addresses #984 — the core + amuleapi half. The Web UI (§4 of the issue) is left to @ngosang, so the issue stays open.

The desktop has two per-file peer panels and the API had no route for either, so a client had to pull the whole `/clients` list and join it on `download_file_hash` / `upload_file_hash` — which is what the bundled Web UI does, with the limitation its own comment admits: A4AF sources have neither hash pointing at the file, so they never appear at all.

```
GET /api/v0/downloads/{hash}/clients
GET /api/v0/shared/{hash}/clients
```

**One handler serves both.** The rows are the same object out of the same cache either way — the relation to the file is a field, not a path — so the routes differ only in which collection the hash must belong to. A partfile with a completed chunk is in both at once and answers identically on both; verified against a live daemon.

Each row adds `role` (`source` / `peer` / `both` / `none`), `a4af`, and — only when asked for — `parts`. `role` and `a4af` are separate because they are orthogonal: a peer can be parked on another file *and* be pulling this one from us, which a fourth `role` value could not express.

## The part bitmaps

The four tags the core has always sent were decoded by nobody — `PART_STATUS`, `UPLOAD_PART_STATUS`, `NEXT_REQUESTED_PART`, `LAST_DOWNLOADING_PART`. All the API offered was a scalar count. Three wire conventions had to be honoured, each with a unit test:

- an **empty tag means the peer holds every part**, not none
- the buffer is **LSB-first** within each byte
- an **absent tag means unchanged**, not zero

Bitmaps are opt-in via `?include_parts=true` — one boolean per chunk per peer — and never appear in SSE payloads.

## Promoted fields

`source_origin`, `available_parts`, `mod_version`, `view_shared_disabled` and `part_progress_percent` were detail-only although the desktop renders them as list columns. They are on the list row now, which also puts them in the SSE client payload — added to **both** `ToJson` and `Equal`, since a field in the first but not the second is silently frozen after the first frame.

## Retired

`GET /downloads/{hash}/a4af` — its rows are these rows now, carrying the whole peer object instead of a bare ECID, and `a4af_auto` was already on the download detail object. The `POST` stays, so the path answers `405`; the dead read handler is deleted.

## Reuse

The per-file sort keys are **derived from** the `/clients` comparator set rather than copied, so a key added there applies to both surfaces. The percent calculation moved out of `HandleClientDetail` into one helper both paths call. Rows go through the same `ParseListParams` / `ListResponse` machinery as every other list.

## Testing

Verified end to end against a live daemon downloading from a LAN source at 80 MiB/s:

```
role "source", a4af false, source_origin "link", available_parts 3312, part_progress_percent 100
include_parts=true → 3312 entries, all true   (file part_count = 3312)
```

That last line is the empty-tag convention working: the seeder is a full source, the core sent an *empty* `PART_STATUS`, and it expands to a complete bitmap rather than an empty one. Also confirmed both routes return byte-identical bodies for that partfile, all four promoted fields reach `client_updated`, and no `parts` array leaks into SSE.

3 new unit tests (34/34 suites pass), ~20 new curl assertions in the existing phase — **93/93 pass**. clang-format and both clang-tidy tiers clean.
