### PR TITLE
amuleapi: address every search by id in the path, and close the multi-search gaps

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -39,7 +39,7 @@ const EVENT_TYPES = [
   "server_added",   "server_updated",   "server_removed",
   "friend_added",   "friend_updated",   "friend_removed",
   "status_changed", "log_appended",
-  "search_result_added", "search_progress",
+  "search_result_added", "search_progress", "search_closed",
   "comments_updated",
 ];
 const es = new EventSource("/api/v0/events", { withCredentials: true });
@@ -160,7 +160,7 @@ Every event belongs to a single channel. The full set, prefix-mapped from the ev
 | `friends` | `friend_*` | The friends list, and whether each one is online |
 | `status` | `status_*` | Connection state + headline counters |
 | `logs` | `log_*` | amuled log buffer (live tail; serverinfo is poll-only) |
-| `search` | `search_*` | Result deltas + completion of an active `POST /search` |
+| `search` | `search_*` | Result deltas, completion, and the freeing of a search |
 
 By default every channel is delivered. To subscribe to a subset, pass `?channels=` with a comma-separated list:
 
@@ -220,7 +220,7 @@ Both `since_id` and `newest_id` are uint64. The client never has to compute them
 
 ## Event catalog
 
-Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`), `client_ecid` for `client_removed`, `friend_ecid` for `friend_removed`, `ecid` for `server_removed` — so the client can drop the cache entry without needing the old object. Two events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge) and `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace). Branch on the event type in your dispatcher accordingly.
+Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`), `client_ecid` for `client_removed`, `friend_ecid` for `friend_removed`, `ecid` for `server_removed` — so the client can drop the cache entry without needing the old object. Three events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge), `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace), and `search_closed` retires a whole result space rather than one item (`{search_id}` — drop the view, not a row). Branch on the event type in your dispatcher accordingly.
 
 ### `downloads` channel
 
@@ -473,7 +473,7 @@ Only the amuled log has a live channel; the serverinfo buffer has no SSE feed an
 
 ### `search` channel
 
-Driven by the refresher state machine that owns the `POST /search` → completion lifecycle (see [REFERENCE.md](REFERENCE.md#search-results)). Events only fire while a search is active; the channel is silent at idle. The [Bootstrap example](#bootstrap-snapshot--stream) omits `/search/results` because searches are normally client-initiated post-boot; if your UI persists a "search-in-progress" state across reloads, fetch `/search/results` and `/search/progress` in step 2 too.
+Driven by the refresher state machine that owns the `POST /search` → completion lifecycle (see [REFERENCE.md](REFERENCE.md#search)). Result and progress events only fire while a search is active; the channel is otherwise silent apart from `search_closed`. The [Bootstrap example](#bootstrap-snapshot--stream) omits the search endpoints because searches are normally client-initiated post-boot; if your UI persists a "search-in-progress" state across reloads, list them with `GET /search` and fetch `GET /search/{id}/results` in step 2 too.
 
 #### `search_result_added`
 
@@ -495,11 +495,11 @@ Emitted per new result that appears in the results map between refresher ticks.
 }
 ```
 
-`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/results` array entry (including `status`, `type`, and the `children[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchresults)); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present only for locally-known/probed hits and omitted otherwise, and `children` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire this event — children are folded into their parent's `children[]`, never emitted as their own `search_result_added`. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
+`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed peer's share, `""` on ordinary hits), `kad_comment_search_running`, `comments[]` and the `children[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present only for locally-known/probed hits and omitted otherwise, and `children` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire this event — children are folded into their parent's `children[]`, never emitted as their own `search_result_added`. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
 
 #### `search_progress`
 
-Emitted whenever a search's completion advances and once more on its completion; every frame carries the `search_id` it refers to. Two triggers, both off the daemon's unambiguous `EC_TAG_SEARCH_LIFECYCLE_*` tags (see [REFERENCE.md](REFERENCE.md#search-results)): the `percent` changing between refresher ticks while the search runs, and the lifecycle flipping to finished (the `state` `running` → `finished` edge). A newly-started search also emits its initial `running` frame. The completion frame is just the terminal `search_progress` with `"state": "finished"` — there is **no** separate `search_finished` event.
+Emitted whenever a search's completion advances and once more on its completion; every frame carries the `search_id` it refers to. Two triggers, both off the daemon's unambiguous `EC_TAG_SEARCH_LIFECYCLE_*` tags (see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults)): the `percent` changing between refresher ticks while the search runs, and the lifecycle flipping to finished (the `state` `running` → `finished` edge). A newly-started search also emits its initial `running` frame. The completion frame is just the terminal `search_progress` with `"state": "finished"` — there is **no** separate `search_finished` event.
 
 ```json
 { "search_id": 42, "state": "running", "percent": 47, "results": 88, "kind": "kad" }
@@ -511,13 +511,25 @@ Emitted whenever a search's completion advances and once more on its completion;
 
 - `search_id` — which search this frame is about.
 - `state` — `"running"` while the search is in flight, `"finished"` on the terminal frame.
-- `percent` — `0..100`, daemon-computed for every search kind. For **global** it is the real server-queue progress. For **Kad**, which has no measurable progress, it is a cosmetic time-ramp derived from the fixed 45 s keyword-search lifetime (capped at 99 until the daemon authoritatively reports completion, then 100); see [REFERENCE.md](REFERENCE.md#search-results). Treat the Kad value as a liveliness indicator, not an accurate completion estimate.
+- `percent` — `0..100`, daemon-computed for every search kind. For **global** it is the real server-queue progress. For **Kad**, which has no measurable progress, it is a cosmetic time-ramp derived from the fixed 45 s keyword-search lifetime (capped at 99 until the daemon authoritatively reports completion, then 100); see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults). Treat the Kad value as a liveliness indicator, not an accurate completion estimate.
 - `kind` — the originally-requested search type (`"local"` | `"global"` | `"kad"` | `"browse"`).
-- `results` — the current results-map size; subscribers can reconcile against any `search_result_added` they may have missed via `GET /search/results`.
+- `results` — the current results-map size; subscribers can reconcile against any `search_result_added` they may have missed via `GET /search/{id}/results`.
 
 A Kad search hitting its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — the lifecycle flips to `finished` and `percent` jumps straight to 100 ahead of the ramp.
 
 A **browse** started via [`POST /clients/{ecid}/shared_files`](REFERENCE.md#post-apiv0clientsecidshared_files) rides this same channel: its `search_id` fires `search_result_added` per file the peer returns and `search_progress` frames with `"kind": "browse"`, where `percent` tracks the directories received so far. A denied / unreachable / lost browse flips to `finished` with the results it managed to collect (often zero) — same terminal frame as a completed one, no distinct failure event.
+
+#### `search_closed`
+
+The search is **gone**: its slot has been freed and its results are no longer readable. A subscriber holding one view per search should drop that view — the next `GET /api/v0/search/{id}/results` for this id is a `404`.
+
+```json
+{ "search_id": 42 }
+```
+
+Three things produce it: [`DELETE /api/v0/search/{id}`](REFERENCE.md#delete-apiv0searchid) from any client, amuleapi evicting an old finished search to stay under its slot cap, and an EC reconnect (which invalidates every cached `search_id` at once).
+
+**What it is not:** a search that amuled evicted from its own 20-entry ring is *retired*, not freed — amuleapi keeps its last-known results for late reads, so that case arrives as a terminal `search_progress` with `"state": "finished"`. Only a vanished slot produces `search_closed`.
 
 ### Filter-bypass: `resync`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -105,8 +105,10 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Search**
 - [`GET /api/v0/search`](#get-apiv0search) — enumerate every search amuled currently holds, including ones this session never started
 - [`POST /api/v0/search`](#post-apiv0search) — start a search (global / local / kad), returns its `search_id`
-- [`GET /api/v0/search/results`](#get-apiv0searchresults) — one search's results + progress envelope (`?search_id=`)
-- [`POST /api/v0/search/stop`](#post-apiv0searchstop) — stop (and optionally free) a search by id
+- [`GET /api/v0/search/{id}/results`](#get-apiv0searchidresults) — one search's results + progress envelope
+- [`POST /api/v0/search/{id}/stop`](#post-apiv0searchidstop) — stop a search, keeping its results
+- [`POST /api/v0/search/{id}/more`](#post-apiv0searchidmore) — widen a running Kad search
+- [`DELETE /api/v0/search/{id}`](#delete-apiv0searchid) — stop a search and free it
 - [`POST /api/v0/search/results/{hash}/download`](#post-apiv0searchresultshashdownload) — promote a result into the download queue
 - [`GET /api/v0/search/results/{hash}/comments`](#get-apiv0searchresultshashcomments) — Kad ratings/comments for a result
 - [`POST /api/v0/search/results/{hash}/comments`](#post-apiv0searchresultshashcomments) — trigger a Kad notes lookup for a result
@@ -198,7 +200,7 @@ Each endpoint documents its own response shape under the endpoint section. List 
 
 ### List pagination and sorting
 
-The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, the two per-file client routes, and `/search/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
+The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, the two per-file client routes, and `/search/{id}/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
@@ -230,7 +232,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 | `GET /shared`         | `name`, `size` |
 | `GET /servers`        | `name`, `users`, `ping`, `files` |
 | `GET /friends`        | `name`, `online` |
-| `GET /search/results` | `name`, `size`, `sources`, `rating` |
+| `GET /search/{id}/results` | `name`, `size`, `sources`, `rating`, `directory` |
 
 ### Bulk mutations and the `results` envelope
 
@@ -1159,7 +1161,7 @@ Browse a peer's shared file list — the API equivalent of "View Files" in the G
 
 The browse runs **asynchronously**: the peer answers over the network, one directory at a time, and a HighID/reachable peer may take seconds while a LowID peer needs a server callback or Kad first. So this endpoint does **not** return the files — it returns a `search_id` and the results flow through the **search machinery**, exactly like a query search:
 
-- `GET /api/v0/search/results?search_id={id}` reads the accumulated files as they arrive (standard search-result fields).
+- `GET /api/v0/search/{id}/results` reads the accumulated files as they arrive (standard search-result fields, plus `directory` — the folder each file sits in inside the peer's share). The browse also appears in [`GET /api/v0/search`](#get-apiv0search) with `kind: "browse"` and the browsed peer's `client_ecid`.
 - The refresher advances `search_progress` for this `search_id` while the browse is live, and emits a `search_finished` SSE event when the peer's list is complete or the browse fails (denied / peer unreachable / connection lost). A denied or failed browse finishes with zero results — there is no distinct error event.
 
 Reusing the search id-space means one poll loop and one SSE stream cover both queries and browses; a client tells them apart by remembering which `search_id` it started with which verb.
@@ -1177,7 +1179,7 @@ Status `202 Accepted` — the browse was started, not completed. Then poll:
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/search/results?search_id=17"
+  "http://$HOST/api/v0/search/17/results"
 ```
 
 **Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `403 forbidden` (guest token — browsing is `ADMIN`-only), `404 not_found` (no peer with that ecid), `405 method_not_allowed` (non-POST), `502 bad_gateway` (core accepted the request but returned no `search_id`), `503 ec_unavailable`.
@@ -1771,7 +1773,7 @@ Only one friend can hold the slot at a time, so granting it clears it on whoever
 
 Browse a friend's shared files. The friend-addressed twin of [`POST /api/v0/clients/{ecid}/shared_files`](#post-apiv0clientsecidshared_files), and more capable: a friend record carries a stored address, so the daemon can browse a friend who is **not currently connected**, which the clients route cannot do.
 
-**Response:** `202 Accepted` → `{ "ok": true, "search_id": 17 }`. Poll [`GET /api/v0/search/results`](#get-apiv0searchresults) with that `search_id`.
+**Response:** `202 Accepted` → `{ "ok": true, "search_id": 17 }`. Poll [`GET /api/v0/search/{id}/results`](#get-apiv0searchidresults) with that id.
 
 **Errors:** `403 forbidden`, `404 not_found`, `502 amuled_rejected`, `503 ec_unavailable`.
 
@@ -2351,18 +2353,21 @@ The search surface is admin-only because firing a global ed2k search has real ne
 
 **Auth:** `GUEST`
 
-Lists every search amuled currently holds — including ones started by a **different** client (another amuleapi request, the monolithic GUI, an amulegui session). Each call is a direct round trip to amuled (`EC_OP_SEARCH_LIST`), independent of the Refresher-maintained `m_state` cache, so a search this process never saw a `POST /search` for still shows up here as soon as amuled is holding it. [`GET /search/results`](#get-apiv0searchresults) can then fetch that same `search_id` — on a cache miss it does its own one-off `EC_OP_SEARCH_LIST` check before returning `404`, so a search this endpoint just listed is never a dead end there.
+Lists every search amuled currently holds — including ones started by a **different** client (another amuleapi request, the monolithic GUI, an amulegui session). Each call is a direct round trip to amuled (`EC_OP_SEARCH_LIST`), independent of the Refresher-maintained `m_state` cache, so a search this process never saw a `POST /search` for still shows up here as soon as amuled is holding it. [`GET /search/{id}/results`](#get-apiv0searchidresults) can then fetch that same `search_id` — on a cache miss it does its own one-off `EC_OP_SEARCH_LIST` check before returning `404`, so a search this endpoint just listed is never a dead end there.
 
 ```json
 {
   "searches": [
     { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished" },
-    { "search_id": 43, "query": "debian",              "kind": "kad",    "state": "running"  }
+    { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running"  },
+    { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running", "client_ecid": 621 }
   ]
 }
 ```
 
-`search_id` is the value to pass to [`GET /search/results`](#get-apiv0searchresults) (`?search_id=`) to read that search's hits, or to [`POST /search/stop`](#post-apiv0searchstop) to stop it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/results`'s `progress.state`.
+`search_id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
+
+`query` is the daemon's name for the search. For a `"browse"` that is **the peer's nickname**, not a query string — a browse has no query. `client_ecid` is the browsed peer's ecid and is present **only** on browse entries, so a consumer can tell whose share is being listed and cross-reference [`GET /clients`](#get-apiv0clients); it is omitted entirely on an ordinary search.
 
 amuled only tracks multiple concurrent searches for clients that advertise multi-search support; `amuleapi` does, so this always reflects the full live set. `searches` is an empty array when amuled holds no searches, never an error.
 
@@ -2372,7 +2377,7 @@ amuled only tracks multiple concurrent searches for clients that advertise multi
 
 **Auth:** `ADMIN`
 
-Kicks off a new search. amuleapi supports **several concurrent searches** — a new search does NOT stop or wipe the others. amuled allocates a globally-unique `search_id` for each start and returns it; every subsequent results/progress/stop call addresses one search by that id. The search you just started becomes the *current* search (the default target when a call omits `search_id`).
+Kicks off a new search. amuleapi supports **several concurrent searches** — a new search does NOT stop or wipe the others. amuled allocates a globally-unique `search_id` for each start and returns it; every subsequent results/stop/more call names that id in the path. There is no implicit "current search": keep the id you are given, or re-discover it through [`GET /search`](#get-apiv0search).
 
 **Body:**
 
@@ -2394,15 +2399,19 @@ Only `query` is required. `type` defaults to `"global"`; valid values are `"loca
 
 **Errors:** `502 amuled_rejected` (daemon returned no search_id), `503 ec_unavailable`.
 
-#### `GET /api/v0/search/results`
+#### `GET /api/v0/search/{id}/results`
 
 **Auth:** `GUEST`
 
-**Query:** `?search_id=N` (optional) — which search to read. Omit it to read the **current** (most-recently-started, by *this session* -- see below) search. An explicit `search_id` that names no live search (never started anywhere, or evicted from amuled's ring — see below) returns `404 not_found`, distinct from a known-but-empty search which returns an idle/empty envelope.
+**Path:** `{id}` — the `search_id` to read, from [`POST /search`](#post-apiv0search) or [`GET /search`](#get-apiv0search). Required. A non-numeric segment or `0` is `400 bad_request`, never a fallback to some other search. An id that names no live search (never started anywhere, freed, or evicted from amuled's ring — see below) returns `404 not_found`, distinct from a known-but-empty search which returns an idle/empty envelope.
 
-Returns one search's results buffer at the moment of the call PLUS a progress envelope so an empty `results` array isn't ambiguous between "no search running", "search in flight with no hits yet", and "search finished with zero hits". The envelope's top-level `search_id` echoes the resolved search (the one requested, or the current one) so a client polling without an id learns which search it is watching and can pin it on later calls.
+Returns one search's results buffer at the moment of the call PLUS a progress envelope so an empty `results` array isn't ambiguous between "search not started", "search in flight with no hits yet", and "search finished with zero hits".
 
-This endpoint does NOT busy-wait — it returns whatever amuled has in its result buffer right now. A client that wants to wait for completion should poll while `progress.state == "running"`. There is no per-GET TTL cache: the refresher polls amuled (`EC_OP_SEARCH_RESULTS` + `EC_OP_SEARCH_PROGRESS`, addressed by `search_id`) every tick for each active search, so this GET reads straight from that refresher-maintained snapshot — successive polls see the growing result set with no extra EC roundtrip. `POST /search` is one way a search becomes active; an unknown `search_id` (one this session never started) triggers a one-off `EC_OP_SEARCH_LIST` check before the `404`, and once confirmed the search is active from that request on, with the refresher polling it every tick from there — so a search another client (or the monolithic GUI) started is fetchable by `search_id` too, not just listable via [`GET /search`](#get-apiv0search). Discovery alone never changes what "the current search" (the no-`search_id` default) means, though: that stays whichever search *this* session's own `POST /search` most recently started.
+This endpoint does NOT busy-wait — it returns whatever amuled has in its result buffer right now. A client that wants to wait for completion should poll while `progress.state == "running"`. While a search is **running** the refresher polls amuled (`EC_OP_SEARCH_RESULTS` + `EC_OP_SEARCH_PROGRESS`, addressed by `search_id`) every tick, so this GET reads straight from that snapshot and successive polls see the growing result set with no extra EC roundtrip.
+
+Once a search is **finished** the refresher stops polling it, so this endpoint refreshes it **on read** instead, coalesced by a ~1 s TTL. That is what keeps a finished search's results live rather than frozen at the moment it completed: a Kad notes lookup started on one of its hits reports back, and a hit you download from it starts reading `status: "downloaded"` / `already_have: true`. Repeated polling of a finished search costs at most one EC roundtrip per second, not one per request.
+
+`POST /search` is one way a search becomes readable; an unknown `search_id` (one this session never started) triggers a one-off `EC_OP_SEARCH_LIST` check before the `404`, and once confirmed it is polled every tick from there — so a search another client (or the monolithic GUI) started is readable here too, not just listable via [`GET /search`](#get-apiv0search).
 
 amuled keeps a bounded ring of recent searches (20). A search evicted from that ring (because 20 newer searches were started) is reported to amuleapi as expired: its slot is retired as `finished` and reads with its `search_id` then return `404`.
 
@@ -2418,16 +2427,18 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
       "rating":       0,
       "status":       "new",
       "type":         "videos",
+      "directory":    "",
       "media":        { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" },
       "children": [
-        { "ecid": 621, "name": "example-distribution-26.04.iso", "hash": "8b54a3c2...", "sources": { "total": 40, "complete": 22 } },
-        { "ecid": 622, "name": "example_distro_2604_amd64.iso",  "hash": "8b54a3c2...", "sources": { "total": 10, "complete":  3 } }
+        { "ecid": 621, "name": "example-distribution-26.04.iso", "hash": "8b54a3c2...", "sources": { "total": 40, "complete": 22 }, "directory": "" },
+        { "ecid": 622, "name": "example_distro_2604_amd64.iso",  "hash": "8b54a3c2...", "sources": { "total": 10, "complete":  3 }, "directory": "" }
       ],
       "kad_comment_search_running": false,
       "comments": []
     }
   ],
   "search_id": 42,
+  "query": "ubuntu desktop iso",
   "progress": {
     "state":    "running",
     "kind":     "kad",
@@ -2437,6 +2448,10 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
 ```
 
 Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints) — **present only** for a hit that is already known/probed locally, and **omitted entirely** for remote hits with no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list.
+
+`directory` is the folder this file sits in **inside a browsed peer's share** — the desktop search list's *Directories* column. It is populated only for results filed from a peer's shared-file listing (see [peer browse](#post-apiv0clientsecidshared_files)) and is `""` on every ordinary server/Kad hit, which never carries it. It is per-result rather than per-search: two copies of one file in different folders of the same share group under a single parent and each keeps its own folder, exactly as the desktop shows them, which is why `children[]` entries carry it too.
+
+`search_id` and `query` identify the search these results belong to. `search_id` echoes the path so clients can key a view on the response alone; `query` is what the search was started with, so a client that adopted an id from [`GET /search`](#get-apiv0search) can label it without a second call. For a **browse**, `query` is the peer's nickname rather than a query string. `query` is `""` only for a search discovered before amuled reported a name for it.
 
 `children` is the result-grouping tree: amuled collapses hits that are the **same file** (same ed2k hash **and** size) but advertised under **different filenames** into one parent row, and `children[]` holds the alternative names. Each child carries the parent's `hash` (that's why they group), its own `sources`, and a distinct `ecid` — pass that `ecid` to [`POST /search/results/{hash}/download`](#post-apiv0searchresultshashdownload) to download the file **under that chosen filename**. `children` is always present and is an empty array for a hit seen under a single name. The top-level `results[]` contains parents only — a child never appears as its own top-level entry.
 
@@ -2450,26 +2465,55 @@ The `progress` object carries the same `state` / `kind` / `percent` fields as th
 
 A client that wants to wait for completion polls while `state == "running"`. Because amuled now reports the lifecycle state directly (no sentinel decode), `state == "running"` unambiguously means in-flight even for Kad — there is no longer any "is `percent: 0` a stalled Kad search or no search at all?" ambiguity; check `state` instead. A Kad search that hits its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — `state` flips to `finished` and `percent` jumps to 100 ahead of the ramp.
 
-**Errors:** `503 ec_unavailable`.
+**Errors:** `400 bad_request` (bad `{id}`), `404 not_found` (no such search), `503 ec_unavailable`.
 
-#### `POST /api/v0/search/stop`
+#### `POST /api/v0/search/{id}/stop`
 
 **Auth:** `ADMIN`
 
-Stops a search. With no body it stops the **current** (most-recently-started) search; its cached results stay readable until it is closed or evicted.
-
-**Body (optional):**
-
-```json
-{ "search_id": 42, "close": false }
-```
-
-- `search_id` — which search to stop. Omit to target the current search. An explicit id that names no live search returns `404 not_found`.
-- `close` — when `true`, also **frees** the search: amuled drops it from its result ring and amuleapi drops its slot, so `GET /search/results?search_id=` for it then returns `404`. Sibling searches are untouched. Use `close` when a consumer is done with a search rather than just pausing it; omit it (or `false`) to stop the in-flight query but keep the results.
+Stops one search. No body. Its cached results stay readable until it is freed or evicted, so a consumer viewing the search keeps seeing the set it was just looking at. Sibling searches are untouched.
 
 **Response:** `200 OK` → `{ "ok": true }`.
 
-**Errors:** `404 not_found` (explicit unknown `search_id`), `400 bad_request` (malformed body), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (bad `{id}`), `404 not_found` (no such search), `405`, `503 ec_unavailable`.
+
+#### `DELETE /api/v0/search/{id}`
+
+**Auth:** `ADMIN`
+
+Stops the search **and frees it**: amuled drops it from its result ring and amuleapi drops its slot, so [`GET /search/{id}/results`](#get-apiv0searchidresults) for it then returns `404`. Sibling searches are untouched. Use this when a consumer is done with a search rather than just pausing it; use `POST /search/{id}/stop` to halt the in-flight query but keep the results.
+
+Freeing a search delivers a [`search_closed`](EVENTS.md#search_closed) event to every SSE subscriber, so other clients holding a view on it find out immediately.
+
+**Response:** `204 No Content`.
+
+**Errors:** `400 bad_request` (bad `{id}`), `404 not_found` (no such search), `405`, `503 ec_unavailable`.
+
+#### `POST /api/v0/search/{id}/more`
+
+**Auth:** `ADMIN`
+
+Widens a running **Kad** search — the desktop's **"More"** button. It re-asks the Kad peers already queried for a wider result frontier; amuled caps this at 4 reasks per search and logs the outcome itself, so this is fire-and-forget. No body.
+
+Kad-only and running-only, matching what the desktop button allows rather than what the core tolerates: amuled turns a `more` on a non-Kad or finished search into a silent no-op, so both are rejected here instead of being answered with a misleading `202`.
+
+**Response:** `202 Accepted` → `{ "ok": true }`.
+
+**Errors:** `400 bad_request` (bad `{id}`, a non-Kad search, or one that has already finished), `400 amuled_rejected`, `403 forbidden` (guest), `404 not_found` (no such search), `405`, `503 ec_unavailable`.
+
+#### Related-files search
+
+There is no endpoint for the desktop's **"Search related files (eD2k, local server)"** action, and none is needed: the GUI simply composes a magic keyword and starts an ordinary local search. Do the same.
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"query":"related::8b54a3c2...::0a1b2c3d...","type":"local"}' \
+  "http://$HOST/api/v0/search"
+```
+
+The query is the literal prefix `related` followed by one or more `::`-separated 32-char hex MD4 hashes — one per file you want related hits for (the desktop passes every selected result). `type` must be `"local"`: the request is answered by the ed2k server you are connected to, and there is no Kad or global equivalent.
+
+Not every server implements related search. Check the connected server's capability first rather than reading an empty result set as "nothing related": [`GET /api/v0/servers`](#get-apiv0servers) reports `related_search` among each server's flags, and the desktop refuses the action outright when it is absent.
 
 #### `POST /api/v0/search/results/{hash}/download`
 
@@ -2485,7 +2529,9 @@ Promote a search result into the transfer queue. Equivalent to clicking "Downloa
 
 **Auth:** `GUEST`
 
-Community ratings/comments for a single search result — the Kad notes retrieved so far plus the running flag. The same data rides each result on [`GET /search/results`](#get-apiv0searchresults); this per-hash endpoint mirrors [`GET /downloads/{hash}/comments`](#get-apiv0downloadshashcomments) for polling one result after starting a lookup.
+Community ratings/comments for a single search result — the Kad notes retrieved so far plus the running flag. The same data rides each result on [`GET /search/{id}/results`](#get-apiv0searchidresults); this per-hash endpoint mirrors [`GET /downloads/{hash}/comments`](#get-apiv0downloadshashcomments) for polling one result after starting a lookup.
+
+The route is deliberately **not** nested under a search id: amuled runs one Kad notes lookup per hash and fans the notes out to every result carrying it, so the lookup is not scoped to one search. This endpoint refreshes whichever search owns the hit before answering, which is what makes the flag below observable on a search that has already finished.
 
 ```json
 {
@@ -2500,7 +2546,9 @@ Community ratings/comments for a single search result — the Kad notes retrieve
 
 `kad_comment_search_running` is `true` while an on-demand Kad notes lookup (triggered by the `POST` below) is in flight; poll until it returns to `false` to know the lookup finished. `username` is the responding Kad node's IP, or `Kad user` when the note carries no IP.
 
-**Errors:** `404 not_found` (no current search result with that hash), `503 ec_unavailable`.
+**Polling is the only mechanism here — there is no event to wait for.** [`comments_updated`](EVENTS.md#comments_updated) is emitted for downloads only and never fires for a search hit, so a client that starts a lookup polls this endpoint (or the results list) while `kad_comment_search_running` is `true`.
+
+**Errors:** `404 not_found` (no live search result with that hash), `503 ec_unavailable`.
 
 #### `POST /api/v0/search/results/{hash}/comments`
 
@@ -2510,7 +2558,7 @@ Trigger an on-demand Kad notes lookup for a search result you have not downloade
 
 **Response:** `202 Accepted` → `{ "status": "kad_search_started" }`.
 
-**Errors:** `400 bad_request` (malformed hash), `403 forbidden` (guest token — the lookup makes the daemon do network work, so it is `ADMIN`-only), `404 not_found` (no current search result with that hash), `400 amuled_rejected` (Kad down, or a search is already using this hash — retry shortly), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (malformed hash), `403 forbidden` (guest token — the lookup makes the daemon do network work, so it is `ADMIN`-only), `404 not_found` (no live search result with that hash), `400 amuled_rejected` (Kad down, or a search is already using this hash — retry shortly), `503 ec_unavailable`.
 
 ---
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -45,6 +45,7 @@
 #include <map>
 
 #include "PrefsSchema.h"
+#include "SearchJson.h" // WriteSearchResultFields, shared with the SSE payload
 #include "State.h"
 
 #include "Constants.h"
@@ -602,6 +603,32 @@ void WriteKadNetworkObject(CJsonWriter &w, const webapi::KadSnapshot &k)
 	w.Key("nodes");
 	w.ValueInt(static_cast<int64_t>(k.nodes));
 	w.EndObject();
+}
+
+// The {id} path segment of every search-scoped route. Accepts a plain
+// non-negative decimal that fits a uint32 and is not 0.
+//
+// Zero is rejected rather than treated as "no search": it used to be the
+// sentinel that meant "whichever search this session started last", and
+// letting it through would quietly resurrect exactly the implicit-target
+// behaviour these routes exist to remove. A non-numeric segment is rejected
+// for the same reason -- it must never fall back to some other search.
+const char *const kBadSearchIdMessage = "`{id}` must be a positive decimal search_id (see GET /search)";
+
+bool ParseSearchIdSegment(const std::string &seg, std::uint32_t &out)
+{
+	if (seg.empty() || seg.size() > 10)
+		return false;
+	std::uint64_t v = 0;
+	for (const char c : seg) {
+		if (c < '0' || c > '9')
+			return false;
+		v = v * 10 + static_cast<std::uint64_t>(c - '0');
+	}
+	if (v == 0 || v > 0xFFFFFFFFull)
+		return false;
+	out = static_cast<std::uint32_t>(v);
+	return true;
 }
 
 // Forward declaration so HandleLogin (which sits above the helper's
@@ -1165,7 +1192,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleStatsTree(req);
 	}
 
-	// search.
+	// search. Every search-scoped operation names its search in the path;
+	// there is no implicit "current search" to fall back to.
 	if (path == "/api/v0/search") {
 		if (req.method == "GET" || req.method == "HEAD") {
 			return HandleSearchList(req);
@@ -1173,23 +1201,19 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method != "POST") {
 			return ErrorResponse(405,
 				"method_not_allowed",
-				"only GET or POST on /search (GET lists active searches, POST starts one -- "
-				"use GET /search/results for a search's results)");
+				"only GET or POST on /search (GET lists searches, POST starts one; "
+				"read one search at GET /search/{id}/results)");
 		}
 		return HandleSearchStart(req);
 	}
-	if (path == "/api/v0/search/stop") {
-		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /search/stop");
-		}
-		return HandleSearchStop(req);
-	}
-	if (path == "/api/v0/search/results") {
-		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /search/results");
-		}
-		return HandleSearchResults(req);
-	}
+
+	// The two hash-addressed routes are matched before anything capturing
+	// {id}. They cannot actually collide (different segment counts, and {id}
+	// is numeric), but ordering them first keeps that independent of the
+	// matcher's internals. Both are deliberately search-AGNOSTIC: the daemon
+	// resolves a download by hash against its whole search list, and a Kad
+	// note fetched for a hash is fanned out to every result carrying it.
+	// Nesting them under {id} would advertise a scoping that does not exist.
 	{
 		static const auto search_download =
 			web_api_path::ParsePattern("/api/v0/search/results/{hash}/download");
@@ -1208,9 +1232,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// /search/results/{hash}/comments — community ratings/comments for a search
 	// result (issue #434). POST triggers an on-demand Kad NOTES lookup; GET
 	// returns the notes retrieved so far plus the running flag. The result's
-	// `comments` also ride the /search/results list, but this per-result path
-	// mirrors /downloads/{hash}/comments for polling a single hash. Matched
-	// before /search/results/{hash}/download (distinct trailing segment).
+	// `comments` also ride the results list, but this per-result path mirrors
+	// /downloads/{hash}/comments for polling a single hash. Matched before
+	// /search/results/{hash}/download (distinct trailing segment).
 	{
 		static const auto search_comments =
 			web_api_path::ParsePattern("/api/v0/search/results/{hash}/comments");
@@ -1226,6 +1250,79 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 					"only GET / HEAD / POST on /search/results/{hash}/comments");
 			}
 			return HandleSearchComments(req, caps["hash"]);
+		}
+	}
+
+	// The two retired paths, answered explicitly rather than falling into the
+	// {id} matcher below -- which would capture "results" / "stop" as an id
+	// and report a confusing "not a valid search id". Naming the replacement
+	// is the whole point of keeping these four lines.
+	if (path == "/api/v0/search/results") {
+		return ErrorResponse(404,
+			"not_found",
+			"retired: results are addressed per search at GET /search/{id}/results");
+	}
+	if (path == "/api/v0/search/stop") {
+		return ErrorResponse(404,
+			"not_found",
+			"retired: use POST /search/{id}/stop, or DELETE /search/{id} to also free it");
+	}
+
+	// /search/{id} — DELETE stops the search AND frees it (results included).
+	{
+		static const auto search_one = web_api_path::ParsePattern("/api/v0/search/{id}");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(search_one, path_segs, caps)) {
+			std::uint32_t sid = 0;
+			if (!ParseSearchIdSegment(caps["id"], sid)) {
+				return ErrorResponse(400, "bad_request", kBadSearchIdMessage);
+			}
+			if (req.method != "DELETE") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only DELETE on /search/{id} (read its results at "
+					"GET /search/{id}/results)");
+			}
+			return HandleSearchClose(req, sid);
+		}
+	}
+
+	// /search/{id}/{action} — results / stop / more.
+	{
+		static const auto search_action = web_api_path::ParsePattern("/api/v0/search/{id}/{action}");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(search_action, path_segs, caps)) {
+			std::uint32_t sid = 0;
+			if (!ParseSearchIdSegment(caps["id"], sid)) {
+				return ErrorResponse(400, "bad_request", kBadSearchIdMessage);
+			}
+			const std::string &action = caps["action"];
+			if (action == "results") {
+				if (req.method != "GET" && req.method != "HEAD") {
+					return ErrorResponse(405,
+						"method_not_allowed",
+						"only GET / HEAD on /search/{id}/results");
+				}
+				return HandleSearchResults(req, sid);
+			}
+			if (action == "stop") {
+				if (req.method != "POST") {
+					return ErrorResponse(
+						405, "method_not_allowed", "only POST on /search/{id}/stop");
+				}
+				return HandleSearchStop(req, sid);
+			}
+			if (action == "more") {
+				if (req.method != "POST") {
+					return ErrorResponse(
+						405, "method_not_allowed", "only POST on /search/{id}/more");
+				}
+				return HandleSearchMore(req, sid);
+			}
+			return ErrorResponse(
+				404, "not_found", "unknown search action (expected results, stop or more)");
 		}
 	}
 
@@ -5968,23 +6065,6 @@ std::size_t ParseTailParam(const std::string &query)
 // param is absent; `value` is the parsed id (0 on a malformed value). Callers
 // treat value 0 as "the current search". Multi-search only — every search on
 // the amuleapi surface is addressed by its daemon-allocated id.
-struct SearchIdParam
-{
-	bool provided = false;
-	std::uint32_t value = 0;
-};
-SearchIdParam ParseSearchIdParam(const std::string &query)
-{
-	SearchIdParam out;
-	const auto qmap = web_api_path::ParseQuery(query);
-	const auto it = qmap.find("search_id");
-	if (it == qmap.end())
-		return out;
-	out.provided = true;
-	out.value = static_cast<std::uint32_t>(std::strtoul(it->second.c_str(), nullptr, 10));
-	return out;
-}
-
 // Return a copy of `all` containing at most `tail` trailing lines.
 // `tail == 0` means "all lines" (no tailing).
 std::vector<std::string> SliceTail(const std::vector<std::string> &all, std::size_t tail)
@@ -6161,96 +6241,13 @@ void WritePointArray(CJsonWriter &w,
 	w.EndArray();
 }
 
+// The results-array element. Fields come from the shared writer so this
+// endpoint and the `search_result_added` SSE payload cannot drift; only the
+// braces are ours.
 void WriteSearchObject(CJsonWriter &w, const webapi::SearchResult &r)
 {
 	w.BeginObject();
-	w.Key("hash");
-	w.ValueString(wxString::FromUTF8(r.hash.c_str()));
-	w.Key("name");
-	w.ValueString(wxString::FromUTF8(r.name.c_str()));
-	w.Key("size");
-	w.ValueInt(static_cast<int64_t>(r.size));
-	w.Key("sources");
-	w.BeginObject();
-	w.Key("total");
-	w.ValueInt(static_cast<int64_t>(r.source_count));
-	w.Key("complete");
-	w.ValueInt(static_cast<int64_t>(r.complete_source_count));
-	w.EndObject();
-	w.Key("already_have");
-	w.ValueBool(r.already_have);
-	w.Key("rating");
-	w.ValueInt(static_cast<int64_t>(r.rating));
-	w.Key("status");
-	w.ValueString(wxString::FromUTF8(r.status.c_str()));
-	w.Key("type");
-	w.ValueString(wxString::FromUTF8(r.type.c_str()));
-	// Media metadata (issue #430) — same shape as the file-detail `media`
-	// object; omitted entirely when the hit carries no media tags.
-	if (r.has_media) {
-		w.Key("media");
-		w.BeginObject();
-		w.Key("length_s");
-		w.ValueInt(static_cast<int64_t>(r.media.length_s));
-		w.Key("bitrate");
-		w.ValueInt(static_cast<int64_t>(r.media.bitrate));
-		w.Key("codec");
-		w.ValueString(wxString::FromUTF8(r.media.codec.c_str()));
-		w.Key("artist");
-		w.ValueString(wxString::FromUTF8(r.media.artist.c_str()));
-		w.Key("album");
-		w.ValueString(wxString::FromUTF8(r.media.album.c_str()));
-		w.Key("title");
-		w.ValueString(wxString::FromUTF8(r.media.title.c_str()));
-		w.EndObject();
-	}
-	// Result grouping (issue #431): the same-hash/same-size hit's
-	// alternative filenames. Always emitted (empty array when the hit was
-	// seen under a single name) so clients can render the expandable tree
-	// without a presence check. Each child shares the parent's `hash`; the
-	// distinct `ecid` selects it for download-under-that-name (see
-	// POST /search/results/{hash}/download).
-	w.Key("children");
-	w.BeginArray();
-	for (const auto &c : r.children) {
-		w.BeginObject();
-		w.Key("ecid");
-		w.ValueInt(static_cast<int64_t>(c.ecid));
-		w.Key("name");
-		w.ValueString(wxString::FromUTF8(c.name.c_str()));
-		w.Key("hash");
-		w.ValueString(wxString::FromUTF8(c.hash.c_str()));
-		w.Key("sources");
-		w.BeginObject();
-		w.Key("total");
-		w.ValueInt(static_cast<int64_t>(c.source_count));
-		w.Key("complete");
-		w.ValueInt(static_cast<int64_t>(c.complete_source_count));
-		w.EndObject();
-		w.EndObject();
-	}
-	w.EndArray();
-	// On-demand Kad community ratings/comments (issue #434). `kad_comment_search_running`
-	// is true while a lookup started via POST /search/results/{hash}/comments is
-	// in flight; `comments` carries the Kad notes retrieved so far (empty until
-	// then). Both are always present so clients need no presence check.
-	w.Key("kad_comment_search_running");
-	w.ValueBool(r.kad_comment_searching);
-	w.Key("comments");
-	w.BeginArray();
-	for (const auto &c : r.comments) {
-		w.BeginObject();
-		w.Key("username");
-		w.ValueString(wxString::FromUTF8(c.username.c_str()));
-		w.Key("filename");
-		w.ValueString(wxString::FromUTF8(c.filename.c_str()));
-		w.Key("rating");
-		w.ValueInt(static_cast<int64_t>(c.rating));
-		w.Key("comment");
-		w.ValueString(wxString::FromUTF8(c.comment.c_str()));
-		w.EndObject();
-	}
-	w.EndArray();
+	webapi::WriteSearchResultFields(w, r);
 	w.EndObject();
 }
 
@@ -6547,7 +6544,8 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	return r;
 }
 
-CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Request &req)
+CHttpServer::Response CApiDispatcher::HandleSearchResults(
+	const CHttpServer::Request &req, std::uint32_t search_id)
 {
 	auto a = Authenticate(req);
 	if (!a.ok)
@@ -6562,28 +6560,17 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	// same state/kind/percent as the `search_progress` SSE event (the
 	// event additionally ships a results count, since it has no results
 	// array beside it).
-	// Address one search by `?search_id=N` (multi-search). No id => the current
-	// (most-recently-started) search. An explicit id that names no live slot
-	// (never started, or evicted from the daemon's ring) is a 404 — distinct
+	// The search is named in the path. An id that names no live slot (never
+	// started, freed, or evicted from the daemon's ring) is a 404 — distinct
 	// from a known-but-empty search, which returns an idle/empty envelope.
-	const SearchIdParam sidp = ParseSearchIdParam(QueryOf(req));
-	if (sidp.provided && sidp.value != 0 && !m_state.HasSearch(sidp.value)) {
-		// Cache miss: before giving up, ask the core once whether it is
-		// holding this id anyway -- see DiscoverSearchIfHeldByCore.
-		if (!DiscoverSearchIfHeldByCore(sidp.value)) {
-			return ErrorResponse(
-				404, "not_found", "no search with that search_id (never started or expired)");
-		}
-		// Discovered but not yet polled: the next refresher tick fills in
-		// real results/progress via the active-search loop. Until then this
-		// falls through to the normal read below, which sees the slot
-		// MarkSearchDiscovered just seeded -- an idle/empty envelope for
-		// this one request, same shape as any other known-but-not-yet-
-		// polled search, rather than a 404 for something just listed.
-	}
-	const std::uint32_t report_id = sidp.value != 0 ? sidp.value : m_state.CurrentSearchId();
-	const std::vector<webapi::SearchResult> results_vec = m_state.Search(sidp.value);
-	const webapi::SearchProgressSnapshot progress = m_state.SearchProgress(sidp.value);
+	if (auto rej = RequireSearch(search_id))
+		return *rej;
+	// A FINISHED search is not polled by the tick, so its cached results
+	// would otherwise be frozen at the moment it completed. Refresh on read,
+	// coalesced by a short TTL.
+	RefreshSearchIfStale(search_id);
+	const std::vector<webapi::SearchResult> results_vec = m_state.Search(search_id);
+	const webapi::SearchProgressSnapshot progress = m_state.SearchProgress(search_id);
 
 	// #357 pagination/sort. This endpoint keeps its own envelope (the
 	// `progress` object rides alongside `results`), so it can't call
@@ -6608,6 +6595,14 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
 				return a.rating < b.rating;
 			} },
+		// Browse listings are read folder by folder, which is how the
+		// desktop sorts its Directories column too. Empty on server/Kad
+		// hits, so sorting a non-browse search by it is a stable no-op
+		// rather than an error.
+		{ "directory",
+			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
+				return a.directory < b.directory;
+			} },
 	};
 	std::vector<const webapi::SearchResult *> window;
 	std::size_t total = 0;
@@ -6625,12 +6620,16 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 		WriteSearchObject(w, *item);
 	w.EndArray();
 	WritePageMeta(w, total, params, window.size());
-	// The search these results belong to. Echoes the resolved id (the one
-	// requested, or the current search when none was given), so a consumer
-	// polling without an explicit id learns which search it is watching and
-	// can pin it on later calls. 0 only when no search has run this session.
+	// The search these results belong to. Echoed even though the caller put
+	// it in the path: clients key their tabs on it and it costs nothing.
 	w.Key("search_id");
-	w.ValueInt(static_cast<int64_t>(report_id));
+	w.ValueInt(static_cast<int64_t>(search_id));
+	// What was searched for. Without it a client that adopted an id (from
+	// GET /search, or from another client) would have to cross-reference the
+	// list endpoint just to label the tab it is already reading. For a browse
+	// this is the peer's name rather than a query string.
+	w.Key("query");
+	w.ValueString(wxString::FromUTF8(m_state.SearchQuery(search_id).c_str()));
 	// Mirrors the `search_progress` SSE event field-for-field. `state`
 	// is canonical and encodes the full lifecycle (running / finished /
 	// idle), so we don't also emit redundant `active` / `complete`
@@ -6650,6 +6649,36 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(const CHttpServer::Req
 	return r;
 }
 
+std::unique_ptr<CHttpServer::Response> CApiDispatcher::RequireSearch(std::uint32_t search_id)
+{
+	if (m_state.HasSearch(search_id))
+		return nullptr;
+	// Cache miss: before giving up, ask the core once whether it holds this
+	// id anyway -- a search amulegui, the monolithic GUI or a previous
+	// amuleapi run started. Seeding it here is what lets a UI adopt one.
+	if (DiscoverSearchIfHeldByCore(search_id))
+		return nullptr;
+	return std::make_unique<CHttpServer::Response>(ErrorResponse(
+		404, "not_found", "no search with that search_id (never started, freed or expired)"));
+}
+
+void CApiDispatcher::RefreshSearchIfStale(std::uint32_t search_id)
+{
+	// ClaimSearchRefresh does the gating: it returns true only for a slot
+	// that exists, is not active (the tick already covers those every
+	// second), and has not been fetched within the TTL -- and it stamps the
+	// slot as it hands out the claim, so two readers racing on the same
+	// finished search cost one roundtrip, not two.
+	static constexpr std::chrono::milliseconds kSearchRefreshTtl{ 1000 };
+	if (!m_state.ClaimSearchRefresh(search_id, kSearchRefreshTtl))
+		return;
+	// A failed roundtrip leaves the cached results in place: serving the
+	// previous set is strictly better than failing a read that has a
+	// perfectly good answer. An expiry is left to the tick's own retirement
+	// path rather than duplicated here.
+	(void)webapi::FetchSearchResults(m_app, m_state, search_id);
+}
+
 // See the declaration in Api.h for why this is shared rather than inlined
 // at each call site.
 bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
@@ -6664,10 +6693,16 @@ bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
 		if (static_cast<std::uint32_t>(entry.GetInt()) != search_id)
 			continue;
 		const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
+		// The list entry carries the daemon's name for the search, which is
+		// the query string (or, for a browse, the peer's nickname). Taking it
+		// here is what lets an adopted search report its own `query` instead
+		// of an empty one.
+		const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
 		m_state.MarkSearchDiscovered(search_id,
 			SearchKindToString(
 				kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : EC_SEARCH_GLOBAL)
-				.ToStdString());
+				.ToStdString(),
+			nameTag ? std::string(nameTag->GetStringData().utf8_str()) : std::string());
 		found = true;
 		break;
 	}
@@ -6717,6 +6752,17 @@ CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Reques
 		const std::uint8_t state_val = stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0;
 		w.Key("state");
 		w.ValueString(SearchLifecycleStateToString(state_val));
+		// Browse ("View Files") entries carry the browsed peer's ecid. Without
+		// it a consumer sees `kind: "browse"` with no way to tell WHOSE share
+		// it is listing -- which is exactly what amulegui uses the tag for when
+		// it rebuilds a browse tab. Omitted entirely on an ordinary search,
+		// which never carries it. `client_` keeps its prefix because this
+		// names a DIFFERENT object than the one being described, unlike the
+		// entry's own `search_id`.
+		if (const CECTag *clientTag = entry.GetTagByName(EC_TAG_CLIENT)) {
+			w.Key("client_ecid");
+			w.ValueInt(static_cast<int64_t>(clientTag->GetInt()));
+		}
 		w.EndObject();
 	}
 	w.EndArray();
@@ -9075,7 +9121,20 @@ CHttpServer::Response CApiDispatcher::HandleBrowse(
 		return ErrorResponse(502, "amuled_rejected", "daemon did not return a search_id for browse");
 	}
 
-	m_state.MarkSearchStarted(search_id, "browse");
+	// A browse's "query" is the peer whose share is being listed -- that is
+	// what the daemon names the search, and what GET /search reports for it.
+	// Take the nickname from the client snapshot when we have one so the
+	// results envelope can label the tab; a peer we have no snapshot for
+	// simply leaves it empty, same as any slot seeded before its name was
+	// observed.
+	std::string peer_name;
+	for (const auto &c : m_state.Clients()) {
+		if (c.ecid == ecid) {
+			peer_name = c.client_name;
+			break;
+		}
+	}
+	m_state.MarkSearchStarted(search_id, "browse", peer_name);
 
 	CHttpServer::Response r;
 	r.status = 202;
@@ -9230,10 +9289,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
 	}
 	// The daemon (in multi-search mode) allocates a globally-unique search_id
-	// and echoes it in the START reply; every subsequent results/progress/stop
-	// call for this search is addressed by that id. amuleapi always runs
-	// multi-search, so the tag is expected — a 0 fallback would collide with
-	// the "current search" sentinel, so guard it.
+	// and echoes it in the START reply; every subsequent results/stop/more
+	// call for this search is addressed by that id, so a reply without one
+	// leaves the caller nothing to address and is reported as such.
 	std::uint32_t search_id = 0;
 	if (const CECTag *t = ec_resp->GetTagByName(EC_TAG_SEARCH_ID)) {
 		search_id = static_cast<std::uint32_t>(t->GetInt());
@@ -9244,12 +9302,13 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 			502, "amuled_rejected", "daemon did not return a search_id for SEARCH_START");
 	}
 
-	// Seed this search's slot and make it current: the refresher polls
-	// EC_OP_SEARCH_RESULTS + _PROGRESS for it (addressed by search_id) each
-	// tick until the daemon reports completion. This is the single fetcher, so
-	// SSE search_result_added / search_progress fire on the same delta a
-	// polling consumer would observe.
-	m_state.MarkSearchStarted(search_id, search_kind);
+	// Seed this search's slot: the refresher polls EC_OP_SEARCH_RESULTS +
+	// _PROGRESS for it (addressed by search_id) each tick until the daemon
+	// reports completion. This is the single fetcher, so SSE
+	// search_result_added / search_progress fire on the same delta a polling
+	// consumer would observe. The query rides along so the results envelope
+	// can report what this search was for.
+	m_state.MarkSearchStarted(search_id, search_kind, query);
 
 	CHttpServer::Response r;
 	r.status = 202;
@@ -9267,71 +9326,24 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 	return r;
 }
 
-CHttpServer::Response CApiDispatcher::HandleSearchStop(const CHttpServer::Request &req)
+// The three per-search actions share one EC exchange: address the search by
+// EC_TAG_SEARCH_ID, send, and turn a failure reply into a 400. Only the
+// opcode, the optional close flag and the success shape differ, so the
+// exchange itself lives here rather than three times over.
+CHttpServer::Response CApiDispatcher::SendSearchOp(
+	ec_opcode_t opcode, std::uint32_t search_id, bool close, int success_status)
 {
-	auto a = Authenticate(req);
-	if (!a.ok)
-		return a.rejection;
-	if (auto rej = RequireAdmin(a))
-		return *rej;
-
-	// Optional JSON body: { "search_id": N, "close": bool }. Both optional so
-	// an empty body keeps the "stop the current search" behavior. `close` frees
-	// the search on the daemon (drops its result ring slot) and locally — use
-	// it when a consumer is done with a search rather than just pausing it.
-	std::uint32_t body_search_id = 0;
-	bool close = false;
-	if (!req.body.empty()) {
-		picojson::value root;
-		std::string parse_err;
-		if (!ParseJsonObjectBody(req.body, root, parse_err)) {
-			return ErrorResponse(400, "bad_request", parse_err.c_str());
-		}
-		const auto &obj = root.get<picojson::object>();
-		const auto sit = obj.find("search_id");
-		if (sit != obj.end()) {
-			if (!sit->second.is<double>() || sit->second.get<double>() < 0) {
-				return ErrorResponse(
-					400, "bad_request", "`search_id` must be a non-negative integer");
-			}
-			body_search_id = static_cast<std::uint32_t>(sit->second.get<double>());
-		}
-		const auto cit = obj.find("close");
-		if (cit != obj.end()) {
-			if (!cit->second.is<bool>()) {
-				return ErrorResponse(400, "bad_request", "`close` must be a boolean");
-			}
-			close = cit->second.get<bool>();
-		}
-	}
-
-	// Resolve to a concrete id: an explicit body id, else the current search.
-	// An explicit id that names no live slot is a 404 (mirrors GET results).
-	// On a cache miss, ask the core first: GET /api/v0/search enumerates
-	// searches this session never started, so without this you could see a
-	// search here and still get a 404 trying to stop or close it -- the same
-	// contradiction already fixed for /search/results, found again by driving
-	// two clients against one daemon (got3nks, PR #680 review).
-	if (body_search_id != 0 && !m_state.HasSearch(body_search_id) &&
-		!DiscoverSearchIfHeldByCore(body_search_id)) {
-		return ErrorResponse(
-			404, "not_found", "no search with that search_id (never started or expired)");
-	}
-	const std::uint32_t target_id = body_search_id != 0 ? body_search_id : m_state.CurrentSearchId();
-
-	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SEARCH_STOP));
-	// Address the specific search; a concrete id is required for the daemon to
-	// stop the right one when several are running. close asks it to also free
-	// the search (EC_TAG_SEARCH_CLOSE), leaving siblings untouched.
-	if (target_id != 0) {
-		ec_req->AddTag(CECTag(EC_TAG_SEARCH_ID, target_id));
-	}
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(opcode));
+	// Always addressed. The old no-id form let the daemon decide what "stop"
+	// meant when the caller had no current search; a concrete id is the only
+	// way to stop the right one when several are running.
+	ec_req->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
 	if (close) {
 		ec_req->AddTag(CECEmptyTag(EC_TAG_SEARCH_CLOSE));
 	}
 	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
 	if (!ec_resp) {
-		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for SEARCH_STOP");
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for the search operation");
 	}
 	std::string ec_err_msg;
 	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
@@ -9340,16 +9352,15 @@ CHttpServer::Response CApiDispatcher::HandleSearchStop(const CHttpServer::Reques
 	}
 	delete ec_resp;
 
-	// On close, drop the local slot too (its refresher polling stops and
-	// /search/results?search_id= now 404s). On a plain stop the results stay
-	// valid — amuled keeps them until the search is closed or evicted — so a
-	// consumer polling /search/results sees the same set it was just viewing.
-	if (close && target_id != 0) {
-		m_state.CloseSearch(target_id);
-	}
-
 	CHttpServer::Response r;
-	r.status = 200;
+	r.status = success_status;
+	if (success_status == 204) {
+		// No body, per RFC 9110: a 204 must not carry one. Clearing the
+		// content type explicitly is what the other 204 handlers do --
+		// a default-constructed Response does not necessarily start empty.
+		r.content_type.clear();
+		return r;
+	}
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
@@ -9358,6 +9369,76 @@ CHttpServer::Response CApiDispatcher::HandleSearchStop(const CHttpServer::Reques
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleSearchStop(
+	const CHttpServer::Request &req, std::uint32_t search_id)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (auto rej = RequireSearch(search_id))
+		return *rej;
+
+	// Stop only: the results stay readable -- amuled keeps them until the
+	// search is closed or evicted -- so a consumer viewing this search sees
+	// the same set it was just looking at. Siblings are untouched.
+	return SendSearchOp(EC_OP_SEARCH_STOP, search_id, /*close=*/false, 200);
+}
+
+CHttpServer::Response CApiDispatcher::HandleSearchClose(
+	const CHttpServer::Request &req, std::uint32_t search_id)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (auto rej = RequireSearch(search_id))
+		return *rej;
+
+	CHttpServer::Response r = SendSearchOp(EC_OP_SEARCH_STOP, search_id, /*close=*/true, 204);
+	if (r.status != 204) {
+		return r;
+	}
+	// Drop the local slot too, so its polling stops and a later
+	// GET /search/{id}/results is a 404. The vanished slot is also what
+	// makes the next diff pass publish `search_closed` to SSE subscribers.
+	m_state.CloseSearch(search_id);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleSearchMore(
+	const CHttpServer::Request &req, std::uint32_t search_id)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (auto rej = RequireSearch(search_id))
+		return *rej;
+
+	// The desktop "More" button re-asks already-queried Kad peers for a wider
+	// result frontier. Both constraints below mirror what that button does
+	// rather than what the core tolerates: CSearchManager::RequestMoreResults
+	// returns false for a non-Kad id and the GUI greys the button out once the
+	// search finishes, so forwarding either case would turn a user's request
+	// into a silent no-op with a 202 on top of it.
+	const webapi::SearchProgressSnapshot progress = m_state.SearchProgress(search_id);
+	if (progress.kind != "kad") {
+		return ErrorResponse(400, "bad_request", "`more` applies to Kad searches only");
+	}
+	if (progress.complete || !progress.active) {
+		return ErrorResponse(
+			400, "bad_request", "`more` applies to a running search; this one has finished");
+	}
+
+	// Fire-and-forget: the daemon acks with a plain EC_OP_MISC_DATA and logs
+	// the real outcome itself, so there is nothing to report but acceptance.
+	return SendSearchOp(EC_OP_SEARCH_REQUEST_MORE, search_id, /*close=*/false, 202);
 }
 
 CHttpServer::Response CApiDispatcher::HandleSearchDownload(
@@ -9493,9 +9574,19 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	// several searches). Grouped children share the parent's hash, so the
 	// parent, which owns any fetched notes, matches first.
 	webapi::SearchResult hit;
-	if (!m_state.FindSearchResultByHash(needle, hit)) {
+	std::uint32_t owner_search_id = 0;
+	if (!m_state.FindSearchResultByHash(needle, hit, &owner_search_id)) {
 		return ErrorResponse(404, "not_found", "no search result with that hash");
 	}
+	// This is THE polling path for a Kad notes lookup: the notes only reach
+	// amuleapi through the owning search's result fetch, and a finished
+	// search is never fetched by the tick. Without this refresh a lookup
+	// started after the search completed -- which is when a user actually
+	// reads a result list -- would leave `kad_comment_search_running` stuck
+	// and `comments` empty forever. Re-read the hit afterwards so the
+	// response reflects the refresh rather than the snapshot before it.
+	RefreshSearchIfStale(owner_search_id);
+	m_state.FindSearchResultByHash(needle, hit, nullptr);
 
 	CHttpServer::Response r;
 	r.status = 200;
@@ -9560,9 +9651,14 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 	// the notes out to every same-hash result, so the specific search doesn't
 	// matter here.
 	webapi::SearchResult known_hit;
-	if (!m_state.FindSearchResultByHash(needle, known_hit)) {
+	std::uint32_t owner_search_id = 0;
+	if (!m_state.FindSearchResultByHash(needle, known_hit, &owner_search_id)) {
 		return ErrorResponse(404, "not_found", "no search result with that hash");
 	}
+	// Refresh the owning search before starting the lookup, for the same
+	// reason the GET does: a finished search is otherwise frozen, and the
+	// flag this POST turns on would never be observed turning off again.
+	RefreshSearchIfStale(owner_search_id);
 
 	auto ec_req = std::make_unique<CECPacket>(EC_OP_SHARED_FILE_SEARCH_KAD_NOTES);
 	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE, file_hash));

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -34,6 +34,8 @@
 #include "State.h" // ServerInfoLog / StatsTreeNode / StatsGraphs / SearchResult
 #include "TtlCache.h"
 
+#include <ec/cpp/ECCodes.h> // ec_opcode_t, for the shared search-op sender
+
 #include <ctime>
 #include <map>
 #include <utility>
@@ -238,9 +240,30 @@ private:
 	// miss, not a per-tick refresher poll -- discovery is rare, so paying
 	// only when actually asked keeps the steady-state EC cost at zero.
 	bool DiscoverSearchIfHeldByCore(std::uint32_t search_id);
+	// Resolve a path-supplied search_id to a live slot, seeding it from the
+	// core on a cache miss. Returns an error response when nothing holds it.
+	// Every search-scoped handler starts with this, so they cannot disagree
+	// on what a 404 means.
+	std::unique_ptr<CHttpServer::Response> RequireSearch(std::uint32_t search_id);
+	// Refresh one search's cached results if it is finished and its last
+	// fetch has aged out. The tick only polls ACTIVE searches, so without
+	// this a finished search's results are a frozen snapshot: a Kad notes
+	// lookup started on one of its hits would never report back, and a hit
+	// downloaded from it would keep claiming `status: "new"`. No-op (and no
+	// EC traffic) for an active search, or for a repeat read inside the TTL.
+	void RefreshSearchIfStale(std::uint32_t search_id);
 	CHttpServer::Response HandleSearchList(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchStart(const CHttpServer::Request &);
-	CHttpServer::Response HandleSearchStop(const CHttpServer::Request &);
+	CHttpServer::Response HandleSearchStop(const CHttpServer::Request &, std::uint32_t search_id);
+	// DELETE /search/{id}: stop it AND free it, daemon-side and locally.
+	CHttpServer::Response HandleSearchClose(const CHttpServer::Request &, std::uint32_t search_id);
+	// POST /search/{id}/more: the desktop "More" button, Kad-only.
+	CHttpServer::Response HandleSearchMore(const CHttpServer::Request &, std::uint32_t search_id);
+	// One addressed EC exchange for stop / close / more: they differ only in
+	// opcode, the close flag and the success status, so the packet build,
+	// the EC_OP_FAILED mapping and the `{ok:true}` body live in one place.
+	CHttpServer::Response SendSearchOp(
+		ec_opcode_t opcode, std::uint32_t search_id, bool close, int success_status);
 	CHttpServer::Response HandleSearchDownload(const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleSearchComments(const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleSearchCommentsKadSearch(
@@ -279,7 +302,7 @@ private:
 	CHttpServer::Response HandleLogServerinfoReset(const CHttpServer::Request &);
 	CHttpServer::Response HandleStatsTree(const CHttpServer::Request &);
 	CHttpServer::Response HandleStatsGraph(const CHttpServer::Request &, const std::string &graph);
-	CHttpServer::Response HandleSearchResults(const CHttpServer::Request &);
+	CHttpServer::Response HandleSearchResults(const CHttpServer::Request &, std::uint32_t search_id);
 
 	// Not const: the credential endpoints write through the config, and
 	// verifying re-reads amuleapi-passwords (so a change made elsewhere

--- a/src/webapi/CMakeLists.txt
+++ b/src/webapi/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable (amuleapi
 	PrefsSchema.cpp
 	Refresher.cpp
 	RefresherTick.cpp
+	SearchJson.cpp
 	StaticFs.cpp
 	State.cpp
 )

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -25,7 +25,10 @@
 #include "EventDiff.h"
 
 #include "EventBus.h"
+#include "SearchJson.h"      // WriteSearchResultFields, shared with GET /search/{id}/results
 #include "ServerFlagNames.h" // Shared server capability-bit tables, decoded to JSON
+
+#include <JsonWriter.h>
 
 #include <algorithm>
 #include <atomic>
@@ -44,7 +47,10 @@ namespace
 // canonical formatter for response bodies, but the event-data
 // payloads we emit here are small and predictable — a few KB at
 // most — and keeping the diff path independent of CJsonWriter
-// avoids dragging wxString into the bus path. Quote-escape only the
+// avoids dragging wxString into the bus path. (The one exception is
+// `search_result_added`, which is documented as carrying exactly a
+// results-list entry and so is built by the shared writer in
+// SearchJson.h rather than restated here.) Quote-escape only the
 // characters JSON disallows: backslash, double-quote, and the C0
 // controls. Tab/CR/LF appear in amule log lines so we encode them
 // explicitly.
@@ -668,55 +674,21 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			// New result entries for this search.
 			for (const auto &kv : search_now) {
 				if (pstate.results.find(kv.first) == pstate.results.end()) {
-					std::ostringstream payload;
-					// The search_id routes the event to a tab/view; the
-					// remaining fields are byte-for-byte identical to
-					// WriteSearchObject (Api.cpp) — sources is a nested
-					// {total, complete} object, matching /search/results[].
-					payload << "{\"search_id\":" << sid << ",\"hash\":\""
-						<< EscJson(kv.second.hash) << "\""
-						<< ",\"name\":\"" << EscJson(kv.second.name) << "\""
-						<< ",\"size\":" << kv.second.size
-						<< ",\"sources\":{\"total\":" << kv.second.source_count
-						<< ",\"complete\":" << kv.second.complete_source_count << "}"
-						<< ",\"already_have\":"
-						<< (kv.second.already_have ? "true" : "false")
-						<< ",\"rating\":" << static_cast<int>(kv.second.rating)
-						<< ",\"status\":\"" << EscJson(kv.second.status) << "\""
-						<< ",\"type\":\"" << EscJson(kv.second.type) << "\"";
-					// Media metadata (issue #430) — same shape as
-					// WriteSearchObject; omitted when the hit has none.
-					if (kv.second.has_media) {
-						const auto &m = kv.second.media;
-						payload << ",\"media\":{\"length_s\":" << m.length_s
-							<< ",\"bitrate\":" << m.bitrate << ",\"codec\":\""
-							<< EscJson(m.codec) << "\",\"artist\":\""
-							<< EscJson(m.artist) << "\",\"album\":\""
-							<< EscJson(m.album) << "\",\"title\":\""
-							<< EscJson(m.title) << "\"}";
-					}
-					// Result grouping (issue #431) — same shape as
-					// WriteSearchObject's children[]; always present
-					// (empty array when the hit had a single name).
-					payload << ",\"children\":[";
-					{
-						bool first = true;
-						for (const auto &c : kv.second.children) {
-							if (!first)
-								payload << ",";
-							first = false;
-							payload << "{\"ecid\":" << c.ecid << ",\"name\":\""
-								<< EscJson(c.name) << "\",\"hash\":\""
-								<< EscJson(c.hash)
-								<< "\",\"sources\":{\"total\":"
-								<< c.source_count
-								<< ",\"complete\":" << c.complete_source_count
-								<< "}}";
-						}
-					}
-					payload << "]";
-					payload << "}";
-					bus.Publish("search_result_added", payload.str());
+					// `search_id` routes the event to a tab/view; every
+					// field after it comes from the same writer
+					// GET /search/{id}/results uses, which is what makes
+					// the documented "byte-for-byte identical to a
+					// results-list entry" promise hold by construction
+					// rather than by review.
+					CJsonWriter w;
+					w.BeginObject();
+					w.Key("search_id");
+					w.ValueInt(static_cast<int64_t>(sid));
+					WriteSearchResultFields(w, kv.second);
+					w.EndObject();
+					const wxScopedCharBuffer utf8 = w.GetBuffer().utf8_str();
+					bus.Publish("search_result_added",
+						std::string(utf8.data(), utf8.length()));
 				}
 			}
 			// search_progress: a percent change while running, the
@@ -746,9 +718,20 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 		}
 		prev.search_initialised = true;
 		// Prune baselines for searches that vanished (closed / EC reset) so
-		// prev.searches can't grow without bound.
+		// prev.searches can't grow without bound, and tell subscribers.
+		// Without the event a consumer holding one tab per search only finds
+		// out on its next read, and with SSE live it may never read again.
+		//
+		// This fires only when the SLOT is gone -- DELETE /search/{id}, the
+		// slot cap evicting an old finished search, or an EC reset. A search
+		// the daemon evicted from its own ring is retired as finished and
+		// kept locally for late reads, so that case is a terminal
+		// search_progress above, never a search_closed.
 		for (auto it = prev.searches.begin(); it != prev.searches.end();) {
 			if (std::find(ids.begin(), ids.end(), it->first) == ids.end()) {
+				std::ostringstream payload;
+				payload << "{\"search_id\":" << it->first << "}";
+				bus.Publish("search_closed", payload.str());
 				it = prev.searches.erase(it);
 			} else {
 				++it;

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2248,6 +2248,13 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 		}
 		// File type, computed from the filename (no EC data needed).
 		r.type = SearchTypeToken(r.name);
+		// Browse-only: the folder this file sits in inside the peer's
+		// share. The core attaches it to results filed from a shared-file
+		// listing and to nothing else, so an ordinary server/Kad hit
+		// simply leaves it empty.
+		if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCHFILE_DIRECTORY)) {
+			r.directory = std::string(x->GetStringData().utf8_str());
+		}
 		// Media metadata (issue #430): present only when the hit carried
 		// FT_MEDIA_* tags (known/probed locally). Any present tag marks
 		// has_media so the API emits the `media` object.
@@ -2324,6 +2331,7 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 		c.hash = child.hash;
 		c.source_count = child.source_count;
 		c.complete_source_count = child.complete_source_count;
+		c.directory = child.directory;
 		pit->second.children.push_back(std::move(c));
 		folded.push_back(kv.first);
 	}

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -56,6 +56,22 @@ class CState;
 // tick body is unit-testable against a mock EC reply.
 bool RefresherTick(CamuleapiApp &app, CState &state);
 
+// Outcome of one EC_OP_SEARCH_RESULTS fetch for a single search.
+enum class SearchFetchOutcome
+{
+	Updated,  //!< results merged into the slot
+	Expired,  //!< the daemon no longer holds this search (EC_TAG_SEARCH_EXPIRED)
+	EcFailed, //!< the roundtrip failed; the slot is untouched
+};
+
+// Pull one search's full result set from the daemon and merge it into that
+// search's slot. Shared by the per-tick poll of ACTIVE searches and by the
+// on-demand refresh the read paths use for a FINISHED one, so both issue the
+// identical request (EC_DETAIL_FULL plus the EC_TAG_SEARCH_PARENT grouping
+// flag) and feed the identical applier — a results list read through either
+// route has the same shape.
+SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state, std::uint32_t search_id);
+
 // Single-threaded SSE diff emission. Called ONLY from the wxApp
 // refresher loop after a successful RefresherTick so that the
 // LastSeenState walk (which mutates app.LastSeenForEvents()) is

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -45,6 +45,28 @@
 namespace webapi
 {
 
+SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state, std::uint32_t search_id)
+{
+	std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_FULL));
+	// Opt into result grouping (issue #431): the empty EC_TAG_SEARCH_PARENT
+	// flag tells the FULL responder to also emit each same-hash/different-name
+	// child so the results list can nest them.
+	req->AddTag(CECEmptyTag(EC_TAG_SEARCH_PARENT));
+	req->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
+	const CECPacket *resp = app.SendRecvSerialized(req.get());
+	if (!resp)
+		return SearchFetchOutcome::EcFailed;
+	SearchFetchOutcome outcome = SearchFetchOutcome::Updated;
+	if (resp->GetTagByName(EC_TAG_SEARCH_EXPIRED)) {
+		outcome = SearchFetchOutcome::Expired;
+	} else {
+		state.MutateSearch(search_id,
+			[&](std::map<std::uint32_t, SearchResult> &cache) { ApplySearchFull(resp, cache); });
+	}
+	delete resp;
+	return outcome;
+}
+
 bool RefresherTick(CamuleapiApp &app, CState &state)
 {
 	// Per-tick budget: a few EC ops via SendRecvSerialized
@@ -227,25 +249,16 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		std::uint32_t percent = 0;
 		std::uint32_t lifecycle_state = 0;
 		bool expired = false;
-		{
-			std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_FULL));
-			// Opt into result grouping (issue #431): the empty
-			// EC_TAG_SEARCH_PARENT flag tells the FULL responder to also
-			// emit each same-hash/different-name child so /search/results
-			// can nest them.
-			req->AddTag(CECEmptyTag(EC_TAG_SEARCH_PARENT));
-			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
-			const CECPacket *resp = app.SendRecvSerialized(req.get());
-			if (!resp)
-				return false;
-			if (resp->GetTagByName(EC_TAG_SEARCH_EXPIRED)) {
-				expired = true;
-			} else {
-				state.MutateSearch(sid, [&](std::map<std::uint32_t, SearchResult> &cache) {
-					ApplySearchFull(resp, cache);
-				});
-			}
-			delete resp;
+		switch (FetchSearchResults(app, state, sid)) {
+		case SearchFetchOutcome::EcFailed:
+			// Same rule as every other step in the tick: a failed roundtrip
+			// bails the whole tick rather than exposing a half-refreshed cache.
+			return false;
+		case SearchFetchOutcome::Expired:
+			expired = true;
+			break;
+		case SearchFetchOutcome::Updated:
+			break;
 		}
 		if (!expired && have_union) {
 			// Already fetched above; absent means the daemon dropped it.

--- a/src/webapi/SearchJson.cpp
+++ b/src/webapi/SearchJson.cpp
@@ -1,0 +1,134 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//
+
+#include "SearchJson.h"
+
+#include "State.h"
+
+#include <JsonWriter.h>
+
+#include <wx/string.h>
+
+namespace webapi
+{
+
+void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
+{
+	w.Key("hash");
+	w.ValueString(wxString::FromUTF8(r.hash.c_str()));
+	w.Key("name");
+	w.ValueString(wxString::FromUTF8(r.name.c_str()));
+	w.Key("size");
+	w.ValueInt(static_cast<int64_t>(r.size));
+	w.Key("sources");
+	w.BeginObject();
+	w.Key("total");
+	w.ValueInt(static_cast<int64_t>(r.source_count));
+	w.Key("complete");
+	w.ValueInt(static_cast<int64_t>(r.complete_source_count));
+	w.EndObject();
+	w.Key("already_have");
+	w.ValueBool(r.already_have);
+	w.Key("rating");
+	w.ValueInt(static_cast<int64_t>(r.rating));
+	w.Key("status");
+	w.ValueString(wxString::FromUTF8(r.status.c_str()));
+	w.Key("type");
+	w.ValueString(wxString::FromUTF8(r.type.c_str()));
+	// Browse-only (the folder inside the peer's share). Always present so
+	// clients need no presence check; empty on every server/Kad hit, which
+	// never carries the tag.
+	w.Key("directory");
+	w.ValueString(wxString::FromUTF8(r.directory.c_str()));
+	// Media metadata (issue #430) — same shape as the file-detail `media`
+	// object; omitted entirely when the hit carries no media tags.
+	if (r.has_media) {
+		w.Key("media");
+		w.BeginObject();
+		w.Key("length_s");
+		w.ValueInt(static_cast<int64_t>(r.media.length_s));
+		w.Key("bitrate");
+		w.ValueInt(static_cast<int64_t>(r.media.bitrate));
+		w.Key("codec");
+		w.ValueString(wxString::FromUTF8(r.media.codec.c_str()));
+		w.Key("artist");
+		w.ValueString(wxString::FromUTF8(r.media.artist.c_str()));
+		w.Key("album");
+		w.ValueString(wxString::FromUTF8(r.media.album.c_str()));
+		w.Key("title");
+		w.ValueString(wxString::FromUTF8(r.media.title.c_str()));
+		w.EndObject();
+	}
+	// Result grouping (issue #431): the same-hash/same-size hit's
+	// alternative filenames. Always emitted (empty array when the hit was
+	// seen under a single name) so clients can render the expandable tree
+	// without a presence check. Each child shares the parent's `hash`; the
+	// distinct `ecid` selects it for download-under-that-name (see
+	// POST /search/results/{hash}/download).
+	w.Key("children");
+	w.BeginArray();
+	for (const auto &c : r.children) {
+		w.BeginObject();
+		w.Key("ecid");
+		w.ValueInt(static_cast<int64_t>(c.ecid));
+		w.Key("name");
+		w.ValueString(wxString::FromUTF8(c.name.c_str()));
+		w.Key("hash");
+		w.ValueString(wxString::FromUTF8(c.hash.c_str()));
+		w.Key("sources");
+		w.BeginObject();
+		w.Key("total");
+		w.ValueInt(static_cast<int64_t>(c.source_count));
+		w.Key("complete");
+		w.ValueInt(static_cast<int64_t>(c.complete_source_count));
+		w.EndObject();
+		w.Key("directory");
+		w.ValueString(wxString::FromUTF8(c.directory.c_str()));
+		w.EndObject();
+	}
+	w.EndArray();
+	// On-demand Kad community ratings/comments (issue #434). `kad_comment_search_running`
+	// is true while a lookup started via POST /search/results/{hash}/comments is
+	// in flight; `comments` carries the Kad notes retrieved so far (empty until
+	// then). Both are always present so clients need no presence check.
+	w.Key("kad_comment_search_running");
+	w.ValueBool(r.kad_comment_searching);
+	w.Key("comments");
+	w.BeginArray();
+	for (const auto &c : r.comments) {
+		w.BeginObject();
+		w.Key("username");
+		w.ValueString(wxString::FromUTF8(c.username.c_str()));
+		w.Key("filename");
+		w.ValueString(wxString::FromUTF8(c.filename.c_str()));
+		w.Key("rating");
+		w.ValueInt(static_cast<int64_t>(c.rating));
+		w.Key("comment");
+		w.ValueString(wxString::FromUTF8(c.comment.c_str()));
+		w.EndObject();
+	}
+	w.EndArray();
+}
+
+} // namespace webapi

--- a/src/webapi/SearchJson.h
+++ b/src/webapi/SearchJson.h
@@ -1,0 +1,51 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//
+
+#ifndef WEBAPI_SEARCHJSON_H
+#define WEBAPI_SEARCHJSON_H
+
+class CJsonWriter;
+
+namespace webapi
+{
+
+struct SearchResult;
+
+// One search hit's JSON fields, WITHOUT the enclosing braces.
+//
+// Two surfaces serve the same object and are documented as carrying the
+// identical shape: the `results[]` array of GET /search/{id}/results, and the
+// `search_result_added` SSE payload (which prepends its own `search_id` and is
+// otherwise byte-for-byte the same). They used to be two hand-written
+// serialisers that had to be kept in step by hand, and had already drifted --
+// the REST one grew `kad_comment_search_running` and `comments[]` that the
+// event never gained. Emitting the fields from one place is what makes the
+// documented promise structural instead of aspirational.
+//
+// Braces are the caller's so the event can put `search_id` first.
+void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r);
+
+} // namespace webapi
+
+#endif // WEBAPI_SEARCHJSON_H

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -119,7 +119,7 @@ std::vector<SearchResult> CState::Search(std::uint32_t search_id) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	std::vector<SearchResult> out;
-	auto it = m_searches.find(ResolveSearchId(search_id));
+	auto it = m_searches.find(search_id);
 	if (it == m_searches.end())
 		return out;
 	out.reserve(it->second.results.size());
@@ -132,7 +132,7 @@ void CState::MutateSearch(
 	std::uint32_t search_id, const std::function<void(std::map<std::uint32_t, SearchResult> &)> &fn)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	auto it = m_searches.find(ResolveSearchId(search_id));
+	auto it = m_searches.find(search_id);
 	if (it != m_searches.end())
 		fn(it->second.results);
 }
@@ -140,7 +140,7 @@ void CState::MutateSearch(
 SearchProgressSnapshot CState::SearchProgress(std::uint32_t search_id) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	auto it = m_searches.find(ResolveSearchId(search_id));
+	auto it = m_searches.find(search_id);
 	if (it == m_searches.end())
 		return SearchProgressSnapshot{};
 	return it->second.progress;
@@ -149,13 +149,31 @@ SearchProgressSnapshot CState::SearchProgress(std::uint32_t search_id) const
 bool CState::HasSearch(std::uint32_t search_id) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	return m_searches.count(ResolveSearchId(search_id)) != 0;
+	return m_searches.count(search_id) != 0;
 }
 
-std::uint32_t CState::CurrentSearchId() const
+std::string CState::SearchQuery(std::uint32_t search_id) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	return m_current_search_id;
+	auto it = m_searches.find(search_id);
+	return it == m_searches.end() ? std::string() : it->second.query;
+}
+
+bool CState::ClaimSearchRefresh(std::uint32_t search_id, std::chrono::milliseconds ttl)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	auto it = m_searches.find(search_id);
+	if (it == m_searches.end())
+		return false;
+	// An active search is already refreshed by the tick every second;
+	// claiming it here would just double the EC traffic on a running search.
+	if (it->second.progress.active)
+		return false;
+	const auto now = std::chrono::steady_clock::now();
+	if (now - it->second.last_fetch < ttl)
+		return false;
+	it->second.last_fetch = now;
+	return true;
 }
 
 std::vector<std::uint32_t> CState::ActiveSearchIds() const
@@ -178,13 +196,16 @@ std::vector<std::uint32_t> CState::AllSearchIds() const
 	return out;
 }
 
-bool CState::FindSearchResultByHash(const std::string &hash_hex, SearchResult &out) const
+bool CState::FindSearchResultByHash(
+	const std::string &hash_hex, SearchResult &out, std::uint32_t *owner_search_id) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	for (const auto &skv : m_searches) {
 		for (const auto &rkv : skv.second.results) {
 			if (rkv.second.hash == hash_hex) {
 				out = rkv.second;
+				if (owner_search_id)
+					*owner_search_id = skv.first;
 				return true;
 			}
 		}
@@ -192,7 +213,30 @@ bool CState::FindSearchResultByHash(const std::string &hash_hex, SearchResult &o
 	return false;
 }
 
-void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind)
+void CState::EvictSurplusSearchSlotsLocked()
+{
+	// Bound the retained slots: a client that never frees its searches would
+	// otherwise accumulate one slot (with its result map) per search for the
+	// whole process lifetime. Evict oldest-first, never an active
+	// (still-polling) one — the surplus is always finished slots.
+	while (m_searches.size() > kMaxSearchSlots) {
+		auto victim = m_searches.end();
+		for (auto it = m_searches.begin(); it != m_searches.end(); ++it) {
+			if (it->second.progress.active) {
+				continue;
+			}
+			if (victim == m_searches.end() || it->second.seq < victim->second.seq) {
+				victim = it;
+			}
+		}
+		if (victim == m_searches.end()) {
+			break; // every remaining slot is still active — nothing to evict
+		}
+		m_searches.erase(victim);
+	}
+}
+
+void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind, const std::string &query)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	SearchSlot &slot = m_searches[search_id];
@@ -204,73 +248,40 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind)
 	slot.progress.active = true;
 	slot.progress.kind = kind;
 	slot.progress.generation = next_generation;
+	slot.query = query;
 	slot.seq = ++m_search_seq;
-	m_current_search_id = search_id;
-
-	// Bound the retained slots: a client that never closes its searches would
-	// otherwise accumulate one slot (with its result vector) per search for the
-	// whole process lifetime. Evict oldest-first, but never the current search
-	// or an active (still-polling) one — the surplus is always finished slots.
-	while (m_searches.size() > kMaxSearchSlots) {
-		auto victim = m_searches.end();
-		for (auto it = m_searches.begin(); it != m_searches.end(); ++it) {
-			if (it->first == m_current_search_id || it->second.progress.active) {
-				continue;
-			}
-			if (victim == m_searches.end() || it->second.seq < victim->second.seq) {
-				victim = it;
-			}
-		}
-		if (victim == m_searches.end()) {
-			break; // all remaining slots are active/current — nothing to evict
-		}
-		m_searches.erase(victim);
-	}
+	slot.last_fetch = {};
+	EvictSurplusSearchSlotsLocked();
 }
 
-void CState::MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind)
+void CState::MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind, const std::string &query)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	if (m_searches.count(search_id)) {
+	auto known = m_searches.find(search_id);
+	if (known != m_searches.end()) {
 		// Already known (self-started, or discovered on an earlier
 		// cache-miss check): leave its accumulated results/progress
 		// alone. Re-seeding here would stomp whatever
 		// WriteSearchProgress/ApplySearchFull already recorded for it
-		// this session.
+		// this session. The query is the one exception — a slot seeded
+		// before the daemon reported a name has an empty one, and
+		// filling it in loses nothing.
+		if (known->second.query.empty())
+			known->second.query = query;
 		return;
 	}
 	SearchSlot &slot = m_searches[search_id];
 	slot.progress.active = true;
 	slot.progress.kind = kind;
+	slot.query = query;
 	slot.seq = ++m_search_seq;
-	// Deliberately NOT touching m_current_search_id: a no-id GET
-	// /search/results should keep meaning "the search THIS session
-	// started", not silently jump to whatever was last discovered.
-
-	// Same bound as MarkSearchStarted, for the same reason -- a busy core
-	// with many concurrent searches shouldn't let discovery alone grow
-	// this session's slot map without limit.
-	while (m_searches.size() > kMaxSearchSlots) {
-		auto victim = m_searches.end();
-		for (auto it = m_searches.begin(); it != m_searches.end(); ++it) {
-			if (it->first == m_current_search_id || it->second.progress.active) {
-				continue;
-			}
-			if (victim == m_searches.end() || it->second.seq < victim->second.seq) {
-				victim = it;
-			}
-		}
-		if (victim == m_searches.end()) {
-			break;
-		}
-		m_searches.erase(victim);
-	}
+	EvictSurplusSearchSlotsLocked();
 }
 
 void CState::WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	auto it = m_searches.find(ResolveSearchId(search_id));
+	auto it = m_searches.find(search_id);
 	if (it != m_searches.end())
 		it->second.progress = std::move(s);
 }
@@ -278,14 +289,7 @@ void CState::WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot
 void CState::CloseSearch(std::uint32_t search_id)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	const auto id = ResolveSearchId(search_id);
-	m_searches.erase(id);
-	if (m_current_search_id == id) {
-		// No reliable "next most-recent" once the current search is gone (Kad
-		// ids sort above ed2k ids, so highest-key is not newest); fall back to
-		// no current until the next POST /search.
-		m_current_search_id = 0;
-	}
+	m_searches.erase(search_id);
 }
 
 void CState::WriteStatsTree(StatsTreeNode t)
@@ -617,11 +621,10 @@ void CState::ResetLists()
 	m_categories.clear();
 	// Drop all search slots on an EC reconnect: the daemon's per-connection
 	// search registry is gone with the old connection, so every cached
-	// search_id is stale. current falls back to none; the next POST /search
-	// re-seeds. (EventDiff re-baselines its per-search state when a slot it was
-	// tracking disappears, so no generation carry-over is needed here.)
+	// search_id is stale; the next POST /search re-seeds. (EventDiff
+	// re-baselines its per-search state when a slot it was tracking
+	// disappears, so no generation carry-over is needed here.)
 	m_searches.clear();
-	m_current_search_id = 0;
 	// The credit store deliberately does NOT go with them. This runs when a
 	// tick failed against a socket that is still up, and dropping the store
 	// there would refetch the whole thing after one null tick -- the cost this

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -25,6 +25,7 @@
 #ifndef WEBAPI_STATE_H
 #define WEBAPI_STATE_H
 
+#include <chrono>
 #include <cstdint>
 #include <ctime>
 #include <functional>
@@ -679,6 +680,14 @@ struct SearchResult
 	// File-type token derived from the filename (like the shared-detail
 	// `file_type`), e.g. "video"/"audio"; "" if the name has no extension.
 	std::string type;
+	// The folder this file sits in inside the browsed peer's share
+	// (EC_TAG_SEARCHFILE_DIRECTORY). The core emits it for results filed
+	// from a peer's shared-file list and for nothing else, so it is empty
+	// on every ordinary server/Kad hit. Per-result rather than per-search:
+	// two copies of one file in different folders of the same share group
+	// under a single parent, each keeping its own folder, exactly as the
+	// desktop's Directories column shows them.
+	std::string directory;
 	// Audio/video media metadata (issue #430), same shape as the file
 	// detail endpoints' `media` object. `has_media` gates it — omitted
 	// when the hit carries no FT_MEDIA_* tags (most remote results).
@@ -708,6 +717,9 @@ struct SearchResult
 		std::string hash; // same as the parent's (that's why they group)
 		std::uint32_t source_count = 0;
 		std::uint32_t complete_source_count = 0;
+		// Same meaning as the parent's `directory`, carried per child
+		// because two copies in different folders group together.
+		std::string directory;
 	};
 	std::vector<Child> children;
 
@@ -764,10 +776,22 @@ struct SearchSlot
 {
 	std::map<std::uint32_t, SearchResult> results;
 	SearchProgressSnapshot progress;
+	// What was searched for, so a consumer reading one search's results
+	// does not have to cross-reference GET /search for the string. For a
+	// browse ("View Files") the daemon's name for the search is the peer's
+	// nickname, not a query. Empty only for a slot seeded by discovery
+	// before its name was observed.
+	std::string query;
 	// Monotonic insertion order, used to evict the oldest slots when the map
 	// exceeds its cap (a client that starts many searches without closing them
 	// would otherwise accumulate slots for the whole process lifetime).
 	std::uint64_t seq = 0;
+	// When this slot's results were last pulled from the daemon. The tick
+	// refreshes active searches every second; a FINISHED search is never
+	// polled again, so reads of it refresh on demand instead, coalesced by
+	// this stamp. Default-constructed (epoch) means "never fetched", which
+	// is always stale.
+	std::chrono::steady_clock::time_point last_fetch{};
 };
 
 // `m_amule_log_lines` in CState caches /logs/amule. amule's EC
@@ -1332,17 +1356,18 @@ public:
 
 	std::vector<ServerSnapshot> Servers() const;
 	std::vector<FriendSnapshot> Friends() const;
-	// Results / progress for one search. search_id == 0 resolves to the
-	// current (most-recently-started) search; an unknown id yields an empty
-	// list / idle progress. HasSearch distinguishes "unknown id" (404) from
-	// "known but empty".
+	// Results / progress for one search. Every caller names a concrete
+	// daemon-allocated id — there is no implicit "current search" — and an
+	// unknown id yields an empty list / idle progress. HasSearch
+	// distinguishes "unknown id" (404) from "known but empty".
 	std::vector<SearchResult> Search(std::uint32_t search_id) const;
 	SearchProgressSnapshot SearchProgress(std::uint32_t search_id) const;
-	// True if the resolved search_id names a live slot. Used for the 404 on an
-	// explicit but expired/never-known id.
+	// True if search_id names a live slot. Used for the 404 on an id that
+	// was never started, was freed, or expired.
 	bool HasSearch(std::uint32_t search_id) const;
-	// The no-id default target (0 when no search this session).
-	std::uint32_t CurrentSearchId() const;
+	// What this search was started with; empty for an unknown id, or for a
+	// discovered slot whose name the daemon had not reported yet.
+	std::string SearchQuery(std::uint32_t search_id) const;
 	// Slots the refresher must still poll (progress.active).
 	std::vector<std::uint32_t> ActiveSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
@@ -1350,7 +1375,20 @@ public:
 	// Find a result carrying this (already-lowercased) hash across ALL open
 	// searches — the hash-keyed comments endpoints are search-agnostic. The
 	// parent owns any fetched Kad notes, so it matches ahead of its children.
-	bool FindSearchResultByHash(const std::string &hash_hex, SearchResult &out) const;
+	// `owner_search_id` reports which slot the hit came from, so the caller
+	// can refresh that slot before reading (see ClaimSearchRefresh).
+	bool FindSearchResultByHash(
+		const std::string &hash_hex, SearchResult &out, std::uint32_t *owner_search_id) const;
+	// Take the right to refresh one search's results from the daemon, for
+	// the read paths that must not serve a frozen snapshot.
+	//
+	// Returns true (and stamps the slot as fetched NOW) only when the slot
+	// exists, is NOT active, and its last fetch is older than `ttl`. Active
+	// slots are excluded because the tick already refreshes them every
+	// second. Stamping before the fetch rather than after is deliberate: it
+	// is what makes this a claim, so two concurrent readers of the same
+	// finished search issue one EC roundtrip between them, not two.
+	bool ClaimSearchRefresh(std::uint32_t search_id, std::chrono::milliseconds ttl);
 
 	// Categories aren't ECID-keyed (they come in via the
 	// preferences packet as an indexed array); keep them as a plain
@@ -1421,29 +1459,25 @@ public:
 	void ClearAmuleLog();
 	void WriteServerInfo(ServerInfoLog s);
 	// Called by POST /search with the daemon-allocated search_id. Creates (or
-	// resets) that search's slot: clears its results, marks it active=true with
-	// the requested `kind`, and makes it the current search. The refresher then
-	// polls EC_OP_SEARCH_RESULTS / _PROGRESS for it each tick, mapping
+	// resets) that search's slot: clears its results and marks it active=true
+	// with the requested `kind` and `query`. The refresher then polls
+	// EC_OP_SEARCH_RESULTS / _PROGRESS for it each tick, mapping
 	// EC_TAG_SEARCH_LIFECYCLE_STATE into `complete` / `active`.
-	void MarkSearchStarted(std::uint32_t search_id, const std::string &kind);
+	void MarkSearchStarted(std::uint32_t search_id, const std::string &kind, const std::string &query);
 	// Seeds a slot for a search this session did NOT start itself -- a
 	// search another client, or the monolithic GUI, started. Called
-	// on-demand from HandleSearchResults on a cache miss, after a one-off
+	// on-demand from the read paths on a cache miss, after a one-off
 	// EC_OP_SEARCH_LIST confirms the core actually holds it (deliberately
 	// NOT a per-tick refresher poll: that would pay an EC roundtrip every
 	// tick, forever, to serve something that happens rarely). Unlike
-	// MarkSearchStarted: does not touch m_current_search_id (a no-id GET
-	// /search/results should keep meaning "the search THIS session
-	// started", not silently jump to whatever was last discovered), and
-	// is idempotent -- a search already known (self-started or previously
-	// discovered) is left untouched rather than having its accumulated
-	// results/progress reset.
-	void MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind);
+	// MarkSearchStarted it is idempotent -- a search already known
+	// (self-started or previously discovered) is left untouched rather than
+	// having its accumulated results/progress reset.
+	void MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind, const std::string &query);
 	// Refresher-side write path for one search's progress snapshot.
 	void WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s);
-	// Drop a search's slot entirely: POST /search/stop with close=true, or the
-	// refresher observing the daemon evicted it (EC_TAG_SEARCH_EXPIRED). If it
-	// was the current search, current falls back to none (0).
+	// Drop a search's slot entirely: DELETE /search/{id}, or the refresher
+	// observing the daemon evicted it (EC_TAG_SEARCH_EXPIRED).
 	void CloseSearch(std::uint32_t search_id);
 	void WriteStatsTree(StatsTreeNode t);
 	void WriteGraphs(StatsGraphs g);
@@ -1498,21 +1532,18 @@ private:
 	// the REST surface by its daemon-allocated search_id. One slot per search
 	// holds that search's results (by result ECID) and its lifecycle progress.
 	std::map<std::uint32_t, SearchSlot> m_searches;
-	// The no-id default target for reads/stop: the most-recently-started
-	// search. 0 when no search has run this session (or the current one was
-	// closed) — reads then resolve to no slot and report an idle envelope.
-	std::uint32_t m_current_search_id = 0;
 	// Ever-increasing sequence stamped on each new slot for oldest-first
 	// eviction. Never wraps in practice (one bump per POST /search).
 	std::uint64_t m_search_seq = 0;
 	// Hard cap on retained slots. Comfortably above the daemon's 20-search
 	// ring so every live search always fits; excess is finished slots a
-	// client never closed, evicted oldest-first in MarkSearchStarted.
+	// client never closed, evicted oldest-first.
 	static constexpr std::size_t kMaxSearchSlots = 64;
 
-	// Resolve a caller-supplied id to a concrete slot key: 0 means "the
-	// current search". MUST be called with m_mu held.
-	std::uint32_t ResolveSearchId(std::uint32_t id) const { return id != 0 ? id : m_current_search_id; }
+	// Trim m_searches back to kMaxSearchSlots, dropping the oldest slot that
+	// is not still being polled. Shared by both slot-creating paths, which
+	// need the identical rule. MUST be called with m_mu held exclusively.
+	void EvictSurplusSearchSlotsLocked();
 };
 
 } // namespace webapi

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -164,8 +164,8 @@ function openSse() {
   // Search has its own channel but doesn't fit the added/updated/removed
   // resource model (no _removed; each search is a fresh result space), so
   // it's surfaced via store keys the search view consumes directly.
-  // search_result_added is byte-for-byte a /search/results[] entry (keyed by
-  // hash, nested sources {total, complete}); search_progress carries
+  // search_result_added is byte-for-byte a /search/{id}/results[] entry (keyed
+  // by hash, nested sources {total, complete}); search_progress carries
   // {state, percent, results, kind} and its terminal frame (state:
   // "finished") is the completion signal. Inert unless a search is active.
   es.addEventListener("search_result_added", (ev) => {
@@ -173,6 +173,13 @@ function openSse() {
   });
   es.addEventListener("search_progress", (ev) => {
     try { store.set("search:progress", JSON.parse(ev.data)); } catch (_) {}
+  });
+
+  // search_closed: the slot is gone (freed by a DELETE from any client, an
+  // EC reset, or the slot cap). A view bound to that id has nothing left to
+  // read, so surface it and let the view decide.
+  es.addEventListener("search_closed", (ev) => {
+    try { store.set("search:closed", JSON.parse(ev.data)); } catch (_) {}
   });
 
   // Comments ride their own event (EVENTS.md §comments_updated) instead of

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -1,11 +1,17 @@
 // Search view: start an ed2k/Kad search, then track it SSE-first: the
 // `search` channel delivers per-result upserts (search_result_added, same
-// shape as a /search/results[] entry, keyed by hash) and live progress
-// (search_progress {state, percent, results, kind}). GET /search/results is
-// only used to seed on mount (a search may already be running), as a single
+// shape as a /search/{id}/results[] entry, keyed by hash) and live progress
+// (search_progress {state, percent, results, kind}). GET /search/{id}/results
+// is only used to seed on mount (a search may already be running), as a single
 // reconcile once the terminal "finished" frame arrives, and as a polling
 // fallback while the stream isn't live. Download selected results into a
 // category.
+//
+// This view shows ONE search at a time -- the one it started, or the newest
+// the daemon holds when it mounts. The API addresses every search by id, so
+// several can run at once and every frame on the channel carries the id it
+// belongs to; frames for the others are ignored here. A per-search tab strip
+// is a separate piece of work.
 
 import { api } from "../api.js";
 import { data } from "../events.js";
@@ -63,6 +69,8 @@ export default function Search({ isGuest }) {
   // poll (full authoritative replace) write here, then we push the values
   // into render state.
   const resultsMap = useRef(new Map());
+  // The search this view is bound to (see fetchResults).
+  const searchId = useRef(0);
   // Trailing throttle: the first pending change schedules a flush ~SYNC_MS out;
   // everything arriving in that window folds into it. Progress text piggybacks
   // on the same flush so it never renders on its own hot path.
@@ -81,9 +89,16 @@ export default function Search({ isGuest }) {
   const progressText = (pr) =>
     pr.state === "running" ? t("search_searching_fmt", { percent: pr.percent || 0 }) : "";
 
+  // Every search-scoped call names its id in the path. `searchId.current` is
+  // the one this view is showing: set by POST /search, or adopted on mount
+  // from the newest entry the daemon holds. With nothing adopted there is
+  // nothing to read, which is the honest answer -- the API no longer has an
+  // implicit "whatever ran last" to fall back on.
   const fetchResults = async () => {
+    const sid = searchId.current;
+    if (!sid) return;
     try {
-      const r = await api.get("search/results");
+      const r = await api.get("search/" + sid + "/results");
       const res = r.results || [];
       resultsMap.current = new Map(res.map((x) => [x.hash, x]));
       scheduleSync();
@@ -105,13 +120,32 @@ export default function Search({ isGuest }) {
   useEffect(() => {
     api.get("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
 
+    // Adopt a search on mount so a reload (or a search started from another
+    // client) still shows something. GET /search lists every search the
+    // daemon holds, newest last in allocation order; prefer a running one,
+    // else take the last entry.
+    const adopt = async () => {
+      try {
+        const r = await api.get("search");
+        const list = r.searches || [];
+        if (!list.length) return;
+        const running = list.filter((x) => x.state === "running").pop();
+        const chosen = running || list[list.length - 1];
+        searchId.current = chosen.search_id;
+        fetchResults();
+      } catch (_) { /* nothing to adopt */ }
+    };
+
     // Live updates from the SSE search channel (opened app-wide by the
-    // shell). search_result_added payloads are /search/results[] entries
+    // shell). search_result_added payloads are /search/{id}/results[] entries
     // verbatim, so upsert them by hash as-is.
     let lastResult = store.get("search:result");
     const offResult = store.subscribe("search:result", (p) => {
       if (!p || p === lastResult) return;
       lastResult = p;
+      // Several searches can be running at once and they all publish on this
+      // channel, so a frame for a different one is not ours to render.
+      if (p.search_id !== searchId.current) return;
       resultsMap.current.set(p.hash, p);
       scheduleSync();
     });
@@ -123,6 +157,7 @@ export default function Search({ isGuest }) {
     const offProgress = store.subscribe("search:progress", (p) => {
       if (!p || p === lastProgress) return;
       lastProgress = p;
+      if (p.search_id !== searchId.current) return;
       pendingProgress.current = progressText(p);
       scheduleSync();
       if (p.state === "finished") {
@@ -132,8 +167,26 @@ export default function Search({ isGuest }) {
       }
     });
 
-    fetchResults(); // a search may already be running
-    return () => { stopPolling(); clearTimeout(syncTimer.current); offResult(); offProgress(); };
+    // The search we are showing can be freed by another client, by the slot
+    // cap, or by an EC reset. Without this the view would keep displaying a
+    // result set whose id now 404s.
+    let lastClosed = store.get("search:closed");
+    const offClosed = store.subscribe("search:closed", (p) => {
+      if (!p || p === lastClosed) return;
+      lastClosed = p;
+      if (p.search_id !== searchId.current) return;
+      stopPolling();
+      searchId.current = 0;
+      resultsMap.current.clear();
+      setResults([]); setSelection(new Set()); setSearching(false);
+      setProgress("");
+    });
+
+    adopt(); // a search may already be running, here or in another client
+    return () => {
+      stopPolling(); clearTimeout(syncTimer.current);
+      offResult(); offProgress(); offClosed();
+    };
   }, []);
   const sizeBytes = (v, unit) => { const n = Number(v); return (!n || n < 0) ? 0 : Math.round(n * SIZE_UNITS[unit]); };
 
@@ -149,7 +202,8 @@ export default function Search({ isGuest }) {
     if (mn) body.min_size = mn;
     if (mx) body.max_size = mx;
     try {
-      await api.post("search", body);
+      const started = await api.post("search", body);
+      searchId.current = started.search_id;
       resultsMap.current.clear();
       setResults([]); setSelection(new Set()); setSearching(true);
       setProgress(progressText({ state: "running", kind: type }));
@@ -160,7 +214,9 @@ export default function Search({ isGuest }) {
 
   const stop = async () => {
     stopPolling(); setSearching(false);
-    try { await api.post("search/stop"); } catch (_) {}
+    const sid = searchId.current;
+    if (!sid) return;
+    try { await api.post("search/" + sid + "/stop"); } catch (_) {}
     fetchResults();
   };
 

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# amuleapi 07-read-stats-and-search-results — /stats/tree, /stats/graphs/{graph}, /search/results.
+# amuleapi 07-read-stats-and-search-results — /stats/tree, /stats/graphs/{graph}, /search/{id}/results.
 # /stats/tree is a recursive structure; /stats/graphs is a time-series with
-# per-graph path-param + ?width=N tailing; /search/results is read-only
+# per-graph path-param + ?width=N tailing; /search/{id}/results is read-only
 # until Phase 5 adds POST /search.
 
 set -u
@@ -74,8 +74,15 @@ TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 # plus the existing tick, so the first full snapshot lands by tick 2).
 sleep 4
 
+# A search to address. Every search-scoped path names its id, so this
+# script starts one rather than relying on a removed implicit default.
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+	-d '{"query":"amuleapi-phase07","type":"local"}' "$HOST/api/v0/search"
+SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+[ -n "$SID" ] || _die "POST /search returned no search_id"
+
 # --- 1. Auth gate. -------------------------------------------------
-for ep in stats/tree stats/graphs/download_speed search/results; do
+for ep in stats/tree stats/graphs/download_speed "search/$SID/results"; do
 	_curl "$HOST/api/v0/$ep"
 	_assert_status 401 "GET /$ep (no creds) → 401"
 done
@@ -214,24 +221,28 @@ _assert_status 404 "GET /stats/graphs/bogus → 404"
 _assert_json_eq '.error.code' not_found \
 	'/stats/graphs/{unknown} carries error.code=not_found'
 
-# --- 6. /search/results — empty until Phase 5's POST /search. ------
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/results"
-_assert_status 200 "GET /search/results → 200"
-_assert_json_eq '.results | type'       array '/search/results .results is array'
-# Tolerant of empty results; if a phase 5 search was triggered earlier
-# and left state, the per-item shape still checks.
+# --- 6. /search/{id}/results. --------------------------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/$SID/results"
+_assert_status 200 "GET /search/{id}/results → 200"
+_assert_json_eq '.results | type'  array  '/search/{id}/results .results is array'
+_assert_json_eq '.search_id'       "$SID" '/search/{id}/results echoes its search_id'
+_assert_json_eq '.query'  amuleapi-phase07 '/search/{id}/results reports its query'
+# Tolerant of empty results; a local search on a fresh daemon may find
+# nothing. The per-item shape still checks when there is an item.
 COUNT=$(printf '%s' "$CURL_BODY" | jq '.results | length')
 if [ "$COUNT" -gt 0 ]; then
 	_assert_json_eq '.results[0].hash | length' 32 \
-		'/search/results[0].hash is 32-char hex'
+		'/search/{id}/results[0].hash is 32-char hex'
 	_assert_json_eq '.results[0].name | type'   string \
-		'/search/results[0].name is string'
+		'/search/{id}/results[0].name is string'
 	_assert_json_eq '.results[0].sources | type' object \
-		'/search/results[0].sources is object'
+		'/search/{id}/results[0].sources is object'
+	_assert_json_eq '.results[0].directory | type' string \
+		'/search/{id}/results[0].directory is string'
 fi
 
 # --- 7. Method gate. -----------------------------------------------
-for ep in stats/tree stats/graphs/download_speed search/results; do
+for ep in stats/tree stats/graphs/download_speed "search/$SID/results"; do
 	_curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/$ep"
 	_assert_status 405 "DELETE /api/v0/$ep → 405"
 done

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -13,7 +13,7 @@
 #   * /logs/serverinfo  (EC_OP_GET_SERVERINFO)
 #   * /stats/tree       (EC_OP_GET_STATSTREE)
 #   * /stats/graphs/{X} (EC_OP_GET_STATSGRAPHS — one fetch serves all 4)
-#   * /search/results   (EC_OP_SEARCH_RESULTS)
+#   * /search/{id}/results (EC_OP_SEARCH_RESULTS, on a finished search)
 #
 # Wire changes:
 #   * /uploads RETIRED → /clients is the unified peer surface
@@ -152,7 +152,7 @@ fi
 
 # --- 3. Lazy-fetch endpoints — fresh per-endpoint snapshot_at. -----
 #
-# Per Phase 4g, /stats/tree, /stats/graphs/{X}, /search/results, and
+# Per Phase 4g, /stats/tree, /stats/graphs/{X}, /search/{id}/results, and
 # /logs/serverinfo no longer ride the refresher tick. Each handler
 # drives its own EC roundtrip on first call, coalesced via 1 s TTL.
 # The `snapshot_at` field on each reflects the per-endpoint fetch
@@ -189,9 +189,21 @@ fi
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/bogus"
 _assert_status 404 "GET /stats/graphs/bogus → 404 (still validated)"
 
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/results"
-_assert_status 200 "GET /search/results → 200 (lazy fetch)"
-_assert_json_eq '.results | type' array '/search/results .results is array'
+# Results are addressed per search, so start one to have an id. A read of
+# a FINISHED search also refreshes it on demand (coalesced by a ~1 s TTL),
+# which is the lazy-fetch behaviour this phase is about.
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+	-d '{"query":"amuleapi-phase10","type":"local"}' "$HOST/api/v0/search"
+SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+[ -n "$SID" ] || _die "POST /search returned no search_id"
+
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/$SID/results"
+_assert_status 200 "GET /search/{id}/results → 200 (lazy fetch)"
+_assert_json_eq '.results | type' array '/search/{id}/results .results is array'
+
+# An id that names no search never falls back to another one.
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/4294967290/results"
+_assert_status 404 "GET /search/{unknown}/results → 404 (no implicit fallback)"
 
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/serverinfo"
 _assert_status 200 "GET /logs/serverinfo → 200 (lazy fetch)"

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -7,22 +7,24 @@
 #   POST /api/v0/search                                   — EC_OP_SEARCH_START
 #       body: {query, type?, file_type?, extension?,
 #              min_size?, max_size?, min_avail?}
-#   POST /api/v0/search/stop                              — EC_OP_SEARCH_STOP
-#   GET  /api/v0/search/results                            — read accumulated
+#   POST /api/v0/search/{id}/stop                          — EC_OP_SEARCH_STOP
+#   POST /api/v0/search/{id}/more                          — EC_OP_SEARCH_REQUEST_MORE
+#   DELETE /api/v0/search/{id}                             — stop + free
+#   GET  /api/v0/search/{id}/results                       — read accumulated
 #   POST /api/v0/search/results/{hash}/download           — EC_OP_DOWNLOAD_SEARCH_RESULT
 #       body: {category?: uint8} (optional)
 #   GET  /api/v0/search/results/{hash}/comments           — Kad ratings/comments for a result
 #   POST /api/v0/search/results/{hash}/comments           — EC_OP_SHARED_FILE_SEARCH_KAD_NOTES
 #   POST /api/v0/clients/{ecid}/shared_files              — browse a peer ("View Files"), returns a search_id
 #
-# /search/results is no longer a per-GET fetch — POST /search marks
+# /search/{id}/results is no longer a per-GET fetch — POST /search marks
 # the search active in state and the refresher polls amuled every
-# tick while it stays active. GET /search/results reads straight
+# tick while it stays active. GET /search/{id}/results reads straight
 # from that state, so subsequent polls already see the fresh query's
 # growing results without any cache coordination.
 #
 # amuled's SEARCH_START is async: results trickle in from servers /
-# Kad over the next several seconds. Smoke polls /search/results with
+# Kad over the next several seconds. Smoke polls /search/{id}/results with
 # bounded retries (up to ~10 s for a global search to harvest results).
 #
 # Important: this smoke depends on the operator's amuled being
@@ -120,8 +122,8 @@ _curl -X POST -H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\"}" "$HOST/api/v0/search"
 _assert_status 401 "POST /search (no token) → 401"
 
-_curl -X POST "$HOST/api/v0/search/stop"
-_assert_status 401 "POST /search/stop (no token) → 401"
+_curl -X POST "$HOST/api/v0/search/1/stop"
+_assert_status 401 "POST /search/{id}/stop (no token) → 401"
 
 _curl -X POST "$HOST/api/v0/search/results/baadbaadbaadbaadbaadbaadbaadbaad/download"
 _assert_status 401 "POST /search/results/{hash}/download (no token) → 401"
@@ -162,11 +164,13 @@ _assert_status 400 "POST /search (malformed JSON) → 400"
 # --- 3. POST /search happy + per-search_id addressing. ---------
 #
 # Multi-search: each POST /search gets its own daemon-allocated search_id
-# and its own result slot; a new search does NOT wipe the others. The
-# no-id GET /search/results resolves to the CURRENT (most-recently-started)
-# search, so the polling loop below sees the new query's results fill up.
+# and its own result slot; a new search does NOT wipe the others. Every
+# read/stop/free names its id in the path -- there is no implicit target,
+# which is what the retired-route and bad-id assertions below pin down.
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
-_assert_status 200 "GET /search/results (baseline before POST) → 200"
+_assert_status 404 "GET /search/results → 404 (retired: id goes in the path)"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/stop"
+_assert_status 404 "POST /search/stop → 404 (retired: id goes in the path)"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
@@ -176,8 +180,20 @@ _assert_json_eq '.ok'    true         'POST /search response.ok==true'
 _assert_json_eq '.query' "$TEST_QUERY" 'POST /search echoes query'
 _assert_json_eq '.search_id | type' number 'POST /search returns a numeric search_id'
 FIRST_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
-_assert_json_eq '.search_id' "$FIRST_SID" 'GET /search/results (no id) echoes the current search_id'
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+_assert_json_eq '.search_id' "$FIRST_SID" 'GET /search/{id}/results echoes its search_id'
+_assert_json_eq '.query' "$TEST_QUERY" 'GET /search/{id}/results reports the query it was started with'
+
+# A malformed or zero {id} is rejected outright. Zero used to be the
+# "whichever search ran last" sentinel, so letting it through would
+# quietly resurrect the implicit target these routes removed.
+for bad in 0 abc -1 99999999999; do
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$bad/results"
+	_assert_status 400 "GET /search/$bad/results → 400 (not a usable search id)"
+done
+# A well-formed id nobody holds is a 404, never a fallback.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/4294967290/results"
+_assert_status 404 "GET /search/{unknown}/results → 404"
 
 # --- 3.1 GET /api/v0/search enumerates the search just started. ---
 # Reachability fix (issue #641): GET /api/v0/search reads live daemon
@@ -240,9 +256,12 @@ if [ -n "$SECOND_TOKEN" ] && [ "$SECOND_TOKEN" != "null" ]; then
 		'second amuleapi instance (never POSTed) still lists the first instance'"'"'s search'
 
 	_curl -H "Authorization: Bearer $SECOND_TOKEN" \
-		"http://$SECOND_HOST/api/v0/search/results?search_id=$FIRST_SID"
-	_assert_status 200 'second amuleapi instance: GET /search/results?search_id=<foreign id> → 200 (not 404)'
-	_assert_json_eq '.search_id' "$FIRST_SID" 'second amuleapi instance /search/results echoes the discovered search_id'
+		"http://$SECOND_HOST/api/v0/search/$FIRST_SID/results"
+	_assert_status 200 'second amuleapi instance: GET /search/{foreign id}/results → 200 (not 404)'
+	_assert_json_eq '.search_id' "$FIRST_SID" 'second amuleapi instance echoes the discovered search_id'
+	# The adopted slot also learns the query from the SEARCH_LIST entry,
+	# so a client that discovered an id can label it without guessing.
+	_assert_json_eq '.query' "$TEST_QUERY" 'second amuleapi instance reports the discovered query'
 else
 	_fail "second amuleapi instance: admin login" "could not obtain a token; log: $(tail -c 300 "$SECOND_LOG")"
 fi
@@ -254,19 +273,19 @@ rm -rf "$SECOND_CONFIG_DIR" "$SECOND_LOG"
 # --- 3.5 Regression: progress shouldn't claim finished right after POST. -
 # amuled briefly reports raw=100 in the "queue-empty-at-start" window
 # before the global-search timer populates m_serverQueue; if amuleapi
-# trusted that raw value naively, GET /search/results right after POST
+# trusted that raw value naively, GET /search/{id}/results right after POST
 # would (incorrectly) say {progress:{percent:100, state:"finished"}}
 # with results=[]. The refresher's state machine masks that window —
 # this asserts the mask is in force.
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
-_assert_status 200 "GET /search/results immediately after POST → 200"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+_assert_status 200 "GET /search/{id}/results immediately after POST → 200"
 _assert_json_eq '.progress.state' running 'progress.state is "running" after POST /search'
 _assert_json_eq '.progress.kind | type' string 'progress.kind is a string'
 
-# --- 4. Poll /search/results until we get hits (max ~10 s). -------
+# --- 4. Poll /search/{id}/results until we get hits (max ~10 s). --
 RESULT_HASH=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50; do
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
 	N=$(printf '%s' "$CURL_BODY" | jq '.results | length')
 	if [ "$N" -gt 0 ]; then
 		RESULT_HASH=$(printf '%s' "$CURL_BODY" | jq -r '.results[0].hash')
@@ -279,29 +298,43 @@ if [ -n "$RESULT_HASH" ]; then
 	_pass "Search returned >0 results within 10 s ($N entries; sample hash $RESULT_HASH)"
 
 	# Per-result shape sanity.
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
-	_assert_json_eq '.results[0].hash | length' 32     '/search/results[0].hash is 32-char hex'
-	_assert_json_eq '.results[0].name | type'   string '/search/results[0].name is string'
-	_assert_json_eq '.results[0].size | type'   number '/search/results[0].size is numeric'
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+	_assert_json_eq '.results[0].hash | length' 32     '/search/{id}/results[0].hash is 32-char hex'
+	_assert_json_eq '.results[0].name | type'   string '/search/{id}/results[0].name is string'
+	_assert_json_eq '.results[0].size | type'   number '/search/{id}/results[0].size is numeric'
+	# Browse-only folder. Always present, empty on a server/Kad hit.
+	_assert_json_eq '.results[0].directory | type' string \
+		'/search/{id}/results[0].directory is a string'
+	_assert_json_eq '.results[0].directory' "" \
+		'directory is empty on an ordinary (non-browse) hit'
 	# Download status + file type (issue #429).
 	_assert_json_eq '[.results[0].status] | inside(["new","downloaded","queued","canceled","queued_canceled"])' \
 		true '/search/results[0].status is a known enum value'
-	_assert_json_eq '.results[0].type | type'   string '/search/results[0].type is string'
+	_assert_json_eq '.results[0].type | type'   string '/search/{id}/results[0].type is string'
 	# Media metadata (issue #430): an object when the hit is locally
 	# known/probed, absent otherwise — both are valid.
 	_assert_json_eq '.results[0].media | type | test("^(object|null)$")' \
-		true '/search/results[0].media is an object or absent'
+		true '/search/{id}/results[0].media is an object or absent'
 	# Result grouping (issue #431): every result carries a children[]
 	# array (empty when the hit was seen under a single name). No result
 	# is itself a child (children are folded into their parent), and each
 	# child object has ecid + name + hash + sources.
-	_assert_json_eq '.results[0].children | type' array '/search/results[0].children is an array'
+	_assert_json_eq '.results[0].children | type' array '/search/{id}/results[0].children is an array'
 	_assert_json_eq '[.results[].children[]?] | all(has("ecid") and has("name") and has("hash") and has("sources"))' \
 		true 'every child has ecid/name/hash/sources'
 	_assert_json_eq '[.results[].children[]?.hash | length] | all(. == 32)' \
 		true 'every child hash is 32-char hex (shared with its parent)'
+	_assert_json_eq '[.results[].children[]?] | all(has("directory"))' \
+		true 'every child carries its own directory (per-result, not per-search)'
 
-	# progress envelope. `progress` exists on every GET /search/results
+	# sort=directory is accepted (browse listings are read folder by
+	# folder); on a non-browse search every value is "" so the order is
+	# simply unchanged, which is the point -- it must not 400.
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$FIRST_SID/results?sort=directory&order=asc"
+	_assert_status 200 "GET /search/{id}/results?sort=directory → 200"
+
+	# progress envelope. `progress` exists on every GET /search/{id}/results
 	# response (even before any POST /search). `state` is canonical
 	# (running | finished | idle) and replaces the old complete/active
 	# booleans. Once we have results, state is "running" (still polling)
@@ -317,11 +350,54 @@ else
 	echo "    info: skipping /search/results/{hash}/download path (no hash to target)"
 fi
 
-# --- 5. POST /search/stop. ----------------------------------------
+# --- 4.5 POST /search/{id}/more — Kad-only, running-only. ---------
+#
+# The global search above is the wrong kind, which is exactly the case the
+# desktop greys the button out for; forwarding it would make amuled turn a
+# user's request into a silent no-op under a 202.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/more"
+_assert_status 400 "POST /search/{id}/more on a global search → 400 (Kad-only)"
+_assert_json_eq '.error.code' bad_request 'more on a non-Kad search reports bad_request'
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/4294967290/more"
+_assert_status 404 "POST /search/{unknown}/more → 404"
+
+# A running Kad search is the supported target. Kad may be down on the test
+# daemon, in which case the start itself fails -- skip rather than fail, like
+# the other Kad-dependent assertions in this suite.
+#
+# Distinct keyword on purpose: amuled refuses a second Kad search for a
+# keyword already on its search list ("Search keyword is already on search
+# list"), and the ramp section below runs its own Kad search on $TEST_QUERY.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/search/stop"
-_assert_status 200 "POST /search/stop → 200"
-_assert_json_eq '.ok' true 'search/stop response.ok==true'
+	-H "Content-Type: application/json" \
+	-d "{\"query\":\"${TEST_QUERY}more\",\"type\":\"kad\"}" "$HOST/api/v0/search"
+if [ "$CURL_STATUS" = "202" ]; then
+	KAD_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$KAD_SID/more"
+	_assert_status 202 "POST /search/{id}/more on a running Kad search → 202"
+	_assert_json_eq '.ok' true 'more response.ok==true'
+	if [ "$HAVE_GUEST" = "1" ]; then
+		_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
+			"$HOST/api/v0/search/$KAD_SID/more"
+		_assert_status 403 "POST /search/{id}/more (guest) → 403"
+	fi
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$KAD_SID" > /dev/null
+else
+	echo "    info: Kad search would not start (Kad down?) — skipping /more happy path"
+fi
+
+# --- 5. POST /search/{id}/stop. -----------------------------------
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/search/$FIRST_SID/stop"
+_assert_status 200 "POST /search/{id}/stop → 200"
+_assert_json_eq '.ok' true 'search stop response.ok==true'
+# Stop keeps the results readable — that is what distinguishes it from
+# DELETE, and a consumer viewing the search must not lose its rows.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+_assert_status 200 "GET /search/{id}/results after stop → 200 (results survive a stop)"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/4294967290/stop"
+_assert_status 404 "POST /search/{unknown}/stop → 404"
 
 # --- 6. POST /search/results/{hash}/download — happy + cleanup. --
 if [ -n "$RESULT_HASH" ]; then
@@ -385,8 +461,12 @@ fi
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 _assert_status 405 "PATCH /search → 405"
 
-_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/stop"
-_assert_status 405 "PATCH /search/stop → 405"
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/stop"
+_assert_status 405 "PATCH /search/{id}/stop → 405"
+_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID"
+_assert_status 405 "GET /search/{id} → 405 (DELETE only)"
+_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/bogus"
+_assert_status 404 "GET /search/{id}/{unknown-action} → 404"
 
 # --- 9. Kad search progress ramp. ---------------------------------
 # Kad has no measurable progress, so amuled synthesises a cosmetic
@@ -401,10 +481,11 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"kad\"}" "$HOST/api/v0/search"
 _assert_status 202 "POST /search type=kad → 202"
+RAMP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
 
 KAD_STATES=""; KAD_PCTS=""; SAW_RUNNING_KAD=0
 for _ in 1 2 3 4 5 6; do
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$RAMP_SID/results"
 	ST=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
 	KD=$(printf '%s' "$CURL_BODY" | jq -r '.progress.kind')
 	PC=$(printf '%s' "$CURL_BODY" | jq -r '.progress.percent')
@@ -454,7 +535,7 @@ else
 	fi
 fi
 
-curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/stop" > /dev/null 2>&1
+curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$RAMP_SID" > /dev/null 2>&1
 
 # --- 10. Search-result Kad comments/ratings (issue #434). ---------
 # GET/POST /search/results/{hash}/comments mirror the download-comments
@@ -501,9 +582,10 @@ _assert_status 405 "PATCH search comments → 405"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search"
+CMT_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
 CMT_HASH=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$CMT_SID/results"
 	N=$(printf '%s' "$CURL_BODY" | jq '.results | length')
 	if [ "$N" -gt 0 ]; then
 		CMT_HASH=$(printf '%s' "$CURL_BODY" | jq -r '.results[0].hash')
@@ -515,9 +597,9 @@ done
 if [ -n "$CMT_HASH" ]; then
 	# Every result carries the comment fields on the list itself.
 	_assert_json_eq '.results[0].kad_comment_search_running | type' boolean \
-		'/search/results[0].kad_comment_search_running is boolean (issue #434)'
+		'/search/{id}/results[0].kad_comment_search_running is boolean (issue #434)'
 	_assert_json_eq '.results[0].comments | type' array \
-		'/search/results[0].comments is an array'
+		'/search/{id}/results[0].comments is an array'
 
 	# Trigger an on-demand Kad notes lookup for the result.
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -534,7 +616,46 @@ if [ -n "$CMT_HASH" ]; then
 		'search comments carries kad_comment_search_running flag'
 	_assert_json_eq '.comments | type' array 'search comments.comments is an array'
 
-	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/stop" > /dev/null 2>&1
+	# The lookup's outcome only reaches amuleapi through the owning
+	# search's result fetch. Stop the search first, then keep polling:
+	# on a FINISHED search this exercises the refresh-on-read path, which
+	# is the only thing that can flip the flag back off. Skipped as
+	# inconclusive when Kad is down -- the flag then never turns on.
+	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$CMT_SID/stop" > /dev/null 2>&1
+	sleep 1
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$CMT_SID/results"
+	_assert_status 200 "GET /search/{id}/results on a finished search → 200 (refreshed on read)"
+	# A Kad NOTES lookup runs for ~45 s (SEARCHKEYWORD_LIFETIME), so poll
+	# past that. Either outcome proves the point: the flag clearing, or a
+	# note arriving. Both can only reach us through the owning search's
+	# result fetch, and this search is FINISHED -- the tick never polls it,
+	# so a frozen slot would show neither, forever.
+	SAW_FLAG=0
+	REPORTED=0
+	for _ in $(seq 1 30); do
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/search/results/$CMT_HASH/comments"
+		RUNNING=$(printf '%s' "$CURL_BODY" | jq -r '.kad_comment_search_running')
+		NOTES=$(printf '%s' "$CURL_BODY" | jq -r '.count')
+		[ "$RUNNING" = "true" ] && SAW_FLAG=1
+		if [ "$SAW_FLAG" = "1" ] && { [ "$RUNNING" = "false" ] || [ "$NOTES" -gt 0 ] 2>/dev/null; }; then
+			REPORTED=1
+			break
+		fi
+		sleep 2
+	done
+	if [ "$SAW_FLAG" = "0" ]; then
+		echo "    info: kad_comment_search_running never turned on — Kad likely down;"
+		echo "    info: skipping the finished-search comments reporting assertion."
+	elif [ "$REPORTED" = "1" ]; then
+		_pass "kad notes lookup on a FINISHED search reports back (running=$RUNNING notes=$NOTES)"
+	else
+		_fail "kad notes on a finished search" \
+			"flag turned on but nothing ever reported back (running=$RUNNING notes=$NOTES)"
+	fi
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$CMT_SID" > /dev/null 2>&1
 else
 	echo "    info: 0 results — skipping search-comments happy path (daemon not connected)"
 fi
@@ -543,8 +664,8 @@ fi
 # amuleapi runs several searches at once, each with its own daemon-
 # allocated search_id and its own result slot. Start an ed2k (global)
 # AND a Kad search back-to-back and verify they coexist: distinct ids,
-# per-id results, no-id => current, unknown id => 404, and stop+close
-# frees one while the sibling survives.
+# per-id results, unknown id => 404, and DELETE frees one while the
+# sibling survives.
 #
 # Regression guard (daemon fix): a Kad search started while an ed2k
 # search is still in-flight must NOT stop/steal the ed2k search — its
@@ -555,9 +676,13 @@ G=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
 SID_G=$(printf '%s' "$G" | jq -r '.search_id')
+# Distinct Kad keyword again: amuled keeps a keyword on its Kademlia
+# search list for the search's lifetime and refuses a second search for
+# the same one, so reusing $TEST_QUERY here would couple this section to
+# how far the earlier Kad sections have wound down.
 K=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"kad\"}" "$HOST/api/v0/search")
+	-d "{\"query\":\"${TEST_QUERY}multi\",\"type\":\"kad\"}" "$HOST/api/v0/search")
 SID_K=$(printf '%s' "$K" | jq -r '.search_id')
 
 if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" != "null" ]; then
@@ -568,29 +693,25 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 	fi
 
 	# Per-id progress kind reflects each search's own type.
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results?search_id=$SID_G"
-	_assert_status 200 "GET /search/results?search_id=<global> → 200"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
+	_assert_status 200 "GET /search/{global}/results → 200"
 	_assert_json_eq '.search_id'      "$SID_G" 'global search echoes its search_id'
 	_assert_json_eq '.progress.kind'  global   'global search progress.kind==global'
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results?search_id=$SID_K"
-	_assert_status 200 "GET /search/results?search_id=<kad> → 200"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_K/results"
+	_assert_status 200 "GET /search/{kad}/results → 200"
 	_assert_json_eq '.search_id'      "$SID_K" 'kad search echoes its search_id'
 	_assert_json_eq '.progress.kind'  kad      'kad search progress.kind==kad'
 
-	# no-id resolves to the current (most-recently-started == the Kad) search.
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
-	_assert_json_eq '.search_id' "$SID_K" 'no-id GET resolves to the current (latest) search'
-
 	# Unknown / never-started id → 404 (distinct from known-but-empty).
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results?search_id=4293000111"
-	_assert_status 404 "GET /search/results?search_id=<unknown> → 404"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/4293000111/results"
+	_assert_status 404 "GET /search/{unknown}/results → 404"
 
 	# Regression: the in-flight global search still harvests despite the
 	# concurrent Kad search. Poll briefly; skip the assertion (don't fail)
 	# if the daemon simply has no ed2k hits for the query.
 	GN=0
 	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results?search_id=$SID_G"
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
 		GN=$(printf '%s' "$CURL_BODY" | jq '.results | length')
 		[ "$GN" -gt 0 ] && break
 		sleep 0.25
@@ -601,26 +722,22 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		echo "    info: global search returned 0 alongside Kad — daemon may lack ed2k hits for '$TEST_QUERY'"
 	fi
 
-	# stop + close the global search: its slot is freed (404), the Kad
-	# search is untouched (still 200).
-	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		-H "Content-Type: application/json" \
-		-d "{\"search_id\":$SID_G,\"close\":true}" "$HOST/api/v0/search/stop"
-	_assert_status 200 "POST /search/stop {search_id:<global>, close:true} → 200"
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results?search_id=$SID_G"
-	_assert_status 404 "GET closed global search → 404"
-	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results?search_id=$SID_K"
-	_assert_status 200 "sibling Kad search survives the close → 200"
+	# DELETE the global search: its slot is freed (404), the Kad search
+	# is untouched (still 200). Freeing one from one tab must never take
+	# a sibling with it.
+	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G"
+	_assert_status 204 "DELETE /search/{global} → 204"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
+	_assert_status 404 "GET freed global search → 404"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_K/results"
+	_assert_status 200 "sibling Kad search survives the DELETE → 200"
 
-	# stop with an explicit unknown id → 404.
-	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		-H "Content-Type: application/json" \
-		-d '{"search_id":4293000111}' "$HOST/api/v0/search/stop"
-	_assert_status 404 "POST /search/stop {search_id:<unknown>} → 404"
+	# DELETE with an id nobody holds → 404.
+	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/4293000111"
+	_assert_status 404 "DELETE /search/{unknown} → 404"
 
-	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		-H "Content-Type: application/json" \
-		-d "{\"search_id\":$SID_K,\"close\":true}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$SID_K" >/dev/null 2>&1
 else
 	_fail "Multi-search setup" "POST /search did not return search_ids (G=$SID_G K=$SID_K)"
 fi
@@ -638,9 +755,9 @@ fi
 # cache -- so a search still listed here is still held by the core,
 # whatever any one client's local view says.
 #
-# POST /search/stop {close:true} sends exactly the EC request amulegui's
-# tab close sends (EC_OP_SEARCH_STOP + EC_TAG_SEARCH_CLOSE), so this
-# exercises the same daemon-side path from a scriptable client.
+# DELETE /search/{id} sends exactly the EC request amulegui's tab close
+# sends (EC_OP_SEARCH_STOP + EC_TAG_SEARCH_CLOSE), so this exercises the
+# same daemon-side path from a scriptable client.
 CLOSE_RES=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
@@ -657,16 +774,14 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	# the contrapositive that proves the removal below is close's doing
 	# and not a side effect of stopping.
 	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		-H "Content-Type: application/json" \
-		-d "{\"search_id\":$SID_CLOSE}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+		"$HOST/api/v0/search/$SID_CLOSE/stop" >/dev/null 2>&1
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 1 \
-		'close: a plain stop (no close) leaves the search on the daemon'
+		'close: a plain stop leaves the search on the daemon'
 
-	# Now close it, and assert it is GONE from the daemon's own list.
-	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		-H "Content-Type: application/json" \
-		-d "{\"search_id\":$SID_CLOSE,\"close\":true}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+	# Now free it, and assert it is GONE from the daemon's own list.
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$SID_CLOSE" >/dev/null 2>&1
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 	_assert_status 200 'close: GET /search after close → 200'
 	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 0 \
@@ -709,8 +824,8 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	# Its results are unaddressable afterwards, too -- the bucket is freed,
 	# not merely hidden from the listing.
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
-		"$HOST/api/v0/search/results?search_id=$SID_CLOSE"
-	_assert_status 404 'close: GET /search/results for the closed id → 404'
+		"$HOST/api/v0/search/$SID_CLOSE/results"
+	_assert_status 404 'close: GET /search/{id}/results for the freed id → 404'
 else
 	_fail "close setup" "POST /search did not return a search_id ($CLOSE_RES)"
 fi
@@ -718,11 +833,12 @@ fi
 # --- 12.1 A foreign search must be stoppable, not just visible. ----
 # Found by driving two clients against one daemon and using the other as
 # an oracle: GET /api/v0/search enumerates live core state, so it lists
-# searches this session never started -- but POST /search/stop gated on
-# the local m_state cache alone and answered 404 for exactly those. You
-# could see a search you could not close. Same contradiction previously
-# fixed for /search/results; the shared DiscoverSearchIfHeldByCore helper
-# is what stops it recurring a third time (got3nks, PR #680 review).
+# searches this session never started -- but the stop path gated on the
+# local m_state cache alone and answered 404 for exactly those. You could
+# see a search you could not close. Same contradiction previously fixed
+# for the results read; every search-scoped handler now resolves its id
+# through one RequireSearch helper, which is what stops it recurring a
+# third time (got3nks, PR #680 review).
 #
 # Stage a genuinely foreign search: a second amuleapi instance starts it,
 # so the primary at $HOST has never seen the id in its own cache.
@@ -761,11 +877,10 @@ if [ -n "$FOREIGN_TOKEN" ] && [ "$FOREIGN_TOKEN" != "null" ]; then
 		_assert_json_eq "[.searches[] | select(.search_id == $SID_FOREIGN)] | length" 1 \
 			'foreign stop: primary session lists the foreign search'
 
-		# ...and can also CLOSE it. This is the assertion that was 404ing.
-		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-			-H "Content-Type: application/json" \
-			-d "{\"search_id\":$SID_FOREIGN,\"close\":true}" "$HOST/api/v0/search/stop"
-		_assert_status 200 'foreign stop: closing a foreign search → 200 (not 404)'
+		# ...and can also FREE it. This is the assertion that was 404ing.
+		_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/search/$SID_FOREIGN"
+		_assert_status 204 'foreign stop: freeing a foreign search → 204 (not 404)'
 
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		_assert_json_eq "[.searches[] | select(.search_id == $SID_FOREIGN)] | length" 0 \
@@ -813,9 +928,8 @@ if [ -n "$SID_AFTER" ] && [ "$SID_AFTER" != "null" ] && [ "$SID_AFTER" != "0" ];
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 	_assert_json_eq "[.searches[] | select(.search_id == $SID_AFTER)] | length" 1 \
 		'failed start: the subsequent search is discoverable'
-	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		-H "Content-Type: application/json" \
-		-d "{\"search_id\":$SID_AFTER,\"close\":true}" "$HOST/api/v0/search/stop" >/dev/null 2>&1
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$SID_AFTER" >/dev/null 2>&1
 else
 	_fail "failed start: subsequent search" "POST /search returned no id ($AFTER_BAD)"
 fi
@@ -848,6 +962,72 @@ _assert_status 404 "POST /clients/{ecid}/shared_files (unknown ecid) → 404"
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/clients/$BROWSE_UNKNOWN_ECID/shared_files"
 _assert_status 405 "GET /clients/{ecid}/shared_files (wrong method) → 405"
+
+# Happy path when a peer happens to be connected: a browse is addressed
+# like any other search, reports kind "browse" with the peer's
+# client_ecid, and its files carry the folder they live in inside the
+# peer's share. Skipped (not failed) with no peer connected, like the
+# other peer-dependent assertions in this suite.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/clients"
+PEER_ECID=$(printf '%s' "$CURL_BODY" | jq -r '.clients[0].ecid // empty')
+if [ -n "$PEER_ECID" ]; then
+	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/clients/$PEER_ECID/shared_files"
+	if [ "$CURL_STATUS" = "202" ]; then
+		BROWSE_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		_pass "POST /clients/{ecid}/shared_files (live peer) → 202 (search_id $BROWSE_SID)"
+
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].kind" browse \
+			'GET /search reports the browse with kind=browse'
+		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].client_ecid" \
+			"$PEER_ECID" 'GET /search reports the browsed peer as client_ecid'
+
+		# Give the peer a moment to answer, then check the browse-only
+		# folder field. An unreachable/denying peer returns nothing, which
+		# is not a failure of this contract.
+		sleep 3
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$BROWSE_SID/results"
+		_assert_status 200 "GET /search/{browse id}/results → 200"
+		BN=$(printf '%s' "$CURL_BODY" | jq '.results | length')
+		if [ "$BN" -gt 0 ]; then
+			_assert_json_eq '[.results[] | has("directory")] | all' true \
+				'every browse result carries a directory'
+			_assert_json_eq '.results[0].directory | type' string \
+				'browse directory is a string'
+		else
+			echo "    info: peer returned no files — skipping the directory assertions"
+		fi
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/search/$BROWSE_SID/results?sort=directory"
+		_assert_status 200 "GET /search/{browse id}/results?sort=directory → 200"
+		curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/search/$BROWSE_SID" >/dev/null 2>&1
+	else
+		echo "    info: browse of peer $PEER_ECID returned $CURL_STATUS — skipping browse happy path"
+	fi
+else
+	echo "    info: no connected peer — skipping the browse happy path"
+fi
+
+# --- Related-files search (docs contract). -------------------------
+# There is no endpoint: the desktop composes a magic keyword and starts an
+# ordinary LOCAL search, so a REST client does the same. Assert the shape
+# is accepted, which is the part that is deterministic; whether the
+# connected server answers depends on its related_search capability flag.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"query":"related::baadbaadbaadbaadbaadbaadbaadbaad","type":"local"}' \
+	"$HOST/api/v0/search"
+_assert_status 202 'POST /search with a related:: query → 202 (no dedicated endpoint needed)'
+REL_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+[ -n "$REL_SID" ] && curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/search/$REL_SID" >/dev/null 2>&1
+# The capability a client should check before reading "no hits" as
+# "nothing related": the connected server advertises it in its flags.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/servers"
+_assert_json_eq '[.servers[]? | .tcp_flags | has("related_search")] | all' true \
+	'every server advertises its related_search capability in tcp_flags'
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
+++ b/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
@@ -252,9 +252,13 @@ else
 		"expected 202, got $CURL_STATUS"
 fi
 
-# Stop the search to leave the daemon clean.
-curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/search/stop" > /dev/null
+# Free the search to leave the daemon clean. The id comes from the start
+# reply -- there is no unaddressed stop to fall back on.
+SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+if [ -n "$SID" ]; then
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$SID" > /dev/null
+fi
 
 # --- 11. Error responses (4xx/5xx) don't get ETag stamped. -------
 #

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -261,10 +261,11 @@ rm -f "$SSE_A" "$SSE_B"
 SSE_PID=$(_sse_start 15)
 sleep 1
 SEARCH_QUERY=ubuntu
-curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+SSE_SEARCH=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$SEARCH_QUERY\",\"type\":\"local\"}" \
-	"$HOST/api/v0/search" > /dev/null
+	"$HOST/api/v0/search")
+SSE_SID=$(printf '%s' "$SSE_SEARCH" | jq -r '.search_id // empty')
 SEARCH_FINISHED=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 \
          21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40; do
@@ -319,9 +320,46 @@ if [ -n "$SEARCH_FINISHED" ]; then
 	else
 		_pass "search_result_added correctly absent (local search returned 0 results)"
 	fi
+	# Every frame on this channel names the search it belongs to, which is
+	# what lets a client demux several concurrent searches.
+	if [ -n "$SSE_SID" ] && echo "$JSON" | jq -e --argjson sid "$SSE_SID" '.search_id == $sid' >/dev/null 2>&1; then
+		_pass "search_progress .data.search_id names the search that produced it"
+	else
+		_fail "search_progress .data.search_id" "expected $SSE_SID in $JSON"
+	fi
 else
 	_fail "search_progress finished frame missing" \
 		"no finished search_progress within 8 s of POST /search; stream sample: $(head -40 "$SSE_OUT")"
+fi
+
+# --- 6.1 search_closed fires when a search is freed. ---------------
+# A subscriber holding one view per search learns the slot is gone from
+# this event; without it, it would only find out by 404ing on a later
+# read, and with SSE live it may never read again.
+if [ -n "$SSE_SID" ]; then
+	SSE_PID=$(_sse_start 8)
+	sleep 1
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$SSE_SID" > /dev/null
+	CLOSED_JSON=""
+	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+		if grep -q "^event: search_closed$" "$SSE_OUT"; then
+			CLOSED_JSON=$(grep -A2 "^event: search_closed$" "$SSE_OUT" \
+				| grep "^data: " | sed 's/^data: //' | head -1)
+			[ -n "$CLOSED_JSON" ] && break
+		fi
+		sleep 0.25
+	done
+	wait $SSE_PID 2>/dev/null
+	if [ -n "$CLOSED_JSON" ] && \
+	   echo "$CLOSED_JSON" | jq -e --argjson sid "$SSE_SID" '.search_id == $sid' >/dev/null 2>&1; then
+		_pass "search_closed fired for the freed search ($CLOSED_JSON)"
+	else
+		_fail "search_closed missing" \
+			"DELETE /search/$SSE_SID produced no matching search_closed; got: $CLOSED_JSON"
+	fi
+else
+	echo "    info: no search_id from POST /search — skipping search_closed"
 fi
 
 # --- comments_updated shape (issue #434). Conditional: the event only

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -2,7 +2,7 @@
 #
 # amuleapi list pagination + sorting (issue #357). Exercises the shared
 # ?limit/&offset/&sort/&order machinery across every list endpoint:
-# /downloads, /shared, /servers, /clients and /search/results.
+# /downloads, /shared, /servers, /clients and /search/{id}/results.
 #
 # Data-tolerant like the other read smokes — it asserts the pagination
 # metadata (`total`/`offset`/`limit`), that `limit` bounds the array
@@ -102,13 +102,20 @@ sleep 3 # let the refresher build its caches
 
 AUTH=(-H "Authorization: Bearer $TOKEN")
 
-# endpoint:array-key pairs. search/results wraps under "results".
+# The search list is addressed per search, so start one to have an id
+# rather than relying on a removed implicit default.
+SEARCH_SID=$(curl -s -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+	-d '{"query":"amuleapi-phase28","type":"local"}' "$HOST/api/v0/search" \
+	| jq -r '.search_id // empty')
+[ -n "$SEARCH_SID" ] || _die "POST /search returned no search_id"
+
+# endpoint:array-key pairs. The search results list wraps under "results".
 ENDPOINTS=(
 	"downloads:downloads"
 	"shared:shared"
 	"servers:servers"
 	"clients:clients"
-	"search/results:results"
+	"search/$SEARCH_SID/results:results"
 )
 
 for pair in "${ENDPOINTS[@]}"; do
@@ -162,6 +169,8 @@ for pair in "${ENDPOINTS[@]}"; do
 	_assert_status 200 "GET /$ep?limit=99999 → 200 (clamped)"
 	_assert_json_le ".limit" 500 "/$ep?limit=99999 echoes limit <= 500"
 done
+
+curl -s -X DELETE "${AUTH[@]}" "$HOST/api/v0/search/$SEARCH_SID" > /dev/null 2>&1
 
 echo
 echo "28-list-pagination-sort: $((TEST_COUNT-FAIL_COUNT))/$TEST_COUNT passed"

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -541,12 +541,17 @@ target_link_libraries (LogTeeTest
 )
 
 # Tests for EmitDiffsAndUpdate's log_appended path and cold-start
-# gating. Pulls EventBus + State along with EventDiff itself — none
-# touch wxWidgets or EC, so the exe is pure stdlib + muleunit.
+# gating. Pulls EventBus + State along with EventDiff itself — no EC,
+# and the only wx dependency is the shared search-result writer below.
 add_executable (EventDiffTest
 	EventDiffTest.cpp
 	${CMAKE_SOURCE_DIR}/src/webapi/EventBus.cpp
 	${CMAKE_SOURCE_DIR}/src/webapi/EventDiff.cpp
+	# search_result_added is documented as carrying exactly a results-list
+	# entry, so EventDiff emits it through the same writer the REST handler
+	# uses instead of a second hand-rolled copy. That writer speaks
+	# CJsonWriter, which is what brings webcommon (and wx base) in here.
+	${CMAKE_SOURCE_DIR}/src/webapi/SearchJson.cpp
 	${CMAKE_SOURCE_DIR}/src/webapi/State.cpp
 )
 target_include_directories (EventDiffTest
@@ -559,6 +564,8 @@ add_test (NAME EventDiffTest COMMAND EventDiffTest)
 target_link_libraries (EventDiffTest
 	muleunit
 	mulecommon
+	webcommon
+	wxWidgets::BASE
 )
 
 # amuleapi-specific: tests CAmuleApiConfig's file-IO + mode-bit

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -462,3 +462,105 @@ TEST(EventDiff, ServerFlagsJsonShape)
 	// describes it -- that is what the field is there for.
 	ASSERT_TRUE(webapi::ServerUdpFlagsJson(0x8000u).find("\"bitmask\":32768") != std::string::npos);
 }
+
+// --- search_result_added is the results-list entry, verbatim ---------
+//
+// EVENTS.md promises the payload is byte-for-byte a
+// GET /search/{id}/results entry with `search_id` prepended. That used to
+// be two hand-written serialisers kept in step by review, and they had
+// already drifted apart. Both now go through WriteSearchResultFields, so
+// this pins the fields the event MUST carry -- including the two the
+// hand-rolled copy had been missing.
+TEST(EventDiff, SearchResultAddedCarriesTheFullResultsEntry)
+{
+	CState state;
+	state.MarkSearchStarted(42, "browse", "SomePeerNick");
+
+	CEventBus bus;
+	LastSeenState prev;
+	// First tick baselines the (empty) slot: cold start never replays
+	// history as events.
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) {
+		SearchResult r;
+		r.ecid = 7;
+		r.hash = "8b54a3c28b54a3c28b54a3c28b54a3c2";
+		r.name = "peer-shared.iso";
+		r.size = 4096;
+		r.source_count = 3;
+		r.complete_source_count = 1;
+		r.status = "new";
+		r.type = "iso";
+		r.directory = "Incoming/ISOs";
+		SearchResult::Child c;
+		c.ecid = 8;
+		c.name = "peer-shared-copy.iso";
+		c.hash = r.hash;
+		c.directory = "Backup/ISOs";
+		r.children.push_back(c);
+		cache.emplace(r.ecid, r);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "search_result_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	// search_id leads, so a consumer can demux before parsing the rest.
+	ASSERT_TRUE(payload.compare(0, 15, "{\"search_id\":42") == 0);
+	// The browse-only folder, on the result and on its child.
+	ASSERT_TRUE(payload.find("\"directory\":\"Incoming/ISOs\"") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"directory\":\"Backup/ISOs\"") != std::string::npos);
+	// The two fields the previously hand-rolled event payload omitted
+	// while the REST writer emitted them.
+	ASSERT_TRUE(payload.find("\"kad_comment_search_running\":false") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"comments\":[]") != std::string::npos);
+}
+
+// --- search_closed fires when a slot disappears ----------------------
+//
+// A subscriber holding one view per search otherwise only learns the
+// search is gone by 404ing on a later read -- and with SSE live it may
+// never read again.
+TEST(EventDiff, SearchClosedFiresOnceWhenTheSlotIsFreed)
+{
+	CState state;
+	state.MarkSearchStarted(42, "global", "ubuntu");
+	state.MarkSearchStarted(43, "kad", "debian");
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // baseline: both known
+
+	// The bus replays from the start on every drain, so count over the
+	// whole history rather than treating a drain as "what is new".
+	auto CountClosed = [&bus]() {
+		std::size_t n = 0;
+		std::string last;
+		for (const auto &e : DrainAll(bus)) {
+			if (e.name == "search_closed") {
+				++n;
+				last = e.data;
+			}
+		}
+		return std::make_pair(n, last);
+	};
+	ASSERT_EQUALS(static_cast<size_t>(0), CountClosed().first);
+
+	state.CloseSearch(42);
+	EmitDiffsAndUpdate(bus, prev, state);
+	const auto after_close = CountClosed();
+	ASSERT_EQUALS(static_cast<size_t>(1), after_close.first);
+	ASSERT_EQUALS(std::string("{\"search_id\":42}"), after_close.second);
+
+	// Further ticks stay silent: the baseline was pruned with the event,
+	// so a freed search is announced exactly once and its surviving
+	// sibling is never swept up with it.
+	EmitDiffsAndUpdate(bus, prev, state);
+	EmitDiffsAndUpdate(bus, prev, state);
+	ASSERT_EQUALS(static_cast<size_t>(1), CountClosed().first);
+	ASSERT_TRUE(state.HasSearch(43));
+}

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1399,6 +1399,58 @@ TEST(Refresher, SearchResultGroupingFoldsChildren)
 	ASSERT_EQUALS(std::string("third.mkv"), it->second.children[1].name);
 }
 
+// --- Browse results carry the folder they live in ---------------------
+//
+// EC_TAG_SEARCHFILE_DIRECTORY is attached by the core only to results
+// filed from a peer's shared-file listing, which is what makes it the
+// browse-only "Directories" column. It is per-RESULT, not per-search: two
+// copies of one file in different folders of the same share group under a
+// single parent and each must keep its own folder.
+TEST(Refresher, SearchResultDirectoryDecodesAndRidesEachChild)
+{
+	std::map<std::uint32_t, SearchResult> cache;
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+
+	CECTag parent(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(200));
+	parent.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("shared.iso")));
+	parent.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4096)));
+	parent.AddTag(CECTag(EC_TAG_SEARCHFILE_DIRECTORY, std::string("Incoming/ISOs")));
+	resp.AddTag(parent);
+
+	CECTag child(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(201));
+	child.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("shared-copy.iso")));
+	child.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4096)));
+	child.AddTag(CECTag(EC_TAG_SEARCH_PARENT, static_cast<std::uint32_t>(200)));
+	child.AddTag(CECTag(EC_TAG_SEARCHFILE_DIRECTORY, std::string("Backup/ISOs")));
+	resp.AddTag(child);
+
+	ApplySearchFull(&resp, cache);
+
+	const auto it = cache.find(200);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_EQUALS(std::string("Incoming/ISOs"), it->second.directory);
+	ASSERT_EQUALS(static_cast<size_t>(1), it->second.children.size());
+	// The child keeps ITS folder rather than inheriting the parent's.
+	ASSERT_EQUALS(std::string("Backup/ISOs"), it->second.children[0].directory);
+}
+
+TEST(Refresher, SearchResultDirectoryEmptyOnOrdinaryHit)
+{
+	// A server/Kad hit never carries the tag, and must report an empty
+	// string rather than anything that could read as a real folder.
+	std::map<std::uint32_t, SearchResult> cache;
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag hit(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(300));
+	hit.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("remote.iso")));
+	resp.AddTag(hit);
+
+	ApplySearchFull(&resp, cache);
+
+	const auto it = cache.find(300);
+	ASSERT_TRUE(it != cache.end());
+	ASSERT_TRUE(it->second.directory.empty());
+}
+
 // --- #359: peer software_version must be locale-independent ----------
 //
 // The daemon formats the version string with gettext, so an unidentified

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -469,10 +469,9 @@ TEST(State, WriteGraphsWithoutConnBlobLeavesExtraSeriesEmpty)
 TEST(State, SearchResultsRoundtripAndOrderByEcid)
 {
 	CState s;
-	// Multi-search: a slot must exist before it can be mutated/read. Seed one
-	// (its id becomes the current search) and populate it.
+	// Multi-search: a slot must exist before it can be mutated/read.
 	const std::uint32_t sid = 1;
-	s.MarkSearchStarted(sid, "global");
+	s.MarkSearchStarted(sid, "global", "ubuntu");
 	s.MutateSearch(sid, [](std::map<std::uint32_t, SearchResult> &cache) {
 		SearchResult a;
 		a.ecid = 50;
@@ -492,36 +491,37 @@ TEST(State, SearchResultsRoundtripAndOrderByEcid)
 		cache.emplace(b.ecid, b);
 	});
 
-	// std::map iterates ECID-ascending → Search() vector is sorted. Read by
-	// explicit id and via the no-id default (0 == current search) — both hit
-	// the same slot.
-	for (std::uint32_t query : { sid, std::uint32_t{ 0 } }) {
-		const auto out = s.Search(query);
-		ASSERT_EQUALS(static_cast<size_t>(2), out.size());
-		ASSERT_EQUALS(std::string("first-by-ecid.iso"), out[0].name);
-		ASSERT_EQUALS(std::string("ascii-name.iso"), out[1].name);
-		ASSERT_TRUE(out[0].already_have);
-		ASSERT_FALSE(out[1].already_have);
-	}
+	// std::map iterates ECID-ascending → Search() vector is sorted.
+	const auto out = s.Search(sid);
+	ASSERT_EQUALS(static_cast<size_t>(2), out.size());
+	ASSERT_EQUALS(std::string("first-by-ecid.iso"), out[0].name);
+	ASSERT_EQUALS(std::string("ascii-name.iso"), out[1].name);
+	ASSERT_TRUE(out[0].already_have);
+	ASSERT_FALSE(out[1].already_have);
+	// The query rides on the slot, so a results read can report what was
+	// searched for without a second lookup.
+	ASSERT_EQUALS(std::string("ubuntu"), s.SearchQuery(sid));
+	// Id 0 is not a search and never resolves to one.
+	ASSERT_TRUE(s.Search(0).empty());
+	ASSERT_FALSE(s.HasSearch(0));
 }
 
 TEST(State, MultiSearchSlotsAreIndependentAndAddressable)
 {
 	CState s;
-	// No search yet: current is 0, nothing is known, reads are empty.
-	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.CurrentSearchId());
+	// No search yet: nothing is known and reads are empty.
 	ASSERT_FALSE(s.HasSearch(42));
-	ASSERT_TRUE(s.Search(0).empty());
+	ASSERT_TRUE(s.Search(42).empty());
 
 	// Two concurrent searches, each with its own result.
-	s.MarkSearchStarted(10, "global");
+	s.MarkSearchStarted(10, "global", "ten");
 	s.MutateSearch(10, [](std::map<std::uint32_t, SearchResult> &cache) {
 		SearchResult r;
 		r.ecid = 1;
 		r.name = "in-ten.iso";
 		cache.emplace(r.ecid, r);
 	});
-	s.MarkSearchStarted(20, "kad");
+	s.MarkSearchStarted(20, "kad", "twenty");
 	s.MutateSearch(20, [](std::map<std::uint32_t, SearchResult> &cache) {
 		SearchResult r;
 		r.ecid = 2;
@@ -529,11 +529,8 @@ TEST(State, MultiSearchSlotsAreIndependentAndAddressable)
 		cache.emplace(r.ecid, r);
 	});
 
-	// Most-recently-started search is current; no-id resolves to it.
-	ASSERT_EQUALS(static_cast<std::uint32_t>(20), s.CurrentSearchId());
-	ASSERT_EQUALS(std::string("in-twenty.iso"), s.Search(0).at(0).name);
-
-	// Each id addresses only its own results — no cross-contamination.
+	// Each id addresses only its own results — no cross-contamination, and
+	// no implicit target that could make an unaddressed read mean either.
 	ASSERT_EQUALS(static_cast<size_t>(1), s.Search(10).size());
 	ASSERT_EQUALS(std::string("in-ten.iso"), s.Search(10).at(0).name);
 	ASSERT_EQUALS(std::string("in-twenty.iso"), s.Search(20).at(0).name);
@@ -541,18 +538,52 @@ TEST(State, MultiSearchSlotsAreIndependentAndAddressable)
 	ASSERT_TRUE(s.HasSearch(20));
 	ASSERT_FALSE(s.HasSearch(30));
 
-	// Progress kind is per-slot.
+	// Progress kind and query are per-slot.
 	ASSERT_EQUALS(std::string("global"), s.SearchProgress(10).kind);
 	ASSERT_EQUALS(std::string("kad"), s.SearchProgress(20).kind);
+	ASSERT_EQUALS(std::string("ten"), s.SearchQuery(10));
+	ASSERT_EQUALS(std::string("twenty"), s.SearchQuery(20));
 
-	// Closing the current search drops its slot and clears current (no reliable
-	// "next newest" once it is gone).
+	// Freeing one search leaves the other completely alone — the property
+	// that makes DELETE /search/{id} safe to issue from one tab.
 	s.CloseSearch(20);
 	ASSERT_FALSE(s.HasSearch(20));
 	ASSERT_TRUE(s.HasSearch(10));
-	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.CurrentSearchId());
 	ASSERT_TRUE(s.Search(20).empty());
 	ASSERT_EQUALS(static_cast<size_t>(1), s.Search(10).size());
+	ASSERT_EQUALS(std::string("in-ten.iso"), s.Search(10).at(0).name);
+}
+
+TEST(State, SearchRefreshIsClaimedOncePerTtlAndOnlyWhenIdle)
+{
+	// The read paths refresh a FINISHED search on demand, because the tick
+	// only polls active ones. ClaimSearchRefresh is what stops that from
+	// turning every GET into an EC roundtrip, and what keeps two concurrent
+	// readers of the same search to one roundtrip between them.
+	CState s;
+	const auto kTtl = std::chrono::milliseconds(1000);
+
+	// Unknown id: nothing to refresh.
+	ASSERT_FALSE(s.ClaimSearchRefresh(99, kTtl));
+
+	// A running search is refreshed by the tick every second already, so the
+	// read path must not add traffic on top of it.
+	s.MarkSearchStarted(7, "global", "still running");
+	ASSERT_FALSE(s.ClaimSearchRefresh(7, kTtl));
+
+	// Once finished it has never been fetched by this path, so the first
+	// caller gets the claim...
+	SearchProgressSnapshot done = s.SearchProgress(7);
+	done.active = false;
+	done.complete = true;
+	s.WriteSearchProgress(7, done);
+	ASSERT_TRUE(s.ClaimSearchRefresh(7, kTtl));
+	// ...and the next one inside the TTL does not, because the claim stamped
+	// the slot rather than waiting for the fetch to finish.
+	ASSERT_FALSE(s.ClaimSearchRefresh(7, kTtl));
+	// A zero TTL means "always stale", which is how the test distinguishes
+	// "coalesced" from "never refreshes again".
+	ASSERT_TRUE(s.ClaimSearchRefresh(7, std::chrono::milliseconds(0)));
 }
 
 TEST(State, BrowseRidesSearchMachinery)
@@ -563,7 +594,7 @@ TEST(State, BrowseRidesSearchMachinery)
 	// and the SSE search channel all treat it identically. Lock that in: the
 	// browse kind is preserved per-slot and its results address only its own id.
 	CState s;
-	s.MarkSearchStarted(17, "browse");
+	s.MarkSearchStarted(17, "browse", "SomePeerNick");
 	s.MutateSearch(17, [](std::map<std::uint32_t, SearchResult> &cache) {
 		SearchResult r;
 		r.ecid = 1;
@@ -574,6 +605,9 @@ TEST(State, BrowseRidesSearchMachinery)
 	ASSERT_EQUALS(std::string("browse"), s.SearchProgress(17).kind);
 	ASSERT_EQUALS(static_cast<size_t>(1), s.Search(17).size());
 	ASSERT_EQUALS(std::string("peer-shared.iso"), s.Search(17).at(0).name);
+	// A browse's "query" is the peer whose share is listed, which is what the
+	// daemon names the search and what GET /search reports for it.
+	ASSERT_EQUALS(std::string("SomePeerNick"), s.SearchQuery(17));
 }
 
 TEST(State, ResetListsLeavesLogsAlone)


### PR DESCRIPTION
Closes #980.

`amuleapi` has run several concurrent searches for a while: the daemon allocates a `search_id` per start, `m_state` keeps one slot per search, the refresher polls each independently, and both SSE events carry the id they belong to. What the REST surface still carried was the **single-search shape it grew out of** - the id was an optional parameter, and omitting it resolved to a per-session "current search", the most recently started one.

This removes that default, moves every search-scoped operation into the path, and fills the gaps a multi-search consumer actually needs. `/api/v0/` is experimental with no consumers outside this repository, so the shape changes land in place.

## Routes

| Verb + path | Replaces |
|---|---|
| `GET /api/v0/search` | unchanged - lists every search the daemon holds |
| `POST /api/v0/search` | unchanged - starts one, returns `search_id` |
| `GET /api/v0/search/{id}/results` | `GET /search/results?search_id=` |
| `POST /api/v0/search/{id}/stop` | `POST /search/stop` |
| `DELETE /api/v0/search/{id}` | `POST /search/stop {"close":true}` |
| `POST /api/v0/search/{id}/more` | **new** |

`{id}` is validated as a positive decimal. `0` and non-numeric segments are `400`, never a fallback - zero especially, since it *was* the "whichever search ran last" sentinel and letting it through would quietly resurrect the behaviour these routes remove. The two retired paths answer `404` naming their replacement rather than falling into the `{id}` matcher and reporting a confusing "not a valid search id".

The hash-addressed `download` and `comments` routes stay exactly where they are, matched first. Both are deliberately search-agnostic - the daemon resolves a download by hash against its whole search list, and a Kad note fetched for a hash is fanned out to every result carrying it - so nesting them under `{id}` would advertise a scoping that does not exist.

**Deleted with the concept:** `m_current_search_id`, `ResolveSearchId`, `CurrentSearchId`, the `search_id: 0` sentinel, `SearchIdParam` / `ParseSearchIdParam`, and the "never evict the current search" carve-out that was duplicated in both slot-creating paths. `grep -rn "current_search\|ResolveSearchId\|CurrentSearchId" src/webapi` is empty.

## The missing data

All of it was already on the wire; no core change, no EC protocol change, no extra round-trip.

- **`query` on the results envelope.** A client that adopted an id had to cross-reference `GET /search` just to label the tab it was already reading. Discovery takes the name from the `EC_OP_SEARCH_LIST` entry, so an adopted search reports it too. For a browse this is the peer's nickname, not a query string.
- **`client_ecid` on a browse entry in `GET /search`.** `EC_OP_SEARCH_LIST` carries the browsed peer and the handler dropped it, so a consumer saw `kind: "browse"` with no way to tell **whose** share it was listing.
- **`directory` on a browse result**, from `EC_TAG_SEARCHFILE_DIRECTORY` - the desktop's *Directories* column. Per-result rather than per-search, so two copies of one file in different folders of the same share keep their own folder when they group, and `children[]` entries carry it too. Added to the accepted `sort` keys.
- **`POST /search/{id}/more`**, the desktop **"More"** button. Kad-only and running-only, matching what that button allows rather than what the core tolerates: `CSearchManager::RequestMoreResults` returns false for a non-Kad id and the GUI greys the button out once the search finishes, so forwarding either case would turn a user's request into a silent no-op under a `202`.

## Finished searches are no longer frozen

The tick only polls **active** searches, so once a search finished its cached results never changed again. Two user-visible consequences, one of them a broken feature: a Kad notes lookup started on a finished search's hit - which is exactly when a user reads a result list - could never report back, because the notes only reach amuleapi through that search's result fetch.

The read paths now refresh an inactive slot on demand. The gating lives in `CState::ClaimSearchRefresh`, which returns the right to fetch only when the slot exists, is not active, and has aged past a 1 s TTL - and stamps the slot **as it hands out the claim**, so two concurrent readers of the same finished search issue one EC roundtrip between them rather than two. Idle cost is unchanged: an active search is left to the tick, and repeated polling of a finished one costs at most one roundtrip per second.

## `search_closed`

A slot can disappear under a subscriber - `DELETE` from another client, the slot cap evicting an old finished search, an EC reset - and until now the diff pass pruned its baseline silently. A consumer holding one view per search only found out by `404`ing on its next read, and with SSE live it might never read again.

Emitted from that same prune loop, on the `search` channel: `{ "search_id": 42 }`. Deliberately **not** fired for a search the daemon evicted from its own ring: that one is retired as `finished` and kept locally for late reads, so it stays a terminal `search_progress`.

## Three things that had two implementations

- **The search-result JSON.** `EVENTS.md` promises `search_result_added` is byte-for-byte a results-list entry with `search_id` prepended. It was a second hand-written serialiser, and it had **already drifted**: the REST writer emitted `kad_comment_search_running` and `comments[]`, the event did not. Both now go through `WriteSearchResultFields` (new `SearchJson.h/.cpp`), so the promise holds by construction, the divergence is fixed, and `directory` landed on both at once instead of being hand-synced into a third place. There is a unit test asserting the event carries the previously-missing fields.
- **The EC results fetch**, now `FetchSearchResults`, shared by the tick and the on-demand refresh - so a results list read through either route is fetched with the identical request and fed through the identical applier.
- **The stop / close / more EC exchange**, which differed only in opcode, the close flag and the success status.

## Related-files search (docs only)

The desktop's *"Search related files"* action needs no endpoint and no opcode - the GUI composes a `related::<md4>[::<md4>...]` keyword and starts an ordinary local search - so it has worked over REST all along and was documented nowhere.

One correction to the issue while documenting it: the desktop does not just fire and hope. It gates the action on `GetRelatedSearchSupport()` and shows an error dialog when the connected server lacks it. The API already exposes that capability as `related_search` in each server's `tcp_flags`, so the docs point a client there rather than implying an empty result set means "nothing related".

## Web UI

Kept working, not redesigned. `views/search.js` keeps the `search_id` from `POST /search`, adopts the newest search from `GET /search` on mount (so a reload or another client's search still shows), ignores stream frames belonging to other searches, and clears itself on `search_closed`. The per-search tab strip is separate work.

## Testing

Unit: 34/34 `ctest` green, with new cases for the `directory` decode (present on a browse result and on each child, empty on an ordinary hit), the refresh claim (skipped while active, granted once per TTL), the per-slot `query`, the shared-writer payload, and `search_closed` firing exactly once for a freed slot while its sibling is untouched.

Live, against a local `amuled` connected to **both** ed2k and Kad, through a freshly built `amuleapi`:

- `19-search.sh`: **135/135**, including the new `/more` (`202` on a running Kad search, `400` on a global one, `400` once finished, `403` for guest, `404` unknown), `DELETE` → `204` then `404` on its results with the sibling still `200`, both retired paths `404`, `{id}` of `0`/`abc`/`-1`/overflow → `400`, `query` on the envelope and on a search adopted by a second amuleapi instance, `directory` on results and children, `sort=directory`, and a Kad notes lookup started on a **finished** search reporting back through the on-read refresh.
- `22-sse-diff-emission.sh` 19/19: `search_closed` observed on the stream after a `DELETE`, and every `search_progress` frame carrying its `search_id`.
- `07` 82/82, `10` 26/26, `20` 30/30, `28` 105/105.
- The full `run-all.sh` matrix: **34 of 35 phases green**. The exceptions are accounted for below.

Running the whole matrix rather than only the scripts I had edited is what caught `28-list-pagination-sort.sh`, which drives the pagination contract across five list endpoints and reaches the search one through a table of `endpoint:key` pairs - a form my grep for the retired paths had not matched. Now parameterised by a search it starts itself: 105/105.

`17-shared-priority-patch.sh` and `30-shared-verify.sh` exit early unless `AMULE_SHARED_DIR` names a directory the daemon shares; with it set they pass 42/42 and 9/9. `33-known-clients.sh` failed once inside the matrix ("1 of 5 connected peers have no row") and passes on re-run - live peer churn, and it touches nothing this change went near.

## Unrelated failures found by running the suite

Two were drift from #987 that I hit and fixed locally, and both turned out to have been fixed upstream in the meantime, so neither is in this diff any more: `10-refresher-lazy-ondemand.sh` using the pre-rename graph endpoint (`download` / `unit: bps` rather than `download_speed` / `bytes_per_second`), and `07`'s `max_points` assertion reading `.points | length <= .max_points`, which pipes the array into the comparison so `.max_points` is looked up on the array and jq errors instead of comparing. Mentioned only so the 13 failures they caused are not mistaken for something this change introduced.

One is still open: `26-rfc-followup-endpoints.sh` expects `POST /servers/0.0.0.0:1/connect` to be a `404` and it now answers `400 bad_request` ("malformed ip:port selector: expected a dotted quad and a port in 1..65535"). Reproducible, and nothing in this diff touches the server routes. It is a disagreement about what the endpoint *should* say rather than mechanical drift, so it wants its own decision rather than a fix smuggled in here.

Also worth knowing for whoever picks up the docs next: `REFERENCE.md#list-envelopes-and-pagination` and `EVENTS.md`'s `REFERENCE.md#get-apiv0logsserverinfo` are dead anchors that predate this change - found while sweeping the search anchors, left alone.

## Rebased onto #995

The branch is rebased onto `6558b2925`. #995 lands in eight of the nine files this change touches, so the merge was re-verified rather than assumed: full build, `ctest` 34/34, both clang-tidy tiers and clang-format clean, and the live suites re-run. The only textual conflict was the list-endpoint sentence in `REFERENCE.md`, where #995 added its per-file client routes to the same line this change renamed `/search/results` on - both kept. `SearchResult` itself is untouched by #995, so the shared writer still covers the whole shape.
