### PR TITLE
fix(web-ui): give the bodyless action button the accent fill

### DIFF
--- a/src/webapi/static/js/views/preferences.js
+++ b/src/webapi/static/js/views/preferences.js
@@ -448,7 +448,7 @@ export default function Preferences({ isGuest }) {
       // action buttons already behave (they are simply not rendered).
       return html`
         <div class=${"field field-inline admin-only" + subCls}>
-          <button class="btn" type="button" disabled=${disabled}
+          <button class="btn btn-primary" type="button" disabled=${disabled}
                   title=${t(f.action.titleKey)} onClick=${() => runAction(f.action)}>
             ${label}
           </button>


### PR DESCRIPTION
The IP-filter "Reload list" button rendered with the plain `.btn` style while the download button sitting two rows below it, on the same `ipfilter_update_url" field, already carried `.btn-primary`. Two controls that drive the same kind of action -- a POST that fires immediately, with no Apply step -- looked like two different weights of control.

Add `.btn-primary` to the `type: "button"` branch of `buildField`, so every bodyless action reads as an action rather than as a neutral secondary control. Verified in the browser: `background` resolves to `var(--accent)` with `--accent-contrast` text, matching the URL row's icon button.

This is the only bodyless action today, but the rule now lives in the shared branch rather than in one call site.