### PR TITLE
amuleapi: stop reporting a valid 0.0.0.0 selector as a malformed one

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5740,9 +5740,13 @@ boost::optional<IpPortSelector> ParseIpPortSelector(const std::string &ip_port)
 	// ParseIpv4Dotted rather than a second sscanf of our own: it landed on
 	// master while this was in review and does exactly this job, with three
 	// other callers already relying on it.
+	//
+	// Only genuine syntax failures are reported here. 0.0.0.0 parses fine
+	// and is rejected by the caller instead, so the two get error messages
+	// that describe what actually happened.
 	IpPortSelector sel;
 	sel.ip_he = 0;
-	if (!ParseIpv4Dotted(ip_str, sel.ip_he) || sel.ip_he == 0)
+	if (!ParseIpv4Dotted(ip_str, sel.ip_he))
 		return boost::none;
 
 	sel.port = static_cast<std::uint16_t>(port);
@@ -5763,6 +5767,19 @@ std::unique_ptr<CHttpServer::Response> ResolveServerEcid(
 		return std::make_unique<CHttpServer::Response>(ErrorResponse(400,
 			"bad_request",
 			"malformed ip:port selector: expected a dotted quad and a port in 1..65535"));
+	}
+	// 0.0.0.0 is well-formed but is not a server address, and it must not be
+	// allowed to reach the lookup below: a ServerSnapshot whose
+	// EC_TAG_SERVER_IP the daemon did not ship keeps `ip == 0`
+	// (Refresher.cpp, which notes that `address` then reads "0.0.0.0:0"), so
+	// a 0.0.0.0 selector would otherwise resolve to whichever such row
+	// happened to share the port -- acting on a server the caller never
+	// named. Rejected with its own message rather than folded into the
+	// syntax error above, which would claim a malformed quad that the caller
+	// can see is not malformed.
+	if (sel->ip_he == 0) {
+		return std::make_unique<CHttpServer::Response>(
+			ErrorResponse(400, "bad_request", "0.0.0.0 is not a server address"));
 	}
 
 	for (const auto &s : state.Servers()) {

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -121,20 +121,49 @@ else
 fi
 
 # --- 4. /servers/<ip>:<port>/connect + DELETE alias. -------------
-# 404 path is always testable.
+# 404 path is always testable. 192.0.2.x is TEST-NET-1 (RFC 5737),
+# reserved for documentation and guaranteed never to be a real server,
+# so this reaches the "well-formed but no such server" branch rather
+# than being turned away earlier as bad input.
+UNKNOWN_SRV=192.0.2.1:1
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
-	"$HOST/api/v0/servers/0.0.0.0:1/connect")
+	"$HOST/api/v0/servers/$UNKNOWN_SRV/connect")
 if [ "$RC" = "404" ]; then
-	_pass "POST /servers/<bogus-ip:port>/connect → 404"
+	_pass "POST /servers/<unknown-ip:port>/connect → 404"
 else
 	_fail "address alias 404" "expected 404, got $RC"
 fi
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${H_AUTH[@]}" \
-	"$HOST/api/v0/servers/0.0.0.0:1")
+	"$HOST/api/v0/servers/$UNKNOWN_SRV")
 if [ "$RC" = "404" ]; then
-	_pass "DELETE /servers/<bogus-ip:port> → 404"
+	_pass "DELETE /servers/<unknown-ip:port> → 404"
 else
 	_fail "address alias DELETE 404" "expected 404, got $RC"
+fi
+# 0.0.0.0 is well-formed but is not a server address, and it must never
+# reach the lookup: a server row whose IP the daemon did not ship keeps
+# ip == 0, so a 0.0.0.0 selector could otherwise resolve to whichever
+# such row shared the port. Rejected as bad input, and the message says
+# so rather than claiming a malformed quad.
+BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/0.0.0.0:4242/connect")
+RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
+	"$HOST/api/v0/servers/0.0.0.0:4242/connect")
+if [ "$RC" = "400" ] && printf '%s' "$BODY" | jq -e '.error.code == "bad_request"' >/dev/null 2>&1; then
+	_pass "POST /servers/0.0.0.0:<port>/connect → 400 (not a server address)"
+else
+	_fail "0.0.0.0 selector rejected" "expected 400 bad_request, got $RC: $BODY"
+fi
+if printf '%s' "$BODY" | jq -e '.error.message | test("malformed") | not' >/dev/null 2>&1; then
+	_pass "0.0.0.0 rejection does not claim a malformed quad"
+else
+	_fail "0.0.0.0 rejection message" "still reports a syntax error: $BODY"
+fi
+# A genuinely malformed selector still reports malformed.
+BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/not-an-ip:4242/connect")
+if printf '%s' "$BODY" | jq -e '.error.message | test("malformed")' >/dev/null 2>&1; then
+	_pass "a malformed selector still reports malformed"
+else
+	_fail "malformed selector message" "expected a malformed-selector error, got: $BODY"
 fi
 # Positive path: only test if there's actually a server in the cache.
 # The address field is the canonical "<ip-or-hostname>:<port>" string


### PR DESCRIPTION
Follow-up to the loose end noted on #996.

`POST /api/v0/servers/0.0.0.0:1/connect` answers:

```json
{"error":{"code":"bad_request","message":"malformed ip:port selector: expected a dotted quad and a port in 1..65535"}}
```

for an input that is a dotted quad with a port in 1..65535. The message describes a syntax failure that did not happen.

## What was actually going on

`ParseIpPortSelector` folded two different rejections into one line:

```cpp
if (!ParseIpv4Dotted(ip_str, sel.ip_he) || sel.ip_he == 0)
    return boost::none;
```

`ParseIpv4Dotted` already reports syntax failure through its return value, so the `== 0` beside it is not a parse check. It is a separate semantic rule - "0.0.0.0 is not a selector" - riding on the syntax error's message.

## The rule is right and stays

My first instinct was to drop the guard and let 0.0.0.0 fall through to the honest `404 no server matches that ip:port`. That would have been a bug. `ServerSnapshot::ip` can legitimately be `0`: when the daemon does not ship `EC_TAG_SERVER_IP` the field stays zero, and `Refresher.cpp` handles exactly that case, noting that `address` then reads `"0.0.0.0:0"`. A 0.0.0.0 selector reaching the lookup could therefore match whichever such row happened to share the port - and connect to, or delete, a server the caller never named.

So only the reporting changes. The zero check moves into `ResolveServerEcid` with a message of its own, next to the two outcomes it sits between.

| Selector | Before | After |
|---|---|---|
| `not-an-ip:4242` | `400` malformed | `400` malformed (unchanged) |
| `1.2.3.4:99999` | `400` malformed | `400` malformed (unchanged) |
| `0.0.0.0:4242` | `400` **malformed** | `400` `0.0.0.0 is not a server address` |
| `192.0.2.1:1` | `404` no server matches | `404` no server matches (unchanged) |

## The test was testing the wrong branch

`26-rfc-followup-endpoints.sh` used `0.0.0.0:1` as its stand-in for "no such server", so it never reached the `404` branch it meant to exercise - it was turned away earlier as bad input, and had been failing on that mismatch. It now uses `192.0.2.1` (TEST-NET-1, RFC 5737: reserved for documentation, guaranteed never to be a real server), which reaches the intended branch.

Two cases added while there, because a message that lies is exactly what this fixes and nothing was pinning either one: 0.0.0.0 is rejected *without* claiming a malformed quad, and a genuinely malformed selector still reports one.

## Verification

Build clean, `ctest` 34/34, clang-format and both clang-tidy tiers clean on the diff with 0 compiler errors.

Live against a local `amuled` + `amuleapi`, all four branches confirmed by hand (the table above is copied from that run), and the suites:

- `26-rfc-followup-endpoints.sh` **40/40** (was 2 failures before this change)
- `14-servers-mutations.sh` **56/56** - the other consumer of `ResolveServerEcid`
- `05-read-servers-kad-categories-prefs.sh` 97/98; the one failure is the pre-existing `/kad.buddy.status` empty-string-outside-its-own-enum gap reported on #989, which shows up only with Kad disabled and is untouched here.
