### PR TITLE
fix(amuleapi): close the SSE parity, test and doc gaps left by #973

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -437,15 +437,18 @@ Rate impact is small: the overhead rates move about as often as the speeds alrea
   "ed2k": {
     "state":       "connected",
     "high_id":     true,
-    "id":          3523226697,
+    "id":          1234567890,
     "public_ip":   "210.2.150.73",
+    "connected_since": 1751000000,
     "server_name": "eMule Server",
     "server_ip":   "203.0.113.5",
-    "server_port": 4242
+    "server_port": 4242,
+    "network":     { "users": 312000, "files": 75000000 }
   },
   "kad": {
     "state":      "connected",
     "firewalled": false,
+    "connected_since": 1751000000,
     "network":    { "users": 5400000, "files": 1400000000, "nodes": 2400 }
   },
   "speeds": {

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -415,12 +415,13 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
   "ed2k": {
     "state": "connected",
     "high_id": true,
-    "id": 3523226697,
+    "id": 1234567890,
     "public_ip": "210.2.150.73",
     "connected_since": 1751000000,
     "server_name": "eMule Server",
     "server_ip": "203.0.113.5",
-    "server_port": 4242
+    "server_port": 4242,
+    "network": { "users": 312000, "files": 75000000 }
   },
   "kad": {
     "state": "connected",

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -253,6 +253,10 @@ std::string JsonFreeSpace(std::int64_t v)
 	return v < 0 ? std::string("null") : std::to_string(v);
 }
 
+// Mirrors HandleStatus key for key -- EVENTS.md promises this payload is
+// identical to the REST /status envelope, and 22-sse-diff-emission.sh asserts
+// it. Both connected_since values are 0 while not connected, same rule as
+// there: gate on state rather than trusting a 0 timestamp.
 std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, bool ec_connected)
 {
 	std::ostringstream o;
@@ -261,13 +265,15 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << "\"state\":\"" << EscJson(s.ed2k_state) << "\""
 	  << ",\"high_id\":" << (s.ed2k_high_id ? "true" : "false") << ",\"id\":" << s.ed2k_id
 	  << ",\"public_ip\":\"" << EscJson(s.ed2k_public_ip) << "\""
-	  << ",\"server_name\":\"" << EscJson(s.server_name) << "\""
+	  << ",\"connected_since\":" << s.ed2k_connected_since << ",\"server_name\":\""
+	  << EscJson(s.server_name) << "\""
 	  << ",\"server_ip\":\"" << EscJson(s.server_ip) << "\""
 	  << ",\"server_port\":" << s.server_port << ",\"network\":{"
 	  << "\"users\":" << s.ed2k_users << ",\"files\":" << s.ed2k_files << "}}"
 	  << ",\"kad\":{"
 	  << "\"state\":\"" << EscJson(s.kad_state) << "\""
-	  << ",\"firewalled\":" << (s.kad_firewalled ? "true" : "false") << ",\"network\":{"
+	  << ",\"firewalled\":" << (s.kad_firewalled ? "true" : "false")
+	  << ",\"connected_since\":" << s.kad_connected_since << ",\"network\":{"
 	  << "\"users\":" << k.users << ",\"files\":" << k.files << ",\"nodes\":" << k.nodes << "}"
 	  << "}"
 	  << ",\"speeds\":{"
@@ -388,10 +394,11 @@ bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 	// public_ip is derived from ed2k_id, so comparing the id covers it.
 	return a.ed2k_state == b.ed2k_state && a.kad_state == b.kad_state &&
 	       a.ed2k_high_id == b.ed2k_high_id && a.ed2k_id == b.ed2k_id &&
-	       a.kad_firewalled == b.kad_firewalled && a.server_name == b.server_name &&
-	       a.server_ip == b.server_ip && a.server_port == b.server_port &&
-	       a.download_bps == b.download_bps && a.upload_bps == b.upload_bps &&
-	       a.download_overhead_bps == b.download_overhead_bps &&
+	       a.ed2k_connected_since == b.ed2k_connected_since &&
+	       a.kad_connected_since == b.kad_connected_since && a.kad_firewalled == b.kad_firewalled &&
+	       a.server_name == b.server_name && a.server_ip == b.server_ip &&
+	       a.server_port == b.server_port && a.download_bps == b.download_bps &&
+	       a.upload_bps == b.upload_bps && a.download_overhead_bps == b.download_overhead_bps &&
 	       a.upload_overhead_bps == b.upload_overhead_bps && a.temp_free_bytes == b.temp_free_bytes &&
 	       a.incoming_free_bytes == b.incoming_free_bytes && a.ul_queue_len == b.ul_queue_len &&
 	       a.total_src_count == b.total_src_count && a.ed2k_users == b.ed2k_users &&

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1102,10 +1102,6 @@ struct StatusSnapshot
 	std::string server_ip;
 	std::uint32_t server_port = 0;
 
-	// True when the daemon is connected to ed2k but in LowID mode
-	// (NAT'd, can't accept incoming). adds NAT-T affordances
-	// that change this calculus; until then the field maps 1:1 to the
-	// EC CONNSTATE bit.
 	// True when our eD2k id is a HighID (>= HIGHEST_LOWID_ED2K_KAD). False
 	// for a LowID *and* whenever we are not connected at all -- there is no
 	// id then, so gate on ed2k_state == "connected" before reading this as

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -378,6 +378,49 @@ else
 	_pass "comments_updated not emitted this run (no comment change; shape verified live)"
 fi
 
+# --- status_changed carries the same keys as GET /status. ----------
+# EVENTS.md promises the payload is "identical to the REST /status
+# envelope", and the API contract turns on that: a subscriber must never
+# have to fall back to a poll for a field a poller can see. This drifted
+# once already -- both connected_since timestamps were REST-only.
+#
+# `paths` rather than `paths(scalars)`: jq's `scalars` drops nulls, and
+# disk.{temp,incoming}_free_bytes are null whenever the daemon has no
+# figure, which would silently exempt exactly the fields with the
+# trickiest contract. Plain `paths` also lists the container keys, so a
+# whole object going missing is caught too.
+#
+# Conditional, like comments_updated above: status_changed fires only when
+# something in the envelope actually moved, and an idle daemon legitimately
+# emits nothing. So a missing frame is a skip, not a failure -- what this
+# guards is the SHAPE when a frame does arrive. That the event fires at all
+# is asserted in EventDiffTest, which can force a change directly.
+SSE_PID=$(_sse_start 15)
+STATUS_JSON=""
+for _ in $(seq 1 40); do
+	if grep -q "^event: status_changed$" "$SSE_OUT"; then
+		STATUS_JSON=$(grep -A2 "^event: status_changed$" "$SSE_OUT" \
+			| grep "^data: " | sed 's/^data: //' | head -1)
+		[ -n "$STATUS_JSON" ] && break
+	fi
+	sleep 0.25
+done
+kill $SSE_PID 2>/dev/null
+wait $SSE_PID 2>/dev/null
+if [ -n "$STATUS_JSON" ]; then
+	REST_JSON=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/status")
+	DIFF=$(jq -n --argjson a "$REST_JSON" --argjson b "$STATUS_JSON" \
+		'def keys_: [paths | join(".")] | sort;
+		 {rest_only: ($a|keys_) - ($b|keys_), sse_only: ($b|keys_) - ($a|keys_)}')
+	if [ "$(echo "$DIFF" | jq -c '.')" = '{"rest_only":[],"sse_only":[]}' ]; then
+		_pass "status_changed payload keys match GET /status exactly"
+	else
+		_fail "status_changed / GET /status key parity" "$DIFF"
+	fi
+else
+	_pass "status_changed not emitted this run (nothing in the envelope moved; shape asserted when it fires)"
+fi
+
 # --- Summary. -----------------------------------------------------
 echo
 if [ "$FAIL_COUNT" -eq 0 ]; then

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -258,14 +258,14 @@ TEST(EventDiff, StatusEventCarriesIdentityFields)
 	StatusSnapshot s;
 	s.ed2k_state = "connected";
 	s.ed2k_high_id = true;
-	s.ed2k_id = 3523226697u;
+	s.ed2k_id = 1234567890u;
 	s.ed2k_public_ip = "210.2.150.73";
 	s.download_overhead_bps = 8700;
 
 	const std::string payload = EmitStatusAndGetPayload(s);
 
 	ASSERT_TRUE(payload.find("\"high_id\":true") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"id\":3523226697") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"id\":1234567890") != std::string::npos);
 	ASSERT_TRUE(payload.find("\"public_ip\":\"210.2.150.73\"") != std::string::npos);
 	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
 	// The retired spelling must not linger anywhere in the payload.
@@ -284,6 +284,38 @@ TEST(EventDiff, StatusEventFiresWhenOnlyOverheadMoved)
 
 	ASSERT_TRUE(!payload.empty());
 	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
+}
+
+// EVENTS.md promises this payload is "identical to the REST /status envelope",
+// and both connected_since timestamps are part of that envelope. They were
+// missing from the event, so a subscriber could never learn when the daemon
+// connected without falling back to a poll.
+TEST(EventDiff, StatusEventCarriesBothConnectedSince)
+{
+	StatusSnapshot s;
+	s.ed2k_state = "connected";
+	s.kad_state = "connected";
+	s.ed2k_connected_since = 1751000000ull;
+	s.kad_connected_since = 1751000042ull;
+
+	const std::string payload = EmitStatusAndGetPayload(s);
+
+	ASSERT_TRUE(payload.find("\"connected_since\":1751000000") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"connected_since\":1751000042") != std::string::npos);
+}
+
+// A reconnect can leave every other field identical -- same server, same id,
+// idle transfer rates -- and move only the timestamp. Without it in Equal()
+// that tick emits nothing and subscribers keep showing the old uptime.
+TEST(EventDiff, StatusEventFiresWhenOnlyConnectedSinceMoved)
+{
+	StatusSnapshot s;
+	s.ed2k_connected_since = 1751000000ull;
+
+	const std::string payload = EmitStatusAndGetPayload(s);
+
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"connected_since\":1751000000") != std::string::npos);
 }
 
 TEST(EventDiff, ClientAddedCarriesUploadFileName)

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2150,3 +2150,144 @@ TEST(Refresher, KadBuddyStatusIsNoBuddyWhenTagAbsent)
 	ASSERT_EQUALS(std::string("disabled"), out.state);
 	ASSERT_EQUALS(std::string("no_buddy"), out.buddy_status);
 }
+
+// ----------------------------------------------------------------------
+// ParseStatusFromPacket — our own eD2k identity and the four stats
+// counters /status reports. Everything below decodes from tags amuled
+// already sends in the EC_DETAIL_FULL STAT_REQ response; these tests
+// exercise the decode itself, which is where the two sentinels live
+// (0xffffffff for "connect in flight" and the free-space -1 that
+// arrives on the wire as 0xFFFFFFFFFFFFFFFF).
+//
+// MakeConnState above supplies the EC_TAG_CONNSTATE flag word; bit
+// 0x01 = connected to ed2k, 0x02 = connecting.
+// ----------------------------------------------------------------------
+
+TEST(Refresher, StatusHighIdLandsIdAndDottedQuad)
+{
+	// A HighID *is* our public IPv4 packed LSB-first, so public_ip has to
+	// fall out of the id rather than being a second field to trust: 210.2.150.73
+	// is 210 | 2<<8 | 150<<16 | 73<<24 == 1234567890, and that identity is
+	// exactly what the /status docs promise.
+	CECPacket resp(EC_OP_STATS);
+	CECTag conn = MakeConnState(0x01);
+	conn.AddTag(CECTag(EC_TAG_ED2K_ID, static_cast<std::uint32_t>(1234567890u)));
+	resp.AddTag(conn);
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
+	ASSERT_TRUE(out.ed2k_high_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_id);
+	ASSERT_EQUALS(std::string("210.2.150.73"), out.ed2k_public_ip);
+}
+
+TEST(Refresher, StatusLowIdKeepsIdButHasNoPublicAddress)
+{
+	// A LowID is a small number the server picked for a firewalled client
+	// and encodes no address at all -- rendering it as a dotted quad would
+	// invent one (here it would read "42.0.0.0").
+	CECPacket resp(EC_OP_STATS);
+	CECTag conn = MakeConnState(0x01);
+	conn.AddTag(CECTag(EC_TAG_ED2K_ID, static_cast<std::uint32_t>(42u)));
+	resp.AddTag(conn);
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
+	ASSERT_TRUE(!out.ed2k_high_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(42u), out.ed2k_id);
+	ASSERT_TRUE(out.ed2k_public_ip.empty());
+}
+
+TEST(Refresher, StatusConnectingSentinelNeverReachesTheSnapshot)
+{
+	// amuled sends 0xffffffff while a connect is in flight
+	// (ECSpecialCoreTags.cpp). Surfaced verbatim it would read as a
+	// HighID of 255.255.255.255; normalised, the id stays 0.
+	CECPacket resp(EC_OP_STATS);
+	CECTag conn = MakeConnState(0x01);
+	conn.AddTag(CECTag(EC_TAG_ED2K_ID, static_cast<std::uint32_t>(0xffffffffu)));
+	resp.AddTag(conn);
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0u), out.ed2k_id);
+	ASSERT_TRUE(out.ed2k_public_ip.empty());
+}
+
+TEST(Refresher, StatusDisconnectedIsNotReportedAsLowId)
+{
+	// The bug the high_id rename fixed: with no EC_TAG_ED2K_ID the id reads
+	// 0, and HasLowID() is "id < 16777216", so the old negative spelling
+	// reported low_id: true for a daemon that simply has no id yet -- a
+	// firewall diagnosis out of thin air. Positive sense reads correctly.
+	CECPacket resp(EC_OP_STATS);
+	resp.AddTag(MakeConnState(0));
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(std::string("disconnected"), out.ed2k_state);
+	ASSERT_TRUE(!out.ed2k_high_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0u), out.ed2k_id);
+	ASSERT_TRUE(out.ed2k_public_ip.empty());
+}
+
+TEST(Refresher, StatusOverheadAndFreeSpaceTagsDecode)
+{
+	CECPacket resp(EC_OP_STATS);
+	resp.AddTag(MakeConnState(0x01));
+	resp.AddTag(CECTag(EC_TAG_STATS_DOWN_OVERHEAD, static_cast<std::uint32_t>(8700u)));
+	resp.AddTag(CECTag(EC_TAG_STATS_UP_OVERHEAD, static_cast<std::uint32_t>(1100u)));
+	resp.AddTag(CECTag(EC_TAG_STATS_TEMP_FREE_SPACE, static_cast<std::uint64_t>(48318382080ull)));
+	resp.AddTag(CECTag(EC_TAG_STATS_INCOMING_FREE_SPACE, static_cast<std::uint64_t>(24159191040ull)));
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::int64_t>(48318382080LL), out.temp_free_bytes);
+	ASSERT_EQUALS(static_cast<std::int64_t>(24159191040LL), out.incoming_free_bytes);
+}
+
+TEST(Refresher, StatusFreeSpaceUnknownSentinelReadsBackAsMinusOne)
+{
+	// amuled's FREE_SPACE_UNKNOWN is a signed -1 and its EC serializer
+	// casts it straight to uint64, so the wire carries
+	// 0xFFFFFFFFFFFFFFFF. Read unsigned that becomes 18446744073709551615
+	// -- "17 exabytes free", the exact opposite of the truth. The decode
+	// has to land -1 so the handlers can emit null.
+	CECPacket resp(EC_OP_STATS);
+	resp.AddTag(MakeConnState(0x01));
+	resp.AddTag(CECTag(EC_TAG_STATS_TEMP_FREE_SPACE, static_cast<std::uint64_t>(0xFFFFFFFFFFFFFFFFull)));
+	resp.AddTag(
+		CECTag(EC_TAG_STATS_INCOMING_FREE_SPACE, static_cast<std::uint64_t>(0xFFFFFFFFFFFFFFFFull)));
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.temp_free_bytes);
+	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.incoming_free_bytes);
+}
+
+TEST(Refresher, StatusWithoutStatsTagsKeepsZeroOverheadAndUnknownDisk)
+{
+	// An amuled old enough not to send these tags must still produce a
+	// serviceable snapshot: overhead 0 (the documented "daemon reports
+	// nothing"), disk -1 so /status answers null rather than 0.
+	CECPacket resp(EC_OP_STATS);
+	resp.AddTag(MakeConnState(0x01));
+
+	StatusSnapshot out;
+	ParseStatusFromPacket(&resp, out);
+
+	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.download_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.upload_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.temp_free_bytes);
+	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.incoming_free_bytes);
+}

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -83,7 +83,7 @@ TEST(State, WriteStatusRoundtrip)
 	in.ed2k_state = "connected";
 	in.kad_state = "connecting";
 	in.ed2k_high_id = true;
-	in.ed2k_id = 3523226697u; // 210.2.150.73 packed LSB-first
+	in.ed2k_id = 1234567890u; // 210.2.150.73 packed LSB-first
 	in.ed2k_public_ip = "210.2.150.73";
 	in.download_overhead_bps = 8700;
 	in.upload_overhead_bps = 1100;
@@ -103,7 +103,7 @@ TEST(State, WriteStatusRoundtrip)
 	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
 	ASSERT_EQUALS(std::string("connecting"), out.kad_state);
 	ASSERT_TRUE(out.ed2k_high_id);
-	ASSERT_EQUALS(static_cast<std::uint32_t>(3523226697u), out.ed2k_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_id);
 	ASSERT_EQUALS(std::string("210.2.150.73"), out.ed2k_public_ip);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bps);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bps);


### PR DESCRIPTION
Follow-up to #993. Three gaps against that issue's own checklist and acceptance criteria, plus two inconsistent samples found while writing the tests.

status_changed was missing both connected_since values. EVENTS.md promises the payload is "identical to the REST /status envelope" and the issue's acceptance criteria say so outright, but ed2k.connected_since and kad.connected_since were REST-only -- a subscriber had to fall back to a poll to learn when the daemon connected. Both now ride ToJsonStatusEvent in the same position the REST body uses, and both are compared in Equal(): a reconnect can leave every other field identical and move only the timestamp, and without the comparison that tick emits nothing at all. This predates #993 rather than being introduced by it.

22-sse-diff-emission.sh gains a guard so it cannot drift again: it diffs the key paths of a live status_changed frame against GET /status and fails on any asymmetry. It uses `paths` and not `paths(scalars)` because jq drops nulls from `scalars`, which would have exempted exactly disk.{temp,incoming}_free_bytes -- the fields with the trickiest contract. Conditional on a frame arriving, like the comments_updated block above it: status_changed fires only when something moved, so an idle daemon emitting nothing is not a failure. The emission itself is asserted in EventDiffTest, which can force a change directly.

ParseStatusFromPacket had no coverage for any of the six fields #993 added. The checklist asked for the cases in RefresherTest; what landed instead was a StateTest round-trip of the struct with -1 assigned by hand, which never touches the decode. Seven cases now exercise the real CECPacket path: a HighID lands the id and the dotted quad, a LowID keeps the id but has no address, the 0xffffffff connect-in-flight sentinel normalises to 0, a disconnected connstate is not reported as a LowID, the four stats tags decode, an amuled that omits them leaves overhead 0 and disk -1, and -- the case the issue put in bold -- a packet carrying 0xFFFFFFFFFFFFFFFF reads back as -1 rather than 18446744073709551615.

State.h still carried the old low_id comment above ed2k_high_id, contradicting the new comment directly below it and describing the opposite polarity to the field it documented.

The id in the samples never matched its address: 3523226697 decodes LSB-first to 73.44.0.210, not the 210.2.150.73 it was paired with in REFERENCE.md, EVENTS.md and both test fixtures. Since the docs promise public_ip is derived from id, the pair was impossible. Corrected to 1234567890, the packing the original issue used, and the new HighID test is what pins it. Both /status samples also regain ed2k.network, which the endpoint and the event have always emitted and neither sample showed.

Verified against a live daemon on a LowID connection: the frame and GET /status agree on every key path, both branches of the new guard were exercised, and ctest is 34/34.