### PR TITLE
fix(gui): make the search Category dropdown a visible download destination

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1075,8 +1075,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
@@ -3502,6 +3502,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6301,10 +6305,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:06+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1099,8 +1099,8 @@ msgstr "خطأ أثناء اﻹتصال بي%s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "صنف"
 
@@ -3560,6 +3560,10 @@ msgstr ""
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "التحميل"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6404,10 +6408,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:07+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1115,8 +1115,8 @@ msgstr "Fallu guardando ficheru known.met: %s"
 msgid "Enter Captcha"
 msgstr "Inxertar Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -3619,6 +3619,10 @@ msgstr "Encaboxar"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descarga"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Descargar na categoría"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6523,10 +6527,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zarrar toles llingüetes"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Descargar na categoría"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:09+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1094,8 +1094,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
@@ -3552,6 +3552,10 @@ msgstr ""
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Изтегляне"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6379,10 +6383,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1074,8 +1074,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
@@ -3501,6 +3501,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6300,10 +6304,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1113,8 +1113,8 @@ msgstr "Error mentre es desava el fitxer %s: %s"
 msgid "Enter Captcha"
 msgstr "Introdueix el Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -3608,6 +3608,10 @@ msgstr "Atura"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Baixada"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Baixa a la categoria"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6495,10 +6499,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Tanca totes les pestanyes"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Baixa a la categoria"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:10+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1117,8 +1117,8 @@ msgstr "Chyba při ukládání souboru %s: %s"
 msgid "Enter Captcha"
 msgstr "Vložte captchu"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
@@ -3602,6 +3602,10 @@ msgstr "Zastavit"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Stahování"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6480,10 +6484,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zavřít všechny taby"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:12+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1102,8 +1102,8 @@ msgstr "Fejl ved forbindelse til %s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -3571,6 +3571,10 @@ msgstr ""
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6424,10 +6428,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Luk alle tabs"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:13+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1122,8 +1122,8 @@ msgstr "Fehler während des Speicherns der Datei '%s': %s"
 msgid "Enter Captcha"
 msgstr "Captcha eingeben"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
@@ -3606,6 +3606,10 @@ msgstr "Stopp"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Herunterladen in Kategorie"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6491,10 +6495,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Alle Reiter schließen"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Herunterladen in Kategorie"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:14+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1124,8 +1124,8 @@ msgstr "Σφάλμα κατά το αποθήκευση του αρχείου kn
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Κατηγορία"
 
@@ -3630,6 +3630,10 @@ msgstr "Σταμάτημα"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Κατέβασμα"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Κατέβασμα στην κατηγορία"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6535,10 +6539,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Κλείσιμο όλων των καρτελών"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Κατέβασμα στην κατηγορία"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1075,8 +1075,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
@@ -3502,6 +3502,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6301,10 +6305,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:14+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1121,8 +1121,8 @@ msgstr "Error guardando el archivo %s: %s"
 msgid "Enter Captcha"
 msgstr "Introduzca el \"captcha\""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -3595,6 +3595,10 @@ msgstr "Parar"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descarga"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Descargar en la categoría"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6463,10 +6467,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Cerrar todas las pestañas"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Descargar en la categoría"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1113,8 +1113,8 @@ msgstr "VIGA: tekkis %s faili salvestamisel: %s"
 msgid "Enter Captcha"
 msgstr "Sisesta inimtesti kontrollkood"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategooria"
 
@@ -3608,6 +3608,10 @@ msgstr "Seiska"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Tõmbamine"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Tõmba kataloogi"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6499,10 +6503,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Sulge kõik lehed"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Tõmba kataloogi"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:16+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1114,8 +1114,8 @@ msgstr "Errorea %s fitxategia gordetzerakoan: %s"
 msgid "Enter Captcha"
 msgstr "Idatzi kaptxa"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
@@ -3609,6 +3609,10 @@ msgstr "Gelditu"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Deskargatu"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Kategori honetan deskargatu"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6498,10 +6502,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Itxi fitxa guztiak"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Kategori honetan deskargatu"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:16+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1114,8 +1114,8 @@ msgstr "Virhe tallennettaessa tiedostoa %s: %s"
 msgid "Enter Captcha"
 msgstr "Syötä kuvavarmennus"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Luokittelu"
 
@@ -3609,6 +3609,10 @@ msgstr "Pysäytä"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Lataa"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Lataa luokassa"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6498,10 +6502,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Sulje kaikki välilehdet"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Lataa luokassa"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:17+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1120,8 +1120,8 @@ msgstr "Erreur lors de la sauvegarde du fichier %s : %s"
 msgid "Enter Captcha"
 msgstr "Entrer le Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Catégorie"
 
@@ -3594,6 +3594,10 @@ msgstr "Arrêter"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Réception"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Télécharger dans la catégorie"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6441,10 +6445,6 @@ msgstr "Tout développer"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Tout réduire"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Télécharger dans la catégorie"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:17+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1135,8 +1135,8 @@ msgstr "Non se puido gardar o ficheiro %s: %s"
 msgid "Enter Captcha"
 msgstr "Introduza o Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -3619,6 +3619,10 @@ msgstr "Deter"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descargar"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Descargar na categoría"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6505,10 +6509,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Pechar todas as lapelas"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Descargar na categoría"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:19+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1105,8 +1105,8 @@ msgstr "שגיאה במהלך שמירת הקובץ known.met: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "קטיגוריה"
 
@@ -3584,6 +3584,10 @@ msgstr "עצור"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "הורדה"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "הורדה בקטיגוריה"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6461,10 +6465,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "הורדה בקטיגוריה"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1105,8 +1105,8 @@ msgstr "Greska prilikom spajanja sa %s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr "Pisati captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -3580,6 +3580,10 @@ msgstr "Stop"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6447,10 +6451,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zatvori sve oznake"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:20+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1114,8 +1114,8 @@ msgstr "Hiba a %s fájl mentése közben: %s"
 msgid "Enter Captcha"
 msgstr "Captcha megadása"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategória"
 
@@ -3588,6 +3588,10 @@ msgstr "Leállít"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Letöltés"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Letöltés kategóriába"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6471,10 +6475,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Az összes fül bezárása"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Letöltés kategóriába"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:20+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1127,8 +1127,8 @@ msgstr "Errore durante il salvataggio del file %s: %s"
 msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -3601,6 +3601,10 @@ msgstr "Ferma"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Download nella categoria"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6448,10 +6452,6 @@ msgstr "Espandi tutto"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Comprimi tutto"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Download nella categoria"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1117,8 +1117,8 @@ msgstr "known.metファイル%sを保存する時にIOエラーが発生しま�
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "カテゴリ"
 
@@ -3609,6 +3609,10 @@ msgstr "中止"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "ダウンロード"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "カテゴリにダウンロードする"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6493,10 +6497,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "全てのタブを閉める"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "カテゴリにダウンロードする"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:23+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1122,8 +1122,8 @@ msgstr "known.met 파일을 저장하는 동안 오류: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "분류"
 
@@ -3629,6 +3629,10 @@ msgstr "멈춤"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "내려받기"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "분류내 내려받기"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6526,10 +6530,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "모든 탭 닫기"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "분류내 내려받기"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:24+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1126,8 +1126,8 @@ msgstr "Įrašant known.met failą įvyko klaida: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -3643,6 +3643,10 @@ msgstr "Sustabdyti"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Atsiųsti"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Atsiunčiamą failą įdėti į kategoriją"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6551,10 +6555,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Užverti visas korteles"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Atsiunčiamą failą įdėti į kategoriją"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:39+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1087,8 +1087,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr "Ievadiet Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -3530,6 +3530,10 @@ msgstr "Apturēt"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Lejupielādēt"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6343,10 +6347,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Aizvērt visas cilnes"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:27+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1116,8 +1116,8 @@ msgstr "Fout bij het bewaren van bestand %s: %s"
 msgid "Enter Captcha"
 msgstr "Voer captcha in"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
@@ -3592,6 +3592,10 @@ msgstr "Stop"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Download in categorie"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6439,10 +6443,6 @@ msgstr "Vouw alles uit"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Vouw alles in"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Download in categorie"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:28+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1122,8 +1122,8 @@ msgstr "Feil under lagring av known.met fila: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -3629,6 +3629,10 @@ msgstr "Stopp"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Nedlasting"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Nedlasting i kategori"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6528,10 +6532,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Stengje alle faneblad"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Nedlasting i kategori"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:29+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1118,8 +1118,8 @@ msgstr "Błąd podczas zapisywania pliku %s: %s"
 msgid "Enter Captcha"
 msgstr "Wpisz Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
@@ -3623,6 +3623,10 @@ msgstr "Zatrzymaj"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Pobieranie"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Pobieranie w kategorii"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6531,10 +6535,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zamknij wszystkie karty"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Pobieranie w kategorii"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:29+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1121,8 +1121,8 @@ msgstr "Erro ao salvar arquivo %s: %s"
 msgid "Enter Captcha"
 msgstr "Insira o Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -3595,6 +3595,10 @@ msgstr "Pare"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Baixar na categoria"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6442,10 +6446,6 @@ msgstr "Espandir tudo"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Colapsar tudo"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Baixar na categoria"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:30+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1120,8 +1120,8 @@ msgstr "Erro ao gravar ficheiro %s: %s"
 msgid "Enter Captcha"
 msgstr "Escrever 'Captcha'"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -3615,6 +3615,10 @@ msgstr "Parar"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Download"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Transferir para a categoria"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6506,10 +6510,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Fechar todos os separadores"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Transferir para a categoria"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:31+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1115,8 +1115,8 @@ msgstr "Eroare în timpul salvării fișierului %s : %s"
 msgid "Enter Captcha"
 msgstr "Introduceți Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
@@ -3618,6 +3618,10 @@ msgstr "Oprește"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Descarcă"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Descarcă în categoria"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6514,10 +6518,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Închide toate ferestrele"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Descarcă în categoria"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:32+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1127,8 +1127,8 @@ msgstr "Ошибка при сохранении файла %s: %s"
 msgid "Enter Captcha"
 msgstr "Введите код"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
@@ -3621,6 +3621,10 @@ msgstr "Остановить"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Загрузить"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Загрузить в категорию"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6491,10 +6495,6 @@ msgstr "Развернуть всё"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Свернуть всё"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Загрузить в категорию"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:32+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1123,8 +1123,8 @@ msgstr "Napaka med shranjevanjem datoteke %s: %s"
 msgid "Enter Captcha"
 msgstr "Vnesite besedilo s slike"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -3639,6 +3639,10 @@ msgstr "Ustavi"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Pridobi"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Prejemaj v kategoriji"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6549,10 +6553,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zapri vse zavihke"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Prejemaj v kategoriji"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:34+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1119,8 +1119,8 @@ msgstr "Gabim duke shpetuar failin known.met: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -3622,6 +3622,10 @@ msgstr "Ndalo"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Shkarkime"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Shkarko ne kategori"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6518,10 +6522,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Mbylli te gjitha tabelat"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Shkarko ne kategori"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:34+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1112,8 +1112,8 @@ msgstr "Fel vid sparandet av %s fil: %s"
 msgid "Enter Captcha"
 msgstr "Ange Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -3607,6 +3607,10 @@ msgstr "Stoppa"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Hämta"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Nedladdning i kategori"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6494,10 +6498,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Stäng alla flikar"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Nedladdning i kategori"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:42+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1074,8 +1074,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
@@ -3501,6 +3501,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6300,10 +6304,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1113,8 +1113,8 @@ msgstr "%s dosyası kaydedilirken hata: %s"
 msgid "Enter Captcha"
 msgstr "Captcha Gir"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Sınıf"
 
@@ -3587,6 +3587,10 @@ msgstr "Durdur"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "İndir"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Sınıfa göre indir"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6434,10 +6438,6 @@ msgstr "Tümünü genişlet"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Tümünü daralt"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Sınıfa göre indir"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:36+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1117,8 +1117,8 @@ msgstr "Помилка під час збереження файлу known.met: 
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категорія"
 
@@ -3639,6 +3639,10 @@ msgstr "Зупинити"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "Звантаження"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "Звантажити в категорію"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6555,10 +6559,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Закрити всі вкладки"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "Звантажити в категорію"
 
 #: src/SearchListCtrl.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1073,8 +1073,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr ""
 
@@ -3500,6 +3500,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6299,10 +6303,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:36+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1117,8 +1117,8 @@ msgstr "保存 %s 文件时发生错误：%s"
 msgid "Enter Captcha"
 msgstr "输入验证码"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "分类"
 
@@ -3591,6 +3591,10 @@ msgstr "停止"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "下载"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "下载分类"
 
 #: src/muuli_wdr.cpp
 msgid "Clear Search Results"
@@ -6438,10 +6442,6 @@ msgstr "全部展开"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "折叠所有"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "下载分类"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 11:21+0200\n"
+"POT-Creation-Date: 2026-08-21 14:34+0200\n"
 "PO-Revision-Date: 2026-08-20 14:37+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1115,8 +1115,8 @@ msgstr "儲存 %s 時發生錯誤：%s"
 msgid "Enter Captcha"
 msgstr "輸入圖形驗證碼"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "分類"
 
@@ -3600,6 +3600,10 @@ msgstr "停止"
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 msgid "Download"
 msgstr "下載"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Download in category"
+msgstr "分類下載"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -6480,10 +6484,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "關閉所有分頁"
-
-#: src/SearchListCtrl.cpp
-msgid "Download in category"
-msgstr "分類下載"
 
 #: src/SearchListCtrl.cpp
 #, c-format

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -1026,7 +1026,9 @@ void CSearchDlg::OnFieldChanged(wxEvent &WXUNUSED(evt))
 	enable |= (CastChild(IDC_SEARCHMINSIZE, wxChoice)->GetSelection() != 2);
 	enable |= (CastChild(IDC_SEARCHMAXSIZE, wxChoice)->GetSelection() != 2);
 	enable |= (CastChild(IDC_TypeSearch, wxChoice)->GetSelection() > 0);
-	enable |= (CastChild(ID_AUTOCATASSIGN, wxChoice)->GetSelection() > 0);
+	// ID_AUTOCATASSIGN is deliberately absent: it picks where a download goes,
+	// not what is searched for, so choosing one is no reason to offer to reset
+	// the search fields (issue #979).
 
 	// These are the IDs of the search-fields
 	int spinfields[] = { IDC_SPINSEARCHMIN, IDC_SPINSEARCHMAX, IDC_SPINSEARCHAVAILABILITY };
@@ -1546,7 +1548,9 @@ void CSearchDlg::OnBnClickedReset(wxCommandEvent &WXUNUSED(evt))
 	CastChild(IDC_SEARCHMAXSIZE, wxChoice)->SetSelection(2);
 	CastChild(IDC_SPINSEARCHAVAILABILITY, wxSpinCtrl)->SetValue(0);
 	CastChild(IDC_TypeSearch, wxChoice)->SetSelection(0);
-	CastChild(ID_AUTOCATASSIGN, wxChoice)->SetSelection(0);
+	// The download category is not reset here. "Reset Fields" is the counterpart
+	// of "Reset Filters" and clears search parameters; quietly redirecting the
+	// next download somewhere else is not part of that (issue #979).
 
 	FindWindow(IDC_SEARCH_RESET)->Enable(false);
 }
@@ -1554,6 +1558,16 @@ void CSearchDlg::OnBnClickedReset(wxCommandEvent &WXUNUSED(evt))
 void CSearchDlg::UpdateCatChoice()
 {
 	wxChoice *c_cat = CastChild(ID_AUTOCATASSIGN, wxChoice);
+
+	// Remember the chosen destination by name, not by index: this runs on every
+	// category add, rename and delete, and a delete shifts every index after it.
+	// The old code unconditionally selected Main afterwards, so touching any
+	// category silently redirected the next download -- invisible while the
+	// control lived in the hidden extended-parameters row, but not now that it
+	// sits beside the Download button (issue #979).
+	const wxString previous =
+		c_cat->GetSelection() == wxNOT_FOUND ? wxString() : c_cat->GetStringSelection();
+
 	c_cat->Clear();
 
 	c_cat->Append(_("Main"));
@@ -1562,7 +1576,17 @@ void CSearchDlg::UpdateCatChoice()
 		c_cat->Append(theApp->glob_prefs->GetCategory(i)->title);
 	}
 
-	c_cat->SetSelection(0);
+	// Falls back to Main when the chosen category was the one just removed or
+	// renamed, which is the only case where the selection cannot be honoured.
+	if (previous.IsEmpty() || !c_cat->SetStringSelection(previous)) {
+		c_cat->SetSelection(0);
+	}
+
+	// With only Main configured there is nothing to choose, so the selector is
+	// noise. Same gate the context menu applies to its own category submenu
+	// (SearchListCtrl.cpp), and it lifts as soon as a second category exists --
+	// this runs on every category change, so no restart is needed.
+	c_cat->Enable(theApp->glob_prefs->GetCatCount() > 1);
 }
 
 void CSearchDlg::UpdateProgress(uint32 new_value)

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -1028,11 +1028,15 @@ void CSearchListCtrl::DownloadSelected(int category)
 {
 	FindWindowById(IDC_SDOWNLOAD)->Enable(false);
 
+	// -1 means "no explicit category", i.e. anything but the right-click
+	// "Download in category" action, which passes one and must keep winning.
+	// The panel's selector used to be read only while the Extended Parameters
+	// checkbox was ticked, because it lived inside that row -- so unticking the
+	// row to reclaim the screen space silently sent the download to Main
+	// instead (issue #979). The selector now sits beside the Download button
+	// and is always visible, so what the user can see is what gets used.
 	if (category == -1) {
-		category = 0;
-		if (CastByID(IDC_EXTENDEDSEARCHCHECK, NULL, wxCheckBox)->GetValue()) {
-			category = CastByID(ID_AUTOCATASSIGN, NULL, wxChoice)->GetSelection();
-		}
+		category = CastByID(ID_AUTOCATASSIGN, NULL, wxChoice)->GetSelection();
 	}
 
 #ifndef CLIENT_GUI

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -251,19 +251,18 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     };
     wxChoice *item15 = new wxChoice( parent, IDC_TypeSearch, wxDefaultPosition, wxDefaultSize, 8, strs15, 0 );
     item13->Add( item15, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
+    // The category selector used to sit here, between File Type and Extension.
+    // It is not a search filter -- nothing about it travels with the query --
+    // so it moved to the button row next to Download, whose destination it is
+    // (issue #979). Five filters remain: three on this row, two on the next.
     wxStaticLine *item16 = new wxStaticLine( parent, -1, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
     item13->Add( item16, wxSizerFlags(1).CenterHorizontal().Border(wxALL, 5) );
-    wxStaticText *item17 = new wxStaticText( parent, -1, _("Category"), wxDefaultPosition, wxDefaultSize, 0 );
-    item13->Add( item17, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    wxString *strs18 = (wxString*) NULL;
-    wxChoice *item18 = new wxChoice( parent, ID_AUTOCATASSIGN, wxDefaultPosition, wxDefaultSize, 0, strs18, 0 );
-    item13->Add( item18, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    wxStaticLine *item19 = new wxStaticLine( parent, -1, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
-    item13->Add( item19, wxSizerFlags().CenterHorizontal().Border(wxALL, 5) );
     wxStaticText *item20 = new wxStaticText( parent, -1, _("Extension"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item20, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     CMuleTextCtrl *item21 = new CMuleTextCtrl( parent, IDC_EDITSEARCHEXTENSION, "", wxDefaultPosition, wxSize(60,-1), wxTE_PROCESS_ENTER );
     item13->Add( item21, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
+    wxStaticLine *item19 = new wxStaticLine( parent, -1, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
+    item13->Add( item19, wxSizerFlags().CenterHorizontal().Border(wxALL, 5) );
     wxStaticText *item22 = new wxStaticText( parent, -1, _("Min Size"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item22, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item23 = new wxBoxSizer( wxHORIZONTAL );
@@ -281,8 +280,8 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item23->Add( item25, wxSizerFlags().Center().Border(wxALL, 5) );
     item13->Add( item23, wxSizerFlags().Center().Border(wxALL, 5) );
 
-    wxStaticLine *item26 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
-    item13->Add( item26, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
+    // Min Size closes the first row and Max Size opens the second, so the
+    // separator that used to divide them would now sit on the row break.
     wxStaticText *item27 = new wxStaticText( parent, -1, _("Max Size"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item27, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item28 = new wxBoxSizer( wxHORIZONTAL );
@@ -306,6 +305,13 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item32, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxSpinCtrl *item33 = new wxSpinCtrl( parent, IDC_SPINSEARCHAVAILABILITY, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000, 0 );
     item13->Add( item33, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
+    // Five filters no longer divide evenly into the 8-column grid: the first row
+    // takes three (File Type, Extension, Min Size) and the second two, so the
+    // second is padded out to a full row. Without this the sizer pulls cells up
+    // from the next row and the two rows stop lining up.
+    for (int pad = 0; pad < 3; ++pad) {
+        item13->Add( 0, 0, wxSizerFlags().Border(wxALL, 5) );
+    }
     item1->Add( item13, wxSizerFlags().Center() );
 
     wxFlexGridSizer *item34 = new wxFlexGridSizer( 1, 0, 0, 0 );
@@ -354,6 +360,20 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxButton *item50 = new wxButton( parent, IDC_SDOWNLOAD, _("Download"), wxDefaultPosition, wxDefaultSize, 0 );
     item50->Enable( false );
     item43->Add( item50, wxSizerFlags().Center().Border(wxALL, 5) );
+    // Where the button beside it sends the file. It sat in the extended-
+    // parameters row until issue #979, which made it read as a search filter --
+    // something neither ed2k nor Kad can do -- and let a chosen category be
+    // hidden and then silently ignored. Here it is always visible and its
+    // meaning is positional. Same wording as the right-click action that does
+    // the same thing (SearchListCtrl.cpp), so the two cannot drift.
+    wxStaticText *item17 = new wxStaticText( parent, -1, _("Download in category"), wxDefaultPosition, wxDefaultSize, 0 );
+    item43->Add( item17, wxSizerFlags().Center().Border(wxALL, 5) );
+    // Empty item list: UpdateCatChoice() fills it and keeps it in step with the
+    // configured categories. nullptr, not the file's usual (wxString*) NULL --
+    // this line is new, so the Tier-2 modernize-use-nullptr check applies to it.
+    wxString *strs18 = nullptr;
+    wxChoice *item18 = new wxChoice( parent, ID_AUTOCATASSIGN, wxDefaultPosition, wxDefaultSize, 0, strs18, 0 );
+    item43->Add( item18, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticLine *item51 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item43->Add( item51, wxSizerFlags().Center().Border(wxALL, 5) );
     // Ordered most to least destructive rightwards, so the mildest sits at the


### PR DESCRIPTION
Closes #979.

The Search panel's **Extended Parameters** row held six controls. Five are search filters that travel with the query; the sixth, **Category**, is not — nothing about it ever reaches the core with a search. It is read once, much later, as the default category when **Download** is pressed.

Sitting in that row made it read as "search only in this category", which aMule cannot do — ed2k and Kad have no notion of local categories. Worse, the code took the neighbourhood literally and gated the value on the same checkbox the real filters use, so a chosen category was **silently dropped** whenever Extended Parameters was unticked: tick it, pick a category, untick it to reclaim the screen space, press Download, and everything lands in *Main* with no warning and no visible reason.

## What changed

The control moves to the always-visible button row, immediately after **Download**, so its meaning becomes positional — it is the destination of the button beside it:

```
Start │ Extend │ Stop │ Download │ Download in category [Main ▾] │ Clear Search Results │ Reset Fields
```

With it always visible, the Extended Parameters gate on the value is gone: *what the user can see is what gets used*. It also stops counting as a search field — choosing a destination no longer arms **Reset Fields**, and **Reset Fields** no longer redirects the next download. Right-click → **Download in category** still passes an explicit category and keeps overriding the panel for that one action.

## Two things worth calling out

**The label reuses an existing string.** The issue proposed a new `_("Download to category")`. `_("Download in category")` already exists as the label of the right-click action that does the identical thing, so this reuses it: same wording for the same operation, no new msgid, and the control arrives **already translated in 30 of the 40 catalogs** instead of starting at zero and waiting on a Weblate round trip. All 30 survived with no fuzzies.

**A second silent redirect is fixed while here.** `UpdateCatChoice()` ended by selecting *Main* unconditionally, so adding, renaming or deleting *any* category reset the chosen destination. That was invisible while the control lived in a usually-hidden row; with it always on screen the user would watch their selection change under them. It now restores the selection **by name** — indices shift when a category is deleted — and falls back to *Main* only when the chosen category is genuinely gone. It also disables the selector while *Main* is the only category, mirroring the gate the context menu already applies to its own category submenu, and lifts as soon as a second category exists without a restart.

## Layout

Removing the control from the extended row left five filters in a `wxFlexGridSizer` built for eight cells per row. The row is rebalanced to three filters over two, with the second row padded so the two stay aligned:

```
File Type [Any  ▾] │ Extension [______] │ Min Size [0][MB ▾]
Max Size  [0][MB ▾] │ Availability [0]
```

## Catalogs

The issue expected no po work beyond ordinary extraction, but the catalogs do change: `msgid "Category"` loses its `src/muuli_wdr.cpp` reference and `"Download in category"` gains one, so the sync gate would fail without regeneration. `scripts/update-po.sh` was run; the diff is reference lines only — zero msgid and zero msgstr content changes.

## Verification

GUI only: no core, EC, `CSearchParams` or preferences change. Built and inspected in the monolithic client, and built for `amulegui`, which shares the panel definition. `msgfmt --check` passes on the catalogs. Both clang-tidy tiers and clang-format are clean.
