### PR TITLE
refactor(amuleapi): one key name for an EC handle, and one for a display name

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -220,7 +220,7 @@ Both `since_id` and `newest_id` are uint64. The client never has to compute them
 
 ## Event catalog
 
-Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`), `client_ecid` for `client_removed`, `friend_ecid` for `friend_removed`, `ecid` for `server_removed` — so the client can drop the cache entry without needing the old object. Three events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge), `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace), and `search_closed` retires a whole result space rather than one item (`{search_id}` — drop the view, not a row). Branch on the event type in your dispatcher accordingly.
+Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`) and `ecid` for every ECID-keyed collection (`client_removed`, `friend_removed`, `server_removed`) — so the client can drop the cache entry without needing the old object. Three events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge), `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace), and `search_closed` retires a whole result space rather than one item (`{search_id}` — drop the view, not a row). Branch on the event type in your dispatcher accordingly.
 
 ### `downloads` channel
 
@@ -352,7 +352,7 @@ Identical to the REST [`/api/v0/friends`](REFERENCE.md#get-apiv0friends) list-it
 
 ```json
 {
-  "friend_ecid":  12,
+  "ecid":         12,
   "name":         "alice",
   "user_hash":    "a1b2c3d4e5060e708090a0b0c0d06f00",
   "ip":           "203.0.113.42",
@@ -370,7 +370,7 @@ One `PATCH /api/v0/friends/{ecid}` can produce **two** `friend_updated` events. 
 #### `friend_removed`
 
 ```json
-{ "friend_ecid": 12 }
+{ "ecid": 12 }
 ```
 
 ### `clients` channel
@@ -381,8 +381,8 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
 
 ```json
 {
-  "client_ecid":            4382,
-  "client_name":            "AnonymousPeer",
+  "ecid":                   4382,
+  "name":                   "AnonymousPeer",
   "user_hash":              "1f2e3a...",
   "ip":                     "203.0.113.42",
   "country_code":           "de",
@@ -420,7 +420,7 @@ Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) li
 #### `client_removed`
 
 ```json
-{ "client_ecid": 4382 }
+{ "ecid": 4382 }
 ```
 
 ### `status` channel

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -860,7 +860,7 @@ Force A4AF source-swapping for this download. Downloads-only.
 
 `client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-peer "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_this_auto` or `swap_others` is a `400`, because the core has no per-source form of those.
 
-A successful single-source swap shows up as that `client_ecid` having left `sources` in the response.
+A successful single-source swap shows up as that `client_ecid` having left `source_ecids` in the response.
 
 The swap moves the peer between two files' source lists, so an SSE subscriber sees `download_updated` for **both** the peer's former download and this one, plus `client_updated` for the peer itself.
 
@@ -1034,8 +1034,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 {
   "clients": [
     {
-      "client_ecid": 4382,
-      "client_name": "AnonymousPeer",
+      "ecid": 4382,
+      "name": "AnonymousPeer",
       "user_hash": "1f2e3a...",
       "ip": "203.0.113.42",
       "country_code": "de",
@@ -1063,7 +1063,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-`client_ecid` identifies the remote *peer*, not a file — it's the URL key for [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) and the identity carried in `client_removed` SSE payloads. `user_hash` is the peer's stable identity *when published* (peers without SecIdent or in their first session don't have one), so `client_ecid` is the always-populated handle.
+`ecid` identifies the remote *peer*, not a file — it's the URL key for [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) and the identity carried in `client_removed` SSE payloads. `user_hash` is the peer's stable identity *when published* (peers without SecIdent or in their first session don't have one), so `ecid` is the always-populated handle.
 
 `upload_file_hash` / `download_file_hash` are the 32-char MD4 hex hashes of the partfile or shared file the peer is currently transferring with — directly resolvable against [`/api/v0/downloads/{hash}`](#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised in `OP_REQFILENAMEANSWER` and is populated only while we're actively downloading from them. `upload_file_name` is the partfile the peer is downloading **from us**, resolved locally against our own partfile list — present only while we're uploading to them.
 
@@ -1094,7 +1094,7 @@ Every one of them falls back to `"unknown"` for a code the daemon does not map, 
 
 **Auth:** `GUEST`
 
-Returns the full detail object for a single peer — every field [`GET /clients`](#get-apiv0clients) returns for that peer, **plus** the detail-only fields below. `{ecid}` is the peer's `client_ecid` (the EC connection id). Bare object, no list envelope.
+Returns the full detail object for a single peer — every field [`GET /clients`](#get-apiv0clients) returns for that peer, **plus** the detail-only fields below. `{ecid}` is the peer's `ecid` (the EC connection id). Bare object, no list envelope.
 
 `ecid`, not `user_hash`, is the resource key: not every peer has a hash (unidentified / some LowID / eDonkey peers expose an empty one), a hash is not unique among a peer's simultaneous connections, and it is unauthenticated unless the peer uses Secure Identification. `ecid` is always present and unique per live connection. Trade-off: `ecid` is reassigned when amuled restarts, so a detail URL is **not** stable across restarts — use the `user_hash` field for a durable reference.
 
@@ -1105,8 +1105,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 ```json
 {
-  "client_ecid": 4382,
-  "client_name": "AnonymousPeer",
+  "ecid": 4382,
+  "name": "AnonymousPeer",
   "user_hash": "1f2e3a...",
   "ip": "203.0.113.42",
   "country_code": "de",
@@ -1157,7 +1157,7 @@ The detail fields mirror the desktop "Client Details" modal. `user_id_hybrid` is
 
 **Auth:** `ADMIN`
 
-Browse a peer's shared file list — the API equivalent of "View Files" in the GUI. `{ecid}` is the peer's `client_ecid`. amuled opens (or reuses) a direct client-to-client connection to that peer and asks it to enumerate its shared directories and files.
+Browse a peer's shared file list — the API equivalent of "View Files" in the GUI. `{ecid}` is the peer's `ecid`. amuled opens (or reuses) a direct client-to-client connection to that peer and asks it to enumerate its shared directories and files.
 
 The browse runs **asynchronously**: the peer answers over the network, one directory at a time, and a HighID/reachable peer may take seconds while a LowID peer needs a server callback or Kad first. So this endpoint does **not** return the files — it returns a `search_id` and the results flow through the **search machinery**, exactly like a query search:
 
@@ -1194,7 +1194,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 Lists every peer the daemon has ever exchanged data with, from its credit store.
 
-Distinct from [`GET /clients`](#get-apiv0clients), which lists the peers connected **right now**. The two differ in identity as well as content: a live client is keyed by `client_ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether a given record has a live counterpart at this moment.
+Distinct from [`GET /clients`](#get-apiv0clients), which lists the peers connected **right now**. The two differ in identity as well as content: a live client is keyed by `ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether a given record has a live counterpart at this moment.
 
 Standard [list envelope](#list-envelopes-and-pagination) under the `known_clients` key, with `limit` / `offset` / `sort` / `order`.
 
@@ -1208,7 +1208,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "known_clients": [
     {
       "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00",
-      "client_name": "example-peer",
+      "name": "example-peer",
       "ip": "192.0.2.10",
       "port": 4665,
       "kad_port": 4675,
@@ -1232,7 +1232,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | Field | Notes |
 |---|---|
 | `user_hash` | 32-char lowercase MD4. The identity; join with `/clients`. |
-| `client_name` | Peer-chosen name. Absent when never recorded. |
+| `name` | Peer-chosen name. Absent when never recorded. |
 | `ip`, `port`, `kad_port` | Last address the peer was seen at. Absent together. |
 | `country_code` | ISO 3166-1 alpha-2, lowercase, resolved by the daemon's GeoIP. Absent when GeoIP is off or the address does not resolve. Artwork: [`GET /flags/{code}.png`](#get-flagscodepng). |
 | `software`, `version` | Same tokens `GET /clients` uses. Absent together. |
@@ -1699,7 +1699,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
 {
   "friends": [
     {
-      "friend_ecid": 12,
+      "ecid": 12,
       "name": "alice",
       "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00",
       "ip": "203.0.113.42",
@@ -1749,7 +1749,7 @@ Sending `client_ecid` together with any address field is a `400`.
 
 **Auth:** `ADMIN`
 
-**Response:** `200 OK` → `{ "ok": true, "friend_ecid": 12 }`.
+**Response:** `200 OK` → `{ "ok": true, "ecid": 12 }`.
 
 Removing the friend that currently holds the friend slot clears it.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2501,9 +2501,9 @@ void WriteDownloadObject(
 // share one definition of the A-field set.
 void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 {
-	w.Key("client_ecid");
+	w.Key("ecid");
 	w.ValueInt(static_cast<int64_t>(c.ecid));
-	w.Key("client_name");
+	w.Key("name");
 	w.ValueString(wxString::FromUTF8(c.client_name.c_str()));
 	w.Key("user_hash");
 	w.ValueString(wxString::FromUTF8(c.user_hash.c_str()));
@@ -2647,7 +2647,7 @@ void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c
 	w.Key("user_hash");
 	w.ValueString(wxString::FromUTF8(c.user_hash.c_str()));
 	if (!c.client_name.empty()) {
-		w.Key("client_name");
+		w.Key("name");
 		w.ValueString(wxString::FromUTF8(c.client_name.c_str()));
 	}
 	if (!c.ip.empty()) {
@@ -3887,7 +3887,7 @@ void WriteA4afObject(CJsonWriter &w, const webapi::FileSnapshot &d)
 	w.BeginObject();
 	w.Key("a4af_auto");
 	w.ValueBool(d.download.a4af_auto);
-	w.Key("sources");
+	w.Key("source_ecids");
 	w.BeginArray();
 	for (const std::uint32_t ecid : d.download.a4af_sources) {
 		w.ValueInt(static_cast<int64_t>(ecid));
@@ -4921,10 +4921,11 @@ void WriteCategoryObject(CJsonWriter &w, const webapi::CategorySnapshot &c)
 void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 {
 	w.BeginObject();
-	// The URL key for /friends/{ecid} and its sub-routes. Like every ECID it
-	// does not survive an amuled restart -- `user_hash` is the durable
-	// reference, when the friend has one.
-	w.Key("friend_ecid");
+	// The friend's own EC handle, so it is spelled `ecid` like every other
+	// self-handle; `client_ecid` below points OUT of this object, which is
+	// what the prefix is for. Like every ECID it does not survive an amuled
+	// restart -- `user_hash` is the durable reference, when the friend has one.
+	w.Key("ecid");
 	w.ValueInt(static_cast<int64_t>(f.ecid));
 	w.Key("name");
 	w.ValueString(wxString::FromUTF8(f.name.c_str()));
@@ -5412,7 +5413,7 @@ CHttpServer::Response CApiDispatcher::HandleFriendRemove(
 	w.BeginObject();
 	w.Key("ok");
 	w.ValueBool(true);
-	w.Key("friend_ecid");
+	w.Key("ecid");
 	w.ValueInt(static_cast<int64_t>(ecid));
 	w.EndObject();
 	FinalizeJsonBody(w, r);

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -196,7 +196,7 @@ std::string ToJson(const FriendSnapshot &f)
 {
 	std::ostringstream o;
 	o << "{"
-	  << "\"friend_ecid\":" << f.ecid << ",\"name\":\"" << EscJson(f.name) << "\""
+	  << "\"ecid\":" << f.ecid << ",\"name\":\"" << EscJson(f.name) << "\""
 	  << ",\"user_hash\":\"" << EscJson(f.user_hash) << "\""
 	  << ",\"ip\":\"" << EscJson(f.ip) << "\""
 	  << ",\"port\":" << f.port << ",\"client_ecid\":" << f.client_ecid
@@ -209,7 +209,7 @@ std::string ToJson(const ClientSnapshot &c)
 {
 	std::ostringstream o;
 	o << "{"
-	  << "\"client_ecid\":" << c.ecid << ",\"client_name\":\"" << EscJson(c.client_name) << "\""
+	  << "\"ecid\":" << c.ecid << ",\"name\":\"" << EscJson(c.client_name) << "\""
 	  << ",\"user_hash\":\"" << EscJson(c.user_hash) << "\""
 	  << ",\"ip\":\"" << EscJson(c.ip) << "\""
 	  << ",\"country_code\":\"" << EscJson(c.country_code) << "\""
@@ -449,23 +449,15 @@ std::string RemovedHashPayload(const FileSnapshot &f)
 {
 	return "{\"hash\":\"" + EscJson(f.hash) + "\"}";
 }
-// ECID-keyed types (servers / clients): same shape, ECID payload.
-std::string RemovedEcidPayload(const ServerSnapshot &s)
+
+// Every ECID-keyed collection identifies a removed entry the same way, now
+// that each object names its own handle `ecid` (issue #976): one shape, one
+// function, rather than a per-type overload that only differed in the key it
+// spelled.
+template <class Snapshot> std::string RemovedEcidPayload(const Snapshot &item)
 {
 	std::ostringstream o;
-	o << "{\"ecid\":" << s.ecid << "}";
-	return o.str();
-}
-std::string RemovedEcidPayload(const FriendSnapshot &f)
-{
-	std::ostringstream o;
-	o << "{\"friend_ecid\":" << f.ecid << "}";
-	return o.str();
-}
-std::string RemovedEcidPayload(const ClientSnapshot &c)
-{
-	std::ostringstream o;
-	o << "{\"client_ecid\":" << c.ecid << "}";
+	o << "{\"ecid\":" << item.ecid << "}";
 	return o.str();
 }
 

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -47,8 +47,8 @@ export const COLS = [
   { key: "address", th: "downloads_peer_col_address", num: true, width: "180px", sortable: true,
     sortVal: (c) => ipNum(c.ip), cell: (c) => c.ip ? c.ip + ":" + c.port : "—" },
   { key: "name", th: "downloads_peer_col_name", width: "170px", sortable: true,
-    sortVal: (c) => (c.client_name || "").toLowerCase(),
-    cell: (c) => html`<span title=${c.client_name}>${c.client_name || "—"}</span>` },
+    sortVal: (c) => (c.name || "").toLowerCase(),
+    cell: (c) => html`<span title=${c.name}>${c.name || "—"}</span>` },
   { key: "user_hash", th: "downloads_peer_col_user_hash", width: "150px", sortable: true,
     sortVal: (c) => c.user_hash || "",
     cell: (c) => html`<span title=${c.user_hash}>${c.user_hash || "—"}</span>` },
@@ -102,7 +102,7 @@ export const IDENT_FILTERS = ["all", ...IDENT_STATES].map((v) => [v, t("download
 // this; the resource starts on the first mount and stays live from then on.
 export function useClients() {
   useEffect(() => {
-    data.register({ key: "clients", eventPrefix: "client", id: "client_ecid",
+    data.register({ key: "clients", eventPrefix: "client", id: "ecid",
       list: () => api.get("clients").then((r) => r.clients || []) });
     data.ensure("clients");
   }, []);
@@ -162,7 +162,7 @@ export function ClientTable({ rows, prefsKey, defaultHidden, defaultSort, toolba
       <div class="spacer"></div>
       <${ColumnPicker} columns=${columns} hidden=${hidden} onToggle=${toggleCol} onReset=${resetPrefs} />
     </div>
-    <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.client_ecid}
+    <${VirtualTable} columns=${shown} rows=${list} rowKey=${(c) => c.ecid}
                      sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                      widths=${widths} onResize=${setWidth}
                      maxHeight="none"
@@ -182,7 +182,7 @@ export function FileClients({ hash, prefsKey, defaultHidden, defaultSort }) {
 
   let rows = clients.filter((c) => c.download_file_hash === hash || c.upload_file_hash === hash);
   if (ident !== "all") rows = rows.filter((c) => c.ident_state === ident);
-  if (q) { const match = textMatcher(q); rows = rows.filter((c) => match((c.client_name || "") + " " + fileNameOf(c))); }
+  if (q) { const match = textMatcher(q); rows = rows.filter((c) => match((c.name || "") + " " + fileNameOf(c))); }
 
   return html`
     <div class="detail-clients">

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -34,7 +34,7 @@ export default function ClientsPanel() {
   if (filter === "downloads") list = list.filter(isDown);
   else if (filter === "uploads") list = list.filter(isUp);
   if (ident !== "all") list = list.filter((c) => c.ident_state === ident);
-  if (q) { const match = textMatcher(q); list = list.filter((c) => match((c.client_name || "") + " " + fileNameOf(c))); }
+  if (q) { const match = textMatcher(q); list = list.filter((c) => match((c.name || "") + " " + fileNameOf(c))); }
 
   const tabs = [
     { key: "all", label: t("downloads_peer_all"), badge: clients.length },

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -285,11 +285,11 @@ if [ "$COUNT" -gt 0 ]; then
 	# no-op: pick any client from /clients and ensure it is absent from the
 	# A4AF list before asserting.
 	OTHER_ECID=$(curl -s -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/clients?limit=1" \
-		| jq -r '.clients[0].client_ecid // empty')
+		| jq -r '.clients[0].ecid // empty')
 	if [ -n "$OTHER_ECID" ]; then
 		IN_A4AF=$(curl -s -H "Authorization: Bearer $TOKEN" \
-			"$HOST/api/v0/downloads/$HASH/a4af" \
-			| jq -r --argjson e "$OTHER_ECID" '[.sources[] | select(. == $e)] | length')
+			"$HOST/api/v0/downloads/$HASH/clients" \
+			| jq -r --argjson e "$OTHER_ECID" '[.clients[] | select(.ecid == $e and .a4af)] | length')
 		if [ "$IN_A4AF" = "0" ]; then
 			_curl -X POST -H "Authorization: Bearer $TOKEN" \
 				-H "Content-Type: application/json" \
@@ -305,8 +305,8 @@ if [ "$COUNT" -gt 0 ]; then
 		-H "Content-Type: application/json" \
 		-d '{"action":"swap_others"}' "$HOST/api/v0/downloads/$HASH/a4af"
 	_assert_status 200 "POST /downloads/{hash}/a4af swap_others → 200"
-	_assert_json_eq '.sources | type' array \
-		'POST /a4af response carries sources array'
+	_assert_json_eq '.source_ecids | type' array \
+		'POST /a4af response carries source_ecids array'
 
 	# Uppercase hash → same hit (case-insensitive route).
 	HASH_UPPER=$(echo "$HASH" | tr '[:lower:]' '[:upper:]')

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -115,7 +115,7 @@ echo "    info: $CCOUNT peers cached (populated via GET_UPDATE CLIENT subtree)"
 if [ "$CCOUNT" -gt 0 ]; then
 	# Per-peer shape. The state enums are wire strings (decoded
 	# server-side from US_* / DS_* / IS_* / SO_* / OBST_* codes).
-	_assert_json_eq '.clients[0].client_ecid | type'    number   '/clients[0].client_ecid is numeric'
+	_assert_json_eq '.clients[0].ecid | type'    number   '/clients[0].ecid is numeric'
 	_assert_json_eq '.clients[0].user_hash | length'    32       '/clients[0].user_hash is 32-char hex'
 	_assert_json_eq '.clients[0].upload_state | type'   string   '/clients[0].upload_state is string'
 	_assert_json_eq '.clients[0].download_state | type' string   '/clients[0].download_state is string'

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -354,7 +354,7 @@ else
 fi
 # Verify every entry in /clients?filter=uploads truly has upload_state=uploading
 BAD=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?filter=uploads" \
-	| jq -r '.clients[] | select(.upload_state != "uploading") | .client_ecid' \
+	| jq -r '.clients[] | select(.upload_state != "uploading") | .ecid' \
 	| head -1)
 if [ -z "$BAD" ]; then
 	_pass "/clients?filter=uploads only returns upload_state=uploading peers"
@@ -399,11 +399,11 @@ fi
 # A superset of the list object: every list field plus the detail-only
 # B fields. Guarded on a live peer; the negative cases run regardless.
 FIRST_ECID=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients" \
-	| jq -r '.clients[0].client_ecid // empty')
+	| jq -r '.clients[0].ecid // empty')
 if [ -n "$FIRST_ECID" ]; then
 	DETAIL=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients/$FIRST_ECID")
 	OK=$(echo "$DETAIL" | jq -r --argjson e "$FIRST_ECID" '
-		(.client_ecid == $e)
+		(.ecid == $e)
 		and has("user_hash")
 		and has("upload_file_name") and has("download_file_name")
 		and has("user_id_hybrid") and has("high_id")

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -182,11 +182,11 @@ if [ "${TOTAL:-0}" -gt 0 ]; then
 	# Optional fields are omitted, never emitted empty: a record written
 	# before the daemon kept per-peer metadata has no name at all, and a
 	# consumer must be able to tell that from "recorded as empty".
-	EMPTY_NAMES=$(_jq '[.known_clients[] | select(has("client_name") and .client_name == "")] | length')
+	EMPTY_NAMES=$(_jq '[.known_clients[] | select(has("name") and .name == "")] | length')
 	if [ "${EMPTY_NAMES:-0}" -eq 0 ]; then
-		_pass "no record carries an empty client_name (absent means unrecorded)"
+		_pass "no record carries an empty name (absent means unrecorded)"
 	else
-		_fail "optional fields" "$EMPTY_NAMES record(s) have client_name == \"\""
+		_fail "optional fields" "$EMPTY_NAMES record(s) have name == \"\""
 	fi
 
 	# first_seen and sessions travel together — both come from the same

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -147,11 +147,11 @@ _curl -X POST -H "Content-Type: application/json" \
 	"$HOST/api/v0/friends"
 _assert_status 201 "POST /friends (address form)"
 
-NEW_ECID=$(_jq '.friend_ecid')
+NEW_ECID=$(_jq '.ecid')
 if [ -n "$NEW_ECID" ] && [ "$NEW_ECID" != "null" ]; then
-	_pass "response carries friend_ecid ($NEW_ECID)"
+	_pass "response carries ecid ($NEW_ECID)"
 else
-	_fail "POST response" "no friend_ecid in: ${CURL_BODY:0:200}"
+	_fail "POST response" "no ecid in: ${CURL_BODY:0:200}"
 fi
 [ "$(_jq '.ip')" = "$TEST_IP" ] && _pass "ip round-trips" || _fail "ip" "got $(_jq '.ip')"
 [ "$(_jq '.port')" = "$TEST_PORT" ] && _pass "port round-trips" || _fail "port" "got $(_jq '.port')"
@@ -179,7 +179,7 @@ _assert_status 200 "PATCH friend_slot=true"
 	|| _fail "friend_slot" "expected true, got $(_jq '.friend_slot') — is the daemon serializing the tag?"
 
 _curl "$HOST/api/v0/friends?limit=500"
-STILL=$(echo "$CURL_BODY" | jq -r --arg e "$NEW_ECID" '[.friends[] | select(.friend_ecid == ($e|tonumber)) | .friend_slot] | first')
+STILL=$(echo "$CURL_BODY" | jq -r --arg e "$NEW_ECID" '[.friends[] | select(.ecid == ($e|tonumber)) | .friend_slot] | first')
 [ "$STILL" = "true" ] && _pass "the slot survives into the list view" \
 	|| _fail "friend_slot in list" "expected true, got $STILL"
 
@@ -247,8 +247,8 @@ fi
 # --- 8. Remove, and prove a stale id does not answer 200. ----------
 _curl -X DELETE "$HOST/api/v0/friends/$NEW_ECID"
 _assert_status 200 "DELETE /friends/$NEW_ECID"
-[ "$(_jq '.friend_ecid')" = "$NEW_ECID" ] && _pass "DELETE echoes the id" \
-	|| _fail "DELETE echo" "got $(_jq '.friend_ecid')"
+[ "$(_jq '.ecid')" = "$NEW_ECID" ] && _pass "DELETE echoes the id" \
+	|| _fail "DELETE echo" "got $(_jq '.ecid')"
 
 _curl -X DELETE "$HOST/api/v0/friends/$NEW_ECID"
 _assert_status 404 "a second DELETE of the same id is a 404"


### PR DESCRIPTION
Closes #976, extended to cover the collections added since it was filed.

The same kind of value — the short-lived handle amuled assigns an object — was spelled `ecid` on servers and search children but `client_ecid` on clients, while every route taking one has always spelled the path segment `{ecid}`. The client object also called its display name `client_name` where every other collection says `name` — and the API had already picked the short spelling once, in the one place it could not avoid: both client collections accept `sort=name`, so a consumer sorted by `name` and then read the value out of `client_name`.

## The rule

> An object names its own handle `ecid`. A reference to a **different** object's handle keeps the owner prefix.

That keeps the prefix carrying information: `client_ecid` inside a friend tells you it points *out* of that object, which is exactly where a reader wants the hint.

## Renamed

| Where | Before | After |
|---|---|---|
| client object (`/clients`, `/clients/{ecid}`, per-file rows, SSE) | `client_ecid`, `client_name` | `ecid`, `name` |
| known-client object | `client_name` | `name` |
| friend object + SSE | `friend_ecid` | `ecid` |
| `DELETE /friends/{ecid}` reply | `friend_ecid` | `ecid` |
| `client_removed` / `friend_removed` | `client_ecid` / `friend_ecid` | `ecid` |
| `POST /downloads/{hash}/a4af` reply | `sources` | `source_ecids` |

The issue predates **friends** (#986) and the **per-file client routes** (#995), so those are included here — the friend object had introduced a second self-prefixed handle, and the per-file rows inherit the client object.

## Deliberately untouched

Every foreign reference keeps its prefix: the a4af and friends request bodies, the friend's link to a live peer, and the browse entry's peer. Post-rename a friend row reads `"ecid": 12` beside `"client_ecid": 4382`, which is the rule doing its job.

## Falls out of it

The three `RemovedEcidPayload` overloads emitted identical JSON once every object named its handle the same way, so they collapse into **one template**. And the bundled web UI reads these keys, so it is updated in the same commit rather than left broken.

Also fixes a test that had gone quiet: the A4AF membership check in `04-read-downloads-shared` still GET-ed `/downloads/{hash}/a4af`, retired in #995, so its 409 assertion was skipping. It reads the per-file client rows now — a stronger check, since it looks at the `a4af` flag rather than a bare id list.

## Testing

Verified live against a daemon with a real connected peer: `/clients` rows carry `ecid` + `name` with no stale keys, per-file rows inherit them, `/known_clients` carries `name`, the friend row shows `"ecid": 280` next to `"client_ecid"`, and the a4af reply carries `source_ecids`.

Curl phases 04, 10, 26, 33, 34 all pass; unit suite 34/34; clang-format and both clang-tidy tiers clean.
