### PR TITLE
fix(gui,core): stop the shared-files reload freezing the GUI and stalling the EC lane

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -104,6 +104,7 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 		SharedDirsApplyTask.cpp
 		SharedFilePeersListCtrl.cpp
 		SharedFilesCtrl.cpp
+		SharedFilesReloadProgress.cpp
 		SharedFilesWnd.cpp
 		SourceListCtrl.cpp
 		StatisticsDlg.cpp

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1345,7 +1345,16 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 { "ok": true }
 ```
 
-Returns `202 Accepted`.
+Returns `202 Accepted`. amuled schedules the re-walk and answers immediately, so the response confirms only that the reload was **scheduled** — it never carries the outcome. The walk begins on amuled's next processing tick, within about a second, and a large or network-mounted share tree can take minutes to finish.
+
+Repeated calls coalesce: requesting a reload while one is already pending, or while a walk is in progress, results in a single further walk rather than one per call.
+
+**Reading the result.** The walk brackets itself with two amule log lines, so read them back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel:
+
+- `Reloading shared files...` when the walk starts
+- `Found 1234 known shared files, 7 unknown` when it ends
+
+The resulting changes also arrive as `shared_added` / `shared_removed` events on the `shared` SSE channel, which is the better signal if you only care about the delta.
 
 **Errors:** `503 ec_unavailable`.
 
@@ -1391,13 +1400,15 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/j
 
 `recursive` is optional and defaults to `false`.
 
-amuled validates every path — a REST client cannot stat the core's filesystem, so a typo would otherwise become a silently dead share. Paths that pass are applied, persisted and rescanned; the rest come back in `rejected`, so **one bad entry does not discard the edit**:
+amuled validates every path — a REST client cannot stat the core's filesystem, so a typo would otherwise become a silently dead share. Paths that pass are applied and persisted before the response returns; the rest come back in `rejected`, so **one bad entry does not discard the edit**:
 
 ```json
 { "ok": true, "rejected": [ { "path": "/typo", "reason": "not_found" } ] }
 ```
 
 `reason` is `not_found` (missing, or not a directory) or `not_readable`. amuled reports these as codes and the API renders them, so its locale never leaks into your response.
+
+The **rescan is scheduled, not completed**, before the response returns: a successful reply means the new roots are validated and persisted, and that the re-walk will start on amuled's next processing tick. Until it finishes, [`GET /api/v0/shared`](#get-apiv0shared) still serves the previous file list. Observe completion the same way as [`POST /api/v0/shared/reload`](#post-apiv0sharedreload), whose notes on log lines and coalescing apply here too.
 
 **Errors:** `400 bad_request` (`directories` not an array, an entry without a non-empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -79,6 +79,7 @@ src/SharedDirWatcher.cpp
 src/SharedFileList.cpp
 src/SharedFilePeersListCtrl.cpp
 src/SharedFilesCtrl.cpp
+src/SharedFilesReloadProgress.cpp
 src/SharedFilesWnd.cpp
 src/SourceListCtrl.cpp
 src/SplashScreen.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6178,7 +6178,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
@@ -6193,11 +6194,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7059,6 +7055,11 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
+msgstr ""
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:06+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6277,7 +6277,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
@@ -6293,11 +6294,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7189,6 +7185,11 @@ msgstr[1] "ملفات مشاركة (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "ملفات مشاركة (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "وجد %i ملف مشاركة معرف"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:07+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6389,7 +6389,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
@@ -6407,11 +6408,6 @@ msgstr "Carpetes compartíes"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Recargar llista de ficheros compartíos."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7303,6 +7299,11 @@ msgstr[1] "Ficheros Compartíos (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheros Compartíos (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Recargar llista de ficheros compartíos."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:09+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6252,7 +6252,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
@@ -6268,11 +6269,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7162,6 +7158,11 @@ msgstr[1] "Споделени файлове (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Споделени файлове (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Известни са %i споделени файлове"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6177,7 +6177,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
@@ -6192,11 +6193,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7058,6 +7054,11 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
+msgstr ""
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:09+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6362,7 +6362,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
@@ -6380,11 +6381,6 @@ msgstr "Carpetes compartides"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Recarrega la llista de fitxers compartits."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7265,6 +7261,11 @@ msgstr[1] "Fitxers compartits (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fitxers compartits (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Recarrega la llista de fitxers compartits."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:10+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6350,7 +6350,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Potvrdit sdílené složky"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Znovu načíst vaše sdílené soubory"
@@ -6367,11 +6368,6 @@ msgstr "Aktualizace sdílených složek"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Znovu načte seznam sdílených souborů."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7266,6 +7262,11 @@ msgstr[2] "Sdílené soubory (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Sdílené soubory (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Znovu načte seznam sdílených souborů."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:12+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6295,7 +6295,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
@@ -6311,11 +6312,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7209,6 +7205,11 @@ msgstr[1] "Delte Filer (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte Filer (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Fandt %i kendte delte filer"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:13+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6360,7 +6360,8 @@ msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar mach
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
@@ -6376,11 +6377,6 @@ msgstr "Freigegebene Ordner werden aktualisiert"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u Verzeichnisse durchsucht..."
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7260,6 +7256,11 @@ msgstr[1] "Freigegebene Dateien (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Freigegebene Dateien (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:14+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6402,7 +6402,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
@@ -6420,11 +6421,6 @@ msgstr "Κοινόχρηστα αρχεία"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7319,6 +7315,11 @@ msgstr[1] "Κοινόχρηστα αρχεία (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Κοινόχρηστα αρχεία (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6178,7 +6178,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
@@ -6193,11 +6194,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7059,6 +7055,11 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
+msgstr ""
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:14+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6334,7 +6334,8 @@ msgstr "Compartirlas recursivamente publicará todos los archivos en las redes e
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
@@ -6350,11 +6351,6 @@ msgstr "Actualizando carpetas compartidas"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Escaneadas %u carpetas..."
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Recargando archivos compartidos: %u archivos escaneados"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7230,6 +7226,11 @@ msgstr[1] "Archivos compartidos (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Archivos compartidos (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Recargando archivos compartidos: %u archivos escaneados"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6364,7 +6364,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
@@ -6382,11 +6383,6 @@ msgstr "Jagatud kataloogid"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Jagatud failide loetelu taaslaadimine."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7274,6 +7270,11 @@ msgstr[1] "Jagatud failid (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jagatud failid (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Jagatud failide loetelu taaslaadimine."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:16+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6363,7 +6363,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
@@ -6381,11 +6382,6 @@ msgstr "Partekatutako karpetak"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7270,6 +7266,11 @@ msgstr[1] "Partekatutako fitxategiak (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Partekatutako fitxategiak (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Partekatutako fitxategi zerrenda birkargatu."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:16+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6363,7 +6363,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
@@ -6381,11 +6382,6 @@ msgstr "Jaetut kansiot"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7270,6 +7266,11 @@ msgstr[1] "Jaetut tiedostot (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Jaetut tiedostot (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Lataa uudelleen lista jaetuista tiedostoista."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:17+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6317,7 +6317,8 @@ msgstr "Les partager récursivement publiera chaque fichier contenu dans les sou
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
@@ -6333,11 +6334,6 @@ msgstr "Mise à jour des dossiers partagés"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u répertoires analysés…"
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7199,6 +7195,11 @@ msgstr[1] "Fichiers partagés (%i, hachage de %u autres fichiers)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fichiers partagés (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:17+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6374,7 +6374,8 @@ msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan deb
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
@@ -6390,11 +6391,6 @@ msgstr "Actualizando os cartafoles compartidos"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Buscáronse %u directorios..."
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7275,6 +7271,11 @@ msgstr[1] "Ficheiros compartidos (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros compartidos (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:19+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6330,7 +6330,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
@@ -6348,11 +6349,6 @@ msgstr "קורא את הספרייה הזמנית"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7245,6 +7241,11 @@ msgstr[1] "קבצים משותפים (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "קבצים משותפים (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "טוען מחדש את רשימת הקבצים המשותפים."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:19+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6318,7 +6318,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
@@ -6334,11 +6335,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7240,6 +7236,11 @@ msgstr[2] "Dijeljeni fajlovi (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dijeljeni fajlovi (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:20+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6338,7 +6338,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
@@ -6356,11 +6357,6 @@ msgstr "Megosztott mappák"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "A megosztott fájlok listájának újratöltése."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7232,6 +7228,11 @@ msgstr[0] "Megosztott fájlok (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Megosztott fájlok (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "A megosztott fájlok listájának újratöltése."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:20+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6324,7 +6324,8 @@ msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
@@ -6340,11 +6341,6 @@ msgstr "Aggiornamento cartelle condivise"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u cartelle analizzate..."
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Ricarica file condivisi: %u file analizzati"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7206,6 +7202,11 @@ msgstr[1] "File condivisi (%i, hashing di altri %u file in corso)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "File condivisi (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Ricarica file condivisi: %u file analizzati"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6360,7 +6360,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
@@ -6378,11 +6379,6 @@ msgstr "一時フォルダを読み中です"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "共有ファイル・リストを再ロードします。"
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7268,6 +7264,11 @@ msgstr[0] "共有ファイル（%i）"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共有ファイル（%i）"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "共有ファイル・リストを再ロードします。"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:23+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6393,7 +6393,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
@@ -6411,11 +6412,6 @@ msgstr "임시 폴더를 읽는중"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7317,6 +7313,11 @@ msgstr[1] "공유된 파일(%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "공유된 파일(%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "공유된 파일 목록을 다시 읽어들입니다."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:24+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6418,7 +6418,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
@@ -6436,11 +6437,6 @@ msgstr "Skaitomas laikinų failų aplankas"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Atnaujinti dalinamų failų sąrašą."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7344,6 +7340,11 @@ msgstr[2] "Dalinami failai (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Dalinami failai (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Atnaujinti dalinamų failų sąrašą."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:39+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6217,7 +6217,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
@@ -6232,11 +6233,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7110,6 +7106,11 @@ msgstr[2] "Kopīgotās datnes (%i, skaitļo %u kontrolsummu)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Kopīgotās datnes (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Ielādē kopīgotās datnes (%u)"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:27+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6315,7 +6315,8 @@ msgstr "Als u ze recursief deelt, wordt elk bestand daaronder gepubliceerd op de
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen bevestigen"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Gedeelde bestanden opnieuw laden..."
 
@@ -6331,11 +6332,6 @@ msgstr "Gedeelde mappen bijwerken"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u mappen gescand..."
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Gedeelde bestanden opnieuw laden: %u bestanden gescand"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7197,6 +7193,11 @@ msgstr[1] "Gedeelde Bestanden (%i, er worden er nog %u gehashed)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Gedeelde bestanden (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Gedeelde bestanden opnieuw laden: %u bestanden gescand"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:28+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6395,7 +6395,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
@@ -6413,11 +6414,6 @@ msgstr "Les mellombels mappe"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Lastar inn att lista over delte filer."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7312,6 +7308,11 @@ msgstr[1] "Delte filer (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Delte filer (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Lastar inn att lista over delte filer."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:29+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6396,7 +6396,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
@@ -6414,11 +6415,6 @@ msgstr "Udostępnione foldery"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Przeładowuje listę udostępnionych plików."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7316,6 +7312,11 @@ msgstr[2] "Udostępnione pliki (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Udostępnione pliki (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Przeładowuje listę udostępnionych plików."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:29+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6318,7 +6318,8 @@ msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as red
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
@@ -6334,11 +6335,6 @@ msgstr "Atualizando pastas compartilhadas"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Varridos %u diretórios..."
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7200,6 +7196,11 @@ msgstr[1] "Arquivos Compartilhados (%i, fazendo hash de %u ou mais)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Arquivos Compartilhados (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:30+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6371,7 +6371,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
@@ -6389,11 +6390,6 @@ msgstr "Pastas partilhadas"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Recarrega a lista de ficheiros partilhados."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7278,6 +7274,11 @@ msgstr[1] "Ficheiros Partilhados (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Ficheiros Partilhados (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Recarrega a lista de ficheiros partilhados."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:31+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6379,7 +6379,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
@@ -6397,11 +6398,6 @@ msgstr "Dosare partajate"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Reîncarcă lista fișierelor partajate."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7294,6 +7290,11 @@ msgstr[2] "Fișiere partajate (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Fișiere partajate (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Reîncarcă lista fișierelor partajate."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:32+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6366,7 +6366,8 @@ msgstr "Рекурсивный общий доступ к ним опублик�
 msgid "Confirm shared folders"
 msgstr "Подтверждение общих папок"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Переподгрузка общих файлов…"
 
@@ -6382,11 +6383,6 @@ msgstr "Обновление общих папок"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "Просканировано каталогов: %u…"
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Переподгрузка общих файлов: просканировано файлов — %u"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7262,6 +7258,11 @@ msgstr[2] "Общие файлы (%i, вычисляется хеш для %u)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Общие файлы (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Переподгрузка общих файлов: просканировано файлов — %u"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:32+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6416,7 +6416,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
@@ -6434,11 +6435,6 @@ msgstr "Deljene mape"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Ponovno naloži seznam deljenih datotek."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7338,6 +7334,11 @@ msgstr[3] "Deljene datoteke (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Deljene datoteke (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Ponovno naloži seznam deljenih datotek."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:34+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6385,7 +6385,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
@@ -6403,11 +6404,6 @@ msgstr "Duke lexuar kartelen temp"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Ringarko listen e faileve te ndara."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7302,6 +7298,11 @@ msgstr[1] "Faile te ndara (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Faile te ndara (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Ringarko listen e faileve te ndara."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:34+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6359,7 +6359,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
@@ -6377,11 +6378,6 @@ msgstr "Delade mappar"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Ladda om listan med delade filer."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7264,6 +7260,11 @@ msgstr[1] "Utdelade filer (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Utdelade filer (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Ladda om listan med delade filer."
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:42+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6177,7 +6177,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
@@ -6192,11 +6193,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7058,6 +7054,11 @@ msgstr[1] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
+msgstr ""
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6310,7 +6310,8 @@ msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
@@ -6326,11 +6327,6 @@ msgstr "Paylaşılan dizinler güncelleniyor"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "%u dizin tarandı…"
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7192,6 +7188,11 @@ msgstr[1] "Payşılan Dosyalar (%i, %u dosyanın daha karma değeri hesaplanıyo
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Paylaşılan Dosyalar (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:36+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6421,7 +6421,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
@@ -6439,11 +6440,6 @@ msgstr "Спільні теки"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "Перезавантажується перелік спільних файлів."
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7344,6 +7340,11 @@ msgstr[2] "Спільні файли (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "Спільні файли (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "Перезавантажується перелік спільних файлів."
 
 #: src/SourceListCtrl.cpp
 #, fuzzy

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6176,7 +6176,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr ""
 
@@ -6191,11 +6192,6 @@ msgstr ""
 #: src/PrefsUnifiedDlg.cpp
 #, c-format
 msgid "Scanned %u directories..."
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/PrefsUnifiedDlg.cpp
@@ -7055,6 +7051,11 @@ msgstr[0] ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Shared Files (%i)"
+msgstr ""
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:36+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6314,7 +6314,8 @@ msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确�
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
@@ -6330,11 +6331,6 @@ msgstr "正在上传共享的文件夹"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr "已扫描 %u 个目录......"
-
-#: src/PrefsUnifiedDlg.cpp
-#, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "正重新加载共享文件：扫描了 %u 个文件"
 
 #: src/PrefsUnifiedDlg.cpp
 msgid "Shared folder"
@@ -7196,6 +7192,11 @@ msgstr[1] "共享的文件 (%i，正在计算另外 %u 个文件的哈希值）"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "共享文件 (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "正重新加载共享文件：扫描了 %u 个文件"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 15:54+0200\n"
+"POT-Creation-Date: 2026-08-21 20:10+0200\n"
 "PO-Revision-Date: 2026-08-20 14:37+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6345,7 +6345,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
@@ -6363,11 +6364,6 @@ msgstr "分享資料夾"
 #, c-format
 msgid "Scanned %u directories..."
 msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp
-#, fuzzy, c-format
-msgid "Reloading shared files: %u files scanned"
-msgstr "重新載入分享檔案清單。"
 
 #: src/PrefsUnifiedDlg.cpp
 #, fuzzy
@@ -7243,6 +7239,11 @@ msgstr[0] "分享檔案 (%i)"
 #, c-format
 msgid "Shared Files (%i)"
 msgstr "分享檔案 (%i)"
+
+#: src/SharedFilesReloadProgress.cpp
+#, fuzzy, c-format
+msgid "Reloading shared files: %u files scanned"
+msgstr "重新載入分享檔案清單。"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/src/CatDialog.cpp
+++ b/src/CatDialog.cpp
@@ -194,6 +194,12 @@ void CCatDialog::OnBnClickedOk(wxCommandEvent &WXUNUSED(evt))
 			CastChild(IDC_PRIOCOMBO, wxChoice)->GetSelection());
 
 		theApp->amuledlg->m_transferwnd->UpdateCategory(index);
+		// UpdateCategory() may have asked for a shared-files re-walk (when the
+		// category's path changed). It is deliberately not run here: this
+		// dialog is modal and about to EndModal, and opening an app-modal
+		// progress dialog on top of one that is closing is asking for
+		// platform-specific misbehaviour. CTransferWnd runs it after
+		// ShowModal() returns instead, parented to the main window.
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->Refresh();
 		theApp->amuledlg->m_searchwnd->UpdateCatChoice();
 	}

--- a/src/ECSpecialMuleTags.cpp
+++ b/src/ECSpecialMuleTags.cpp
@@ -883,9 +883,10 @@ void CEC_Prefs_Packet::Apply() const
 		if (theApp->sharedfiles) {
 			theApp->sharedfiles->EnableDirectoryWatcher(thePrefs::AutoRescanSharedDirs());
 			// Same for a changed exclusion filter: re-walk so newly excluded
-			// files leave the shareset and un-excluded ones return.
+			// files leave the shareset and un-excluded ones return. Scheduled
+			// rather than inline -- this runs inside the EC request handler.
 			if (excludeChanged) {
-				theApp->sharedfiles->Reload();
+				theApp->sharedfiles->RequestReload();
 			}
 		}
 	}

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1738,7 +1738,10 @@ static CECPacket *Get_EC_Response_SetSharedDirs(const CECPacket *request)
 	// Persist before reloading: FindSharedFiles starts by re-reading the
 	// intent files from disk, so the in-memory lists alone wouldn't stick.
 	theApp->glob_prefs->SaveSharedFolders();
-	theApp->sharedfiles->Reload();
+	// The lists above are written and persisted synchronously, so the reply
+	// still means "directories accepted and saved"; only the rescan is
+	// deferred to the next Process() tick.
+	theApp->sharedfiles->RequestReload();
 
 	return response;
 }
@@ -3660,7 +3663,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = Get_EC_Response_PartFile_Cmd(request);
 		break;
 	case EC_OP_SHAREDFILES_RELOAD:
-		theApp->sharedfiles->Reload();
+		// Scheduled, not performed: the walk would otherwise run inline in
+		// this handler and every EC client would wait out the whole thing.
+		theApp->sharedfiles->RequestReload();
 		response = new CECPacket(EC_OP_NOOP);
 		break;
 	case EC_OP_GET_SHARED_DIRS:

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -2428,8 +2428,10 @@ void CPreferences::RemoveCat(size_t index)
 
 		m_CatList.erase(it);
 
-		// remove cat directory from shares
-		theApp->sharedfiles->Reload();
+		// remove cat directory from shares. Scheduled, not inline: this is
+		// reached from the EC_OP_DELETE_CATEGORY handler as well as the GUI,
+		// and an inline walk there blocks the whole EC lane.
+		theApp->sharedfiles->RequestReload();
 	}
 }
 
@@ -2484,9 +2486,10 @@ bool CPreferences::UpdateCategory(
 		// keep path as it was
 	} else if (category->path != path) {
 		// path changed: reload shared files, adding files in the new path and removing those from the
-		// old path
+		// old path. Scheduled for the same reason as the removal above --
+		// EC_OP_UPDATE_CATEGORY reaches here through CEC_Category_Tag::Apply.
 		category->path = path;
-		theApp->sharedfiles->Reload();
+		theApp->sharedfiles->RequestReload();
 	}
 	category->title = name;
 	category->comment = comment;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -39,6 +39,7 @@
 #include <wx/listctrl.h> // shared-folders editor (remote GUI)
 #include <set>           // set-compare of shared roots (session refresh)
 #include <wx/progdlg.h>
+#include "SharedFilesReloadProgress.h" // ReloadSharedFilesWithProgress
 #include <wx/stdpaths.h>
 #include <wx/tooltip.h>
 #include <wx/utils.h> // wxGetUserHome
@@ -1477,8 +1478,13 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 	// + cancel) when shareddir_list itself changed. We only need to
 	// trigger a fresh Reload here for the other paths IDC_INCFILES /
 	// IDC_TEMPFILES affect.
+	// The three settings below each need a re-walk, and a single OK can change
+	// all three -- which used to mean up to three full walks back to back, each
+	// freezing the dialog. Collect the need and do one walk at the end instead.
+	bool needsSharedReload = false;
+
 	if (!sharedDirsCommitted && (CfgChanged(IDC_INCFILES) || CfgChanged(IDC_TEMPFILES))) {
-		theApp->sharedfiles->Reload();
+		needsSharedReload = true;
 	}
 
 	if (CfgChanged(IDC_AUTO_RESCAN_SHARED)) {
@@ -1492,7 +1498,7 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		// shared tree: turning the toggle off should drop symlinked
 		// entries already in the shareset, turning it on should pick
 		// them up.
-		theApp->sharedfiles->Reload();
+		needsSharedReload = true;
 	}
 
 	if (CfgChanged(IDC_EXCLUDE_SHARE_PATTERNS) || CfgChanged(IDC_EXCLUDE_SHARE_REGEX)) {
@@ -1514,8 +1520,29 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		// Re-scan so newly excluded files leave the shareset and files no
 		// longer matching return.
 		if (!sharedDirsCommitted) {
-			theApp->sharedfiles->Reload();
+			needsSharedReload = true;
 		}
+	}
+
+	// One walk for whichever of the three settings changed. Progress-and-yield
+	// rather than a bare Reload(): the walk costs roughly a stat per shared
+	// file, so on a large or network-mounted tree it runs for seconds to
+	// minutes, and without a yield callback CSharedFileList pumps nothing at
+	// all -- the window greys out as "not responding" with no indication why.
+	//
+	// Pumping here is safe: wxProgressDialog's yield is restricted to UI
+	// events, so it cannot dispatch the queued socket events that carry EC
+	// requests, and no client can be answered from the transiently-empty
+	// share map the walk builds through. Same reason CommitSharedDirsWithProgress
+	// above can do this.
+	//
+	// No cancel button, for the same reason as the shared-files Reload button:
+	// FindSharedFiles clears the map before walking, so an abort would leave a
+	// partial share list with nothing to restore. CommitSharedDirsWithProgress
+	// can offer one only because it keeps the previous directory list to
+	// re-walk against.
+	if (needsSharedReload) {
+		ReloadSharedFilesWithProgress(this);
 	}
 
 	if (CfgChanged(IDC_OSDIR) || CfgChanged(IDC_ONLINESIG)) {
@@ -3092,10 +3119,12 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 	theApp->glob_prefs->SaveSharedFolders();
 
 	bool reloadAborted = false;
+	// Its own lambda rather than ReloadSharedFilesWithProgress(): this path is
+	// the one caller that *can* offer cancel, because it keeps the previous
+	// directory list to re-walk against on abort. The wording is shared so the
+	// two cannot drift.
 	auto reloadYield = [&progress, &reloadAborted](size_t filesScanned) -> bool {
-		const wxString msg = CFormat(_("Reloading shared files: %u files scanned")) %
-				     static_cast<unsigned>(filesScanned);
-		if (!progress.Pulse(msg)) {
+		if (!progress.Pulse(SharedFilesScannedMessage(filesScanned))) {
 			reloadAborted = true;
 			return false;
 		}

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -657,7 +657,9 @@ void CSharedDirWatcher::FlushPendingEvents()
 			      "forcing a full shared-files reload to resync"));
 		m_pendingEvents.clear();
 		m_fallbackPending = false;
-		m_parent->Reload();
+		// Scheduled: this flush runs on the core event loop, so an inline walk
+		// would block it (and any EC request behind it) for the walk's length.
+		m_parent->RequestReload();
 		return;
 	}
 

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -1064,7 +1064,19 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 		return true;
 	}
 
-	AddDebugLogLineN(logKnownFiles, "Reload shared files");
+	// Any completed walk satisfies an outstanding RequestReload(), so drop the
+	// flag here rather than only in Process(). That lets a GUI caller run the
+	// walk itself (with progress) right after something that requested one,
+	// without Process() then running a second, redundant walk a tick later.
+	// A request that arrives while a walk is running took the `reloading`
+	// early-return above and is still pending, so it is not lost.
+	m_reloadPending = false;
+
+	// Info, not debug: now that EC callers get an immediate reply instead of
+	// blocking until the walk ends, the log is how they observe it starting.
+	// The end-of-walk "Found %i known shared files" summary is already an
+	// info line, so the two form a matched pair in release builds.
+	AddLogLineN(_("Reloading shared files..."));
 	reloading = true;
 	Notify_SharedFilesRemoveAllItems();
 
@@ -1381,6 +1393,15 @@ void CSharedFileList::SendListToServer()
 
 void CSharedFileList::Process()
 {
+	// Deferred reloads requested by callers on the core event loop (EC
+	// handlers, the watcher's dropped-events fallback) run here rather than
+	// inline in the caller. The `reloading` check means a request that
+	// arrives mid-walk stays pending and runs on a later tick instead of
+	// re-entering; Reload() would return early anyway, silently dropping it.
+	if (m_reloadPending && !reloading) {
+		m_reloadPending = false;
+		Reload();
+	}
 	Publish();
 	if (!m_lastPublishED2KFlag || (::GetTickCount64() - m_lastPublishED2K < ED2KREPUBLISHTIME)) {
 		return;

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -72,6 +72,29 @@ public:
 	// Cancellable + progress-reporting variant. Returns true if the
 	// walk completed normally, false if `yieldCb` requested abort.
 	bool Reload(ReloadYieldCb yieldCb);
+
+	// Ask for a full shared-files reload to run from the next Process()
+	// tick instead of inline in the caller. Callers that sit on the core
+	// event loop -- every EC request handler, and the directory watcher's
+	// dropped-events fallback -- use this so they can answer immediately
+	// rather than blocking for the whole walk. On a large or network-
+	// mounted share tree that walk is seconds to minutes, and because
+	// amuleapi's EC lane is a single serialised worker, a blocking reload
+	// there stalls the refresher and turns unrelated endpoints into 503s.
+	//
+	// Repeat requests before the tick coalesce into one walk, and a request
+	// arriving mid-walk keeps the flag set so it runs afterwards instead of
+	// nesting.
+	//
+	// A plain bool is deliberate: every setter and the reader run on the
+	// core event loop. If a caller off that thread ever needs this, that
+	// caller is the thing to fix -- do not make this atomic.
+	void RequestReload() { m_reloadPending = true; }
+
+	// True when a RequestReload() is outstanding. GUI callers use this to run
+	// the owed walk themselves behind a progress dialog rather than letting it
+	// land silently on a Process() tick -- see ReloadSharedFilesWithProgress().
+	bool IsReloadPending() const { return m_reloadPending; }
 	void SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd = false);
 	void RemoveFile(CKnownFile *toremove);
 	CKnownFile *GetFileByID(const CMD4Hash &filehash);
@@ -246,6 +269,8 @@ private:
 		bool &aborted);
 	void FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborted);
 	bool reloading;
+	// Set by RequestReload(), drained by Process(). See RequestReload().
+	bool m_reloadPending = false;
 
 	void SendListToServer();
 	uint64 m_lastPublishED2K;

--- a/src/SharedFilesReloadProgress.cpp
+++ b/src/SharedFilesReloadProgress.cpp
@@ -1,0 +1,68 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "SharedFilesReloadProgress.h"
+
+#include <wx/progdlg.h>
+#include <wx/window.h>
+
+#include "SharedFileList.h"
+#include "amule.h" // theApp
+#include "OtherFunctions.h"
+
+wxString SharedFilesScannedMessage(std::size_t filesScanned)
+{
+	return CFormat(_("Reloading shared files: %u files scanned")) % static_cast<unsigned>(filesScanned);
+}
+
+void ReloadSharedFilesWithProgress(wxWindow *parent)
+{
+#ifndef CLIENT_GUI
+	const wxString body = SharedFilesScannedMessage(0);
+	wxProgressDialog progress(_("Reloading shared files..."),
+		body,
+		/*maximum=*/100,
+		parent,
+		wxPD_APP_MODAL | wxPD_AUTO_HIDE);
+	theApp->sharedfiles->Reload([&progress](size_t filesScanned) -> bool {
+		progress.Pulse(SharedFilesScannedMessage(filesScanned));
+		// Always continue: see the no-cancel note in the header.
+		return true;
+	});
+	progress.Update(100);
+#else
+	// amulegui: the walk runs on amuled. CSharedFilesRem::Reload only posts
+	// EC_OP_SHAREDFILES_RELOAD and returns, so a dialog would just flash.
+	(void)parent;
+	theApp->sharedfiles->Reload();
+#endif
+}
+
+void ReloadSharedFilesIfPending(wxWindow *parent)
+{
+	if (theApp->sharedfiles && theApp->sharedfiles->IsReloadPending()) {
+		ReloadSharedFilesWithProgress(parent);
+	}
+}
+// File_checked_for_headers

--- a/src/SharedFilesReloadProgress.h
+++ b/src/SharedFilesReloadProgress.h
@@ -1,0 +1,85 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef SHAREDFILESRELOADPROGRESS_H
+#define SHAREDFILESRELOADPROGRESS_H
+
+#include <cstddef>
+
+#include <wx/string.h>
+
+class wxWindow;
+
+// Declarations only, with the implementation in the .cpp. This header is
+// included by several GUI translation units, and pulling amule.h (and the
+// C++ standard headers behind it) in here put std::byte in scope ahead of the
+// <windows.h> family that some of those TUs include further down -- rpcndr.h
+// then declares ::byte and every later use is ambiguous. Keeping the heavy
+// includes on the other side of the .cpp boundary removes that ordering trap
+// for every caller rather than fixing it one include block at a time.
+
+//! The one wording for reload progress, so every caller reports it identically.
+wxString SharedFilesScannedMessage(std::size_t filesScanned);
+
+/**
+ * Run a shared-files reload behind a progress dialog.
+ *
+ * CSharedFileList::Reload() walks every configured share root on the calling
+ * thread, costing roughly a stat per shared file. On a large or network-
+ * mounted tree that is seconds to minutes, and the no-callback overload yields
+ * nothing at all -- so every GUI action that triggered one used to freeze the
+ * window with no repaint, no progress and no indication why. Passing a yield
+ * callback keeps the walk on this thread but pumps the event loop every 256
+ * files, so the window repaints and stays draggable.
+ *
+ * Shared by every GUI entry point that can trigger a walk -- the shared-files
+ * Reload button, the preferences Apply, and the category add/rename/delete
+ * paths -- so they all behave the same and the dialog exists once.
+ *
+ * **Pumping here is safe.** wxProgressDialog restricts its yield to UI events,
+ * so it does not dispatch the queued socket events that carry EC requests
+ * (they reach the main loop via CoreNotify_* and wxQueueEvent). A remote client
+ * therefore cannot be answered from the transiently-empty share map that
+ * FindSharedFiles builds through, which is the hazard that rules out pumping
+ * the loop generally during a walk.
+ *
+ * **No cancel button, deliberately.** FindSharedFiles() clears m_Files_map
+ * before it starts walking, so an aborted walk leaves a partially populated
+ * share list with nothing to roll back to. PrefsUnifiedDlg's shared-directory
+ * commit can offer cancel only because it keeps the previous directory list
+ * and re-walks against it; none of these callers has such prior state. A
+ * cancel here needs a real rollback story first.
+ */
+void ReloadSharedFilesWithProgress(wxWindow *parent);
+
+/**
+ * Run the walk only if one is owed, i.e. something just called
+ * RequestReload(). Used by the category paths, where the reload is requested
+ * deep in CPreferences (shared with the daemon, so it cannot raise a dialog
+ * itself) and only when the change actually affects the shareset.
+ */
+void ReloadSharedFilesIfPending(wxWindow *parent);
+
+#endif // SHAREDFILESRELOADPROGRESS_H
+// File_checked_for_headers

--- a/src/SharedFilesWnd.cpp
+++ b/src/SharedFilesWnd.cpp
@@ -30,6 +30,7 @@
 
 #include "SharedFilesWnd.h" // Interface declarations
 #include "SharedFilesCtrl.h"
+#include "SharedFilesReloadProgress.h" // ReloadSharedFilesWithProgress
 #include "SharedFilePeersListCtrl.h"
 #include "muuli_wdr.h"     // Needed for ID_SHFILELIST
 #include "KnownFileList.h" // Needed for CKnownFileList
@@ -262,7 +263,7 @@ void CSharedFilesWnd::SelectionUpdated()
 
 void CSharedFilesWnd::OnBtnReloadShared(wxCommandEvent &WXUNUSED(evt))
 {
-	theApp->sharedfiles->Reload();
+	ReloadSharedFilesWithProgress(this);
 #ifndef CLIENT_GUI
 	// remote gui will update display when data is back
 	SelectionUpdated();

--- a/src/TransferWnd.cpp
+++ b/src/TransferWnd.cpp
@@ -50,6 +50,8 @@
 #include "Statistics.h"     // Needed for theStats
 #include "SharedFileList.h" // Needed for CSharedFileList
 #include "GuiEvents.h"      // Needed for CoreNotify_*
+// ReloadSharedFilesIfPending
+#include "SharedFilesReloadProgress.h"
 
 wxBEGIN_EVENT_TABLE(CTransferWnd, wxPanel)
 	EVT_RIGHT_DOWN(CTransferWnd::OnNMRclickDLtab)
@@ -266,6 +268,10 @@ void CTransferWnd::OnAddCategory(wxCommandEvent &WXUNUSED(event))
 #endif
 	);
 	dialog.ShowModal();
+	// A new category's incoming dir joins the shareset, so the dialog may have
+	// left a re-walk owed. Run it now the modal is gone, behind its own
+	// progress dialog, rather than letting it freeze the app on a core tick.
+	ReloadSharedFilesIfPending(this);
 }
 
 void CTransferWnd::OnDelCategory(wxCommandEvent &WXUNUSED(event))
@@ -284,6 +290,11 @@ void CTransferWnd::RemoveCategory(int index)
 		}
 		theApp->glob_prefs->SaveCats();
 		theApp->amuledlg->m_searchwnd->UpdateCatChoice();
+		// RemoveCat() asks for a re-walk (the category's directory leaves the
+		// shareset). Run it here behind a progress dialog rather than letting
+		// it land silently on a core tick -- CPreferences is shared with the
+		// daemon, so it cannot raise one itself.
+		ReloadSharedFilesIfPending(this);
 	}
 }
 
@@ -307,6 +318,9 @@ void CTransferWnd::OnEditCategory(wxCommandEvent &WXUNUSED(event))
 		m_dlTab->GetSelection());
 
 	dialog.ShowModal();
+	// Same as OnAddCategory: an edited path moves files in and out of the
+	// shareset, and the re-walk is owed once the modal closes.
+	ReloadSharedFilesIfPending(this);
 }
 
 void CTransferWnd::OnSetDefaultCat(wxCommandEvent &event)

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -603,6 +603,19 @@ public:
 		return true;
 	}
 
+	// Remote-side shim for the daemon's deferred-reload request. On the
+	// daemon this defers the walk to the next Process() tick so an EC
+	// handler need not block on it; here Reload() only posts
+	// EC_OP_SHAREDFILES_RELOAD and returns, so it is already the
+	// non-blocking thing RequestReload() exists to provide. amuled then
+	// defers on its own side when it receives the packet.
+	void RequestReload() { Reload(); }
+
+	// Always false on the remote side: there is no local walk to owe. When a
+	// category change reaches CPreferencesRem it goes out over EC, and amuled
+	// schedules its own reload; the GUI must not also run or announce one.
+	bool IsReloadPending() const { return false; }
+
 	// Remote-side no-op. The actual watcher lives on amuled and is
 	// driven there by the EC-synced AutoRescanSharedDirs pref; on the
 	// GUI side there is nothing to enable/disable locally.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -8619,12 +8619,27 @@ CHttpServer::Response CApiDispatcher::HandleSharedReload(const CHttpServer::Requ
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	// EC_OP_SHAREDFILES_RELOAD: amuled re-walks every configured share
-	// root and re-publishes the contents. Synchronous on amuled's side
-	// but bounded by I/O over the share tree — typical small libraries
-	// complete in well under a second. Inline RefresherTick re-pulls
-	// the shared-files cache so SSE subscribers see `shared_added` /
-	// `_removed` events for the delta before the response lands.
+	// EC_OP_SHAREDFILES_RELOAD: amuled schedules a re-walk of every
+	// configured share root and answers immediately, so 202 is literal --
+	// accepted and scheduled, not completed. The walk starts on amuled's
+	// next Process() tick (within about a second) and repeated calls while
+	// one is pending or running coalesce into a single walk.
+	//
+	// This used to be synchronous on amuled's side, on the assumption that
+	// the walk "completes in well under a second". That is exactly the
+	// assumption that fails on the trees where it matters -- a large or
+	// network-mounted share -- and because our EC lane is one serialised
+	// worker, the blocked roundtrip held the in-flight slot, filled the
+	// queue and turned unrelated endpoints into 503s.
+	//
+	// Completion is observable through the amule log (GET /logs/amule, or
+	// the log_appended SSE event) and the shared_added / shared_removed
+	// events, not through this response.
+	//
+	// SimpleConnControlOp still runs an inline RefresherTick. For this
+	// endpoint it now snapshots state from before the walk, so it buys
+	// nothing -- but it is harmless (a few EC roundtrips) and shared with
+	// the connect/disconnect endpoints, so it stays as-is.
 	return SimpleConnControlOp(m_app, m_state, EC_OP_SHAREDFILES_RELOAD, 202);
 }
 

--- a/unittests/curl-tests/amuleapi/36-shared-reload.sh
+++ b/unittests/curl-tests/amuleapi/36-shared-reload.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# amuleapi 36-shared-reload — POST /shared/reload.
+#
+# Endpoint:
+#   POST /api/v0/shared/reload   → 202 {"ok":true}
+#
+# amuled schedules a re-walk of every configured share root and answers
+# immediately, so the call is accepted (202), never completed (200). The walk
+# starts on amuled's next Process() tick and its result is only ever visible
+# as amule log lines ("Reloading shared files..." then "Found N known shared
+# files"), which a client reads through /logs/amule or the SSE log channel.
+# There is therefore nothing to assert about the outcome here; the contract
+# under test is the accept path, its guards, and that repeated calls coalesce
+# rather than erroring or queueing up.
+#
+# Why this endpoint has its own smoke: the reload used to run inline in
+# amuled's EC handler. Because amuleapi's EC lane is a single serialised
+# worker, that blocked roundtrip held the in-flight slot for the whole walk
+# and turned unrelated endpoints into 503s. The elapsed-time check below is a
+# smoke for that, not a proof — on a small test library even a synchronous
+# walk finishes quickly, so it only catches a gross regression.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+GUEST_PASS=${GUEST_PASS:-guestpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_36_shared_reload_body.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 30 -o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| _fail "$label" "body was not valid JSON" "body: $CURL_BODY"
+	if [ "$actual" = "$expected" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable."
+fi
+
+echo "amuleapi 36-shared-reload smoke @ $HOST"
+
+ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
+
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+HAVE_GUEST=0
+[ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
+
+sleep 4
+
+# --- 1. Auth guards. -----------------------------------------------
+_curl -X POST "$HOST/api/v0/shared/reload"
+_assert_status 401 "POST /shared/reload (no creds) → 401"
+
+if [ "$HAVE_GUEST" -eq 1 ]; then
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/reload"
+	_assert_status 403 "POST /shared/reload (guest) → 403"
+else
+	echo "    info: no guest password configured; skipping the 403 guard check"
+fi
+
+# --- 2. Accept path. -----------------------------------------------
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_assert_status 202 "POST /shared/reload (admin) → 202"
+_assert_json_eq '.ok' true "/shared/reload → ok=true"
+
+# --- 3. Repeated calls coalesce. -----------------------------------
+# A second request while the first is still pending (or its walk running)
+# must be accepted the same way, not rejected as a conflict and not queued
+# into a second walk. Only the status is observable from here; that the two
+# collapse into one walk is amuled-side and shows up in its log.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_assert_status 202 "POST /shared/reload again immediately → 202"
+_assert_json_eq '.ok' true "second /shared/reload → ok=true"
+
+# --- 4. The reply does not wait for the walk. ----------------------
+# Generous bound: this is a smoke against a regression to the old inline
+# behaviour, not a timing guarantee. SimpleConnControlOp also runs an inline
+# RefresherTick, so a handful of EC roundtrips are included in the figure.
+START=$(date +%s)
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+ELAPSED=$(( $(date +%s) - START ))
+_assert_status 202 "POST /shared/reload (timed) → 202"
+if [ "$ELAPSED" -le 10 ]; then
+	_pass "/shared/reload returned in ${ELAPSED}s (does not block on the walk)"
+else
+	_fail "/shared/reload returned in ${ELAPSED}s" \
+		"expected the reply to be scheduled, not to wait for the directory walk"
+fi
+
+# --- 5. The API stays usable while the walk runs. ------------------
+# The reload request must not be the thing that occupies the EC service's
+# in-flight slot for the walk's duration; if it were, these would 503.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/status"
+_assert_status 200 "GET /status right after a reload → 200 (not 503)"
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared"
+_assert_status 200 "GET /shared right after a reload → 200"
+_assert_json_eq '.shared | type' array "/shared still serves a coherent list"
+
+# --- 6. Method gate. -----------------------------------------------
+_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_assert_status 405 "GET /shared/reload → 405"
+
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_assert_status 405 "DELETE /shared/reload → 405"
+
+# --- Summary. -----------------------------------------------------
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -215,6 +215,7 @@ PHASES=(
 	33-known-clients.sh
 	34-friends.sh
 	35-ipfilter-actions.sh
+	36-shared-reload.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
Closes #969.

`CSharedFileList::Reload()` walks every configured share root on the caller's thread, and the no-callback overload yields nothing at all — the loop that would pump the event loop every 256 files is skipped entirely when no callback is passed. Two groups of callers made that user-visible: the GUI actions that trigger a walk freeze the window with no repaint and no indication why, and the EC request handlers run the walk inline, so every EC client waits it out.

## How long is "a while"

Measured here: **20 000 files → ~4.3 s** (three runs, 4.435 / 4.337 / 4.246 s) on a warm cache and a local SSD, against a fixed overhead of 0.045 s. That is ~0.21 ms per file, and the cost is per *file*, not per byte — the walk does three stats and an indexed lookup per file and never opens one. Hashing, which does read every byte, is queued onto `CThreadScheduler` after the walk and never blocked anything.

The number that matters is the other one: three of those four operations are syscalls, and on NFS/CIFS/sshfs or a spun-down disk each can be a network round trip at 1–10 ms rather than ~0.07 ms. The same 20 000 files then take minutes, which is the case the issue is really about.

## EC handlers: five sites, not two

The issue lists two inline `Reload()` calls in EC handlers. There are **five** reachable from an EC request, all with the same defect:

| EC opcode | Path |
|---|---|
| `EC_OP_SHAREDFILES_RELOAD` | `ExternalConn.cpp` |
| `EC_OP_SET_SHARED_DIRS` | `ExternalConn.cpp` |
| `EC_OP_SET_PREFERENCES` | `ECSpecialMuleTags.cpp` — exclusion filter changed |
| `EC_OP_UPDATE_CATEGORY` | → `CEC_Category_Tag::Apply` → `UpdateCategory` → `Preferences.cpp` — category path changed |
| `EC_OP_DELETE_CATEGORY` | → `Notify_CategoryDelete` → `CategoryDelete` → `RemoveCat` → `Preferences.cpp` |

The last two dispatch synchronously: `HandleNotification` calls `ntf.Notify()` directly when it is already on the main thread under `AMULE_DAEMON`, and only queues an event when off-thread. So deleting a category from amulegui blocks the EC lane for a full walk, exactly as pressing Reload does.

All five now call `RequestReload()`, which sets a flag drained at the top of `CSharedFileList::Process()` — the once-per-second core tick. The `reloading` guard means a request arriving mid-walk stays pending and runs afterwards rather than nesting. The watcher's dropped-events fallback in `SharedDirWatcher.cpp` moves over too; the issue's own proposed doc-comment names it, though its file list omits it.

## GUI: all six paths, one implementation

Six GUI actions could trigger a walk with no progress and no yield — the shared-files **Reload** button, preferences **Apply** with Incoming/Temp dir, follow-symlinks, or exclusion patterns changed, and **category delete** / **category path change**.

Rather than five copies of the same dialog, this adds one `ReloadSharedFilesWithProgress()` in `src/SharedFilesReloadProgress.h` and routes every caller through it. `CommitSharedDirsWithProgress` keeps its own lambda — it is the only caller that *can* offer cancel, because it keeps the previous directory list to re-walk against on abort — but takes its wording from the same `SharedFilesScannedMessage()`, so the two cannot drift. After this the progress string exists in exactly one place in the tree.

The three preferences settings also **collapse into a single walk**. All three live in one `OnOk`, so changing all three previously ran three consecutive full walks.

The category paths raise the dialog through `ReloadSharedFilesIfPending()`, because the request is made deep in `CPreferences`, which is shared with the daemon and cannot raise one itself. `Reload()` now clears the pending flag, so a GUI-run walk satisfies the request instead of leaving `Process()` to run a second, redundant one a tick later.

**No cancel button, deliberately.** `FindSharedFiles()` clears `m_Files_map` before it walks, so an aborted walk leaves a partial share list with nothing to restore.

## Pumping the event loop is safe here

The issue warns against pumping from the walk, because the share map is transiently empty and a client answered from that state would see thousands of spurious `shared_removed` events. That warning looked like it applied to the progress dialog too: EC requests do reach the main loop, via `CoreNotify_*` and `wxQueueEvent`.

It does not. A standalone probe — queue 50 non-UI events, then call `Pulse()` 50 times — dispatched **0 of 50**. `wxProgressDialog` restricts its yield to UI events, so it cannot dispatch the queued socket events that carry EC requests. That reasoning is recorded in the header rather than left implicit.

## Strings and catalogs

**No new translatable strings.** `_("Reloading shared files...")` and `_("Reloading shared files: %u files scanned")` both already existed in `PrefsUnifiedDlg`; reusing the first also covers the reload's start line, promoted from a debug line (compiled out in release) to info so clients that no longer block on the call can still see the walk begin. The catalog diff is reference lines plus one string relocating in the pot; `msgfmt --statistics` is identical to master on every catalog checked. The new header is registered in `POTFILES.in` so its strings stay extractable in their own right.

## API

`POST /api/v0/shared/reload` keeps returning `202`, which is now literally true. `REFERENCE.md` documents that `202` means accepted and scheduled, that repeated calls coalesce, and that completion is observed through the amule log or the `shared_*` SSE events — matching the shape `POST /shared/{hash}/verify` already uses. `PUT /shared/directories` documents that the roots are persisted before the response but the rescan is scheduled.

## Verification

Against a live daemon with a 20 000-file share:

- `POST /shared/reload` ×2 back to back: both `202`, **0.048 s total**. `PUT /shared/directories`: `202` in **0.014 s**.
- The API answered `200` throughout the walk, with the shared count climbing *after* the response.
- **5 rapid reloads produced exactly 1 walk**, re-confirmed after the refactor.
- Start and end log lines appear as a matched pair in a release-level log.
- New `36-shared-reload.sh`: **13/13 pass**.
- Negative control — the one EC line reverted to inline — blocked for **5.75 s** where the fix returns in ~0.05 s, so the test is not vacuous.

Both clang-tidy tiers clean over 22 TUs, clang-format clean, all five binaries build.

**Not demonstrated:** the `503 ec_unavailable` wall itself. The blocking is measured, but at this scale a 5.75 s walk does not exhaust the 8-deep EC queue, so the 503 consequence follows from the queue mechanics rather than from an observation.

**Deliberately not fixed**, per the issue: the walk still occupies amuled's event loop while it runs, so EC requests issued *during* a walk still wait for it. Making the walk genuinely concurrent needs an incremental scan that diffs against the live map instead of clearing it — a separate, larger change.
