### PR TITLE
feat(core): log shared-file discovery, hashing and ffprobe at info level

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3096,6 +3096,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6865,6 +6870,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6877,13 +6889,6 @@ msgstr ""
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6908,6 +6913,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -7859,6 +7886,16 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3146,6 +3146,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6987,6 +6992,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7001,13 +7013,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "وجد %i ملف مشاركة معرف"
 msgstr[1] "وجد %i ملف مشاركة معرف"
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "وجد %i ملفات مشاركة معروفة , %i غير معروفة"
-msgstr[1] "وجد %i ملفات مشاركة معروفة , %i غير معروفة"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7030,6 +7035,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "خطأ أثناء اﻹتصال بي%s (%s:%i): %d"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "وجد %i ملف مشاركة معرف"
+msgstr[1] "وجد %i ملف مشاركة معرف"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -7998,6 +8025,16 @@ msgstr ""
 
 #: src/ThreadTasks.cpp
 #, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
@@ -8821,6 +8858,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "وجد %i ملفات مشاركة معروفة , %i غير معروفة"
+#~ msgstr[1] "وجد %i ملفات مشاركة معروفة , %i غير معروفة"
 
 #, fuzzy
 #~ msgid "Percent of total files"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3201,6 +3201,11 @@ msgstr "AVISU:"
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7101,6 +7106,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7115,13 +7127,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Alcontróse %i ficheru compartíu"
 msgstr[1] "Alcontráronse %i ficheros compartíos"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Alcontróse %i ficheru compartíu, %i desconocíu"
-msgstr[1] "Alcontráronse %i ficheros compartíos, %i desconocíos"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7144,6 +7149,28 @@ msgstr "Direutoriu compartíu non alcontráu, saltando: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Ensin ficheros que compartir en direutoriu: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Fallu guardando ficheru known.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Cargando ficheru server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Ensin ficheros que compartir en direutoriu: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Alcontróse %i ficheru compartíu"
+msgstr[1] "Alcontráronse %i ficheros compartíos"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8165,6 +8192,16 @@ msgid "aMule text client"
 msgstr "Veceru de testu aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Desaniciando ficheru: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Resumiendo xubíes del ficheru: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convirtiendo antiguos hashsets AICH en  '%s' a 64b en '%s'."
@@ -9007,6 +9044,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Alcontróse %i ficheru compartíu, %i desconocíu"
+#~ msgstr[1] "Alcontráronse %i ficheros compartíos, %i desconocíos"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3139,6 +3139,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6960,6 +6965,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6972,13 +6984,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] "Известни са %i споделени файлове"
-msgstr[1] "Известни са %i споделени файлове"
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Известни са %i споделени файлове"
 msgstr[1] "Известни са %i споделени файлове"
 
@@ -7003,6 +7008,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Споделени файлове (%i)"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Известни са %i споделени файлове"
+msgstr[1] "Известни са %i споделени файлове"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -7969,6 +7996,16 @@ msgstr ""
 
 #: src/ThreadTasks.cpp
 #, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
@@ -8792,6 +8829,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Известни са %i споделени файлове"
+#~ msgstr[1] "Известни са %i споделени файлове"
 
 #~ msgid " kB/s"
 #~ msgstr " кБ/с"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3095,6 +3095,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6864,6 +6869,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6876,13 +6888,6 @@ msgstr ""
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6907,6 +6912,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -7858,6 +7885,16 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3190,6 +3190,11 @@ msgstr "AVÍS: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7069,6 +7074,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7083,13 +7095,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "S'ha trobat %i fitxer compartit"
 msgstr[1] "S'han trobat %i fitxers compartits"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "S'ha trobat %i fitxer compartit conegut, %i desconeguts"
-msgstr[1] "S'han trobat %i fitxers compartits coneguts, %i desconeguts"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7112,6 +7117,28 @@ msgstr "Carpeta compartida no trobada, omitint: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "No s'ha trobat cap fitxer en el directori: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Error mentre es desava el fitxer %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "S'està carregant el fitxer server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "No s'ha trobat cap fitxer en el directori: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "S'ha trobat %i fitxer compartit"
+msgstr[1] "S'han trobat %i fitxers compartits"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8111,6 +8138,16 @@ msgid "aMule text client"
 msgstr "client de text de l'aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "S'està esborrant el fitxer: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "S'està reprenent la pujada del fitxer: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "S'està convertint els conjunts de resums AICH antics en '%s' a 64b en '%s'."
@@ -8952,6 +8989,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "S'ha trobat %i fitxer compartit conegut, %i desconeguts"
+#~ msgstr[1] "S'han trobat %i fitxers compartits coneguts, %i desconeguts"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3195,6 +3195,11 @@ msgstr "VAROVÁNÍ: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7061,6 +7066,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7075,14 +7088,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
-msgstr[2] ""
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Nalezeno %i známých a %i neznámých sdílených souborů"
-msgstr[1] "Nalezeno %i známých a %i neznámých sdílených souborů"
 msgstr[2] ""
 
 #: src/SharedFileList.cpp
@@ -7107,6 +7112,29 @@ msgstr "Sdílený adresář nenalezen, přeskakuji: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Chyba při ukládání souboru %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Načítám soubor server.met: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Znovu načíst vaše sdílené soubory"
+msgstr[1] "Znovu načíst vaše sdílené soubory"
+msgstr[2] "Znovu načíst vaše sdílené soubory"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8086,6 +8114,16 @@ msgid "aMule text client"
 msgstr "Textový klient aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Mazání souboru: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Obnovuji odesílání souboru %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Převádí se staré AICH hashsety v '%s' do 64b v '%s'."
@@ -8927,6 +8965,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Nalezeno %i známých a %i neznámých sdílených souborů"
+#~ msgstr[1] "Nalezeno %i známých a %i neznámých sdílených souborů"
+#~ msgstr[2] ""
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3155,6 +3155,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7006,6 +7011,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7018,13 +7030,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] "Fandt %i kendte delte filer"
-msgstr[1] "Fandt %i kendte delte filer"
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] "Fandt %i kendte delte filer"
 msgstr[1] "Fandt %i kendte delte filer"
 
@@ -7049,6 +7054,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Fejl ved forbindelse til %s (%s:%i): %d"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Suspender upload af fil: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Fandt %i kendte delte filer"
+msgstr[1] "Fandt %i kendte delte filer"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8017,6 +8044,16 @@ msgid "aMule text client"
 msgstr ""
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Hasher"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Genoptager uploads af fil: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konverter gamle AICH hashsæt i '%s' til 64b i '%s'."
@@ -8851,6 +8888,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Fandt %i kendte delte filer"
+#~ msgstr[1] "Fandt %i kendte delte filer"
 
 #~ msgid " kB/s"
 #~ msgstr " kB/s"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3195,6 +3195,11 @@ msgstr "WARNUNG: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7064,6 +7069,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7078,13 +7090,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i bekannte freigegebene Datei gefunden"
 msgstr[1] "%i bekannte freigegebene Dateien gefunden"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "%i bekannte Datei gefunden, %i unbekannt"
-msgstr[1] "%i bekannte Dateien gefunden, %i unbekannt"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7107,6 +7112,28 @@ msgstr "Freigegebenes Verzeichnis nicht gefunden, überspringe: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Fehler während des Speicherns der Datei '%s': %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Lade Datei server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "%i bekannte freigegebene Datei gefunden"
+msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8119,6 +8146,16 @@ msgid "aMule text client"
 msgstr "aMule Textclient"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Lösche Datei: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Wiederaufnahme des Hochladens der Datei '%s'."
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Wandle alte AICH-Prüfsummensätze von '%s' um in 64b in '%s'."
@@ -8966,6 +9003,12 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "%i bekannte Datei gefunden, %i unbekannt"
+#~ msgstr[1] "%i bekannte Dateien gefunden, %i unbekannt"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3212,6 +3212,11 @@ msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ:"
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7117,6 +7122,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7131,13 +7143,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
 msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο και %i άγνωστο"
-msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία και %i άγνωστα"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7160,6 +7165,28 @@ msgstr "Ο διακομιστής δεν βρέθηκε: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Σφάλμα κατά το αποθήκευση του αρχείου known.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Φόρτωση του αρχείου διακομιστών: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο"
+msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8183,6 +8210,16 @@ msgid "aMule text client"
 msgstr "Διακομιστής κειμένου του aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Σβήσιμο αρχείου: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Συνέχεια του ανεβάσματος του αρχείου: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Μετατροπή των παλιών συνόλων κατακερματισμού AICH στο '%s' σε 64b στο '%s'."
@@ -9025,6 +9062,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Βρέθηκε %i γνωστό κοινόχρηστο αρχείο και %i άγνωστο"
+#~ msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία και %i άγνωστα"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3096,6 +3096,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6865,6 +6870,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6877,13 +6889,6 @@ msgstr ""
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6908,6 +6913,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -7859,6 +7886,16 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3188,6 +3188,11 @@ msgstr "AVISO: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7009,6 +7014,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Vigilante de directorios compartidos: desbordamiento/error de backend (%s); volviendo a recargar completamente"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Vigilante de directorios compartidos: eventos descartados por el backend, forzando una recarga completa de archivos compartidos para resincronizar"
 
@@ -7023,13 +7035,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Encontrado %i archivo compartido"
 msgstr[1] "Encontrados %i archivos compartidos"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Encontrado %i archivo compartido, %i desconocido"
-msgstr[1] "Encontrados %i archivos compartidos, %i desconocidos"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7052,6 +7057,28 @@ msgstr "Directorio compartido no encontrado, se omite: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "No se han encontrado archivos para compartir en el directorio: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Error guardando el archivo %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Cargando el archivo server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "No se han encontrado archivos para compartir en el directorio: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Encontrado %i archivo compartido"
+msgstr[1] "Encontrados %i archivos compartidos"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8064,6 +8091,16 @@ msgid "aMule text client"
 msgstr "Cliente de texto de aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Borrando archivo: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Reanudando las subidas del archivo: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convirtiendo antiguos hashset de AICH en '%s' a 64b en '%s'."
@@ -8909,6 +8946,12 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Encontrado %i archivo compartido, %i desconocido"
+#~ msgstr[1] "Encontrados %i archivos compartidos, %i desconocidos"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3190,6 +3190,11 @@ msgstr "HOIATUS: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7075,6 +7080,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7089,13 +7101,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Leitud %i tuntud ja jagatud faili"
 msgstr[1] "Leitud %i tuntud ja jagatud faili."
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Leitud %i tuntud ja jagatud faili, %i tundmatut"
-msgstr[1] "Leitud %i tuntud ja jagatud faili, %i tundmatut."
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7118,6 +7123,28 @@ msgstr "Jagatud kataloogi ei leitud, jätan vahele: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Kataloogis '%s' pole jagatavaid faile"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "VIGA: tekkis %s faili salvestamisel: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Laen server.met faili: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Kataloogis '%s' pole jagatavaid faile"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Leitud %i tuntud ja jagatud faili"
+msgstr[1] "Leitud %i tuntud ja jagatud faili."
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8112,6 +8139,16 @@ msgid "aMule text client"
 msgstr "aMule tekstiline klient"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Kustutan faili: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Taastan faili '%s' saatmise"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konverteerin vanad '%s' AICH kontrollsummad 64b '%s'."
@@ -8954,6 +8991,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Leitud %i tuntud ja jagatud faili, %i tundmatut"
+#~ msgstr[1] "Leitud %i tuntud ja jagatud faili, %i tundmatut."
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3191,6 +3191,11 @@ msgstr "OHARRA: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7073,6 +7078,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7087,13 +7099,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
 msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "%i ezagututako partekatutako eta ezezagun %i aurkiturik"
-msgstr[1] "%i ezagututako partekatutako eta %i ezezagun aurkiturik"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7116,6 +7121,28 @@ msgstr "Partekatutako direktorioa ez da aurkitu, baztertzen: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Errorea %s fitxategia gordetzerakoan: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "server.met fitxategia kargatzen: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Ezagututako partekatutako fitxategi %i aurkiturik"
+msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8113,6 +8140,16 @@ msgid "aMule text client"
 msgstr "aMule testu bezeroa"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "fitxategia ezabatzen:%s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Fitxategiaren igoerak berriarazten: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s'-ko AICH egiaztapen zaharra 64b-ekoa bihurtzen '%s'-en."
@@ -8954,6 +8991,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "%i ezagututako partekatutako eta ezezagun %i aurkiturik"
+#~ msgstr[1] "%i ezagututako partekatutako eta %i ezezagun aurkiturik"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3191,6 +3191,11 @@ msgstr "VAROITUS: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7073,6 +7078,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7087,13 +7099,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
 msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Löydetty %i tunnettu jaettu tiedosto, %i tuntematonta"
-msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa, %i tuntematonta"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7116,6 +7121,28 @@ msgstr "Jaettua kansiota ei löytynyt, hypätään yli: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Virhe tallennettaessa tiedostoa %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Lataan tiedostoa server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Löydetty %i tunnettu jaettu tiedosto"
+msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8113,6 +8140,16 @@ msgid "aMule text client"
 msgstr "aMule tekstiasiakas"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Poistetaan tiedosto: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Jatketaan tiedoston %s lähetyksiä"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Muunnetaan vanhat AICH-tarkistejoukot '%s' 64-bittisiksi '%s'."
@@ -8954,6 +8991,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Löydetty %i tunnettu jaettu tiedosto, %i tuntematonta"
+#~ msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa, %i tuntematonta"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3187,6 +3187,11 @@ msgstr "AVERTISSEMENT : "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7004,6 +7009,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Observateur de répertoire partagé : dépassement de capacité/erreur du backend (%s) ; rechargement complet en cours"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Observateur de répertoire partagé : des événements ont été perdus par le backend, ce qui force un rechargement complet des fichiers partagés pour resynchroniser"
 
@@ -7018,13 +7030,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i fichier partagé connu trouvé"
 msgstr[1] "%i fichiers partagés connus trouvés"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "%i fichier partagé connu trouvé, %i inconnu"
-msgstr[1] "%i fichiers partagés connus trouvés, %i inconnus"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7047,6 +7052,28 @@ msgstr "Répertoire partagé non trouvé, on passe : %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Erreur lors de la sauvegarde du fichier %s : %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Chargement du fichier server.met : %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "%i fichier partagé connu trouvé"
+msgstr[1] "%i fichiers partagés connus trouvés"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8059,6 +8086,16 @@ msgid "aMule text client"
 msgstr "client texte aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Fichier supprimé : %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Reprise des envois du fichier : %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Conversion des anciens hashsets AICH en '%s' vers 64b en '%s'."
@@ -8904,6 +8941,12 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "%i fichier partagé connu trouvé, %i inconnu"
+#~ msgstr[1] "%i fichiers partagés connus trouvés, %i inconnus"
 
 #~ msgid " MB/s"
 #~ msgstr " Mo/s"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3208,6 +3208,11 @@ msgstr "AVISO: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7079,6 +7084,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7093,13 +7105,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Atopado %i ficheiro compartido"
 msgstr[1] "Atopados %i ficheiros compartidos"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Atopado %i ficheiro compartidos, %i descoñecido"
-msgstr[1] "Atopados %i ficheiros compartidos, %i descoñecidos"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7122,6 +7127,28 @@ msgstr "Directorio compartido non atopado, saltando: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Non se puido gardar o ficheiro %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Cargando ficheiro server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Atopado %i ficheiro compartido"
+msgstr[1] "Atopados %i ficheiros compartidos"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8134,6 +8161,16 @@ msgid "aMule text client"
 msgstr "Texto do cliente de aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Eliminando ficheiro: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Continuando enviando o ficheiro: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convertendo conxuntos hash XICA[AICH] antigos en «%s» a 64b en «%s»."
@@ -8976,6 +9013,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Atopado %i ficheiro compartidos, %i descoñecido"
+#~ msgstr[1] "Atopados %i ficheiros compartidos, %i descoñecidos"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3167,6 +3167,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7042,6 +7047,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7056,13 +7068,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "נמצא %i קובץ משותף מוכר"
 msgstr[1] "נמצא %i קובץ משותף מוכר"
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "נמצא %i שידוע שהם משותפים, %i לא ידועים"
-msgstr[1] "נמצא %i שידוע שהם משותפים, %i לא ידועים"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7085,6 +7090,28 @@ msgstr "לא נמצא השרת: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "שגיאה במהלך שמירת הקובץ known.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "משהה את העלאה של קובץ: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "נמצא %i קובץ משותף מוכר"
+msgstr[1] "נמצא %i קובץ משותף מוכר"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8093,6 +8120,16 @@ msgid "aMule text client"
 msgstr "לקוח טסטואלי של אֵימיול"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "מוחק את הקובץ: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "ממשיך את העלאה של קובץ: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "ממיר את קבוצת הגיבובים בפורמט AICH עבור '%s' ל 64b עבור '%s'."
@@ -8926,6 +8963,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "נמצא %i שידוע שהם משותפים, %i לא ידועים"
+#~ msgstr[1] "נמצא %i שידוע שהם משותפים, %i לא ידועים"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3163,6 +3163,11 @@ msgstr "UPOZORENJE: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7033,6 +7038,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7047,14 +7060,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
 msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
-msgstr[2] ""
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova, %i nepoznatih"
-msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova, %i nepoznatih"
 msgstr[2] ""
 
 #: src/SharedFileList.cpp
@@ -7079,6 +7084,29 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Greska prilikom spajanja sa %s (%s:%i): %d"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova"
+msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova"
+msgstr[2] ""
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8047,6 +8075,16 @@ msgid "aMule text client"
 msgstr ""
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Hashing"
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
@@ -8872,6 +8910,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Pronadjeno %i poznatih dijeljenih fajlova, %i nepoznatih"
+#~ msgstr[1] "Pronadjeno %i poznatih dijeljenih fajlova, %i nepoznatih"
+#~ msgstr[2] ""
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3177,6 +3177,11 @@ msgstr "FIGYELEM: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7041,6 +7046,12 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7054,12 +7065,6 @@ msgstr "Fájl %s hozzáadása a megosztásokhoz"
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i ismert megosztott fájlt találtam"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "%i ismert és %i ismeretlen megosztott fájlt találtam"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7081,6 +7086,27 @@ msgstr "Megosztott könyvtár nem található, mellőzve: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Hiba a %s fájl mentése közben: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "server.met fájl betöltése: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "%i ismert megosztott fájlt találtam"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8080,6 +8106,16 @@ msgid "aMule text client"
 msgstr "aMule szöveges kliens"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Fájl törlése: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Fájl feltöltés folytatása: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "A régi AICH hashkészlet konvertálása 64b-re '%s'-ből '%s'-be."
@@ -8921,6 +8957,11 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "%i ismert és %i ismeretlen megosztott fájlt találtam"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3194,6 +3194,11 @@ msgstr "ATTENZIONE: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7011,6 +7016,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Monitoraggio cartelle condivise: overflow o errore del backend (%s); si ricorre a una ricarica completa"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Monitoraggio cartelle condivise: eventi persi dal backend, ricarica completa dei file condivisi per risincronizzare"
 
@@ -7025,13 +7037,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Trovati %i file condiviso conosciuto"
 msgstr[1] "Trovati %i file condivisi conosciuti"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Trovato %i file conosciuto, %i sconosciuto"
-msgstr[1] "Trovati %i file condivisi conosciuti, %i sconosciuti"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7054,6 +7059,28 @@ msgstr "Cartella condivisa non trovata, ignoro: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nessun file condivisibile trovato nella cartella: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Errore durante il salvataggio del file %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Caricamento file server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Nessun file condivisibile trovato nella cartella: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Trovati %i file condiviso conosciuto"
+msgstr[1] "Trovati %i file condivisi conosciuti"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8066,6 +8093,16 @@ msgid "aMule text client"
 msgstr "Client testuale aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Cancellazione file in corso: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Ripristino invio del file: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Conversione dei vecchi hashset AICH in '%s' a 64b: '%s'."
@@ -8911,6 +8948,12 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Trovato %i file conosciuto, %i sconosciuto"
+#~ msgstr[1] "Trovati %i file condivisi conosciuti, %i sconosciuti"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3192,6 +3192,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7071,6 +7076,12 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7084,12 +7095,6 @@ msgstr ""
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i個の既知の共有ファイルが見つかりました"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "%i個の既知、%i個の未知の共有ファイルが見つかりました"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7111,6 +7116,27 @@ msgstr "サーバは見付かりませんでした： %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "known.metファイル%sを保存する時にIOエラーが発生しました"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "server.metファイルをロード中です：%s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8120,6 +8146,16 @@ msgid "aMule text client"
 msgstr "aMuleテキストクライアント"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "ファイルを削除します：%s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "ファイル %s のアップロードを再開します"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s' の古いAICHハッシュセットを '%s' の64bに変換中です。"
@@ -8954,6 +8990,11 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "%i個の既知、%i個の未知の共有ファイルが見つかりました"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3212,6 +3212,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7116,6 +7121,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7130,13 +7142,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "알려진 공유 파일 %i개를 찾았음"
 msgstr[1] "알려진 공유 파일 %i개를 찾았음"
-
-#: src/SharedFileList.cpp
-#, fuzzy, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "알려진 공유 파일 %i개, 알수없는 %i개를 찾았음 "
-msgstr[1] "알려진 공유 파일 %i개, 알수없는 %i개를 찾았음 "
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7159,6 +7164,28 @@ msgstr "서버가 발견되지 않음: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "known.met 파일을 저장하는 동안 오류: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "server.met 파일을 읽음: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "알려진 공유 파일 %i개를 찾았음"
+msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8169,6 +8196,16 @@ msgid "aMule text client"
 msgstr ""
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "파일 삭제: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "파일의 올려주기를 재시작합니다: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s'의 낡은 AICH 해시셋을 64b로 '%s'에 변환합니다."
@@ -9005,6 +9042,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "알려진 공유 파일 %i개, 알수없는 %i개를 찾았음 "
+#~ msgstr[1] "알려진 공유 파일 %i개, 알수없는 %i개를 찾았음 "
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3225,6 +3225,11 @@ msgstr "DĖMESIO: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7137,6 +7142,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7152,14 +7165,6 @@ msgid_plural "Found %i known shared files"
 msgstr[0] "Aptiktas %i dalinamas failas"
 msgstr[1] "Aptikti %i dalinami failai"
 msgstr[2] "Aptikta %i dalinamų failų"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Aptiktas %i žinomas dalinamas failai, %i nežinomų"
-msgstr[1] "Aptikti %i žinomi dalinami failai, %i nežinomų"
-msgstr[2] "Aptikta %i žinomų dalinamų failų, %i nežinomų"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7183,6 +7188,29 @@ msgstr "serveris nerastas: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Įrašant known.met failą įvyko klaida: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Įkeliamas server.met failas: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Aptiktas %i dalinamas failas"
+msgstr[1] "Aptikti %i dalinami failai"
+msgstr[2] "Aptikta %i dalinamų failų"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8203,6 +8231,16 @@ msgid "aMule text client"
 msgstr "aMule tekstinis klientas"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Šalinamas failas: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Tęsiame failos siuntimą: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Senos klaidų taisymo maišos reikšmės keičiamos „%s“ keičiamos 64b „%s“."
@@ -9045,6 +9083,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Aptiktas %i žinomas dalinamas failai, %i nežinomų"
+#~ msgstr[1] "Aptikti %i žinomi dalinami failai, %i nežinomų"
+#~ msgstr[2] "Aptikta %i žinomų dalinamų failų, %i nežinomų"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3121,6 +3121,11 @@ msgstr "BRĪDINĀJUMS: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6912,6 +6917,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6924,13 +6937,6 @@ msgstr ""
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6956,6 +6962,29 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Parādīt kopīgoto datņu sarakstu."
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Ielādē server.met datni: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Ielādē kopīgotās datnes"
+msgstr[1] "Ielādē kopīgotās datnes"
+msgstr[2] "Ielādē kopīgotās datnes"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -7911,6 +7940,16 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Dzēš datni: %s"
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3184,6 +3184,11 @@ msgstr "WAARSCHUWING: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7002,6 +7007,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Gedeelde map-wachter: back-end overstroming/fout (%s); terugvallen op volledig herladen"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Gedeelde map-wachter: gebeurtenissen zijn door de back-end laten vallen, wat het volledig herladen van de gedeelde bestanden vereist om te hersynchronizeren"
 
@@ -7016,13 +7028,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "%i bekend gedeeld bestand gevonden"
 msgstr[1] "%i bekende gedeelde bestanden gevonden"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "%i bekend gedeeld bestand gevonden, %i onbekend"
-msgstr[1] "%i bekende gedeelde bestanden gevonden, %i onbekend"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7045,6 +7050,28 @@ msgstr "Gedeelde map niet gevonden, wordt overgeslagen: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Geen deelbare bestanden gevonden in map: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Fout bij het bewaren van bestand %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Laden van server.met bestand: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Geen deelbare bestanden gevonden in map: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "%i bekend gedeeld bestand gevonden"
+msgstr[1] "%i bekende gedeelde bestanden gevonden"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8058,6 +8085,16 @@ msgid "aMule text client"
 msgstr "aMule tekstclient"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Verwijderen van bestand: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Verder gaan met uploads van bestand: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Oude AICH-hashsets in '%s' worden omgezet in 64b in '%s'."
@@ -8906,6 +8943,12 @@ msgstr "aMule lijkt te worden uitgevoerd. Sluit het en voer het verwijderprogram
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Gebruikersgegevens op $APPDATA\\aMule worden verwijderd..."
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "%i bekend gedeeld bestand gevonden, %i onbekend"
+#~ msgstr[1] "%i bekende gedeelde bestanden gevonden, %i onbekend"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3211,6 +3211,11 @@ msgstr "ÅTVARING: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7110,6 +7115,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7124,13 +7136,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Fann %i kjend delt fil"
 msgstr[1] "Fann %i kjende delte filer"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Fann %i kjend delt fil, %i ukjend"
-msgstr[1] "Fann %i kjende delte filer, %i ukjende"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7153,6 +7158,28 @@ msgstr "tenar ikkje funnen: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Feil under lagring av known.met fila: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Lastar server.met fila: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Fann %i kjend delt fil"
+msgstr[1] "Fann %i kjende delte filer"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8173,6 +8200,16 @@ msgid "aMule text client"
 msgstr "aMule tekstklient"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Slettar fila: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Held fram opplastingar av fila: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konverterer gamle AICH hashsett i '%s'·til·64b·i·'%s'."
@@ -9015,6 +9052,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Fann %i kjend delt fil, %i ukjend"
+#~ msgstr[1] "Fann %i kjende delte filer, %i ukjende"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3205,6 +3205,11 @@ msgstr "OSTRZEŻENIE: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7112,6 +7117,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7127,14 +7140,6 @@ msgid_plural "Found %i known shared files"
 msgstr[0] "Znaleziono %i znany udostępniony plik"
 msgstr[1] "Znaleziono %i znane udostępnionych plików"
 msgstr[2] "Znaleziono %i znanych udostępnionych plików"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Znaleziono %i znany udostępniony plik, %i nieznanych"
-msgstr[1] "Znaleziono %i znane udostępnionych plików, %i nieznanych"
-msgstr[2] "Znaleziono %i znanych udostępnionych plików, %i nieznanych"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7158,6 +7163,29 @@ msgstr "Nie znaleziono katalogu udostępnionego, pomijam: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Błąd podczas zapisywania pliku %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Otwieram plik server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Znaleziono %i znany udostępniony plik"
+msgstr[1] "Znaleziono %i znane udostępnionych plików"
+msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8161,6 +8189,16 @@ msgid "aMule text client"
 msgstr "Tekstowy klient aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Usuwanie pliku: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Wznawianie wysyłania pliku: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konwertuję stare zestawy skrótów AICH w '%s' do 64b w '%s'."
@@ -9003,6 +9041,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Znaleziono %i znany udostępniony plik, %i nieznanych"
+#~ msgstr[1] "Znaleziono %i znane udostępnionych plików, %i nieznanych"
+#~ msgstr[2] "Znaleziono %i znanych udostępnionych plików, %i nieznanych"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3188,6 +3188,11 @@ msgstr "CUIDADO: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7005,6 +7010,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Monitor de diretórios compartilhados: estouro/erro do backend (%s); recorrendo ao recarregamento completo"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Monitor de diretórios compartilhados: eventos descartados pelo backend; forçando um recarregamento completo dos arquivos compartilhados para ressincronizar"
 
@@ -7019,13 +7031,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Encontrado %i arquivo conhecido compartilhado"
 msgstr[1] "Encontrados %i arquivos conhecidos compartilhados"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Encontrado %i arquivo conhecido, %i desconhecido"
-msgstr[1] "Encontrados %i arquivos conhecidos, %i desconhecidos"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7048,6 +7053,28 @@ msgstr "Diretório compartilhado não encontrado, pulando: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Erro ao salvar arquivo %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Carregando arquivo server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Encontrado %i arquivo conhecido compartilhado"
+msgstr[1] "Encontrados %i arquivos conhecidos compartilhados"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8060,6 +8087,16 @@ msgid "aMule text client"
 msgstr "Cliente em modo texto do aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Apagando arquivo: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Continuando uploads para o arquivo: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Convertendo hashsets AICH antigos de '%s' para 64b em '%s'."
@@ -8905,6 +8942,12 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Encontrado %i arquivo conhecido, %i desconhecido"
+#~ msgstr[1] "Encontrados %i arquivos conhecidos, %i desconhecidos"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3197,6 +3197,11 @@ msgstr "AVISO: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7081,6 +7086,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7095,13 +7107,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
 msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Encontrado %i ficheiro partilhado conhecido, %i desconhecido"
-msgstr[1] "Encontrados %i ficheiros partilhados conhecidos, %i desconhecidos"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7124,6 +7129,28 @@ msgstr "Pasta partilhada não encontrada, a ignorar: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Erro ao gravar ficheiro %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "A carregar o ficheiro server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Encontrado %i ficheiro partilhado conhecido"
+msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8122,6 +8149,16 @@ msgid "aMule text client"
 msgstr "Cliente de texto do aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "A eliminar o ficheiro: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "A continuar uploads do ficheiro: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Conversão de grupos de chaves AICH antigas em '%s' para 64b em '%s'."
@@ -8963,6 +9000,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Encontrado %i ficheiro partilhado conhecido, %i desconhecido"
+#~ msgstr[1] "Encontrados %i ficheiros partilhados conhecidos, %i desconhecidos"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3200,6 +3200,11 @@ msgstr "ATENȚIE:"
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7093,6 +7098,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7108,14 +7121,6 @@ msgid_plural "Found %i known shared files"
 msgstr[0] "S-a găsit %i fișier partajat cunoscut"
 msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
 msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "S-a găsit %i fișier partajat cunoscut, %i necunoscut"
-msgstr[1] "S-au găsit %i fișiere partajate cunoscute, %i necunoscute"
-msgstr[2] "S-au găsit %i de fișiere partajate cunoscute, %i necunoscute"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7139,6 +7144,29 @@ msgstr "Directorul partajat nu a fost găsit, se omite: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Eroare în timpul salvării fișierului %s : %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Se încarcă fișierul server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "S-a găsit %i fișier partajat cunoscut"
+msgstr[1] "S-au găsit %i fișiere partajate cunoscute"
+msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8140,6 +8168,16 @@ msgid "aMule text client"
 msgstr "client text aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Se șterge fișierul: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Se reia încărcarea fișierului: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Se convertește vechile indexări AICH în '%s' la 64b în '%s'."
@@ -8981,6 +9019,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "S-a găsit %i fișier partajat cunoscut, %i necunoscut"
+#~ msgstr[1] "S-au găsit %i fișiere partajate cunoscute, %i necunoscute"
+#~ msgstr[2] "S-au găsit %i de fișiere partajate cunoscute, %i necunoscute"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3210,6 +3210,11 @@ msgstr "ПРЕДУПРЕЖДЕНИЕ: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7059,6 +7064,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Наблюдатель общих папок: переполнение или ошибка бэкенда (%s); переход к полной переподгрузке"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Наблюдатель общих папок: бэкенд потерял события, принудительная полная переподгрузка общих файлов для синхронизации"
 
@@ -7074,14 +7087,6 @@ msgid_plural "Found %i known shared files"
 msgstr[0] "Найден %i известный публикуемый файл"
 msgstr[1] "Найдено %i известных публикуемых файла"
 msgstr[2] "Найдено %i известных публикуемых файлов"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Найден %i известный публикуемый файл, %i неизвестных"
-msgstr[1] "Найдено %i известных публикуемых файла, %i неизвестных"
-msgstr[2] "Найдено %i известных публикуемых файлов, %i неизвестных"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7106,6 +7111,29 @@ msgstr "Публикуемая директория не найдена, про�
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Нет публикуемых файлов в директории: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Ошибка при сохранении файла %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Подгрузка файла server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Нет публикуемых файлов в директории: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Найден %i известный публикуемый файл"
+msgstr[1] "Найдено %i известных публикуемых файла"
+msgstr[2] "Найдено %i известных публикуемых файлов"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8124,6 +8152,16 @@ msgid "aMule text client"
 msgstr "Текстовый клиент aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Удаление файла: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Возобновление отдачи файла: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Преобразование старых наборов хешей AICH в «%s» в 64-битные в «%s»."
@@ -8971,6 +9009,13 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Найден %i известный публикуемый файл, %i неизвестных"
+#~ msgstr[1] "Найдено %i известных публикуемых файла, %i неизвестных"
+#~ msgstr[2] "Найдено %i известных публикуемых файлов, %i неизвестных"
 
 #~ msgid " MB/s"
 #~ msgstr " МБ/с"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3221,6 +3221,11 @@ msgstr "OPOZORILO: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7132,6 +7137,15 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7148,15 +7162,6 @@ msgstr[0] "Najdenih %i znanih deljenih datotek"
 msgstr[1] "Najdena %i znana deljena datoteka"
 msgstr[2] "Najdeni %i znani deljeni datoteki"
 msgstr[3] "Najdene %i znane deljene datoteke"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Najdenih %i znanih deljenih datotek, %i neznanih"
-msgstr[1] "Najdena %i znana deljena datoteka, %i neznanih"
-msgstr[2] "Najdeni %i znani deljeni datoteki, %i neznanih"
-msgstr[3] "Najdene %i znane deljene datoteke, %i neznanih"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7181,6 +7186,30 @@ msgstr "Deljene mape ni bilo moč najti, preskakujem: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Napaka med shranjevanjem datoteke %s: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Nalaganje datoteke server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Najdenih %i znanih deljenih datotek"
+msgstr[1] "Najdena %i znana deljena datoteka"
+msgstr[2] "Najdeni %i znani deljeni datoteki"
+msgstr[3] "Najdene %i znane deljene datoteke"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8180,6 +8209,16 @@ msgid "aMule text client"
 msgstr "aMule besedilni odjemalec"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Brisanje datoteke: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Nadaljevanje ppošiljanja za datoteko: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Pretvarjanje starih naborov kod NIRP v »%s« v 64b v »%s«."
@@ -9021,6 +9060,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Najdenih %i znanih deljenih datotek, %i neznanih"
+#~ msgstr[1] "Najdena %i znana deljena datoteka, %i neznanih"
+#~ msgstr[2] "Najdeni %i znani deljeni datoteki, %i neznanih"
+#~ msgstr[3] "Najdene %i znane deljene datoteke, %i neznanih"
 
 #~ msgid " MB/s"
 #~ msgstr " MiB/s"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3205,6 +3205,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7100,6 +7105,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7114,13 +7126,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "U gjend %i fail i njohur i ndare"
 msgstr[1] "U gjenden %i faile te njohura te ndara"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "U gjenden %i faile te njohur te ndare, %i te panjohura"
-msgstr[1] "U gjenden %i faile te njohura te ndara,%i te panjohura"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7143,6 +7148,28 @@ msgstr "Serveri nuk u gjend: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Gabim duke shpetuar failin known.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Duke ngarkuar failin e server.met: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "U gjend %i fail i njohur i ndare"
+msgstr[1] "U gjenden %i faile te njohura te ndara"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8152,6 +8179,16 @@ msgid "aMule text client"
 msgstr "Teksti i klientit aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Duke fshire failin: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Rimarrja e ngarkimeve te failit: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Duke kembyer hashsetet e vjetra AICH ne '%s' 64b ne '%s'."
@@ -8986,6 +9023,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "U gjenden %i faile te njohur te ndare, %i te panjohura"
+#~ msgstr[1] "U gjenden %i faile te njohura te ndara,%i te panjohura"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3189,6 +3189,11 @@ msgstr "VARNING: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7068,6 +7073,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7082,13 +7094,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Hittade %i känd delad fil"
 msgstr[1] "Hittade %i kända delad filer"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Hittade %i känd delad fil, %i okänd"
-msgstr[1] "Hittade %i kända delade filer, %i okänd"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7111,6 +7116,28 @@ msgstr "Delad mapp hittades inte, hoppar över: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Inga delbara filer hittade i mappen: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Fel vid sparandet av %s fil: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Laddar server.met fil: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Inga delbara filer hittade i mappen: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Hittade %i känd delad fil"
+msgstr[1] "Hittade %i kända delad filer"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8110,6 +8137,16 @@ msgid "aMule text client"
 msgstr "aMule textklient"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Tar bort fil: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Återupptar uppladdning av filen: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Konvertera gamla AICH-hashsets i '%s' till 64b i '%s'."
@@ -8951,6 +8988,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Hittade %i känd delad fil, %i okänd"
+#~ msgstr[1] "Hittade %i kända delade filer, %i okänd"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3095,6 +3095,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6864,6 +6869,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6876,13 +6888,6 @@ msgstr ""
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6907,6 +6912,28 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "பயனர் %s (%u) பகிர்ந்த கோப்பகம் '%s'"
+msgstr[1] "பயனர் %s (%u) பகிர்ந்த கோப்பகம் '%s'"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -7858,6 +7885,16 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3180,6 +3180,11 @@ msgstr "UYARI: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6997,6 +7002,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "Paylaşılan dizin izleyici: arka uç taşması/hatası (%s); tam yeniden yüklemeye geri dönülüyor"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "Paylaşılan dizin izleyici: arka uç tarafından atlanan olaylar mevcut ve bu, eşleşmeyi tekrar sağlamak için paylaşılan dosyaların tamamen yeniden yüklenmesini zorluyor"
 
@@ -7011,13 +7023,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "Bilinen %i adet paylaşılmış dosya bulundu"
 msgstr[1] "Bilinen %i adet paylaşılmış dosya bulundu"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Bilinen %i adet paylaşılmış dosya bulundu. Bilinmeyen %i adet"
-msgstr[1] "Bilinen %i adet paylaşılmış dosya bulundu. Bilinmeyen %i adet"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7040,6 +7045,28 @@ msgstr "Paylaşılan dizin bulunamadı, atlanıyor: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "%s dosyası kaydedilirken hata: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Server.met dosyası yükleniyor: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Bilinen %i adet paylaşılmış dosya bulundu"
+msgstr[1] "Bilinen %i adet paylaşılmış dosya bulundu"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8052,6 +8079,16 @@ msgid "aMule text client"
 msgstr "aMule metin aracı"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Dosya siliniyor: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Şu dosya için gönderimler sürdürülüyor: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "'%s' içindeki eski AICH adresleme setleri '%s' içindeki 64 b'ye çevriliyor."
@@ -8897,6 +8934,12 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Bilinen %i adet paylaşılmış dosya bulundu. Bilinmeyen %i adet"
+#~ msgstr[1] "Bilinen %i adet paylaşılmış dosya bulundu. Bilinmeyen %i adet"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3221,6 +3221,11 @@ msgstr "ЗАСТЕРЕЖЕННЯ: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7137,6 +7142,14 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7152,14 +7165,6 @@ msgid_plural "Found %i known shared files"
 msgstr[0] "Знайдено %i новий спільний файл"
 msgstr[1] "Знайдено %i нові спільні файли"
 msgstr[2] "Знайдено %i нових спільних файлів"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "Знайдено %i відомий спільний файл, невідомих - %i"
-msgstr[1] "Знайдено %i відомі спільні файли, невідомих - %i"
-msgstr[2] "Знайдено %i відомих спільних файли, невідомих - %i"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7183,6 +7188,29 @@ msgstr "Спільна тека не знайдена, пропускаємо: %
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Не знайдені спільні файли в теці: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "Помилка під час збереження файлу known.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "Завантажую файл server.met: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "Не знайдені спільні файли в теці: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "Знайдено %i новий спільний файл"
+msgstr[1] "Знайдено %i нові спільні файли"
+msgstr[2] "Знайдено %i нових спільних файлів"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 #, fuzzy
@@ -8208,6 +8236,16 @@ msgid "aMule text client"
 msgstr "Текстовий клієнт aMule"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "Видаляється файл: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "Відновлюється вивантаження файлу: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "Перетворюється старий набір хешів AICH в '%s' до 64b в '%s'."
@@ -9050,6 +9088,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "Знайдено %i відомий спільний файл, невідомих - %i"
+#~ msgstr[1] "Знайдено %i відомі спільні файли, невідомих - %i"
+#~ msgstr[2] "Знайдено %i відомих спільних файли, невідомих - %i"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3094,6 +3094,11 @@ msgstr ""
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6863,6 +6868,12 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -6875,13 +6886,6 @@ msgstr ""
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6906,6 +6910,27 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] ""
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -7855,6 +7880,16 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing file: %s"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Rebuilding AICH hashset for file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3184,6 +3184,11 @@ msgstr "警告: "
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7001,6 +7006,13 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr "共享目录监测：后端溢出/错误 (%s); 回退到完整加载"
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr "共享目录监测：事件被后端丢弃，强制完整的共享文件重加载以重新同步"
 
@@ -7015,13 +7027,6 @@ msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "发现 %i 个已知共享文件"
 msgstr[1] "发现 %i 个已知共享文件"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "发现 %i 个已知共享的文件， %i 个未知"
-msgstr[1] "发现 %i 个已知共享的文件， %i 个未知"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7044,6 +7049,28 @@ msgstr "找不到共享目录，跳过：%s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "在目录中没有找到可以共享的文件：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "保存 %s 文件时发生错误：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "正在载入 server.met 文件：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "在目录中没有找到可以共享的文件：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "发现 %i 个已知共享文件"
+msgstr[1] "发现 %i 个已知共享文件"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8053,6 +8080,16 @@ msgid "aMule text client"
 msgstr "aMule 文本客户端"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "正在删除文件: %s"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "继续上传此文件: %s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "正把 “%s” 中旧的 AICH 校验和集转换为 “%s” 中的 64b。"
@@ -8898,6 +8935,12 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "发现 %i 个已知共享的文件， %i 个未知"
+#~ msgstr[1] "发现 %i 个已知共享的文件， %i 个未知"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 20:10+0200\n"
+"POT-Creation-Date: 2026-08-21 21:31+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3182,6 +3182,11 @@ msgstr "警告："
 
 #: src/MediaProbe.cpp
 msgid "Media metadata: no ffprobe binary found. Install ffmpeg, or set the ffprobe path in preferences; length, bitrate and codec will not be extracted."
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Extracting media metadata with ffprobe: %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7051,6 +7056,12 @@ msgid "Shared-dir watcher: backend overflow/error (%s); falling back to full rel
 msgstr ""
 
 #: src/SharedDirWatcher.cpp
+#, c-format
+msgid "Shared-dir watcher: %u new subdirectory found since last run, rescanning shares"
+msgid_plural "Shared-dir watcher: %u new subdirectories found since last run, rescanning shares"
+msgstr[0] ""
+
+#: src/SharedDirWatcher.cpp
 msgid "Shared-dir watcher: events dropped by backend, forcing a full shared-files reload to resync"
 msgstr ""
 
@@ -7064,12 +7075,6 @@ msgstr "正在加入分享檔案 %s"
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] "找到 %i 個已知的分享檔案"
-
-#: src/SharedFileList.cpp
-#, c-format
-msgid "Found %i known shared file, %i unknown"
-msgid_plural "Found %i known shared files, %i unknown"
-msgstr[0] "發現 %i 個已知、%i 個不明的分享檔案"
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7091,6 +7096,27 @@ msgstr "找不到分享目錄，略過：%s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "目錄中找不到可分享的檔案：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing file: %s"
+msgstr "儲存 %s 時發生錯誤：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing removed file: %s"
+msgstr "正在載入 server.met 檔案：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u files under removed directory: %s"
+msgstr "目錄中找不到可分享的檔案：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Discovered %u new shared file"
+msgid_plural "Discovered %u new shared files"
+msgstr[0] "找到 %i 個已知的分享檔案"
 
 #: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "User Name"
@@ -8085,6 +8111,16 @@ msgid "aMule text client"
 msgstr "aMule 文字模式客戶端"
 
 #: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing file: %s"
+msgstr "正刪除檔案：%s "
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Rebuilding AICH hashset for file: %s"
+msgstr "繼續上傳檔案：%s"
+
+#: src/ThreadTasks.cpp
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr "將 %s 的舊 AICH hash 值組轉換為 %s 的 64b 格式。"
@@ -8926,6 +8962,11 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, c-format
+#~ msgid "Found %i known shared file, %i unknown"
+#~ msgid_plural "Found %i known shared files, %i unknown"
+#~ msgstr[0] "發現 %i 個已知、%i 個不明的分享檔案"
 
 #, fuzzy
 #~ msgid " MB/s"

--- a/src/MediaProbe.cpp
+++ b/src/MediaProbe.cpp
@@ -462,6 +462,19 @@ bool Probe(const wxString &ffprobePath,
 		return false;
 	}
 
+	// A job is queued only once hashing has finished, so the file existed
+	// moments ago -- but nothing re-checks between the queue and this worker
+	// picking the job up, and that gap widens whenever the probe queue backs
+	// up. Without this a file deleted in the meantime would be announced as
+	// being probed (issue #968) and then have a process spawned on it purely
+	// to fail. One stat is nothing against a fork+exec.
+	if (!file.FileExists()) {
+		AddDebugLogLineN(logMediaProbe,
+			CFormat(wxT("MediaProbe: %s vanished before probing, skipping")) %
+				file.GetPrintable());
+		return false;
+	}
+
 	// -show_entries constrains the output to what we care about: each stream's
 	// codec_name plus its codec_type (so we can prefer the video track's codec,
 	// then the audio track's, over subtitle / data streams), and the format-
@@ -480,9 +493,14 @@ bool Probe(const wxString &ffprobePath,
 	argv.Add(wxT("default=nk=0:nw=1"));
 	argv.Add(file.GetRaw());
 
-	// Traced under the dedicated logMediaProbe category so a subsystem that
-	// silently shells out to ffprobe is diagnosable when the category is on.
-	AddDebugLogLineN(logMediaProbe, CFormat(wxT("MediaProbe: probing %s")) % file.GetPrintable());
+	// Info level, not debug: media metadata is a feature the user explicitly
+	// enables and points at a binary, and until now got no feedback that it
+	// was being used, that the binary worked, or which file was being probed
+	// -- the debug trace this replaces is compiled out of release builds
+	// (issue #968). Emitted here, immediately before the spawn, so it fires
+	// once per actual ffprobe execution rather than once per queued job; the
+	// queue-time trace in SharedFileList stays at debug level.
+	AddLogLineN(CFormat(_("Extracting media metadata with ffprobe: %s")) % file.GetPrintable());
 
 	// Bounded + killable: this runs on the dedicated CMediaProbeThread, so a
 	// slow/hung ffprobe can only ever delay other probes — never completions.

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -96,7 +96,6 @@ CSharedDirWatcher::CSharedDirWatcher(CSharedFileList *parent)
 : m_parent(parent)
 , m_watcher(NULL)
 , m_debounceTimer(this, ID_FSWATCHER_DEBOUNCE)
-, m_fallbackPending(false)
 #ifdef __APPLE__
 , m_macPumpTimer(this, ID_FSWATCHER_MAC_PUMP)
 #endif
@@ -306,7 +305,7 @@ void CSharedDirWatcher::OnFileSystemEvent(wxFileSystemWatcherEvent &event)
 				      "falling back to full reload")) %
 			    (event.GetErrorDescription().IsEmpty() ? wxString("unspecified")
 								   : event.GetErrorDescription()));
-		m_fallbackPending = true;
+		m_resyncReason = ResyncDroppedEvents;
 		ScheduleProcessing();
 		return;
 	}
@@ -605,9 +604,10 @@ void CSharedDirWatcher::ColdDiscoverSubdirs()
 	// list doesn't yet reflect the newly-discovered subdirs. We
 	// can't enumerate them via per-file events (they happened while
 	// the watcher was offline), so route through the fallback path:
-	// FlushPendingEvents will see m_fallbackPending and call the
+	// FlushPendingEvents will see m_resyncReason and call the
 	// bulk Reload() once the debounce fires.
-	m_fallbackPending = true;
+	m_resyncReason = ResyncColdDiscovery;
+	m_coldDiscoveredDirs = static_cast<unsigned>(discovered.size());
 	ScheduleProcessing();
 }
 
@@ -652,11 +652,25 @@ void CSharedDirWatcher::FlushPendingEvents()
 	// delivered. Drop the queue and fall back to a full Reload, which
 	// re-syncs everything from scratch at the cost of one expensive
 	// re-walk. Log at error level so the user sees it.
-	if (m_fallbackPending) {
-		AddLogLineC(_("Shared-dir watcher: events dropped by backend, "
-			      "forcing a full shared-files reload to resync"));
+	if (m_resyncReason != ResyncNone) {
+		if (m_resyncReason == ResyncColdDiscovery) {
+			// Routine, not a fault: directories appeared while aMule was off.
+			// Reported at info level and saying what actually happened, so the
+			// extra share rescan right after startup has a stated reason
+			// instead of looking like an unexplained second scan.
+			AddLogLineN(CFormat(wxPLURAL("Shared-dir watcher: %u new subdirectory found "
+						     "since last run, rescanning shares",
+					    "Shared-dir watcher: %u new subdirectories found "
+					    "since last run, rescanning shares",
+					    m_coldDiscoveredDirs)) %
+				    m_coldDiscoveredDirs);
+		} else {
+			AddLogLineC(_("Shared-dir watcher: events dropped by backend, "
+				      "forcing a full shared-files reload to resync"));
+		}
 		m_pendingEvents.clear();
-		m_fallbackPending = false;
+		m_resyncReason = ResyncNone;
+		m_coldDiscoveredDirs = 0;
 		// Scheduled: this flush runs on the core event loop, so an inline walk
 		// would block it (and any EC request behind it) for the walk's length.
 		m_parent->RequestReload();

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -101,7 +101,7 @@ private:
 	void ScheduleProcessing();
 
 	// Walk m_pendingEvents and apply each one to CSharedFileList via
-	// NotifyPathAdded/Removed/Modified. Skipped if m_fallbackPending
+	// NotifyPathAdded/Removed/Modified. Skipped if a resync is owed
 	// was set by a wxFSW_EVENT_WARNING / _ERROR event since the last
 	// flush -- in that case we fall back to the bulk Reload() because
 	// the watcher backend has signalled it dropped events and we
@@ -161,12 +161,40 @@ private:
 	// debounce flush. RENAME stores the destination in `renamedTo`.
 	std::unordered_map<wxString, PendingPathEvents> m_pendingEvents;
 
-	// Set when the watcher backend reports overflow / drop (inotify
-	// queue overflow, kqueue race, Windows ReadDirectoryChangesW
-	// buffer exhaust). FlushPendingEvents() responds by calling the
-	// bulk Reload() because incremental state can no longer be
-	// trusted. Cleared after the fallback fires.
-	bool m_fallbackPending;
+	// Why a full-reload resync is owed; cleared once the fallback fires.
+	//
+	// ResyncDroppedEvents means the watcher backend reported overflow or drop
+	// (inotify queue overflow, kqueue race, Windows ReadDirectoryChangesW
+	// buffer exhaust). FlushPendingEvents() responds with the bulk Reload()
+	// because the per-path deltas can no longer be trusted -- a real fault,
+	// and logged as one.
+	//
+	// ResyncColdDiscovery means subdirectories simply appeared while aMule was
+	// not running. Nothing failed. Both reasons used to share one bool and so
+	// one message, which would have reported this routine case as a watcher
+	// failure, in red.
+	//
+	// That is hard to provoke in practice: CPreferences::ReloadSharedFolders
+	// expands recursive roots into the shared-dir union and the startup Reload
+	// runs before the watcher is enabled, so ColdDiscoverSubdirs normally
+	// finds nothing left to discover -- adding subdirectories while aMule is
+	// stopped and restarting does *not* produce the wrong message (verified
+	// against the pre-change build). What remains is the narrow window where a
+	// directory appears between that Reload and Enable(), plus whatever the
+	// expansion skips. Separating the reasons is cheap and means that if the
+	// path is ever reached it says what happened rather than blaming the
+	// backend (issue #968).
+	enum ResyncReason
+	{
+		ResyncNone,
+		//! Backend overflow/error: per-path deltas untrustworthy.
+		ResyncDroppedEvents,
+		//! New subdirs found at startup; nothing failed.
+		ResyncColdDiscovery,
+	};
+	ResyncReason m_resyncReason = ResyncNone;
+	//! Subdirectory count for the ResyncColdDiscovery message.
+	unsigned m_coldDiscoveredDirs = 0;
 #ifdef __APPLE__
 	wxTimer m_macPumpTimer;
 #endif

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -447,24 +447,27 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 		}
 	}
 
-	if (addedFiles == 0) {
-		AddLogLineN(
-			CFormat(wxPLURAL(
-				"Found %i known shared file", "Found %i known shared files", GetCount())) %
-			GetCount());
+	// One unconditional summary. The new-file count used to ride along as a
+	// suffix here, in one of two mutually exclusive variants, and only for this
+	// route -- the watcher reported nothing at all. It now has its own line,
+	// emitted from Process() for both routes (issue #968), so this says one
+	// thing and the two-argument variant is retired. That also drops a msgid
+	// whose plural form was selected on GetCount() rather than on the count it
+	// was actually pluralising.
+	AddLogLineN(
+		CFormat(wxPLURAL("Found %i known shared file", "Found %i known shared files", GetCount())) %
+		GetCount());
 
+	if (addedFiles == 0) {
 		// Make sure the AICH-hashes are up to date. This is the startup sync
 		// run once the shared/known list is authoritative, so it opts into the
 		// orphan-prune (drop known2_64.met entries no longer owned by any known
 		// file). Post-hashing syncs deliberately do not prune -- see
 		// CAICHSyncTask's ctor doc.
+		//
+		// Unchanged condition: this scheduling has nothing to do with logging
+		// and must keep firing exactly when it did before.
 		CThreadScheduler::AddTask(new CAICHSyncTask(true));
-	} else {
-		// New files, AICH thread will be run at the end of the hashing thread.
-		AddLogLineN(CFormat(wxPLURAL("Found %i known shared file, %i unknown",
-				    "Found %i known shared files, %i unknown",
-				    GetCount())) %
-			    GetCount() % addedFiles);
 	}
 
 	if (excluded > 0) {
@@ -641,6 +644,9 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 	AddDebugLogLineN(logKnownFiles, CFormat("Hashing new unknown shared file '%s'") % fname);
 
 	hashTasks.push_back(new CHashingTask(directory, fname));
+	// This branch *is* the definition of "a new file was discovered", and it is
+	// the one point both discovery routes pass through (issue #968).
+	++m_discoveredNewFiles;
 	return kAddPathQueued;
 }
 
@@ -921,6 +927,20 @@ void CSharedFileList::NotifyPathAdded(const wxString &fullPath)
 		}
 		break;
 	case kAddPathKnown:
+		// A file already in known.met, moved or renamed into a shared
+		// directory: nothing is hashed and nothing is probed, so without this
+		// the file would silently become shared and be published to peers with
+		// no info-level record at all (issue #968).
+		//
+		// Deliberately here and not inside AddPathToShares, which the bulk walk
+		// also calls: there the already-known case is the overwhelming majority
+		// of entries, and one line per file would bury everything else under
+		// thousands of "nothing happened" lines on every rescan. The watcher
+		// path is different in kind -- it is an event, it fires at
+		// unpredictable times, its volume is bounded by real filesystem
+		// activity rather than by tree size, and no summary line covers it.
+		AddLogLineN(CFormat(_("Now sharing file: %s")) % fullPath);
+		break;
 	case kAddPathExcluded:
 	case kAddPathSkipped:
 		// AddPathToShares already wrote a debug log line; no
@@ -948,6 +968,9 @@ void CSharedFileList::NotifyPathRemoved(const wxString &fullPath)
 		file = it->second;
 	}
 
+	// Symmetric with "Now sharing file" above: a shared file disappearing
+	// behind the user's back is at least as interesting as one appearing.
+	AddLogLineN(CFormat(_("Stopped sharing removed file: %s")) % fullPath);
 	AddDebugLogLineN(
 		logKnownFiles, CFormat("Watcher: detaching deleted file '%s' from shares") % fullPath);
 	RemoveFile(file);
@@ -985,6 +1008,23 @@ void CSharedFileList::NotifyDirRemoved(const wxString &dirPath)
 		return;
 	}
 
+	// One summary line, not one per file: a removed subtree can hold thousands
+	// of files and the count is already in hand.
+	//
+	// The count is what this call actually detached, which on some backends is
+	// only part of the subtree. macOS FSEvents delivers per-file DELETEs racing
+	// the directory DELETE, so NotifyPathRemoved above already detached some
+	// files individually (each with its own line) and only the remainder is
+	// left for this sweep -- removing a 6-file directory was observed as four
+	// per-file lines plus a summary saying two. Every file is still logged
+	// exactly once and none is double-counted, so the accounting is right even
+	// though the shape is not the single tidy line it is on a backend that
+	// coalesces the subtree into one event. Reporting the directory's original
+	// size instead would be a lie about what this call did, and suppressing the
+	// per-file lines would mean losing them whenever the directory event never
+	// arrives at all.
+	AddLogLineN(CFormat(_("Stopped sharing %u files under removed directory: %s")) %
+		    static_cast<unsigned>(victims.size()) % dirPath);
 	AddDebugLogLineN(logKnownFiles,
 		CFormat("Watcher: detaching %zu shared file(s) under removed dir '%s'") % victims.size() %
 			dirPath);
@@ -1402,6 +1442,19 @@ void CSharedFileList::Process()
 		m_reloadPending = false;
 		Reload();
 	}
+
+	// Flushed after the drain above, so that when a reload runs on this tick
+	// its count is printed immediately after its own "Found N known shared
+	// files" summary rather than arriving a second later, detached from it.
+	// Only when non-zero: a pass that discovered nothing says nothing.
+	if (m_discoveredNewFiles) {
+		AddLogLineN(CFormat(wxPLURAL("Discovered %u new shared file",
+				    "Discovered %u new shared files",
+				    m_discoveredNewFiles)) %
+			    m_discoveredNewFiles);
+		m_discoveredNewFiles = 0;
+	}
+
 	Publish();
 	if (!m_lastPublishED2KFlag || (::GetTickCount64() - m_lastPublishED2K < ED2KREPUBLISHTIME)) {
 		return;

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -272,6 +272,18 @@ private:
 	// Set by RequestReload(), drained by Process(). See RequestReload().
 	bool m_reloadPending = false;
 
+	// New files discovered since the last Process() tick, counted at the one
+	// place discovery is actually decided (AddPathToShares' queued branch) so
+	// every route is covered without plumbing: the bulk walk, the watcher's
+	// create and rename handling, a newly appeared shared subdirectory, and
+	// the modify-treated-as-add path. Flushed once per tick, which coalesces
+	// a batch of files into a single line instead of one per file.
+	//
+	// A plain unsigned is enough: every increment and the flush run on the
+	// main thread (the bulk walk, the filesystem-watcher event handler and
+	// the core timer are all the main thread).
+	unsigned m_discoveredNewFiles = 0;
+
 	void SendListToServer();
 	uint64 m_lastPublishED2K;
 	bool m_lastPublishED2KFlag;

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -123,14 +123,34 @@ void CHashingTask::Entry()
 	knownfile->m_AvailPartFrequency.insert(
 		knownfile->m_AvailPartFrequency.begin(), knownfile->GetPartCount(), 0);
 
+	// Info level, not debug: AddDebugLogLineN compiles to nothing outside a
+	// debug build, so in the binaries users actually run there was no record
+	// at all that the client was reading every byte of a file (issue #968).
+	// Emitted here rather than where the task was queued, because tasks run
+	// serially on CThreadScheduler long after the directory walk that queued
+	// them -- a queue-time line would not say what is happening now. It sits
+	// after the open/length/size guards above, so a file that is skipped never
+	// claims to have been hashed.
+	//
+	// The full path, not m_filename: the same basename can exist in several
+	// shared directories, and "which file is it chewing on" is the question
+	// this line exists to answer.
 	if ((m_toHash & EH_MD4) && (m_toHash & EH_AICH)) {
 		knownfile->GetAICHHashset()->FreeHashSet();
+		AddLogLineN(CFormat(_("Hashing file: %s")) % fullPath);
 		AddDebugLogLineN(
 			logHasher, CFormat("Starting to create MD4 and AICH hash for file: %s") % m_filename);
 	} else if ((m_toHash & EH_MD4)) {
+		AddLogLineN(CFormat(_("Hashing file: %s")) % fullPath);
 		AddDebugLogLineN(logHasher, CFormat("Starting to create MD4 hash for file: %s") % m_filename);
 	} else if ((m_toHash & EH_AICH)) {
 		knownfile->GetAICHHashset()->FreeHashSet();
+		// Distinct wording: this fires for files discovered long ago whose AICH
+		// master hash is missing from known2_64.met, so calling it "hashing"
+		// would wrongly suggest the file was just found. After a known2_64.met
+		// loss this re-reads the entire library, which is exactly the silent
+		// multi-hour case worth a line.
+		AddLogLineN(CFormat(_("Rebuilding AICH hashset for file: %s")) % fullPath);
 		AddDebugLogLineN(
 			logHasher, CFormat("Starting to create AICH hash for file: %s") % m_filename);
 	} else {


### PR DESCRIPTION
Closes #968.

When aMule discovers and hashes new shared files, or shells out to `ffprobe` for media metadata, a release build says **nothing at all**. Not "filtered out by the log settings" — the trace statements are compiled out of the binary entirely, because `AddDebugLogLineN` expands to `do {} while(false)` unless `__DEBUG__`, and only a debug configuration defines it.

That is easy to confirm rather than take on trust: the string `"Starting to create MD4..."` does not appear in a release binary at all. A user sharing a large directory, or who has just pointed the preferences at an `ffprobe` binary, sees an idle-looking client that is in fact reading every file on disk and spawning a child process per media file.

## What this adds

Four info-level lines, each carrying the file's **full path** — the same basename can exist in several shared directories, and "which file is it chewing on" is the question these exist to answer.

| Line | Where | Why there |
|---|---|---|
| `Hashing file: %s` | `CHashingTask::Entry` | Where the work happens, not where the task was queued — tasks run serially long after the walk that queued them. After the open/length/size guards, so a skipped file never claims to have been hashed. |
| `Rebuilding AICH hashset for file: %s` | same, AICH-only branch | Fires for files discovered long ago. After a `known2_64.met` loss it re-reads the entire library; calling that "hashing" would wrongly suggest the files were newly found. |
| `Extracting media metadata with ffprobe: %s` | `MediaProbe::Probe` | Immediately before the spawn, so it fires once per actual execution rather than once per queued job. |
| `Now sharing file: %s` / `Stopped sharing removed file: %s` | watcher add/remove | The cases that do no work and so left no other trace — a file already in `known.met` moved into a shared directory silently became shared and was published to peers. |

Plus one summary line, `Discovered N new shared files`, counted in `AddPathToShares`' queued branch — the single point both discovery routes pass through — and flushed from the once-per-second tick, which coalesces a batch into one line. It replaces the old two-variant summary, whose new-file count rode along as a suffix and existed only for the bulk walk; the watcher route reported nothing at all. The retired msgid also had its plural selected on `GetCount()` rather than on the count it was pluralising. **The AICH sync scheduling condition is unchanged.**

The watcher's resync flag is also split into a reason, so a cold-discovered subdirectory is not reported as a backend failure — see the caveat below.

One extra fix fell out of the acceptance criteria: nothing re-checked that a file still existed between a probe being queued and the worker picking it up, and that gap widens whenever the probe queue backs up. Such a file is now skipped rather than announced and then handed to a doomed `fork`+`exec`.

## Verification

Everything was verified headlessly by running a **pre-fix and post-fix `amuled` side by side** on identical configs and fixtures, in **Release** builds — which matters, since the whole premise is that these traces vanish outside a debug build.

| Scenario | pre-fix | post-fix |
|---|---|---|
| First start, 8 new files (2 media) | `Hashing` 0, `ffprobe` 0 | `Hashing` **8**, `ffprobe` **2** |
| **Restart, unchanged tree** | 0 | **0 / 0 / 0**, still `Found 8 known shared files` |
| Drop 1 new `.mp3` into a running daemon | — | **1** hashing + **1** ffprobe, no reload needed |
| 0-byte file | — | **no line** — guards run first |
| 50 files via bulk walk | — | **one** `Discovered 50 new shared files` |
| 50 files dropped live (watcher) | — | **one**, identical wording |
| 1 file | — | `Discovered 1 new shared file` (singular) |
| 100-file unchanged restart | — | **zero** `Discovered` lines |
| Move a known file out, then back | — | `Stopped sharing removed file:` then `Now sharing file:`, nothing hashed |
| Delete `known2_64.met`, restart | — | **4 AICH-rebuild lines, 0 hashing lines** |

At scale, a 20 000-file first run:

- **stdout 0 bytes, 0 per-file lines on stdout or stderr** — `AddLogLineN`, not `...NS`.
- All **20 000** lines readable via `GET /api/v0/logs/amule`.
- `log_appended` SSE **batches**: 30 live files produced **2 events**, not 30; largest payload 5.6 KB.
- `/status`, `/shared/directories` and `/logs/amule` all `200` afterwards; 20 060 files served.
- Logfile grew to **4.0 MB**. That is the real cost of the feature: lines are strictly proportional to work genuinely being done, never timer-driven, but a large scan will push older lines out of the log ring buffer faster than before.

## Two caveats worth reading before approving

**The watcher resync split is defensive, not a demonstrated fix.** The issue expects that adding subdirectories while aMule is off produces a bogus critical `events dropped by backend` line at startup. It does not: `CPreferences::ReloadSharedFolders` expands recursive roots into the shared-dir union and the startup `Reload` runs before the watcher is enabled, so `ColdDiscoverSubdirs` finds nothing left to discover. I ran that exact scenario twice against the pre-change build and got a clean startup. What remains is the narrow window where a directory appears between that `Reload` and `Enable()`. The split is kept because two unrelated conditions sharing one flag and one message is a latent trap, but the code comment states plainly that the scenario was not reproducible, so nobody later mistakes it for a fixed live bug.

**Directory removal does not produce a single summary line on macOS.** FSEvents delivers per-file DELETEs racing the directory DELETE, so `NotifyPathRemoved` detaches some files individually before `NotifyDirRemoved` sweeps the rest. Removing a 6-file shared subdirectory was observed as four per-file lines plus a summary saying two. Every file is logged exactly once and none is double-counted, so the accounting is right — it just is not the single tidy line the issue expects, and it may well behave differently on inotify. Documented at the summary line rather than engineered around: reporting the directory's original size would be a lie about what that call did, and suppressing the per-file lines would lose them entirely whenever the directory event never arrives.

## Catalogs

8 new msgids, 1 retired. Unlike a pure-reference regeneration the counts do move, and the arithmetic is exact: per catalog, total msgids +7, with the single drop in *translated* being the retired string that had a translation — the 8 new ones land as 6 fuzzy (msgmerge matched them against similar existing strings) plus 2 untranslated. No existing translation is lost.
