### PR TITLE
fix(amuleapi): answer 503 before the first snapshot on the friends mutations

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5223,6 +5223,9 @@ CHttpServer::Response CApiDispatcher::HandleFriendAdd(const CHttpServer::Request
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
 	picojson::value root;
 	std::string parse_err;
 	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
@@ -5379,6 +5382,9 @@ CHttpServer::Response CApiDispatcher::HandleFriendRemove(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
 	std::uint32_t ecid = 0;
 	if (!ParseEcidPath(ecid_str, ecid)) {
 		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
@@ -5428,6 +5434,9 @@ CHttpServer::Response CApiDispatcher::HandleFriendPatch(
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
+
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
 
 	std::uint32_t ecid = 0;
 	if (!ParseEcidPath(ecid_str, ecid)) {


### PR DESCRIPTION
Follow-up to #986, from reviewing it after merge.

`POST /friends`, `DELETE /friends/{ecid}` and `PATCH /friends/{ecid}` resolve their target against the cached state - `FindClientByEcid` for the add-by-connected-peer form, `FindFriendByEcid` for the other two - and none checked that a snapshot had arrived first.

Before the first EC tick the cache is empty, so every lookup misses and all three answer:

```
404 not_found   "no friend with that ecid"
```

That tells the client the friend is **gone** when the truth is amuleapi **isn't ready yet**, and the two are not distinguishable from the response.

The reference **already documents `503 ec_unavailable`** for all three, and every sibling that resolves an ECID against the cache already guards (`HandleServerDelete`, `HandleServerConnect`, `HandleServerPatch`). So this is the code diverging from its own published contract - the same shape as #985's second bug - not an intentional difference. Docs need no change.

### The audit

Rather than fix only what I'd spotted by eye, I swept every `CApiDispatcher` handler for "reads a cached collection, has no `RequireSnapshot`, and does not go through `ListResponse`". Four hits:

| handler | verdict |
|---|---|
| `HandleFriendAdd` | fixed |
| `HandleFriendRemove` | fixed |
| `HandleFriendPatch` | fixed |
| `HandleBrowse` | **not a defect** - its only cache read fetches a peer's display name for `MarkSearchStarted`, and the code already notes a miss "simply leaves it empty". The browse itself is a pass-through to EC. |

Re-running the sweep after the fix leaves only `HandleBrowse`. `GET /friends` was never affected: it goes through `ListResponse`, which guards.

### Testing

Builds clean, `clang-format` clean, unit suite 34/34.

**No test accompanies this**, deliberately. The behaviour it changes is only observable *before* the first snapshot, and the curl suite waits that window out by design - `03-read-status.sh` polls up to 15 s for it to close. Nothing constructs `CApiDispatcher`/`CState` directly either. Same gap as #985's acceptance criterion 2; a pre-snapshot harness would be its own change.
