### PR TITLE
amuleapi: give GET /search a recency signal, and seed a discovered search's real state

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2371,9 +2371,9 @@ Lists every search amuled currently holds — including ones started by a **diff
 ```json
 {
   "searches": [
-    { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished" },
-    { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running"  },
-    { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running", "client_ecid": 621 }
+    { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished", "started_at": 1751000000 },
+    { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running",  "started_at": 1751000042 },
+    { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running",  "client_ecid": 621 }
   ]
 }
 ```
@@ -2381,6 +2381,10 @@ Lists every search amuled currently holds — including ones started by a **diff
 `search_id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
 
 `query` is the daemon's name for the search. For a `"browse"` that is **the peer's nickname**, not a query string — a browse has no query. `client_ecid` is the browsed peer's ecid and is present **only** on browse entries, so a consumer can tell whose share is being listed and cross-reference [`GET /clients`](#get-apiv0clients); it is omitted entirely on an ordinary search.
+
+`started_at` is the Unix second amuleapi started the search, and it is the **only recency signal on this list**: entries arrive ordered by `search_id`, and id order is not start order — Kad search ids carry a high-bit mask and therefore always sort above eD2k ones. Sort on `started_at` when you need "the newest search".
+
+It is **omitted** for any search this `amuleapi` process did not start itself — one begun by another client, by the desktop GUI, or restored from the daemon's on-disk ring after a restart. The daemon ships no timestamp of its own, so there is nothing to report for those; treat a missing `started_at` as *unknown*, not as oldest.
 
 amuled only tracks multiple concurrent searches for clients that advertise multi-search support; `amuleapi` does, so this always reflects the full live set. `searches` is an empty array when amuled holds no searches, never an error.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -6714,11 +6714,21 @@ bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
 		// here is what lets an adopted search report its own `query` instead
 		// of an empty one.
 		const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
+		// ...and its lifecycle state, which was being dropped and replaced
+		// with an assumed "active". A finished search seeded as running is
+		// not just cosmetic: POST /search/{id}/more rejects a finished
+		// search, so it would have accepted one until the next tick
+		// corrected the flag, and answered 202 for a request amuled turns
+		// into a no-op. 1 = running, 2 = finished (SearchLifecycleStateToString).
+		const CECTag *stateTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
+		const std::uint8_t state_val = stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0;
 		m_state.MarkSearchDiscovered(search_id,
 			SearchKindToString(
 				kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : EC_SEARCH_GLOBAL)
 				.ToStdString(),
-			nameTag ? std::string(nameTag->GetStringData().utf8_str()) : std::string());
+			nameTag ? std::string(nameTag->GetStringData().utf8_str()) : std::string(),
+			state_val == 1,
+			state_val == 2);
 		found = true;
 		break;
 	}
@@ -6755,8 +6765,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Reques
 	w.BeginArray();
 	for (const CECTag &entry : *ec_resp) {
 		w.BeginObject();
+		const std::uint32_t sid = static_cast<std::uint32_t>(entry.GetInt());
 		w.Key("search_id");
-		w.ValueInt(static_cast<int64_t>(entry.GetInt()));
+		w.ValueInt(static_cast<int64_t>(sid));
 		const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
 		w.Key("query");
 		w.ValueString(nameTag ? nameTag->GetStringData() : wxString());
@@ -6778,6 +6789,18 @@ CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Reques
 		if (const CECTag *clientTag = entry.GetTagByName(EC_TAG_CLIENT)) {
 			w.Key("client_ecid");
 			w.ValueInt(static_cast<int64_t>(clientTag->GetInt()));
+		}
+		// When THIS amuleapi started the search. The daemon ships no
+		// timestamp and hands its searches back id-ascending (the listing
+		// walks a std::map), and id order is not recency -- Kad ids carry
+		// SEARCH_ID_KAD_MASK and always sort above ed2k ones -- so without
+		// this a client has nothing to rank the list by. Omitted, not zeroed,
+		// for a search this process did not start: another client's, or one
+		// the daemon restored from disk. Those are unknowable here, and a 0
+		// would read as 1970 rather than "no idea".
+		if (const std::time_t started = m_state.SearchStartedAt(sid); started != 0) {
+			w.Key("started_at");
+			w.ValueInt(static_cast<int64_t>(started));
 		}
 		w.EndObject();
 	}

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -159,6 +159,13 @@ std::string CState::SearchQuery(std::uint32_t search_id) const
 	return it == m_searches.end() ? std::string() : it->second.query;
 }
 
+std::time_t CState::SearchStartedAt(std::uint32_t search_id) const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	auto it = m_searches.find(search_id);
+	return it == m_searches.end() ? 0 : it->second.started_at;
+}
+
 bool CState::ClaimSearchRefresh(std::uint32_t search_id, std::chrono::milliseconds ttl)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
@@ -250,11 +257,16 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind,
 	slot.progress.generation = next_generation;
 	slot.query = query;
 	slot.seq = ++m_search_seq;
+	slot.started_at = std::time(nullptr);
 	slot.last_fetch = {};
 	EvictSurplusSearchSlotsLocked();
 }
 
-void CState::MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind, const std::string &query)
+void CState::MarkSearchDiscovered(std::uint32_t search_id,
+	const std::string &kind,
+	const std::string &query,
+	bool active,
+	bool complete)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	auto known = m_searches.find(search_id);
@@ -271,7 +283,13 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id, const std::string &ki
 		return;
 	}
 	SearchSlot &slot = m_searches[search_id];
-	slot.progress.active = true;
+	// The daemon's own lifecycle state for this search, not an assumption.
+	// A finished search seeded as active reads as running until the next
+	// tick corrects it, and POST /search/{id}/more gates on exactly that.
+	// `started_at` stays 0: this session did not start it, and the daemon
+	// ships no timestamp to borrow.
+	slot.progress.active = active;
+	slot.progress.complete = complete;
 	slot.progress.kind = kind;
 	slot.query = query;
 	slot.seq = ++m_search_seq;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -797,6 +797,15 @@ struct SearchSlot
 	// exceeds its cap (a client that starts many searches without closing them
 	// would otherwise accumulate slots for the whole process lifetime).
 	std::uint64_t seq = 0;
+	// Wall-clock second this session started the search, for ranking the
+	// entries GET /search returns: that listing comes straight off
+	// EC_OP_SEARCH_LIST, which walks a std::map keyed by search_id and
+	// carries no timestamp, so it arrives id-ascending -- and id order is
+	// not recency, since Kad ids carry SEARCH_ID_KAD_MASK (0x80000000) and
+	// therefore always sort above ed2k ones. 0 for a search this session did
+	// not start (another client's, or one the daemon restored from disk),
+	// which is unknowable here rather than zero-valued.
+	std::time_t started_at = 0;
 	// When this slot's results were last pulled from the daemon. The tick
 	// refreshes active searches every second; a FINISHED search is never
 	// polled again, so reads of it refresh on demand instead, coalesced by
@@ -1375,6 +1384,10 @@ public:
 	// What this search was started with; empty for an unknown id, or for a
 	// discovered slot whose name the daemon had not reported yet.
 	std::string SearchQuery(std::uint32_t search_id) const;
+	// When this session started the search, or 0 when it did not start it
+	// (see SearchSlot::started_at). An unknown id reports 0 too; a caller
+	// that must tell those apart checks HasSearch first.
+	std::time_t SearchStartedAt(std::uint32_t search_id) const;
 	// Slots the refresher must still poll (progress.active).
 	std::vector<std::uint32_t> ActiveSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
@@ -1480,7 +1493,18 @@ public:
 	// MarkSearchStarted it is idempotent -- a search already known
 	// (self-started or previously discovered) is left untouched rather than
 	// having its accumulated results/progress reset.
-	void MarkSearchDiscovered(std::uint32_t search_id, const std::string &kind, const std::string &query);
+	// `active` / `complete` come from the lifecycle state the same
+	// EC_OP_SEARCH_LIST entry carries. Seeding them rather than assuming
+	// "active" matters because callers gate on them: POST /search/{id}/more
+	// rejects a finished search, and would otherwise accept one for the tick
+	// or so it took to be corrected. A slot seeded inactive is not polled by
+	// the tick, which is fine -- the read paths refresh an inactive slot on
+	// demand (ClaimSearchRefresh).
+	void MarkSearchDiscovered(std::uint32_t search_id,
+		const std::string &kind,
+		const std::string &query,
+		bool active,
+		bool complete);
 	// Refresher-side write path for one search's progress snapshot.
 	void WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s);
 	// Drop a search's slot entirely: DELETE /search/{id}, or the refresher

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -121,16 +121,25 @@ export default function Search({ isGuest }) {
     api.get("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
 
     // Adopt a search on mount so a reload (or a search started from another
-    // client) still shows something. GET /search lists every search the
-    // daemon holds, newest last in allocation order; prefer a running one,
-    // else take the last entry.
+    // client) still shows something.
+    //
+    // GET /search arrives id-ascending and id order is NOT recency: Kad
+    // search ids carry a high-bit mask, so a Kad search always sorts above
+    // an ed2k one no matter which ran first. Rank by `started_at` instead,
+    // which amuleapi stamps for the searches it started. Entries without it
+    // (another client's, or restored from the daemon's on-disk ring) rank
+    // last -- unknown, not oldest -- and only win if nothing else is on
+    // offer. Running beats finished either way, since that is the one a user
+    // is most likely still watching.
+    const newest = (list) =>
+      list.slice().sort((a, b) => (b.started_at || 0) - (a.started_at || 0))[0];
     const adopt = async () => {
       try {
         const r = await api.get("search");
         const list = r.searches || [];
         if (!list.length) return;
-        const running = list.filter((x) => x.state === "running").pop();
-        const chosen = running || list[list.length - 1];
+        const chosen = newest(list.filter((x) => x.state === "running")) || newest(list);
+        if (!chosen) return;
         searchId.current = chosen.search_id;
         fetchResults();
       } catch (_) { /* nothing to adopt */ }

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -211,6 +211,14 @@ _assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].kind" globa
 	'GET /search entry reports kind==global'
 _assert_json_eq "[[.searches[] | select(.search_id == $FIRST_SID)][0].state] | inside([\"running\",\"finished\"])" \
 	true 'GET /search entry state is running or finished (never idle for an active search)'
+# started_at is the list's only recency signal: entries arrive id-ascending
+# and id order is not start order (Kad ids carry a high-bit mask and sort
+# above ed2k ones), so a client that wants "the newest search" sorts on this.
+# Present because THIS amuleapi started the search.
+_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].started_at | type" number \
+	'GET /search stamps started_at on a search this session started'
+_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].started_at > 1700000000" \
+	true 'started_at is a plausible recent unix second, not 0'
 
 if [ "$HAVE_GUEST" = "1" ]; then
 	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/search"
@@ -254,6 +262,10 @@ if [ -n "$SECOND_TOKEN" ] && [ "$SECOND_TOKEN" != "null" ]; then
 	_assert_status 200 "second amuleapi instance: GET /search → 200"
 	_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)] | length" 1 \
 		'second amuleapi instance (never POSTed) still lists the first instance'"'"'s search'
+	# ...but cannot stamp it: that instance did not start the search and the
+	# daemon ships no timestamp, so the key is omitted rather than zeroed.
+	_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0] | has(\"started_at\")" \
+		false 'a foreign search carries no started_at (unknown, not 1970)'
 
 	_curl -H "Authorization: Bearer $SECOND_TOKEN" \
 		"http://$SECOND_HOST/api/v0/search/$FIRST_SID/results"

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -554,6 +554,56 @@ TEST(State, MultiSearchSlotsAreIndependentAndAddressable)
 	ASSERT_EQUALS(std::string("in-ten.iso"), s.Search(10).at(0).name);
 }
 
+TEST(State, SearchStartedAtStampsOnlyOurOwnSearches)
+{
+	// GET /search has no recency signal of its own: the daemon returns its
+	// searches id-ascending and ships no timestamp, and id order is not
+	// recency because Kad ids carry a high-bit mask and always sort above
+	// ed2k ones. `started_at` is what a client ranks by instead -- and it
+	// exists only for searches THIS session started.
+	CState s;
+	s.MarkSearchStarted(5, "global", "ubuntu");
+	const std::time_t ours = s.SearchStartedAt(5);
+	ASSERT_TRUE(ours != 0);
+
+	// A search another client started, adopted through discovery, has no
+	// start time we could know. 0 means "unknown", which is why the REST
+	// layer omits the key rather than emitting a 1970 timestamp.
+	s.MarkSearchDiscovered(2147483651u, "kad", "debian", /*active=*/true, /*complete=*/false);
+	ASSERT_TRUE(s.HasSearch(2147483651u));
+	ASSERT_EQUALS(static_cast<std::time_t>(0), s.SearchStartedAt(2147483651u));
+
+	// An id nobody holds reports 0 too; HasSearch is what separates them.
+	ASSERT_EQUALS(static_cast<std::time_t>(0), s.SearchStartedAt(999));
+	ASSERT_FALSE(s.HasSearch(999));
+}
+
+TEST(State, DiscoveredSearchKeepsTheDaemonsLifecycleState)
+{
+	// Discovery used to seed every adopted search as active regardless of
+	// what the daemon said. POST /search/{id}/more gates on exactly that,
+	// so a FINISHED search adopted this way was accepted and answered 202
+	// for a request amuled turns into a no-op.
+	CState s;
+	s.MarkSearchDiscovered(42, "kad", "debian", /*active=*/false, /*complete=*/true);
+	const auto finished = s.SearchProgress(42);
+	ASSERT_TRUE(!finished.active);
+	ASSERT_TRUE(finished.complete);
+	ASSERT_EQUALS(std::string("kad"), finished.kind);
+
+	// A still-running one is seeded running, so the tick keeps polling it.
+	s.MarkSearchDiscovered(43, "global", "ubuntu", /*active=*/true, /*complete=*/false);
+	const auto running = s.SearchProgress(43);
+	ASSERT_TRUE(running.active);
+	ASSERT_TRUE(!running.complete);
+
+	// A slot seeded inactive is not polled by the tick, so the read paths
+	// have to be able to refresh it on demand -- otherwise adopting a
+	// finished search would show an empty result list forever.
+	ASSERT_TRUE(s.ClaimSearchRefresh(42, std::chrono::milliseconds(1000)));
+	ASSERT_FALSE(s.ClaimSearchRefresh(43, std::chrono::milliseconds(1000)));
+}
+
 TEST(State, SearchRefreshIsClaimedOncePerTtlAndOnlyWhenIdle)
 {
 	// The read paths refresh a FINISHED search on demand, because the tick


### PR DESCRIPTION
Two defects in #996, both mine, found reviewing it after it merged.

## 1. The web UI adopted the wrong search on mount

`views/search.js` ranked the `GET /search` listing with a comment claiming "newest last in allocation order", then took the last entry. That premise is wrong twice over:

- The listing walks `CSearchList::GetKnownSearchIds()`, a `std::map<uint32_t, wxString>`, so it arrives **id-ascending** and never in start order.
- Id order is not recency either: Kad search ids carry `SEARCH_ID_KAD_MASK` (`0x80000000`), so a Kad search **always** sorts above an eD2k one no matter which ran first.

Reproduced against a live daemon - Kad search started first, eD2k search three seconds later:

```
=== as returned (id-ascending):
{"search_id":4,"query":"ed2ksecond","started_at":1787344126}
{"search_id":2147483650,"query":"kadfirst","started_at":1787344123}

old adopt() -> last entry:      kadfirst   (id 2147483650)
new adopt() -> max started_at:  ed2ksecond (id 4)
```

The old rule adopts the search that started **earlier**, purely because of the mask.

The codebase had already warned about this. `CloseSearch` used to carry *"Kad ids sort above ed2k ids, so highest-key is not newest"*; #996 deleted that comment along with `m_current_search_id` and then walked straight into what it warned about.

### The fix needs a signal that did not exist

There was nothing on the listing to rank by, so this adds one. `started_at` is the unix second amuleapi started the search, stamped in `MarkSearchStarted` and emitted on `GET /search`.

**No EC change.** `EC_OP_SEARCH_LIST` ships id, name, browse-peer, kind and lifecycle state and no timestamp, and nothing new is asked of the daemon - the stamp is purely amuleapi-side.

That has one honest consequence: amuleapi can only stamp searches **it** started. For one begun by another client, by the desktop GUI, or restored from the daemon's on-disk ring after a restart, the key is **omitted rather than zeroed** - a `0` would read as 1970 rather than "unknown". The view ranks running searches by it, falls back to the whole list, and treats unstamped entries as unknown rather than oldest.

## 2. Discovery threw away the daemon's lifecycle state

`DiscoverSearchIfHeldByCore` read `EC_TAG_SEARCH_LIFECYCLE_KIND` and `EC_TAG_SEARCH_NAME` off the `SEARCH_LIST` entry while ignoring `EC_TAG_SEARCH_LIFECYCLE_STATE` sitting in the same entry, and `MarkSearchDiscovered` hardcoded `active = true`.

Pre-existing, but #996 made correctness depend on it: `POST /search/{id}/more` rejects a finished search by reading that flag, so a finished search adopted through discovery was accepted and answered `202` for a request amuled turns into a no-op - precisely the outcome the guard was written to prevent.

Seeding the real state instead, verified with two amuleapi instances against one daemon:

```
instance B, first read of the foreign id (discovery path):
{"search_id":5,"query":"localfinish","progress":{"state":"finished","kind":"local","percent":0}}

fresh instance C, immediate POST /more on a discovered FINISHED kad search:
{"error":{"code":"bad_request","message":"`more` applies to a running search; this one has finished"}} [HTTP 400]
```

Both used to read `running`, and the second used to answer `202`.

### Why this is only safe now

Seeding a slot inactive means the refresher tick will not poll it, so before #996 an adopted finished search would have shown an empty result list forever. The refresh-on-read path added there (`ClaimSearchRefresh`) covers exactly that case, and a unit test pins the pairing so the two cannot drift apart again.

## Verification

Build clean, `ctest` 34/34, clang-format and both clang-tidy tiers clean on the diff with 0 compiler errors.

Live against a local `amuled` connected to both eD2k and Kad:

- `19-search.sh` **138/138** (135 before, plus three new assertions: `started_at` present and plausible on an own search, and absent on a foreign one)
- The ordering bug and both discovery behaviours reproduced before and after, transcripts above
- New `StateTest` cases: `started_at` is stamped only for our own searches and reads 0 for discovered and unknown ids; a discovered search keeps the daemon's `active`/`complete`, and an inactive one is claimable for refresh while an active one is not
