### PR TITLE
fix(core): do not let a cancelled or already-running walk swallow a reload request

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -1098,19 +1098,26 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 	// deltaHF - removed the old ugly button and changed the code to use the new small one
 	// Kry - bah, let's use a var.
 	if (reloading) {
-		// Already running. Surface that to the caller as a non-abort,
-		// non-complete state — they shouldn't react as if they
-		// cancelled, but also haven't completed a fresh scan.
+		// Already running. The walk in flight started before this caller's
+		// roots or filters were in place, so it cannot be the fresh scan they
+		// asked for -- leave a request standing so the next tick runs one.
+		// Without this a caller that commits new shared roots and reads the
+		// return as success persists them and never walks them.
+		//
+		// Surfaced to the caller as a non-abort, non-complete state: they
+		// shouldn't react as if they cancelled, but haven't completed a
+		// fresh scan either.
+		m_reloadLatch.Request();
 		return true;
 	}
 
-	// Any completed walk satisfies an outstanding RequestReload(), so drop the
-	// flag here rather than only in Process(). That lets a GUI caller run the
-	// walk itself (with progress) right after something that requested one,
-	// without Process() then running a second, redundant walk a tick later.
-	// A request that arrives while a walk is running took the `reloading`
-	// early-return above and is still pending, so it is not lost.
-	m_reloadPending = false;
+	// Take any outstanding RequestReload() with us: this walk is the one that
+	// satisfies it, so a GUI caller can run it (with progress) right after
+	// something requested one without Process() running a second, redundant
+	// walk a tick later. Anything requested from here on belongs to the next
+	// walk -- this one is already past the files it would be about -- and an
+	// abort below hands this request back rather than swallowing it.
+	const bool servingRequest = m_reloadLatch.BeginWalk();
 
 	// Info, not debug: now that EC callers get an immediate reply instead of
 	// blocking until the walk ends, the log is how they observe it starting.
@@ -1176,6 +1183,10 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 	// never fires while the pin set is unpopulated (which would
 	// drop records the scan was about to pin). Only on non-aborted
 	// scans: a cancelled mid-scan leaves the pin set partial.
+	// A cancelled walk satisfies nothing, so give the request back and let a
+	// later tick run it properly.
+	m_reloadLatch.EndWalk(servingRequest, aborted);
+
 	if (!aborted && filelist) {
 		filelist->MarkInitialShareScanComplete();
 	}
@@ -1438,8 +1449,7 @@ void CSharedFileList::Process()
 	// inline in the caller. The `reloading` check means a request that
 	// arrives mid-walk stays pending and runs on a later tick instead of
 	// re-entering; Reload() would return early anyway, silently dropping it.
-	if (m_reloadPending && !reloading) {
-		m_reloadPending = false;
+	if (m_reloadLatch.ShouldStartFromTick(reloading)) {
 		Reload();
 	}
 

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -26,7 +26,8 @@
 #ifndef SHAREDFILELIST_H
 #define SHAREDFILELIST_H
 
-#include <atomic> // Needed for std::atomic (m_listGeneration)
+#include "SharedFilesReloadLatch.h" // Needed for CSharedFilesReloadLatch
+#include <atomic>                   // Needed for std::atomic (m_listGeneration)
 #include <functional>
 #include <list>
 #include <map>
@@ -89,12 +90,12 @@ public:
 	// A plain bool is deliberate: every setter and the reader run on the
 	// core event loop. If a caller off that thread ever needs this, that
 	// caller is the thing to fix -- do not make this atomic.
-	void RequestReload() { m_reloadPending = true; }
+	void RequestReload() { m_reloadLatch.Request(); }
 
 	// True when a RequestReload() is outstanding. GUI callers use this to run
 	// the owed walk themselves behind a progress dialog rather than letting it
 	// land silently on a Process() tick -- see ReloadSharedFilesWithProgress().
-	bool IsReloadPending() const { return m_reloadPending; }
+	bool IsReloadPending() const { return m_reloadLatch.IsPending(); }
 	void SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd = false);
 	void RemoveFile(CKnownFile *toremove);
 	CKnownFile *GetFileByID(const CMD4Hash &filehash);
@@ -269,8 +270,11 @@ private:
 		bool &aborted);
 	void FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborted);
 	bool reloading;
-	// Set by RequestReload(), drained by Process(). See RequestReload().
-	bool m_reloadPending = false;
+	// Set by RequestReload(), drained by Process(). The rules it enforces --
+	// coalescing, a mid-walk request belonging to the next walk, and an
+	// aborted walk giving its request back -- live in the latch so they can be
+	// tested without a CSharedFileList. See RequestReload().
+	CSharedFilesReloadLatch m_reloadLatch;
 
 	// New files discovered since the last Process() tick, counted at the one
 	// place discovery is actually decided (AddPathToShares' queued branch) so

--- a/src/SharedFilesReloadLatch.h
+++ b/src/SharedFilesReloadLatch.h
@@ -1,0 +1,88 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef SHAREDFILESRELOADLATCH_H
+#define SHAREDFILESRELOADLATCH_H
+
+/**
+ * The "a shared-files reload is owed" flag, on its own so the rules can be
+ * tested without standing up a CSharedFileList (which needs theApp, the
+ * preferences and a filesystem to walk).
+ *
+ * Three rules, and the middle one is why this is not a plain bool:
+ *
+ *  - Requests coalesce. Ten callers asking before the next tick get one walk.
+ *  - A request that arrives *during* a walk belongs to the NEXT walk. The walk
+ *    in flight is already past the files that request was about, so it cannot
+ *    satisfy it. BeginWalk() takes the outstanding request with it, which
+ *    leaves anything requested afterwards standing.
+ *  - A walk that aborts satisfies nothing, so EndWalk() hands the request back
+ *    rather than letting a cancelled scan swallow it.
+ *
+ * Single-threaded by contract: every caller runs on the core event loop. That
+ * is deliberate and a caller off that thread is the thing to fix, not this.
+ */
+class CSharedFilesReloadLatch
+{
+public:
+	/// Ask for a walk. Repeat calls before the next BeginWalk() coalesce.
+	void Request() { m_pending = true; }
+
+	/// True while a walk is owed.
+	bool IsPending() const { return m_pending; }
+
+	/// Whether the core tick should start a walk now. A walk already running
+	/// leaves the request standing for a later tick rather than nesting.
+	bool ShouldStartFromTick(bool walkRunning) const { return m_pending && !walkRunning; }
+
+	/**
+	 * Called as a walk starts. Takes the outstanding request with it and
+	 * returns whether there was one, so anything requested from here on is
+	 * owed to the next walk. Pass the result to EndWalk().
+	 */
+	bool BeginWalk()
+	{
+		const bool had = m_pending;
+		m_pending = false;
+		return had;
+	}
+
+	/**
+	 * Called as a walk finishes. An aborted walk gives its request back; a
+	 * completed one has satisfied it. Requests that arrived mid-walk are
+	 * untouched either way — they were never taken.
+	 */
+	void EndWalk(bool hadRequest, bool aborted)
+	{
+		if (aborted && hadRequest) {
+			m_pending = true;
+		}
+	}
+
+private:
+	bool m_pending = false;
+};
+
+#endif // SHAREDFILESRELOADLATCH_H
+// File_checked_for_headers

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -468,6 +468,20 @@ target_link_libraries (ECCryptTest
 	CRYPTOPP::CRYPTOPP
 )
 
+add_executable (SharedFilesReloadLatchTest
+	SharedFilesReloadLatchTest.cpp
+)
+add_test (NAME SharedFilesReloadLatchTest COMMAND SharedFilesReloadLatchTest)
+target_include_directories (SharedFilesReloadLatchTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+target_link_libraries (SharedFilesReloadLatchTest
+	muleunit
+	mulecommon
+)
+
 add_executable (JsonWriterTest
 	JsonWriterTest.cpp
 )

--- a/unittests/tests/SharedFilesReloadLatchTest.cpp
+++ b/unittests/tests/SharedFilesReloadLatchTest.cpp
@@ -1,0 +1,126 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include "SharedFilesReloadLatch.h"
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(SharedFilesReloadLatch)
+
+TEST(SharedFilesReloadLatch, StartsIdle)
+{
+	CSharedFilesReloadLatch latch;
+	ASSERT_TRUE(!latch.IsPending());
+	ASSERT_TRUE(!latch.ShouldStartFromTick(/*walkRunning=*/false));
+}
+
+TEST(SharedFilesReloadLatch, RequestsCoalesce)
+{
+	// Ten EC callers before the next tick must produce one walk, not ten.
+	CSharedFilesReloadLatch latch;
+	for (int i = 0; i < 10; ++i) {
+		latch.Request();
+	}
+	ASSERT_TRUE(latch.ShouldStartFromTick(false));
+	ASSERT_TRUE(latch.BeginWalk());
+	latch.EndWalk(true, /*aborted=*/false);
+	ASSERT_TRUE(!latch.IsPending());
+	ASSERT_TRUE(!latch.ShouldStartFromTick(false));
+}
+
+TEST(SharedFilesReloadLatch, TickDoesNotStartWhileAWalkRuns)
+{
+	// A request arriving mid-walk waits for a later tick rather than nesting.
+	CSharedFilesReloadLatch latch;
+	latch.Request();
+	ASSERT_TRUE(!latch.ShouldStartFromTick(/*walkRunning=*/true));
+	ASSERT_TRUE(latch.ShouldStartFromTick(/*walkRunning=*/false));
+}
+
+TEST(SharedFilesReloadLatch, RequestDuringAWalkSurvivesIt)
+{
+	// The walk in flight is already past the files the new request is about,
+	// so completing must not consume it. This is why BeginWalk() takes the
+	// request rather than EndWalk() clearing the flag.
+	CSharedFilesReloadLatch latch;
+	latch.Request();
+	const bool serving = latch.BeginWalk();
+	ASSERT_TRUE(serving);
+	ASSERT_TRUE(!latch.IsPending());
+
+	latch.Request(); // arrives while the walk is running
+	latch.EndWalk(serving, /*aborted=*/false);
+
+	ASSERT_TRUE(latch.IsPending());
+	ASSERT_TRUE(latch.ShouldStartFromTick(false));
+}
+
+TEST(SharedFilesReloadLatch, AbortedWalkGivesTheRequestBack)
+{
+	// A cancelled scan leaves a partial share list and satisfies nothing.
+	CSharedFilesReloadLatch latch;
+	latch.Request();
+	const bool serving = latch.BeginWalk();
+	latch.EndWalk(serving, /*aborted=*/true);
+	ASSERT_TRUE(latch.IsPending());
+}
+
+TEST(SharedFilesReloadLatch, AbortedWalkWithNoRequestInventsNone)
+{
+	// A user-initiated walk that nobody asked for, then cancelled, must not
+	// leave a request behind for the next tick to act on.
+	CSharedFilesReloadLatch latch;
+	const bool serving = latch.BeginWalk();
+	ASSERT_TRUE(!serving);
+	latch.EndWalk(serving, /*aborted=*/true);
+	ASSERT_TRUE(!latch.IsPending());
+}
+
+TEST(SharedFilesReloadLatch, AbortedWalkKeepsAMidWalkRequestOnce)
+{
+	// Both rules at once: the walk aborts (its own request comes back) while
+	// another request arrived mid-walk. One flag, so one walk is owed, not two
+	// -- the next walk covers both.
+	CSharedFilesReloadLatch latch;
+	latch.Request();
+	const bool serving = latch.BeginWalk();
+	latch.Request();
+	latch.EndWalk(serving, /*aborted=*/true);
+	ASSERT_TRUE(latch.IsPending());
+
+	const bool nextServing = latch.BeginWalk();
+	ASSERT_TRUE(nextServing);
+	latch.EndWalk(nextServing, false);
+	ASSERT_TRUE(!latch.IsPending());
+}
+
+TEST(SharedFilesReloadLatch, CompletedWalkWithNoRequestChangesNothing)
+{
+	CSharedFilesReloadLatch latch;
+	const bool serving = latch.BeginWalk();
+	latch.EndWalk(serving, false);
+	ASSERT_TRUE(!latch.IsPending());
+}


### PR DESCRIPTION
Follow-up from reviewing #1006. Two ways a reload request could disappear, both the same missing rule.

**A cancelled walk swallowed the request.** `FindSharedFiles()` clears the share map before walking, so an aborted scan leaves a partial list — but the flag was cleared at the *top* of `Reload()`, so nothing ran the walk that was still owed. Today the one cancel-capable caller papers over it by re-walking the restored directory list on abort, so the invariant held by caller discipline rather than by construction.

**An already-running walk reported success.** `Reload()` returns early when a walk is in flight, returning `true` — which means "not aborted" to its one inspecting caller. That caller commits new shared roots, persists them, reads success and moves on, while the walk in flight started *before* those roots existed and cannot be the scan it asked for. Nothing set the flag, so the new roots would not be walked until something else happened to trigger a reload.

## The rule

A request is satisfied by a walk that both **covers** it and **completes**. The flag moves into `CSharedFilesReloadLatch`:

- `BeginWalk()` takes the outstanding request — so anything requested *mid-walk* stays standing, which is why clearing at the start was right and moving the clear to the end would have been wrong.
- `EndWalk(had, aborted)` hands it back when the walk aborted.
- The already-running early return now leaves a request standing.

## Tests

The latch is a dependency-free header, so the rules are unit-tested instead of living only in a comment — coalescing, the tick not starting while a walk runs, a mid-walk request surviving completion, an aborted walk giving its request back, an aborted walk with no request inventing none, and the two combined collapsing to one owed walk.

I checked they actually catch the old behaviour before trusting them: reverting `EndWalk` to swallow-on-abort makes `AbortedWalkGivesTheRequestBack` fail, and restoring it passes. 35/35 suites, clang-format and both clang-tidy tiers clean.

## Severity

Neither bug is reachable today as far as I could trace — the cancel path compensates, and I could not construct a route to the already-running case in the monolithic GUI, since a `Process()`-driven walk freezes the UI and the progress walk is modal. This closes the invariant so it stops depending on callers behaving, rather than fixing a live defect.
