### PR TITLE
fix(core): correct seven defects in the shared-file discovery logging

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3101,6 +3101,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6926,8 +6936,17 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7886,6 +7905,11 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing downloaded file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3151,6 +3151,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7048,8 +7058,17 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8022,6 +8041,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "سعة نطاق التحميل الحقيقية"
 
 #: src/ThreadTasks.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3206,6 +3206,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7162,8 +7172,17 @@ msgstr "Cargando ficheru server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Ensin ficheros que compartir en direutoriu: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Ensin ficheros que compartir en direutoriu: %s"
+msgstr[1] "Ensin ficheros que compartir en direutoriu: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Ensin ficheros que compartir en direutoriu: %s"
+msgstr[1] "Ensin ficheros que compartir en direutoriu: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8190,6 +8209,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Veceru de testu aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Desaniciando ficheru: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3144,6 +3144,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7021,8 +7031,17 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -7993,6 +8012,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Файлове за сваляне (%i)"
 
 #: src/ThreadTasks.cpp
 #, c-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3100,6 +3100,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6925,8 +6935,17 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7885,6 +7904,11 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing downloaded file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3195,6 +3195,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7130,8 +7140,17 @@ msgstr "S'està carregant el fitxer server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "No s'ha trobat cap fitxer en el directori: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "No s'ha trobat cap fitxer en el directori: %s"
+msgstr[1] "No s'ha trobat cap fitxer en el directori: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "No s'ha trobat cap fitxer en el directori: %s"
+msgstr[1] "No s'ha trobat cap fitxer en el directori: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8136,6 +8155,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "client de text de l'aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "S'està esborrant el fitxer: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3200,6 +3200,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7124,9 +7134,20 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Načítám soubor server.met: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Načítám soubor server.met: %s"
+msgstr[1] "Načítám soubor server.met: %s"
+msgstr[2] "Načítám soubor server.met: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8112,6 +8133,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Textový klient aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Mazání souboru: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3160,6 +3160,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7066,9 +7076,18 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Suspender upload af fil: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Suspender upload af fil: %s"
+msgstr[1] "Suspender upload af fil: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8042,6 +8061,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Hasher"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3200,6 +3200,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7125,8 +7135,17 @@ msgstr "Lade Datei server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Keine freigebbaren Dateien im Ordner gefunden: %s"
+msgstr[1] "Keine freigebbaren Dateien im Ordner gefunden: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Keine freigebbaren Dateien im Ordner gefunden: %s"
+msgstr[1] "Keine freigebbaren Dateien im Ordner gefunden: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8144,6 +8163,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule Textclient"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Lösche Datei: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3217,6 +3217,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7177,9 +7187,18 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Φόρτωση του αρχείου διακομιστών: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Φόρτωση του αρχείου διακομιστών: %s"
+msgstr[1] "Φόρτωση του αρχείου διακομιστών: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8208,6 +8227,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Διακομιστής κειμένου του aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Σβήσιμο αρχείου: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3101,6 +3101,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6926,8 +6936,17 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7886,6 +7905,11 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing downloaded file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3193,6 +3193,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7070,8 +7080,17 @@ msgstr "Cargando el archivo server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "No se han encontrado archivos para compartir en el directorio: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "No se han encontrado archivos para compartir en el directorio: %s"
+msgstr[1] "No se han encontrado archivos para compartir en el directorio: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "No se han encontrado archivos para compartir en el directorio: %s"
+msgstr[1] "No se han encontrado archivos para compartir en el directorio: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8089,6 +8108,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Cliente de texto de aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Borrando archivo: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3195,6 +3195,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7136,8 +7146,17 @@ msgstr "Laen server.met faili: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Kataloogis '%s' pole jagatavaid faile"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Kataloogis '%s' pole jagatavaid faile"
+msgstr[1] "Kataloogis '%s' pole jagatavaid faile"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Kataloogis '%s' pole jagatavaid faile"
+msgstr[1] "Kataloogis '%s' pole jagatavaid faile"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8137,6 +8156,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstiline klient"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Kustutan faili: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3196,6 +3196,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7134,8 +7144,17 @@ msgstr "server.met fitxategia kargatzen: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+msgstr[1] "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+msgstr[1] "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8138,6 +8157,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule testu bezeroa"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "fitxategia ezabatzen:%s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3196,6 +3196,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7134,8 +7144,17 @@ msgstr "Lataan tiedostoa server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+msgstr[1] "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+msgstr[1] "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8138,6 +8157,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstiasiakas"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Poistetaan tiedosto: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3192,6 +3192,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7065,8 +7075,17 @@ msgstr "Chargement du fichier server.met : %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Aucun fichier partageable trouvé dans le répertoire : %s"
+msgstr[1] "Aucun fichier partageable trouvé dans le répertoire : %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Aucun fichier partageable trouvé dans le répertoire : %s"
+msgstr[1] "Aucun fichier partageable trouvé dans le répertoire : %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8084,6 +8103,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "client texte aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Fichier supprimé : %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3213,6 +3213,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7140,8 +7150,17 @@ msgstr "Cargando ficheiro server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Non se atoparon ficheiros que se puideran compartir: %s"
+msgstr[1] "Non se atoparon ficheiros que se puideran compartir: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Non se atoparon ficheiros que se puideran compartir: %s"
+msgstr[1] "Non se atoparon ficheiros que se puideran compartir: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8159,6 +8178,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Texto do cliente de aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Eliminando ficheiro: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3172,6 +3172,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7102,9 +7112,18 @@ msgid "Stopped sharing removed file: %s"
 msgstr "משהה את העלאה של קובץ: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "משהה את העלאה של קובץ: %s"
+msgstr[1] "משהה את העלאה של קובץ: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8118,6 +8137,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "לקוח טסטואלי של אֵימיול"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "מוחק את הקובץ: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3168,6 +3168,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7097,8 +7107,19 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8073,6 +8094,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Hashing"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3182,6 +3182,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7099,8 +7109,15 @@ msgstr "server.met fájl betöltése: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Nincsen megosztott fájl ebben a könyvtárban: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Nincsen megosztott fájl ebben a könyvtárban: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8104,6 +8121,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule szöveges kliens"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Fájl törlése: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3199,6 +3199,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7072,8 +7082,17 @@ msgstr "Caricamento file server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Nessun file condivisibile trovato nella cartella: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Nessun file condivisibile trovato nella cartella: %s"
+msgstr[1] "Nessun file condivisibile trovato nella cartella: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Nessun file condivisibile trovato nella cartella: %s"
+msgstr[1] "Nessun file condivisibile trovato nella cartella: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8091,6 +8110,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Client testuale aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Cancellazione file in corso: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3197,6 +3197,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7128,9 +7138,16 @@ msgid "Stopped sharing removed file: %s"
 msgstr "server.metファイルをロード中です：%s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "server.metファイルをロード中です：%s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8144,6 +8161,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMuleテキストクライアント"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "ファイルを削除します：%s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3217,6 +3217,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7176,9 +7186,18 @@ msgid "Stopped sharing removed file: %s"
 msgstr "server.met 파일을 읽음: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "server.met 파일을 읽음: %s"
+msgstr[1] "server.met 파일을 읽음: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8194,6 +8213,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "파일 삭제: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3230,6 +3230,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7200,9 +7210,20 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Įkeliamas server.met failas: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Įkeliamas server.met failas: %s"
+msgstr[1] "Įkeliamas server.met failas: %s"
+msgstr[2] "Įkeliamas server.met failas: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8229,6 +8250,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstinis klientas"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Šalinamas failas: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3126,6 +3126,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6974,9 +6984,20 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Ielādē server.met datni: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Ielādē server.met datni: %s"
+msgstr[1] "Ielādē server.met datni: %s"
+msgstr[2] "Ielādē server.met datni: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -7941,6 +7962,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr ""
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Dzēš datni: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3189,6 +3189,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7063,8 +7073,17 @@ msgstr "Laden van server.met bestand: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Geen deelbare bestanden gevonden in map: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Geen deelbare bestanden gevonden in map: %s"
+msgstr[1] "Geen deelbare bestanden gevonden in map: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Geen deelbare bestanden gevonden in map: %s"
+msgstr[1] "Geen deelbare bestanden gevonden in map: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8083,6 +8102,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstclient"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Verwijderen van bestand: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3216,6 +3216,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7170,9 +7180,18 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Lastar server.met fila: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Lastar server.met fila: %s"
+msgstr[1] "Lastar server.met fila: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8198,6 +8217,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule tekstklient"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Slettar fila: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3210,6 +3210,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7176,8 +7186,19 @@ msgstr "Otwieram plik server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Nie znaleziono plików do udostępniania w katalogu: %s"
+msgstr[1] "Nie znaleziono plików do udostępniania w katalogu: %s"
+msgstr[2] "Nie znaleziono plików do udostępniania w katalogu: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Nie znaleziono plików do udostępniania w katalogu: %s"
+msgstr[1] "Nie znaleziono plików do udostępniania w katalogu: %s"
+msgstr[2] "Nie znaleziono plików do udostępniania w katalogu: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8187,6 +8208,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Tekstowy klient aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Usuwanie pliku: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3193,6 +3193,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7066,8 +7076,17 @@ msgstr "Carregando arquivo server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Arquivos compartilháveis não encontrado no diretório: %s"
+msgstr[1] "Arquivos compartilháveis não encontrado no diretório: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Arquivos compartilháveis não encontrado no diretório: %s"
+msgstr[1] "Arquivos compartilháveis não encontrado no diretório: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8085,6 +8104,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Cliente em modo texto do aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Apagando arquivo: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3202,6 +3202,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7142,8 +7152,17 @@ msgstr "A carregar o ficheiro server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Não foram encontrados ficheiros partilhados no directório: %s"
+msgstr[1] "Não foram encontrados ficheiros partilhados no directório: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Não foram encontrados ficheiros partilhados no directório: %s"
+msgstr[1] "Não foram encontrados ficheiros partilhados no directório: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8147,6 +8166,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Cliente de texto do aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "A eliminar o ficheiro: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3205,6 +3205,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7157,8 +7167,19 @@ msgstr "Se încarcă fișierul server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Nu au fost găsite fișiere partajabile în directorul: %s"
+msgstr[1] "Nu au fost găsite fișiere partajabile în directorul: %s"
+msgstr[2] "Nu au fost găsite fișiere partajabile în directorul: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Nu au fost găsite fișiere partajabile în directorul: %s"
+msgstr[1] "Nu au fost găsite fișiere partajabile în directorul: %s"
+msgstr[2] "Nu au fost găsite fișiere partajabile în directorul: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8166,6 +8187,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "client text aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Se șterge fișierul: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3215,6 +3215,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7124,8 +7134,19 @@ msgstr "Подгрузка файла server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Нет публикуемых файлов в директории: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Нет публикуемых файлов в директории: %s"
+msgstr[1] "Нет публикуемых файлов в директории: %s"
+msgstr[2] "Нет публикуемых файлов в директории: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Нет публикуемых файлов в директории: %s"
+msgstr[1] "Нет публикуемых файлов в директории: %s"
+msgstr[2] "Нет публикуемых файлов в директории: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8150,6 +8171,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Текстовый клиент aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Удаление файла: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3226,6 +3226,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7199,8 +7209,21 @@ msgstr "Nalaganje datoteke server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "V mapi ni bilo moč najti datotek za deliti: %s"
+msgstr[1] "V mapi ni bilo moč najti datotek za deliti: %s"
+msgstr[2] "V mapi ni bilo moč najti datotek za deliti: %s"
+msgstr[3] "V mapi ni bilo moč najti datotek za deliti: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "V mapi ni bilo moč najti datotek za deliti: %s"
+msgstr[1] "V mapi ni bilo moč najti datotek za deliti: %s"
+msgstr[2] "V mapi ni bilo moč najti datotek za deliti: %s"
+msgstr[3] "V mapi ni bilo moč najti datotek za deliti: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8207,6 +8230,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule besedilni odjemalec"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Brisanje datoteke: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3210,6 +3210,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7160,9 +7170,18 @@ msgid "Stopped sharing removed file: %s"
 msgstr "Duke ngarkuar failin e server.met: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Duke ngarkuar failin e server.met: %s"
+msgstr[1] "Duke ngarkuar failin e server.met: %s"
+
+#: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8177,6 +8196,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Teksti i klientit aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Duke fshire failin: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3194,6 +3194,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7129,8 +7139,17 @@ msgstr "Laddar server.met fil: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Inga delbara filer hittade i mappen: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Inga delbara filer hittade i mappen: %s"
+msgstr[1] "Inga delbara filer hittade i mappen: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Inga delbara filer hittade i mappen: %s"
+msgstr[1] "Inga delbara filer hittade i mappen: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8135,6 +8154,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule textklient"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Tar bort fil: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3100,6 +3100,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6925,8 +6935,17 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -7885,6 +7904,11 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing downloaded file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3185,6 +3185,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7058,8 +7068,17 @@ msgstr "Server.met dosyası yükleniyor: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Dizinde paylaşılabilir dosya bulunamadı: %s"
+msgstr[1] "Dizinde paylaşılabilir dosya bulunamadı: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Dizinde paylaşılabilir dosya bulunamadı: %s"
+msgstr[1] "Dizinde paylaşılabilir dosya bulunamadı: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8077,6 +8096,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule metin aracı"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Dosya siliniyor: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3226,6 +3226,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7201,8 +7211,19 @@ msgstr "Завантажую файл server.met: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "Не знайдені спільні файли в теці: %s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "Не знайдені спільні файли в теці: %s"
+msgstr[1] "Не знайдені спільні файли в теці: %s"
+msgstr[2] "Не знайдені спільні файли в теці: %s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "Не знайдені спільні файли в теці: %s"
+msgstr[1] "Не знайдені спільні файли в теці: %s"
+msgstr[2] "Не знайдені спільні файли в теці: %s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8234,6 +8255,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "Текстовий клієнт aMule"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "Видаляється файл: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3099,6 +3099,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -6923,8 +6933,15 @@ msgstr ""
 
 #: src/SharedFileList.cpp
 #, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr ""
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] ""
 
 #: src/SharedFileList.cpp
 #, c-format
@@ -7880,6 +7897,11 @@ msgstr ""
 
 #: src/TextClient.h
 msgid "aMule text client"
+msgstr ""
+
+#: src/ThreadTasks.cpp
+#, c-format
+msgid "Hashing downloaded file: %s"
 msgstr ""
 
 #: src/ThreadTasks.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3189,6 +3189,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7062,8 +7072,17 @@ msgstr "正在载入 server.met 文件：%s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "在目录中没有找到可以共享的文件：%s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "在目录中没有找到可以共享的文件：%s"
+msgstr[1] "在目录中没有找到可以共享的文件：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "在目录中没有找到可以共享的文件：%s"
+msgstr[1] "在目录中没有找到可以共享的文件：%s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8078,6 +8097,11 @@ msgstr "这是一个已废弃的命令，将来可能被删除，请使用 '%s' 
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule 文本客户端"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "正在删除文件: %s"
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 21:31+0200\n"
+"POT-Creation-Date: 2026-08-21 22:27+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3187,6 +3187,16 @@ msgstr ""
 #: src/MediaProbe.cpp
 #, c-format
 msgid "Extracting media metadata with ffprobe: %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe timed out or was cancelled for %s"
+msgstr ""
+
+#: src/MediaProbe.cpp
+#, c-format
+msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
@@ -7109,8 +7119,15 @@ msgstr "正在載入 server.met 檔案：%s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
-msgid "Stopped sharing %u files under removed directory: %s"
-msgstr "目錄中找不到可分享的檔案：%s"
+msgid "Stopped sharing %u file under removed directory: %s"
+msgid_plural "Stopped sharing %u files under removed directory: %s"
+msgstr[0] "目錄中找不到可分享的檔案：%s"
+
+#: src/SharedFileList.cpp
+#, fuzzy, c-format
+msgid "Now sharing %u file found in a new shared directory"
+msgid_plural "Now sharing %u files found in new shared directories"
+msgstr[0] "目錄中找不到可分享的檔案：%s"
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format
@@ -8109,6 +8126,11 @@ msgstr ""
 #: src/TextClient.h
 msgid "aMule text client"
 msgstr "aMule 文字模式客戶端"
+
+#: src/ThreadTasks.cpp
+#, fuzzy, c-format
+msgid "Hashing downloaded file: %s"
+msgstr "正刪除檔案：%s "
 
 #: src/ThreadTasks.cpp
 #, fuzzy, c-format

--- a/src/MediaProbe.cpp
+++ b/src/MediaProbe.cpp
@@ -508,15 +508,20 @@ bool Probe(const wxString &ffprobePath,
 	// the worker itself or the shutdown join.
 	wxArrayString stdout_lines;
 	const int rc = RunBoundedFFProbe(ffprobePath, argv, timeoutMs, keepRunning, stdout_lines);
+	// Failures are info level too. Announcing the extraction and then reporting
+	// nothing when it fails is worse than the silence this feature replaced: a
+	// misconfigured or broken ffprobe would produce one confident "extracting"
+	// line per file and, in a release build where AddDebugLogLineN compiles to
+	// nothing, no error whatsoever. Whether the binary actually works is one of
+	// the questions these lines exist to answer.
 	if (rc == kKilled) {
-		AddDebugLogLineN(logMediaProbe,
-			CFormat(wxT("MediaProbe: ffprobe timed out / cancelled for %s")) %
-				file.GetPrintable());
+		AddLogLineN(CFormat(_("Media metadata: ffprobe timed out or was cancelled for %s")) %
+			    file.GetPrintable());
 		return false;
 	}
 	if (rc != 0) {
-		AddDebugLogLineN(logMediaProbe,
-			CFormat(wxT("MediaProbe: ffprobe failed (rc=%d) for %s")) % rc % file.GetPrintable());
+		AddLogLineN(CFormat(_("Media metadata: ffprobe failed (code %d) for %s")) % rc %
+			    file.GetPrintable());
 		return false;
 	}
 

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -502,7 +502,9 @@ void CSharedDirWatcher::ScanNewSubdirRace(const CPath &parent)
 		for (CPath f = files.GetFirstFile(CDirIterator::File, wxEmptyString, dirFlags); f.IsOk();
 			f = files.GetNextFile()) {
 			CPath fullFile = parent.JoinPaths(f);
-			m_parent->NotifyPathAdded(fullFile.GetRaw());
+			// bulkScan: this is a whole-tree walk, so an already-known file is
+			// counted into one summary rather than announced per file.
+			m_parent->NotifyPathAdded(fullFile.GetRaw(), /*bulkScan=*/true);
 		}
 	}
 
@@ -606,7 +608,13 @@ void CSharedDirWatcher::ColdDiscoverSubdirs()
 	// the watcher was offline), so route through the fallback path:
 	// FlushPendingEvents will see m_resyncReason and call the
 	// bulk Reload() once the debounce fires.
-	m_resyncReason = ResyncColdDiscovery;
+	// Never downgrade a pending fault: if the backend already reported dropped
+	// events, that is the more serious reason and must keep its critical
+	// message. Enable() can run again while a resync is still owed (toggling
+	// the auto-rescan preference, for one), which is how the two could meet.
+	if (m_resyncReason == ResyncNone) {
+		m_resyncReason = ResyncColdDiscovery;
+	}
 	m_coldDiscoveredDirs = static_cast<unsigned>(discovered.size());
 	ScheduleProcessing();
 }

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -446,6 +446,8 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 			addedFiles++;
 		}
 	}
+	// Accepted tasks only, matching what the old "%i unknown" suffix counted.
+	m_discoveredNewFiles += addedFiles;
 
 	// One unconditional summary. The new-file count used to ride along as a
 	// suffix here, in one of two mutually exclusive variants, and only for this
@@ -550,6 +552,8 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath &directory,
 			addedFiles++;
 			break;
 		case kAddPathKnown:
+		case kAddPathAlreadyShared:
+			// Both are "known" for the summary count; only the attach differs.
 			knownFiles++;
 			break;
 		case kAddPathExcluded:
@@ -636,6 +640,7 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 			}
 		} else {
 			AddDebugLogLineN(logKnownFiles, CFormat("File already shared, skipping: %s") % fname);
+			return kAddPathAlreadyShared;
 		}
 		return kAddPathKnown;
 	}
@@ -644,9 +649,11 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 	AddDebugLogLineN(logKnownFiles, CFormat("Hashing new unknown shared file '%s'") % fname);
 
 	hashTasks.push_back(new CHashingTask(directory, fname));
-	// This branch *is* the definition of "a new file was discovered", and it is
-	// the one point both discovery routes pass through (issue #968).
-	++m_discoveredNewFiles;
+	// Not counted here. CThreadScheduler::DoAddTask dedups on (type, desc) and
+	// silently drops a task already queued, so a re-walk while hashing is still
+	// pending constructs the same tasks again -- counting at construction would
+	// report those files as discovered twice. Both routes count where the
+	// scheduler actually accepts the task instead.
 	return kAddPathQueued;
 }
 
@@ -887,7 +894,7 @@ void CSharedFileList::RemoveFile(CKnownFile *toremove)
 // without firing the bulk Reload() path, which on a 100 k+ file
 // shareset blocks the GUI for minutes per event. See issue #745.
 
-void CSharedFileList::NotifyPathAdded(const wxString &fullPath)
+void CSharedFileList::NotifyPathAdded(const wxString &fullPath, bool bulkScan)
 {
 	if (fullPath.IsEmpty()) {
 		return;
@@ -923,7 +930,9 @@ void CSharedFileList::NotifyPathAdded(const wxString &fullPath)
 		// will call SafeAddKFile() when it finishes, which is
 		// what publishes the file to peers + the GUI.
 		for (TaskList::iterator it = hashTasks.begin(); it != hashTasks.end(); ++it) {
-			CThreadScheduler::AddTask(*it);
+			if (CThreadScheduler::AddTask(*it)) {
+				++m_discoveredNewFiles;
+			}
 		}
 		break;
 	case kAddPathKnown:
@@ -939,12 +948,20 @@ void CSharedFileList::NotifyPathAdded(const wxString &fullPath)
 		// path is different in kind -- it is an event, it fires at
 		// unpredictable times, its volume is bounded by real filesystem
 		// activity rather than by tree size, and no summary line covers it.
-		AddLogLineN(CFormat(_("Now sharing file: %s")) % fullPath);
+		if (bulkScan) {
+			// One line per file would be thousands during a tree walk; the
+			// tick prints a single summary instead.
+			++m_attachedKnownFiles;
+		} else {
+			AddLogLineN(CFormat(_("Now sharing file: %s")) % fullPath);
+		}
 		break;
+	case kAddPathAlreadyShared:
 	case kAddPathExcluded:
 	case kAddPathSkipped:
 		// AddPathToShares already wrote a debug log line; no
-		// further action needed.
+		// further action needed. Already-shared in particular must not
+		// announce a share that did not happen.
 		break;
 	}
 }
@@ -1023,7 +1040,9 @@ void CSharedFileList::NotifyDirRemoved(const wxString &dirPath)
 	// size instead would be a lie about what this call did, and suppressing the
 	// per-file lines would mean losing them whenever the directory event never
 	// arrives at all.
-	AddLogLineN(CFormat(_("Stopped sharing %u files under removed directory: %s")) %
+	AddLogLineN(CFormat(wxPLURAL("Stopped sharing %u file under removed directory: %s",
+			    "Stopped sharing %u files under removed directory: %s",
+			    static_cast<unsigned>(victims.size()))) %
 		    static_cast<unsigned>(victims.size()) % dirPath);
 	AddDebugLogLineN(logKnownFiles,
 		CFormat("Watcher: detaching %zu shared file(s) under removed dir '%s'") % victims.size() %
@@ -1447,6 +1466,16 @@ void CSharedFileList::Process()
 	// its count is printed immediately after its own "Found N known shared
 	// files" summary rather than arriving a second later, detached from it.
 	// Only when non-zero: a pass that discovered nothing says nothing.
+	// Already-known files attached by a bulk subdirectory scan: one line for
+	// the batch, mirroring the summary the removal side emits.
+	if (m_attachedKnownFiles) {
+		AddLogLineN(CFormat(wxPLURAL("Now sharing %u file found in a new shared directory",
+				    "Now sharing %u files found in new shared directories",
+				    m_attachedKnownFiles)) %
+			    m_attachedKnownFiles);
+		m_attachedKnownFiles = 0;
+	}
+
 	if (m_discoveredNewFiles) {
 		AddLogLineN(CFormat(wxPLURAL("Discovered %u new shared file",
 				    "Discovered %u new shared files",

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -197,7 +197,14 @@ public:
 	// All three are safe to call from the wxFileSystemWatcher event
 	// thread (i.e. wx's main thread on every supported backend), and
 	// take list_mut internally via AddFile/RemoveFile.
-	void NotifyPathAdded(const wxString &fullPath);
+	// bulkScan: the caller is walking a whole directory tree (the watcher's
+	// new-subdirectory race scan), not reacting to a single filesystem event.
+	// In that mode an already-known file is counted rather than announced
+	// individually -- moving a large known tree into a recursive share would
+	// otherwise emit one info line per file, thousands of them, in a single
+	// debounce flush on the core event loop. Removal already summarises, so
+	// this also keeps the two directions symmetric.
+	void NotifyPathAdded(const wxString &fullPath, bool bulkScan = false);
 	void NotifyPathRemoved(const wxString &fullPath);
 	void NotifyPathModified(const wxString &fullPath);
 
@@ -249,10 +256,20 @@ private:
 	// reaches the GUI view).
 	enum AddPathResult
 	{
-		kAddPathSkipped,  // broken link, zero size, stat failed
-		kAddPathExcluded, // name matched the user's exclusion filter
-		kAddPathKnown,    // matched a CKnownFile, attached (or already attached)
-		kAddPathQueued    // unknown file, CHashingTask pushed
+		//! Broken link, zero size, stat failed.
+		kAddPathSkipped,
+		//! Name matched the user's exclusion filter.
+		kAddPathExcluded,
+		//! Matched a CKnownFile and was newly attached.
+		kAddPathKnown,
+		// Matched a CKnownFile that was *already* in the share set, so AddFile
+		// declined -- the same content reachable from a second shared
+		// directory, or a repeated watcher event. Split out from
+		// kAddPathKnown because callers that announce a file becoming shared
+		// must not claim a share that did not happen.
+		kAddPathAlreadyShared,
+		//! Unknown file; a CHashingTask was pushed.
+		kAddPathQueued
 	};
 	AddPathResult AddPathToShares(const CPath &directory,
 		const CPath &fname,
@@ -283,6 +300,10 @@ private:
 	// main thread (the bulk walk, the filesystem-watcher event handler and
 	// the core timer are all the main thread).
 	unsigned m_discoveredNewFiles = 0;
+
+	//! Already-known files attached during a bulk subdirectory scan, summarised
+	//! by Process() rather than announced one line each. See NotifyPathAdded.
+	unsigned m_attachedKnownFiles = 0;
 
 	void SendListToServer();
 	uint64 m_lastPublishED2K;

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -135,13 +135,28 @@ void CHashingTask::Entry()
 	// The full path, not m_filename: the same basename can exist in several
 	// shared directories, and "which file is it chewing on" is the question
 	// this line exists to answer.
+	// m_owner is set only when the task belongs to a partfile -- completion
+	// hashing of a finished download, or a corrupt-part re-hash. Those are
+	// real disk work and worth a line, but the path being read is an internal
+	// temp name like Temp/003.part, which means nothing to a user and does not
+	// match anything they can see in the UI. Report the download's own name
+	// instead, and say which kind of work it is.
+	const bool ownedByPartfile = (m_owner != nullptr);
 	if ((m_toHash & EH_MD4) && (m_toHash & EH_AICH)) {
 		knownfile->GetAICHHashset()->FreeHashSet();
-		AddLogLineN(CFormat(_("Hashing file: %s")) % fullPath);
+		if (ownedByPartfile) {
+			AddLogLineN(CFormat(_("Hashing downloaded file: %s")) % m_owner->GetFileName());
+		} else {
+			AddLogLineN(CFormat(_("Hashing file: %s")) % fullPath);
+		}
 		AddDebugLogLineN(
 			logHasher, CFormat("Starting to create MD4 and AICH hash for file: %s") % m_filename);
 	} else if ((m_toHash & EH_MD4)) {
-		AddLogLineN(CFormat(_("Hashing file: %s")) % fullPath);
+		if (ownedByPartfile) {
+			AddLogLineN(CFormat(_("Hashing downloaded file: %s")) % m_owner->GetFileName());
+		} else {
+			AddLogLineN(CFormat(_("Hashing file: %s")) % fullPath);
+		}
 		AddDebugLogLineN(logHasher, CFormat("Starting to create MD4 hash for file: %s") % m_filename);
 	} else if ((m_toHash & EH_AICH)) {
 		knownfile->GetAICHHashset()->FreeHashSet();


### PR DESCRIPTION
Follow-up to #1009, fixing seven defects found in review. Ordered most severe first.

## 1. `Now sharing file:` flooded on a directory move

`ScanNewSubdirRace` walks a whole tree and calls `NotifyPathAdded` per file, so moving a large **known** tree into a recursive share emitted one info line per file, in a single debounce flush on the core event loop. The rationale in #1009's own comment was wrong — it argued that watcher volume is "bounded by real filesystem activity rather than by tree size", which is untrue on exactly that path. Removal already summarised, so the two directions were asymmetric too.

`NotifyPathAdded` now takes a `bulkScan` flag: the tree walk counts, and the tick prints one summary. A genuine single-file move still gets its own line, which is what the original issue asked for.

**Measured on a 500-file known tree:** 500 per-file lines before, one summary line after.

```
Stopped sharing 500 files under removed directory: .../Share/movie/
Now sharing 500 files found in new shared directories
```

## 2. `ffprobe` failures stayed invisible in release builds

The `Extracting media metadata with ffprobe:` line was info level while both failure paths below it remained `AddDebugLogLineN`, which compiles to nothing outside a debug build. A misconfigured or broken `ffprobe` therefore produced one confident "extracting" line per file and **no error at all** — worse than the silence the feature replaced, because it looks like it is working. Whether the binary actually works is one of the questions #1009 set out to answer.

Both failures are now info level. **Verified against a stub that exits 3, in a release build:**

```
Extracting media metadata with ffprobe: .../broken.mp3
Media metadata: ffprobe failed (code 3) for .../broken.mp3
```

Before, only the first line appeared.

## 3. The discovery counter counted queue attempts, not accepted tasks

`CThreadScheduler::DoAddTask` dedups on `(type, desc)` and silently drops a task already queued, so a re-walk while hashing is still pending re-counted the same files. Both routes now count where the scheduler accepts, which is exactly what the retired `%i unknown` suffix counted.

**Honest limit:** I could not reproduce the over-count. Hashing ~960 MB completed in about six seconds here, so every re-walk found the files already known and never re-queued. The fix is verified as non-regressing (3000 files → sum 3000 across three extra reloads; 120 × 8 MB → 120) and is correct by construction, but the original defect is inferred from the dedup path rather than observed.

## 4. Partfile hashing reported an internal temp path

`m_owner` is set only for completion hashing and the corrupt-part rehash, and those logged `.../Temp/003.part` — a name that matches nothing the user can see. They now report the download's own name.

Worth stating the frequency, since it drove the decision: this is **not** per chunk. Per-part verification during a download goes through `CPartFileHashThread` → `HashSinglePart()`, which never constructs a `CHashingTask`. The two sites are `CompleteFile(bIsHashingDone=false)` — once per finished download — and `LoadPartFile`, when a `.part` file's mtime does not match the `.met`, which is normally never. One line per completed download is proportionate for what is otherwise a silent multi-second pause on a large file.

## 5. Cold discovery could downgrade a pending fault

`m_resyncReason` was assigned unconditionally, so a cold-discovered subdirectory could overwrite a pending `ResyncDroppedEvents` and suppress its critical warning — something the bool it replaced could not do, since both paths simply set it true. It now sets the routine reason only when nothing more serious is owed. `Enable()` can run again while a resync is still pending (toggling the auto-rescan preference), which is how the two meet.

Verified by inspection only: provoking it needs a real backend overflow plus an `Enable()` re-entry.

## 6. `1 files`

The removed-directory summary used `_()` rather than `wxPLURAL`. macOS FSEvents races per-file deletes against the directory delete, so small counts are routine rather than a corner case — as #1009's own comment documented. Now `Stopped sharing 1 file under removed directory:`.

## 7. `Now sharing file:` claimed a share that did not happen

`AddPathToShares` returned `kAddPathKnown` whether `AddFile()` attached the file or declined it as already shared, so the same content reachable from a second shared directory was announced as newly shared when nothing happened. That outcome is now a distinct `kAddPathAlreadyShared`; the bulk walk still counts it as known, so the summary is unchanged.

**Verified both ways** with a control build: pre-fix logs one false `Now sharing file: .../ShareB/twin.bin` for a duplicate copy, post-fix logs none.

## Verification summary

All behavioural checks ran against **release** builds with pre-fix and post-fix daemons on identical fixtures.

| # | Pre-fix | Post-fix |
|---|---|---|
| 1 | 500 per-file lines | 0, one summary |
| 2 | no error line | `ffprobe failed (code 3)` |
| 6 | would render `1 files` | `1 file` |
| 7 | 1 false claim | 0 |
| 3 | not reproducible here | non-regressing (3000 → 3000) |
| 4, 5 | inspection only | — |

Both clang-tidy tiers clean, clang-format clean, 5 new msgids and 1 replaced by its plural pair.
