### PR TITLE
amuleapi: carry part_progress_percent on the client SSE payload, and stop restating the chunk size

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -409,10 +409,15 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "remote_queue_rank":      0,
   "score":                  150,
   "obfuscation_status":     "enabled",
-  "friend_slot":            false
+  "friend_slot":            false,
+  "part_progress_percent":  75.0
 }
 ```
-Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `available_parts`, `mod_version` and `view_shared_disabled`. It never carries a `parts` bitmap — those are opt-in on the per-file client routes only, being one boolean per chunk per peer.
+Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `available_parts`, `mod_version` and `view_shared_disabled`.
+
+`part_progress_percent` follows the same rule as on the REST row: it is how much of the file we are downloading **from** this peer the peer already holds, and the key is **omitted entirely** when there is no such file, rather than sent as a negative sentinel. It is derived from `available_parts` and the linked download's part count, so it moves when `available_parts` does, and drops out if that download goes away.
+
+It never carries a `parts` bitmap — those are opt-in on the per-file client routes only, being one boolean per chunk per peer.
 
 
 `upload_file_hash` (file we're uploading TO this peer) and `download_file_hash` (file we're downloading FROM this peer) are 32-char MD4 hex hashes — directly resolvable against [`/api/v0/downloads/{hash}`](REFERENCE.md#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised while we download from them; `upload_file_name` is the partfile they're downloading from us, resolved locally — see [`GET /clients`](REFERENCE.md#get-apiv0clients) for details.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2303,12 +2303,12 @@ void FinalizeJsonBody(CJsonWriter &w, CHttpServer::Response &r)
 // per Q3). The `include_envelope_keys` flag controls whether we
 // emit the snapshot_at envelope around it — list mode wraps in its
 // own envelope, detail mode is the bare object.
-// PARTSIZE — the byte width of a single partfile chunk in amule
-// (9.28 MB). Authoritative copy is in `protocol/ed2k/Constants.h`;
-// duplicated here to avoid pulling that header into Api.cpp (which
-// would cascade into the protocol-level types). amule has never
-// changed PARTSIZE since the ed2k spec was frozen.
-constexpr std::uint64_t kPartSize = 9728000ull;
+// The chunk size and the part-count arithmetic both live in State.h now
+// (webapi::kPartSizeBytes / webapi::PartCountForSize). They used to be a
+// literal here plus six separately open-coded ceiling divisions, which is
+// the duplication that mattered; the constant still cannot come from
+// `protocol/ed2k/Constants.h` directly, because that header is written
+// against amule's legacy typedefs (see the note beside the definition).
 
 // Render the per-part state array from the decoded gap list +
 // per-part source counts. Algorithm cribbed from the reference REST
@@ -2328,15 +2328,15 @@ void WriteProgressParts(CJsonWriter &w, const webapi::FileSnapshot &f)
 		w.EndArray();
 		return;
 	}
-	const std::uint64_t part_count = (f.size + kPartSize - 1) / kPartSize;
+	const std::uint64_t part_count = webapi::PartCountForSize(f.size);
 	std::vector<bool> has_gap(part_count, false);
 	const auto &gaps = f.download.decoded_gaps;
 	const std::size_t gap_pair_count = gaps.size() / 2;
 	for (std::size_t g = 0; g < gap_pair_count; ++g) {
 		const std::uint64_t gap_start = gaps[2 * g];
 		const std::uint64_t gap_end = gaps[2 * g + 1];
-		const std::uint64_t start_idx = gap_start / kPartSize;
-		const std::uint64_t end_idx = gap_end / kPartSize;
+		const std::uint64_t start_idx = gap_start / webapi::kPartSizeBytes;
+		const std::uint64_t end_idx = gap_end / webapi::kPartSizeBytes;
 		for (std::uint64_t i = start_idx; i <= end_idx && i < part_count; ++i) {
 			has_gap[static_cast<std::size_t>(i)] = true;
 		}
@@ -2437,8 +2437,7 @@ void WriteDownloadObject(
 		// Detail-only fields (GET /downloads/{hash}); omitted from the
 		// list. `part_count` and `remaining_time` are computed here from
 		// the snapshot — no EC tag exists for them.
-		const std::int64_t part_count =
-			(f.size == 0) ? 0 : static_cast<std::int64_t>((f.size + kPartSize - 1) / kPartSize);
+		const std::int64_t part_count = static_cast<std::int64_t>(webapi::PartCountForSize(f.size));
 		// ETA seconds; -1 when stalled/paused (speed ~0), mirroring the
 		// desktop getTimeRemaining().
 		std::int64_t remaining_time = -1;
@@ -2825,7 +2824,7 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.Key("aich_hash");
 	w.ValueString(wxString::FromUTF8(f.aich_hash.c_str()));
 	w.Key("part_count");
-	w.ValueInt(f.size == 0 ? 0 : static_cast<int64_t>((f.size + kPartSize - 1) / kPartSize));
+	w.ValueInt(static_cast<int64_t>(webapi::PartCountForSize(f.size)));
 	w.Key("queued_count");
 	w.ValueInt(static_cast<int64_t>(f.queued_count));
 	w.Key("comment");
@@ -3402,30 +3401,6 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 
 namespace
 {
-// Completeness of the file we download FROM this peer: parts the peer has over
-// that file's part count. Only the download link carries a meaningful
-// denominator -- a peer that merely downloads from us has no percent. Left at
-// its < 0 sentinel when not computable, which is how the writers know to omit
-// the field. Used by the detail endpoint and by the per-file client rows.
-void ComputePartProgressPercent(const webapi::CState &state, webapi::ClientSnapshot &cli)
-{
-	if (!cli.has_available_parts || cli.download_file_hash.empty()) {
-		return;
-	}
-	webapi::FileSnapshot f;
-	if (!state.FindDownload(cli.download_file_hash, f) || f.size == 0) {
-		return;
-	}
-	const std::uint64_t part_count = (f.size + kPartSize - 1) / kPartSize;
-	if (part_count == 0) {
-		return;
-	}
-	double pct = 100.0 * static_cast<double>(cli.available_parts) / static_cast<double>(part_count);
-	if (pct > 100.0)
-		pct = 100.0;
-	cli.part_progress_percent = pct;
-}
-
 // One peer row of a per-file client list: the ordinary /clients object plus the
 // three things that only make sense relative to a file.
 struct FileClientRow
@@ -3549,7 +3524,7 @@ CHttpServer::Response CApiDispatcher::HandleFileClients(
 		}
 	}
 
-	const std::uint64_t part_count = file.size > 0 ? (file.size + kPartSize - 1) / kPartSize : 0;
+	const std::uint64_t part_count = webapi::PartCountForSize(file.size);
 	const auto &a4af_sources = file.download.a4af_sources;
 
 	std::vector<FileClientRow> rows;

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -235,7 +235,13 @@ std::string ToJson(const ClientSnapshot &c)
 	  << EscJson(c.source_origin) << "\""
 	  << ",\"available_parts\":" << c.available_parts << ",\"mod_version\":\"" << EscJson(c.mod_version)
 	  << "\""
-	  << ",\"view_shared_disabled\":" << (c.view_shared_disabled ? "true" : "false") << "}";
+	  << ",\"view_shared_disabled\":" << (c.view_shared_disabled ? "true" : "false");
+	// Omitted, not sent as the negative sentinel, exactly as the REST row
+	// does it: the field only exists for a peer we are downloading from.
+	if (c.part_progress_percent >= 0.0) {
+		o << ",\"part_progress_percent\":" << c.part_progress_percent;
+	}
+	o << "}";
 	return o.str();
 }
 
@@ -387,7 +393,13 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 	       a.remote_queue_rank == b.remote_queue_rank && a.score == b.score &&
 	       a.obfuscation_status == b.obfuscation_status && a.friend_slot == b.friend_slot &&
 	       a.source_origin == b.source_origin && a.available_parts == b.available_parts &&
-	       a.mod_version == b.mod_version && a.view_shared_disabled == b.view_shared_disabled;
+	       a.mod_version == b.mod_version && a.view_shared_disabled == b.view_shared_disabled &&
+	       // Derived from available_parts and the linked file's part count,
+	       // so it normally moves only when a compared field does. The case
+	       // that needs it in its own right is the file going away: the
+	       // percent drops back to its sentinel while every other field
+	       // holds, and without this the payload would change with no event.
+	       a.part_progress_percent == b.part_progress_percent;
 }
 bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 {
@@ -527,6 +539,17 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	auto new_servers = ByEcid(state.Servers());
 	auto new_friends = ByEcid(state.Friends());
 	auto new_clients = ByEcid(state.Clients());
+	// part_progress_percent is derived, not refreshed: it needs the part count
+	// of the file the peer is a source for, which lives in a different
+	// snapshot, so the refresher leaves it at its sentinel and the REST
+	// handlers fill it in per request. Do the same here, or the event would
+	// be the one payload a subscriber has to re-GET to complete -- the exact
+	// thing EVENTS.md promises it never has to. Computed on the copies before
+	// both the Equal() comparison and the serialiser see them, so the
+	// baseline and the payload always agree.
+	for (auto &kv : new_clients) {
+		ComputePartProgressPercent(state, kv.second);
+	}
 	// Read the full dashboard for status_changed — the event payload
 	// mirrors the REST /status nested envelope which pulls from
 	// StatusSnapshot + KadSnapshot + ec_connected. Dashboard() takes

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -763,11 +763,24 @@ const char *ClientIdentStateName(std::uint8_t code)
 
 // Decode one per-part BitVector tag into a bool vector.
 //
-// Two shapes on the wire, and the empty one is the trap: the core sends a tag
-// with no payload when the peer holds EVERY part (ECSpecialCoreTags.cpp), so an
-// empty tag means "full", not "unknown". The caller learns that through
-// `out_all` because the true length is the file's part count, which is known
-// only where the row is rendered.
+// Two shapes on the wire, and the empty one is the trap: for
+// EC_TAG_CLIENT_PART_STATUS the core sends a tag with no payload when the peer
+// holds EVERY part (ECSpecialCoreTags.cpp), so an empty tag means "full", not
+// "unknown". The caller learns that through `out_all` because the true length
+// is the file's part count, which is known only where the row is rendered.
+//
+// The shorthand is download-side ONLY. EC_TAG_CLIENT_UPLOAD_PART_STATUS is
+// always sent as a buffer, with no AllTrue() branch, so a full uploader
+// arrives as an all-ones bitmap instead. Both are normalised to the same
+// fixed-length array by the renderer, so nothing downstream sees the
+// difference -- but do not read the two tags as symmetrical.
+//
+// An empty UPLOAD tag is not impossible, just narrow: the core emits it when
+// `upPartStatus.size() == file->GetPartCount()` and SizeBuffer() is 0, which
+// needs both to be zero, i.e. a zero-byte file (CKnownFile sets part count 0
+// for one). It decodes to `out_all` here and is then dropped by the
+// renderer's `part_count == 0` guard rather than becoming a bogus all-true
+// bitmap -- so that guard is load-bearing, not dead code.
 //
 // The buffer holds ceil(bits/8) bytes, so decoding yields a multiple of 8 and
 // the tail beyond the file's part count is padding to be trimmed by the
@@ -1015,10 +1028,11 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 		cs.upload_file_name = std::string(t->GetStringData().utf8_str());
 	}
 	// Per-part bitmaps. Both tags carry a raw BitVector buffer, bit i at
-	// buffer[i / 8] & (1 << (i & 7)) -- LSB-first within each byte -- and an
-	// EMPTY tag is the core's shorthand for "has every part", not for "no
-	// data". Absent means unchanged, per the tagmap convention the rest of
-	// this decoder follows, so the has_ flags only ever go from false to true.
+	// buffer[i / 8] & (1 << (i & 7)) -- LSB-first within each byte, matching
+	// BitVector::s_posMask. An EMPTY tag is the core's shorthand for "has
+	// every part" on the DOWNLOAD tag only; see DecodePartStatusTag. Absent
+	// means unchanged, per the tagmap convention the rest of this decoder
+	// follows, so the has_ flags only ever go from false to true.
 	DecodePartStatusTag(
 		c, EC_TAG_CLIENT_PART_STATUS, cs.part_status, cs.part_status_all, cs.has_part_status);
 	DecodePartStatusTag(c,

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -33,6 +33,37 @@
 namespace webapi
 {
 
+std::uint64_t PartCountForSize(std::uint64_t size)
+{
+	// Ceiling division. An empty file falls out as 0 without a special case,
+	// since kPartSizeBytes - 1 < kPartSizeBytes.
+	return (size + kPartSizeBytes - 1) / kPartSizeBytes;
+}
+
+// Completeness of the file we download FROM this peer: parts the peer has over
+// that file's part count. Only the download link carries a meaningful
+// denominator -- a peer that merely downloads from us has no percent. Left at
+// its < 0 sentinel when not computable, which is how the writers know to omit
+// the field.
+void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli)
+{
+	if (!cli.has_available_parts || cli.download_file_hash.empty()) {
+		return;
+	}
+	FileSnapshot f;
+	if (!state.FindDownload(cli.download_file_hash, f) || f.size == 0) {
+		return;
+	}
+	const std::uint64_t part_count = PartCountForSize(f.size);
+	if (part_count == 0) {
+		return;
+	}
+	double pct = 100.0 * static_cast<double>(cli.available_parts) / static_cast<double>(part_count);
+	if (pct > 100.0)
+		pct = 100.0;
+	cli.part_progress_percent = pct;
+}
+
 bool CState::HasFirstSnapshot() const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -782,6 +782,38 @@ struct SearchProgressSnapshot
 
 // One concurrent search's cached state: its results (keyed by result ECID)
 // and its lifecycle progress. CState holds a map of these keyed by the
+// The byte width of one partfile chunk. Authoritative copy is PARTSIZE in
+// `protocol/ed2k/Constants.h`, which is deliberately NOT included here: that
+// header is written against amule's legacy `uint64`/`uint32` typedefs from
+// src/Types.h, and dragging those into the webapi layer (and into its unit
+// tests) costs more than one restated number. amule has never changed
+// PARTSIZE since the ed2k spec was frozen.
+//
+// One copy, in one place, is the point: the literal used to sit in Api.cpp
+// beside six separately open-coded ceiling divisions.
+constexpr std::uint64_t kPartSizeBytes = 9728000ull;
+
+// Number of eD2k chunks a file of `size` bytes is split into: ceil(size /
+// kPartSizeBytes), and 0 for an empty file.
+//
+// Matches CKnownFile::SetFileSize's m_iPartCount, which reaches the same
+// answer the long way round (floor + 1, then decremented back on an exact
+// multiple) -- worth knowing, because a mismatch here would silently trim
+// or pad every per-part bitmap.
+std::uint64_t PartCountForSize(std::uint64_t size);
+
+// Fill in ClientSnapshot::part_progress_percent, which is derived rather
+// than refreshed: it needs the part count of the file this peer is a source
+// for, which lives in a different snapshot. Left at its < 0 sentinel when
+// not computable, which is how the writers know to omit the field.
+//
+// Shared rather than owned by the REST layer because the SSE client payload
+// has to carry the same value: EVENTS.md promises an `_updated` subscriber
+// gets the full new state and never has to re-GET, and this field was the
+// one exception to that.
+class CState;
+void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli);
+
 // daemon-allocated search_id (see m_searches).
 struct SearchSlot
 {

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -596,3 +596,76 @@ TEST(EventDiff, SearchClosedFiresOnceWhenTheSlotIsFreed)
 	ASSERT_EQUALS(static_cast<size_t>(1), CountClosed().first);
 	ASSERT_TRUE(state.HasSearch(43));
 }
+
+// --- the client payload carries part_progress_percent ------------------
+//
+// EVENTS.md promises an `_updated` subscriber gets the full new state and
+// never has to re-GET. This field was the one exception on the client
+// resource: it is derived rather than refreshed (it needs the part count of
+// the linked download, which lives in a different snapshot), so the diff pass
+// never computed it and the payload silently lacked a key the REST row had.
+TEST(EventDiff, ClientEventCarriesPartProgressPercent)
+{
+	CState state;
+	// A 4-part file (3 * PARTSIZE + a byte) the peer is a source for, holding
+	// 3 of its 4 chunks.
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 1;
+		f.hash = "8b54a3c28b54a3c28b54a3c28b54a3c2";
+		f.name = "four-parts.iso";
+		f.size = kPartSizeBytes * 3 + 1;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+	state.MutateClients([](std::map<std::uint32_t, ClientSnapshot> &clients) {
+		ClientSnapshot c;
+		c.ecid = 7;
+		c.client_name = "peer";
+		c.download_file_hash = "8b54a3c28b54a3c28b54a3c28b54a3c2";
+		c.available_parts = 3;
+		c.has_available_parts = true;
+		clients.emplace(c.ecid, c);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "client_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	// 3 of 4 parts. Asserting the prefix rather than the full double keeps
+	// this independent of ostream's default precision.
+	ASSERT_TRUE(payload.find("\"part_progress_percent\":75") != std::string::npos);
+}
+
+TEST(EventDiff, ClientEventOmitsPartProgressPercentWithNoLinkedFile)
+{
+	// A peer that only downloads FROM us has no meaningful denominator, so
+	// the field stays at its sentinel and the key is omitted -- the same rule
+	// the REST row follows. A negative percent must never reach the wire.
+	CState state;
+	state.MutateClients([](std::map<std::uint32_t, ClientSnapshot> &clients) {
+		ClientSnapshot c;
+		c.ecid = 8;
+		c.client_name = "leech";
+		clients.emplace(c.ecid, c);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "client_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("part_progress_percent") == std::string::npos);
+	ASSERT_TRUE(payload.find("-1") == std::string::npos);
+}


### PR DESCRIPTION
Follow-up to the review of #995. Three findings, none of them introduced by that PR.

## 1. `part_progress_percent` was missing from `client_added` / `client_updated`

EVENTS.md promises an `_updated` subscriber "gets the full new state and never needs to re-GET", and documents the client payload as the `/clients` list row. It was that row minus one key:

```
REST /clients row: 33 keys | SSE client_*: 32 keys
REST only: ['part_progress_percent']
```

**It was not an oversight in the event code.** The field is *derived*, not refreshed: computing it needs the part count of the file the peer is a source for, which lives in a different snapshot (`state.FindDownload(...)`). So the refresher leaves it at its `< 0` sentinel and the REST handlers fill it in per request. The diff pass never did, so the value it serialised was always the sentinel and the key was always omitted.

The diff pass now computes it on its own snapshot copies **before** either the `Equal()` comparison or the serialiser sees them, so the baseline and the payload cannot disagree. Emitted under the same rule the REST row uses: the key is omitted when not computable, never sent as a negative number.

`Equal()` gains the field too. That is normally redundant, since the percent is a function of `available_parts` and the linked file's part count and both `available_parts` and `download_file_hash` are already compared. It earns its place in one case: when the linked download goes away the percent drops back to its sentinel while every other field holds, and without it the payload would change with no event to carry it.

`ComputePartProgressPercent` moves out of `Api.cpp`'s anonymous namespace into `State.cpp` so both callers share one definition. Copying it would have recreated exactly the drift this fixes.

After: `REST /clients row: 33 | SSE client_*: 33`, no divergence in either direction.

Note this is a different case from `parts`, which is deliberately excluded and documented as such - that exclusion is about payload size (one boolean per chunk per peer). A single double does not carry that rationale.

## 2. The chunk size was restated, with six open-coded ceiling divisions

`Api.cpp` carried its own `kPartSize = 9728000` and then spelled `(size + kPartSize - 1) / kPartSize` out at **six** separate call sites. That is now `webapi::kPartSizeBytes` plus `webapi::PartCountForSize`, in `State.h` beside the code that needs them.

The constant still cannot be read from `protocol/ed2k/Constants.h` directly. I tried, and it does not compile: that header is written against amule's legacy `uint64` / `uint32` typedefs from `src/Types.h`, so pulling it in drags those into the webapi layer and its unit tests. The old comment blamed "cascading into the protocol-level types", which is not quite what happens; the comment now records the actual reason.

## 3. `DecodePartStatusTag`'s comment claimed a symmetry the wire does not have

It said *"Both tags carry a raw BitVector buffer … and an EMPTY tag is the core's shorthand for 'has every part'"*. The shorthand is download-side only: `EC_TAG_CLIENT_PART_STATUS` gets an `AllTrue()` branch that sends an empty tag, while `EC_TAG_CLIENT_UPLOAD_PART_STATUS` is always sent as a buffer, so a full uploader arrives as an all-ones bitmap instead. Both normalise to the same fixed-length array in the renderer, so **no behaviour changes** - but the two tags should not be read as interchangeable.

The comment also now records that an empty UPLOAD tag is *narrow rather than impossible*. It needs `upPartStatus.size() == file->GetPartCount()` with a zero-byte buffer, which means both are zero - a zero-byte file, for which `CKnownFile` sets part count 0 under a branch the core deliberately kept. It decodes to `out_all` and is then dropped by the renderer's `part_count == 0` guard rather than becoming a bogus all-true bitmap. That guard is load-bearing, not dead code, and a future reader should not delete it on the strength of a "cannot happen".

## Verification

Build clean, `ctest` **35/35**, clang-format and both clang-tidy tiers clean on the diff with 0 compiler errors.

Two new `EventDiffTest` cases pin the parity fix: a peer holding 3 of a 4-part file's chunks produces `"part_progress_percent":75` on the event, and a peer with no linked download produces a payload with neither the key nor a negative sentinel anywhere in it.

The key-set comparison above is mechanical - it parses `WriteClientObject` (with `WriteClientBaseFields` inlined) and `ToJson(const ClientSnapshot &)` and diffs the emitted key lists, which is how the gap was found in the first place.
