### PR TITLE
fix(core): summarise media-probe logging over a scan instead of per file

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -54,6 +54,7 @@ src/LibSocketAsio.cpp
 src/ListenSocket.cpp
 src/Logger.cpp
 src/MediaProbe.cpp
+src/MediaProbeThread.cpp
 src/MuleNotebook.cpp
 src/MuleTextCtrl.cpp
 src/MuleTrayIcon.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3112,6 +3112,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -3162,6 +3162,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -3217,6 +3217,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -3155,6 +3155,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3111,6 +3111,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -3206,6 +3206,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -3211,6 +3211,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3171,6 +3171,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -3211,6 +3211,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -3228,6 +3228,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3112,6 +3112,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -3204,6 +3204,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -3206,6 +3206,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -3207,6 +3207,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3207,6 +3207,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -3203,6 +3203,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -3224,6 +3224,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -3183,6 +3183,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -3179,6 +3179,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -3193,6 +3193,18 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -3210,6 +3210,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -3208,6 +3208,18 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -3228,6 +3228,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -3241,6 +3241,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3137,6 +3137,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -3200,6 +3200,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -3227,6 +3227,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -3221,6 +3221,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -3204,6 +3204,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -3213,6 +3213,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -3216,6 +3216,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -3226,6 +3226,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -3237,6 +3237,24 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -3221,6 +3221,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -3205,6 +3205,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3111,6 +3111,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -3196,6 +3196,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -3237,6 +3237,22 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3110,6 +3110,18 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -3200,6 +3200,20 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-21 22:27+0200\n"
+"POT-Creation-Date: 2026-08-22 00:01+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -3198,6 +3198,18 @@ msgstr ""
 #, c-format
 msgid "Media metadata: ffprobe failed (code %d) for %s"
 msgstr ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file (%u failed)"
+msgid_plural "Extracted media metadata from %u files (%u failed)"
+msgstr[0] ""
+
+#: src/MediaProbeThread.cpp
+#, c-format
+msgid "Extracted media metadata from %u file"
+msgid_plural "Extracted media metadata from %u files"
+msgstr[0] ""
 
 #: src/MuleNotebook.cpp src/muuli_wdr.cpp
 msgid "Close"

--- a/src/MediaProbe.cpp
+++ b/src/MediaProbe.cpp
@@ -456,7 +456,8 @@ bool Probe(const wxString &ffprobePath,
 	const CPath &file,
 	MediaInfo &out,
 	unsigned timeoutMs,
-	const std::atomic<bool> &keepRunning)
+	const std::atomic<bool> &keepRunning,
+	bool bulk)
 {
 	if (ffprobePath.IsEmpty()) {
 		return false;
@@ -500,7 +501,9 @@ bool Probe(const wxString &ffprobePath,
 	// (issue #968). Emitted here, immediately before the spawn, so it fires
 	// once per actual ffprobe execution rather than once per queued job; the
 	// queue-time trace in SharedFileList stays at debug level.
-	AddLogLineN(CFormat(_("Extracting media metadata with ffprobe: %s")) % file.GetPrintable());
+	if (!bulk) {
+		AddLogLineN(CFormat(_("Extracting media metadata with ffprobe: %s")) % file.GetPrintable());
+	}
 
 	// Bounded + killable: this runs on the dedicated CMediaProbeThread, so a
 	// slow/hung ffprobe can only ever delay other probes — never completions.
@@ -515,13 +518,17 @@ bool Probe(const wxString &ffprobePath,
 	// nothing, no error whatsoever. Whether the binary actually works is one of
 	// the questions these lines exist to answer.
 	if (rc == kKilled) {
-		AddLogLineN(CFormat(_("Media metadata: ffprobe timed out or was cancelled for %s")) %
-			    file.GetPrintable());
+		if (!bulk) {
+			AddLogLineN(CFormat(_("Media metadata: ffprobe timed out or was cancelled for %s")) %
+				    file.GetPrintable());
+		}
 		return false;
 	}
 	if (rc != 0) {
-		AddLogLineN(CFormat(_("Media metadata: ffprobe failed (code %d) for %s")) % rc %
-			    file.GetPrintable());
+		if (!bulk) {
+			AddLogLineN(CFormat(_("Media metadata: ffprobe failed (code %d) for %s")) % rc %
+				    file.GetPrintable());
+		}
 		return false;
 	}
 

--- a/src/MediaProbe.h
+++ b/src/MediaProbe.h
@@ -102,11 +102,18 @@ wxString DetectedPath(bool redetect = false);
 //
 // Callers MUST run this off the main thread — it blocks for the duration
 // of the child (typically 30-100 ms, at most `timeoutMs`).
+//! \param bulk true when the caller is draining a batch of queued probes (a
+//! share scan), in which case this stays silent and the caller reports one
+//! summary for the batch -- otherwise a large media library produces one
+//! "extracting" line per file, and one more per failure, which is exactly the
+//! scale-with-the-share-size property the discovery lines were summarised to
+//! avoid. A batch of one is a genuine single-file event and still speaks.
 bool Probe(const wxString &ffprobePath,
 	const CPath &file,
 	MediaInfo &out,
 	unsigned timeoutMs,
-	const std::atomic<bool> &keepRunning);
+	const std::atomic<bool> &keepRunning,
+	bool bulk = false);
 
 } // namespace MediaProbe
 

--- a/src/MediaProbeThread.cpp
+++ b/src/MediaProbeThread.cpp
@@ -98,6 +98,16 @@ void *CMediaProbeThread::Entry()
 			workList.swap(m_jobList);
 		}
 
+		// A batch of one is a genuine single-file event -- a file just dropped
+		// into a shared directory -- and keeps its per-file lines. Anything
+		// larger is a share scan draining, where one line per file (and a
+		// second per failure) would make the log scale with the size of the
+		// media library. Those report one summary below instead, matching how
+		// the bulk share walk summarises its discoveries.
+		const bool bulk = (workList.size() > 1);
+		unsigned probed = 0;
+		unsigned failed = 0;
+
 		for (const MediaProbeJob &job : workList) {
 			// Shut down promptly rather than draining a long backlog.
 			if (!m_bRun) {
@@ -114,7 +124,8 @@ void *CMediaProbeThread::Entry()
 				continue;
 			}
 			MediaInfo info;
-			if (MediaProbe::Probe(exe, job.path, info, kProbeTimeoutMs, m_bRun)) {
+			++probed;
+			if (MediaProbe::Probe(exe, job.path, info, kProbeTimeoutMs, m_bRun, bulk)) {
 				// Marshal the result to the main thread, which
 				// resolves the hash to the CKnownFile and attaches
 				// the FT_MEDIA_* tags (doing that here would race the
@@ -122,6 +133,28 @@ void *CMediaProbeThread::Entry()
 				CMediaProbeEvent evt(
 					job.hash, info.length_seconds, info.bitrate_kbps, info.codec);
 				wxQueueEvent(wxTheApp, evt.Clone());
+			} else {
+				++failed;
+			}
+		}
+
+		// One line for the whole drain. Only in bulk mode -- a single-file
+		// batch already said its piece per file, and saying it twice would be
+		// noise. Failures are named in the summary rather than hidden: the
+		// point of reporting them at all is that a misconfigured ffprobe must
+		// not look like success.
+		if (bulk && probed > 0) {
+			if (failed > 0) {
+				AddLogLineN(
+					CFormat(wxPLURAL("Extracted media metadata from %u file (%u failed)",
+						"Extracted media metadata from %u files (%u failed)",
+						probed)) %
+					probed % failed);
+			} else {
+				AddLogLineN(CFormat(wxPLURAL("Extracted media metadata from %u file",
+						    "Extracted media metadata from %u files",
+						    probed)) %
+					    probed);
 			}
 		}
 	}


### PR DESCRIPTION
#1013 removed the scale-with-the-share-size property from the discovery lines by summarising the bulk walk — and then deepened it on the other side, because promoting the ffprobe failure paths to info level added a *second* per-file line. The two halves of that change pulled in opposite directions.

Concretely, on a 10 000-file media library:

| | before | after |
|---|---|---|
| First scan | **10 000** lines | **1** summary |
| First scan, misconfigured ffprobe | **20 000** lines | **1** summary naming the failure count |

The gate makes that a normal case rather than a worst case: `MaybeScheduleMediaProbe` only queues audio/video files, so a 10 000-file *media* share really does mean 10 000 probes.

## The change

`MediaProbe::Probe` takes a `bulk` flag, mirroring the `bulkScan` flag `NotifyPathAdded` already uses for exactly this reason. `CMediaProbeThread` already drains its queue in batches (`workList.swap(m_jobList)`), so **batch size decides**:

- a batch of **one** is a genuine single-file event — a file just dropped into a shared directory — and keeps its per-file lines, including the failure reason;
- anything larger is a scan draining, and reports one summary for the whole batch.

Failures stay visible, which was the point of promoting them in #1013: the summary names how many failed, so a broken ffprobe still cannot look like success.

```
Extracted media metadata from 60 files
Extracted media metadata from 60 files (60 failed)
```

## Verification

Release builds, pre/post daemons on identical fixtures, 60 distinct mp3s.

| Scenario | pre-fix | post-fix |
|---|---|---|
| 60-file library, first scan | **60** per-file lines, 0 summaries | **2** lines total (see below) |
| Same with a stub ffprobe exiting 7 | 60 "extracting" + 60 "failed" | **3** lines, summary reads `(60 failed)` |
| One mp3 dropped into a running daemon | per-file line | per-file line, unchanged, no redundant summary |

The "2 lines" is one per-file line plus the summary: the very first job queued during a scan drains alone, so it is a batch of one and speaks for itself. That is a benign artefact of using batch size as the signal — one line rather than sixty — and it self-corrects as soon as the queue has more than one job in it.

## Catalogs

`src/MediaProbeThread.cpp` was never listed in `po/POTFILES.in`, so the strings added here would have shipped unextractable and untranslatable. Registered it; that is why the pot gains four msgids (two plural pairs) rather than the two singular forms the diff shows.
