### PR TITLE
docs(amuleapi): document the POST /a4af response shape

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -861,11 +861,15 @@ Force A4AF source-swapping for this download. Downloads-only.
 
 `client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-peer "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_this_auto` or `swap_others` is a `400`, because the core has no per-source form of those.
 
-A successful single-source swap shows up as that `client_ecid` having left `source_ecids` in the response.
-
 The swap moves the peer between two files' source lists, so an SSE subscriber sees `download_updated` for **both** the peer's former download and this one, plus `client_updated` for the peer itself.
 
-**Response:** `200 OK` — the post-action A4AF view (same shape as the `GET`).
+**Response:** `200 OK` — the post-action A4AF view of this download:
+
+```json
+{ "a4af_auto": false, "source_ecids": [ 1234, 5678 ] }
+```
+
+`source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it.
 
 **Errors:** `400 bad_request` (missing or unknown `action`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 


### PR DESCRIPTION
`POST /downloads/{hash}/a4af` described its response as "the same shape as the `GET`" — but the `GET` on that path was retired in #995 and now answers 405, so the shape it pointed at is documented nowhere. A consumer had no way to learn what the call returns beyond one passing mention of `source_ecids` in the surrounding prose.

Replace the dangling reference with the actual body, and fold the loose sentence about a single-source swap into it so the explanation lives next to the sample instead of two paragraphs above it:

    { "a4af_auto": false, "source_ecids": [ 1234, 5678 ] }

Verified against a running daemon: `GET` answers 405 and `POST {"action":"swap_others"}` returns `{"a4af_auto":false,"source_ecids":[]}`, matching the sample.

Docs only — no code, no Web UI change.