### PR TITLE
fix(core): do not stamp a new path onto a file whose share add was declined

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -627,6 +627,11 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 		// maintains keys off the file's current GetFilePath() rather
 		// than whatever stale path was stamped on the CKnownFile by
 		// a previous shared-list membership.
+		//
+		// Kept so the decline below can undo it: that reasoning only holds
+		// when AddFile actually inserts, because AddFile writes m_pathIndex
+		// only on a fresh insert.
+		const CPath previousPath = toadd->GetFilePath();
 		toadd->SetFilePath(directory);
 		if (AddFile(toadd)) {
 			AddDebugLogLineN(logKnownFiles, CFormat("Added known file '%s' to shares") % fname);
@@ -639,6 +644,25 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 				Notify_SharedFilesShowFile(toadd);
 			}
 		} else {
+			// The share set already holds this content, indexed under the
+			// path it was first found at. Put the file back on that path:
+			// the stamp above would otherwise leave GetFilePath() disagreeing
+			// with the index key, and nothing reconciles them. That skew is
+			// not cosmetic -- RemoveFile erases by a key it recomputes from
+			// GetFilePath(), so the erase silently misses and leaks the real
+			// entry, after which NotifyPathAdded short-circuits on the leaked
+			// key and the file can never be shared again without a restart.
+			// The upload worker also opens GetFilePath(), so it would read
+			// the copy the index does not know about and, on failure, invoke
+			// its own "removing from list of shared files" recovery against a
+			// file that is still present and serveable (issue #1017).
+			//
+			// First copy found wins and stays authoritative, which is stable
+			// across reloads. Re-keying the index to follow the new path would
+			// work too, but would make "last directory walked wins" the
+			// semantics, so which physical copy serves uploads would depend on
+			// the sort order of the shared roots.
+			toadd->SetFilePath(previousPath);
 			AddDebugLogLineN(logKnownFiles, CFormat("File already shared, skipping: %s") % fname);
 			return kAddPathAlreadyShared;
 		}
@@ -881,9 +905,25 @@ void CSharedFileList::RemoveFile(CKnownFile *toremove)
 	// Same path key we wrote into the index in AddFile(). erase() is a
 	// no-op if the entry isn't present (e.g. the file was inserted
 	// before m_pathIndex existed in an older save snapshot).
+	//
+	// The premise -- that the key we recompute here is the key AddFile wrote
+	// -- holds only while GetFilePath() still matches what was indexed. When
+	// it does not, this erase silently misses and leaves the real entry
+	// behind, which then makes the file permanently unshareable because
+	// NotifyPathAdded short-circuits on it. That is invisible without the
+	// diagnostic below, which is how issue #1017 survived unnoticed.
 	const wxString key =
 		NormalizePathKey(toremove->GetFilePath().JoinPaths(toremove->GetFileName()).GetRaw());
-	m_pathIndex.erase(key);
+	const size_t erasedFromIndex = m_pathIndex.erase(key);
+	if (erasedFromIndex == 0 && !m_pathIndex.empty()) {
+		// Not fatal on its own -- the older-snapshot case above is legitimate
+		// -- but it is the signature of a desynchronised index, so say so
+		// rather than leaking an entry in silence.
+		AddDebugLogLineC(logKnownFiles,
+			CFormat("Path index: no entry under '%s' to erase for a file being removed from "
+				"shares; the index may be out of step with the file's path") %
+				key);
+	}
 	/* This file keywords must not be published to kad anymore */
 	m_keywords->RemoveKeywords(toremove);
 }

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -268,6 +268,12 @@ private:
 		// directory, or a repeated watcher event. Split out from
 		// kAddPathKnown because callers that announce a file becoming shared
 		// must not claim a share that did not happen.
+		//
+		// The file's path is left exactly as it was, which is load-bearing
+		// rather than incidental: AddFile writes m_pathIndex only on a fresh
+		// insert, so stamping the second directory onto the file would leave
+		// GetFilePath() disagreeing with the key it is indexed under, and
+		// nothing reconciles the two (issue #1017).
 		kAddPathAlreadyShared,
 		//! Unknown file; a CHashingTask was pushed.
 		kAddPathQueued


### PR DESCRIPTION
Closes #1017.

`AddPathToShares` sets the file's path before calling `AddFile`, so the path index `AddFile` maintains keys off the file's *current* path rather than a stale one. That reasoning only holds when `AddFile` actually inserts: it writes `m_pathIndex` on a fresh insert and returns `false` otherwise. So when the same content is reachable from two shared directories, the second walk stamps the second directory onto the `CKnownFile` and is then declined, leaving `GetFilePath()` disagreeing with the key the file is indexed under, with nothing to reconcile them.

## Reproduced, not just reasoned

Worth saying up front, since the issue notes this was surfaced by #1013 rather than by a user report: it reproduces end to end.

An instrumented build shows the skew forming:

```
DIAG stamp '.../shareA' onto movie.mkv (was '')        -> ADDED, indexed under shareA
DIAG stamp '.../shareB' onto movie.mkv (was shareA)    -> DECLINED, path now shareB,
                                                          index key unchanged
```

and the user-visible consequence follows exactly as described:

| Step | before | after |
|---|---|---|
| `rm shareB/movie.mkv` (the stamped copy) | no reaction; still listed as shared, but its path now points at a deleted file | no reaction; stays shared, path points at the surviving copy |
| `rm shareA/movie.mkv` (the indexed copy) | detaches, but `RemoveFile`'s erase misses and leaks the key | detaches, erase hits |
| put a file back at `shareA/movie.mkv` | **stays unshared** — permanently, until the process restarts | **re-shares** correctly |

**One correction to the reproduction steps in the issue.** They say to share both, start aMule and let the walk finish. That is not sufficient on its own: on a first run `known.met` is empty, so `FindKnownFile` matches neither copy, both are hashed as new, and the declined branch never executes. It takes a **restart** (or a reload after hashing completes) before the walk can decline. Without that step the first attempt looks clean — which is what happened on my first attempt, and nearly had me report it as unreproducible.

## The fix

Roll the stamp back on decline, so the first copy found stays authoritative. That is stable across reloads and already agrees with what the index says.

The alternative — calling `RefreshPathIndex(toadd)` to re-key onto the new path — restores the invariant just as well and is a one-liner, but it makes "last directory walked wins" the semantics, so `sharedPaths.sort()` would decide which physical copy serves uploads and that could change on any reload or preferences edit. Having watched the walk order pick the loser in the trace above, the rollback is clearly the more predictable of the two.

## Hardening

`RemoveFile`'s `erase(recomputed key)` is only correct while the invariant holds, and it fails **silently** when it does not — which is how this survived unnoticed. It now logs when the erase finds nothing.

`AddDebugLogLineC`, deliberately not `...N`: the `N` variant compiles to `do {} while(false)` outside `__DEBUG__`, so it would have been invisible in exactly the builds where this matters. Verified rather than assumed — a build carrying the diagnostic *without* the rollback prints it in a release build, critical-flagged, naming the skewed path:

```
! KnownFileList: Path index: no entry under '.../shareB/movie.mkv' to erase for a file
  being removed from shares; the index may be out of step with the file's path
```

## Scope

Two files. No behaviour change in `AddFile`, `RefreshPathIndex`, the watcher or the upload worker, as the issue notes. The bulk walk still counts a declined add as a known file, so `Found N known shared files` and `Discovered N new shared files` are unaffected.

No new user-visible strings, so the catalogs are untouched (`check-potfiles.sh` passes, zero msgid delta). Both clang-tidy tiers and clang-format are clean.

The `m_pathIndex` leak across a `FindSharedFiles` reload — index entries for paths no longer shared at all — is left alone, as the issue asks; it wants its own change and its own risk assessment.
