### PR TITLE
fix(prefs): show progress during the shared-folders rollback walk

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1349,10 +1349,10 @@ Returns `202 Accepted`. amuled schedules the re-walk and answers immediately, so
 
 Repeated calls coalesce: requesting a reload while one is already pending, or while a walk is in progress, results in a single further walk rather than one per call.
 
-**Reading the result.** The walk brackets itself with two amule log lines, so read them back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel:
+**Reading the result.** The walk brackets itself with two amule log lines, so read them back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel. Both are localised and the second is pluralised, so a client matching on them should pin the daemon's locale:
 
 - `Reloading shared files...` when the walk starts
-- `Found 1234 known shared files, 7 unknown` when it ends
+- `Found 1234 known shared files` when it ends
 
 The resulting changes also arrive as `shared_added` / `shared_removed` events on the `shared` SSE channel, which is the better signal if you only care about the delta.
 

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -40,6 +40,8 @@
 #include <set>           // set-compare of shared roots (session refresh)
 #include <wx/progdlg.h>
 #include "SharedFilesReloadProgress.h" // ReloadSharedFilesWithProgress
+
+#include <memory> // std::unique_ptr (progress dialog lifetime)
 #include <wx/stdpaths.h>
 #include <wx/tooltip.h>
 #include <wx/utils.h> // wxGetUserHome
@@ -3043,7 +3045,12 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 	// not we go straight into the file-list Reload.
 	const wxString initialBody = recursiveIntents.empty() ? _("Reloading shared files...")
 							      : _("Scanning for subdirectories...");
-	wxProgressDialog progress(_("Updating shared folders"),
+	// Held by pointer so it can be destroyed before the rollback below rather
+	// than at end of scope. wxPD_APP_MODAL keeps its disabler until
+	// destruction, so raising the rollback's dialog while this one is merely
+	// hidden would stack two app-modal dialogs -- the misbehaviour
+	// CatDialog.cpp:197-202 documents avoiding.
+	auto progress = std::make_unique<wxProgressDialog>(_("Updating shared folders"),
 		initialBody,
 		/*maximum=*/100,
 		this,
@@ -3072,7 +3079,7 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 			auto onProgress = [&](wxThreadEvent &ev) {
 				const wxString status = CFormat(_("Scanned %u directories...")) %
 							static_cast<unsigned>(ev.GetInt());
-				if (!progress.Pulse(status)) {
+				if (!progress->Pulse(status)) {
 					task.Cancel(); // wxThread::Delete joins the worker
 					userCancelled = true;
 					done = true;
@@ -3096,7 +3103,7 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 			if (userCancelled || task.WasCancelled()) {
 				// shareddir_list was never touched yet — nothing to
 				// roll back.
-				progress.Update(100);
+				progress->Update(100);
 				return SharedDirsCommitResult::CancelledByUser;
 			}
 			finalShares = task.GetExpandedShares();
@@ -3124,7 +3131,7 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 	// directory list to re-walk against on abort. The wording is shared so the
 	// two cannot drift.
 	auto reloadYield = [&progress, &reloadAborted](size_t filesScanned) -> bool {
-		if (!progress.Pulse(SharedFilesScannedMessage(filesScanned))) {
+		if (!progress->Pulse(SharedFilesScannedMessage(filesScanned))) {
 			reloadAborted = true;
 			return false;
 		}
@@ -3132,22 +3139,37 @@ PrefsUnifiedDlg::SharedDirsCommitResult PrefsUnifiedDlg::CommitSharedDirsWithPro
 	};
 
 	const bool reloadOk = theApp->sharedfiles->Reload(reloadYield);
-	progress.Update(100);
+	progress->Update(100);
+	// Gone before the rollback runs, for the modality reason above and
+	// because wxProgressDialog latches its cancelled state: on the path that
+	// matters here the user has just cancelled, so anything reusing this
+	// dialog would get false from its first Pulse(), abort the rollback walk
+	// and leave m_Files_map half-populated.
+	progress.reset();
 
 	if (!reloadOk || reloadAborted) {
 		// Roll back: both the in-memory state and the on-disk
 		// files (shareddir.dat + shareddir-explicit.dat +
 		// shareddir-recursive.dat) have to be reverted. The
 		// in-memory shared-file map is partially populated against
-		// the new list, so rebuild it from the restored list
-		// (without a yield callback — the restored list is by
-		// construction the one the user was already running with
-		// before this OK click).
+		// the new list, so rebuild it from the restored list.
+		//
+		// Through the shared helper rather than a bare Reload(): this walk is
+		// the same size as the one just cancelled, and the user got here
+		// *because* that one was taking too long. A no-yield Reload freezes
+		// the window with the dialog already hidden -- no repaint, no
+		// progress, no explanation, on the one path where the user has
+		// already said they were tired of waiting.
+		//
+		// The helper is also the right shape, not merely the convenient one:
+		// it offers no cancel, which is what a rollback needs, since
+		// FindSharedFiles clears m_Files_map before walking and there is no
+		// earlier list left to fall back to.
 		theApp->glob_prefs->shareddir_list = originalShares;
 		theApp->glob_prefs->shareddir_explicit_list = originalExplicit;
 		theApp->glob_prefs->shareddir_recursive_list = originalRecursive;
 		theApp->glob_prefs->SaveSharedFolders();
-		theApp->sharedfiles->Reload(nullptr);
+		ReloadSharedFilesWithProgress(this);
 		return SharedDirsCommitResult::CancelledByUser;
 	}
 


### PR DESCRIPTION
Closes #1018.

## Part B — the rollback walk

Cancelling the shared-folders scan in Preferences starts a second walk of comparable size — the previous directory list rather than the new one — and that one ran through `Reload(nullptr)`. A null yield callback pumps nothing, so the window stops repainting, cannot be dragged, and the window manager may grey it out. The progress dialog is gone by then too: `Update(100)` reaches the maximum on a `wxPD_AUTO_HIDE` dialog, so there is no window, no progress and no explanation.

The user reaches that line by cancelling a scan *because it was taking too long*, which makes it the worst instance of the freeze rather than the mildest. Reachable since `edd742e9e` (May); left behind when #1006 routed the other GUI walks through a yielding dialog.

It now goes through `ReloadSharedFilesWithProgress()` like every other GUI walk. The helper is the right shape as well as the shared one: it offers **no cancel**, which is exactly what a rollback needs, since `FindSharedFiles()` clears `m_Files_map` before walking and there is no earlier list left to fall back to.

## Why the helper turned out to be a drop-in after all

The issue ruled it out because it raises its own `wxPD_APP_MODAL` dialog and stacking that on the commit dialog is the misbehaviour `CatDialog.cpp:197-202` documents. That is true only while the commit dialog is still alive — `wxPD_AUTO_HIDE` hides it, but `wxPD_APP_MODAL` holds its disabler until *destruction*.

So the dialog is now held by `unique_ptr` and `reset()` before the rollback rather than living to end of scope. That also disposes of the trap the issue identified, without needing `Resume()` or a second dialog: `wxProgressDialog` latches its cancelled state (`progdlgg.h`: `Canceled // can be cancelled and, in fact, was`) and every later `Update()` / `Pulse()` returns `false`. On this path the user has just cancelled, so reusing that dialog would abort the rollback on its first `Pulse()` and leave `m_Files_map` half-populated — turning a cosmetic freeze into real loss of the share list.

Reset by pointer rather than an inner scope so the diff stays on the lines that change instead of reindenting ninety lines around them.

No new translatable string, and no second dialog to keep in sync.

## Part A — the documented log line

`REFERENCE.md` promised `Found 1234 known shared files, 7 unknown`; #1009 retired that suffix and the code emits only the pluralised `Found %i known shared files`. Since `POST /shared/reload` returns `202` and has no other completion signal, a client following the documented text never matched.

Corrected, plus half a sentence noting both bracketing lines are localised and the second pluralised, so a client matching on them pins the daemon's locale.

## Testing

Monolithic, remote GUI and daemon all build clean; `clang-format` (18.1.8, the CI version) clean.

**Not exercised by hand.** It needs a deliberately slow share, Preferences → OK → Cancel, and a check that `shareddir.dat` / `shareddir-explicit.dat` / `shareddir-recursive.dat` come back to their pre-OK state. The reasoning above is from the code and the wx headers, not from a run.

## One correction to the issue

Its acceptance grep expects only two remaining matches. `src/SharedFileList.cpp:1110` is a third — the no-arg `Reload()` overload forwarding to `Reload(nullptr)`, on the deferred `Process()` path the issue itself puts out of scope. That criterion cannot pass as written; it should name three, or exclude the overload.
