### PR TITLE
fix(amuleapi): correct nine defects from the #995 follow-up review

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -869,7 +869,7 @@ The swap moves the peer between two files' source lists, so an SSE subscriber se
 { "a4af_auto": false, "source_ecids": [ 1234, 5678 ] }
 ```
 
-`source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it.
+`source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it. The same peers appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients), which carries the whole peer object rather than a bare ECID.
 
 **Errors:** `400 bad_request` (missing or unknown `action`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 
@@ -1062,11 +1062,18 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "remote_queue_rank": 0,
       "score": 150,
       "obfuscation_status": "enabled",
-      "friend_slot": false
+      "friend_slot": false,
+      "source_origin": "kad",
+      "available_parts": 42,
+      "mod_version": "",
+      "view_shared_disabled": false,
+      "part_progress_percent": 87.5
     }
   ]
 }
 ```
+
+The last five were originally detail-only and were promoted onto this row (and onto the `client_added` / `client_updated` SSE payloads) so a client rendering a peer list does not have to fan out a detail request per row. `part_progress_percent` is **omitted**, not sent as a sentinel, when the peer is not a source for anything we are downloading — see the detail section below for what all five mean.
 
 `ecid` identifies the remote *peer*, not a file — it's the URL key for [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) and the identity carried in `client_removed` SSE payloads. `user_hash` is the peer's stable identity *when published* (peers without SecIdent or in their first session don't have one), so `ecid` is the always-populated handle.
 
@@ -1085,7 +1092,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `ident_state` | `not_available`, `id_needed`, `identified`, `id_failed`, `bad_guy`, `unknown` |
 | `obfuscation_status` | `undefined`, `enabled`, `supported`, `not_supported`, `disabled`, `unknown` |
 | `software` | `emule`, `cdonkey`, `lxmule`, `amule`, `shareaza`, `emule_plus`, `hydranode`, `mldonkey`, `lphant`, `edonkey_hybrid`, `edonkey`, `old_emule`, `compat`, `unknown` |
-| `source_origin` (detail only) | `server`, `kad`, `source_exchange`, `passive`, `link`, `source_seeds`, `search_result`, `unknown` |
+| `source_origin` | `server`, `kad`, `source_exchange`, `passive`, `link`, `source_seeds`, `search_result`, `unknown` |
 
 Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an absent or unexpected token. Note the two distinct sentinels on `obfuscation_status`: `"undefined"` is *the peer has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
 
@@ -1150,7 +1157,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-The detail fields mirror the desktop "Client Details" modal. `user_id_hybrid` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `available_parts` is the count of parts the peer holds of the linked file; `mod_version` is the peer's client-mod string (often `""`); `view_shared_disabled` is `true` when the peer forbids browsing its shared files. `is_friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `dl_up_modifier` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`available_parts` over that file's part count) and is **omitted** when there is no linked download or the part count is unknown.
+The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `available_parts`, `mod_version`, `view_shared_disabled` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `user_id_hybrid` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `available_parts` is the count of parts the peer holds of the linked file; `mod_version` is the peer's client-mod string (often `""`); `view_shared_disabled` is `true` when the peer forbids browsing its shared files. `is_friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `dl_up_modifier` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`available_parts` over that file's part count) and is **omitted** when there is no linked download or the part count is unknown.
 
 > `is_friend` and `dl_up_modifier` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `is_friend` reads `false` and `dl_up_modifier` reads `0`.
 

--- a/src/libwebcommon/JsonWriter.cpp
+++ b/src/libwebcommon/JsonWriter.cpp
@@ -118,32 +118,35 @@ void CJsonWriter::ValueUInt(uint64_t v)
 	m_needs_comma = true;
 }
 
+std::string JsonDoubleToString(double v)
+{
+	if (std::isnan(v) || std::isinf(v)) {
+		// JSON has no spelling for these.
+		return "null";
+	}
+	// %.17g is the shortest round-trippable form for IEEE 754 doubles.
+	char buf[64];
+	std::snprintf(buf, sizeof(buf), "%.17g", v);
+	// JSON numbers are always C-locale (a '.' decimal point), but snprintf
+	// honours LC_NUMERIC, which amuleapi/amuleweb inherit from --locale.
+	// %g never emits digit grouping, so the only possible locale artifact is
+	// the decimal separator; normalise it to '.' so the output is valid JSON
+	// regardless of the process locale.
+	const char decimal_point = *std::localeconv()->decimal_point;
+	if (decimal_point != '.') {
+		for (char *p = buf; *p; ++p) {
+			if (*p == decimal_point) {
+				*p = '.';
+			}
+		}
+	}
+	return buf;
+}
+
 void CJsonWriter::ValueDouble(double v)
 {
 	MaybeComma();
-	if (std::isnan(v) || std::isinf(v)) {
-		*m_buf += wxT("null");
-	} else {
-		// %.17g is the shortest round-trippable form for IEEE 754
-		// doubles. JSON doesn't allow `+Inf`, `-Inf` or `NaN` so we
-		// already handled those above.
-		char buf[64];
-		std::snprintf(buf, sizeof(buf), "%.17g", v);
-		// JSON numbers are always C-locale (a '.' decimal point), but snprintf
-		// honours LC_NUMERIC, which amuleapi/amuleweb inherit from --locale.
-		// %g never emits digit grouping, so the only possible locale artifact is
-		// the decimal separator; normalise it to '.' so the output is valid JSON
-		// regardless of the process locale.
-		const char decimal_point = *std::localeconv()->decimal_point;
-		if (decimal_point != '.') {
-			for (char *p = buf; *p; ++p) {
-				if (*p == decimal_point) {
-					*p = '.';
-				}
-			}
-		}
-		*m_buf += wxString::FromAscii(buf);
-	}
+	*m_buf += wxString::FromAscii(JsonDoubleToString(v).c_str());
 	m_needs_comma = true;
 }
 

--- a/src/libwebcommon/JsonWriter.h
+++ b/src/libwebcommon/JsonWriter.h
@@ -27,6 +27,7 @@
 
 #include <wx/string.h>
 #include <cstdint>
+#include <string>
 
 // Streaming JSON output. Appends to an internal or caller-owned wxString
 // buffer; the buffer holds JSON text suitable for UTF-8 emission via
@@ -43,6 +44,20 @@
 // Commas between siblings are inserted automatically. Calling Key()
 // outside an object, or omitting it inside one, is a programmer error
 // (no runtime check; tests cover the legal patterns).
+// One JSON number formatting for doubles, shared by CJsonWriter::ValueDouble
+// and by the hand-rolled ostringstream payload builders in the SSE layer.
+//
+// Two things it gets right that `ostream << double` does not: %.17g, the
+// shortest round-trippable form for an IEEE 754 double (the stream default is
+// 6 significant digits, so the same value reads differently on SSE and REST),
+// and a C-locale decimal point. JSON numbers are always '.'-separated, but
+// ostream and snprintf both honour LC_NUMERIC -- which amuleapi inherits from
+// --locale -- so on an it/de/fr locale an unnormalised double emits "33,3333"
+// and the whole frame stops being valid JSON.
+//
+// NaN and the infinities become `null`; JSON has no spelling for them.
+std::string JsonDoubleToString(double v);
+
 class CJsonWriter
 {
 public:

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2871,7 +2871,6 @@ const ListComparators<webapi::ClientSnapshot> &ClientComparators()
 				return a.software < b.software;
 			} },
 	};
-	;
 	return kComps;
 }
 
@@ -3616,6 +3615,14 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 				      clients.end(),
 				      [&](const webapi::ClientSnapshot &c) { return !matches(c); }),
 			clients.end());
+	}
+
+	// Same derived field the per-file rows and the detail object carry. It
+	// was omitted here, which left the SSE payload (which always carries it)
+	// contradicting both EVENTS.md's "same field set as the /clients list
+	// row" and REFERENCE.md's claim that it is detail-only.
+	for (auto &client : clients) {
+		ComputePartProgressPercent(m_state, client);
 	}
 
 	ListParams params;
@@ -6052,10 +6059,6 @@ std::size_t ParseTailParam(const std::string &query)
 	return static_cast<std::size_t>(capped);
 }
 
-// Parse an optional `?search_id=N` query param. `provided` is false when the
-// param is absent; `value` is the parsed id (0 on a malformed value). Callers
-// treat value 0 as "the current search". Multi-search only — every search on
-// the amuleapi surface is addressed by its daemon-allocated id.
 // Return a copy of `all` containing at most `tail` trailing lines.
 // `tail == 0` means "all lines" (no tailing).
 std::vector<std::string> SliceTail(const std::vector<std::string> &all, std::size_t tail)
@@ -9135,15 +9138,30 @@ CHttpServer::Response CApiDispatcher::HandleBrowse(
 
 	// A browse's "query" is the peer whose share is being listed -- that is
 	// what the daemon names the search, and what GET /search reports for it.
-	// Take the nickname from the client snapshot when we have one so the
+	// Take the nickname from the snapshot that actually owns this ECID so the
 	// results envelope can label the tab; a peer we have no snapshot for
 	// simply leaves it empty, same as any slot seeded before its name was
 	// observed.
+	//
+	// Which collection depends on how the browse was addressed. CECID hands
+	// out one global counter, so a CFriend's ECID never collides with a
+	// client's -- but it never *matches* one either, and searching the client
+	// list for it silently found nothing: every friend browse stored an empty
+	// name while GET /search reported the real nick for the same id.
 	std::string peer_name;
-	for (const auto &c : m_state.Clients()) {
-		if (c.ecid == ecid) {
-			peer_name = c.client_name;
-			break;
+	if (by_friend) {
+		for (const auto &f : m_state.Friends()) {
+			if (f.ecid == ecid) {
+				peer_name = f.name;
+				break;
+			}
+		}
+	} else {
+		for (const auto &c : m_state.Clients()) {
+			if (c.ecid == ecid) {
+				peer_name = c.client_name;
+				break;
+			}
 		}
 	}
 	m_state.MarkSearchStarted(search_id, "browse", peer_name);
@@ -9592,7 +9610,13 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	// and `comments` empty forever. Re-read the hit afterwards so the
 	// response reflects the refresh rather than the snapshot before it.
 	RefreshSearchIfStale(owner_search_id);
-	m_state.FindSearchResultByHash(needle, hit, nullptr);
+	// A refresh can drop the hit -- the daemon frees a search's results when
+	// it is closed, and the set is rebuilt wholesale rather than merged. The
+	// bool was discarded here, so that case answered 200 from the pre-refresh
+	// copy: a result the daemon no longer has, reported as if it did.
+	if (!m_state.FindSearchResultByHash(needle, hit, nullptr)) {
+		return ErrorResponse(404, "not_found", "no search result with that hash");
+	}
 
 	CHttpServer::Response r;
 	r.status = 200;
@@ -9658,11 +9682,6 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 	if (!m_state.FindSearchResultByHash(needle, known_hit, &owner_search_id)) {
 		return ErrorResponse(404, "not_found", "no search result with that hash");
 	}
-	// Refresh the owning search before starting the lookup, for the same
-	// reason the GET does: a finished search is otherwise frozen, and the
-	// flag this POST turns on would never be observed turning off again.
-	RefreshSearchIfStale(owner_search_id);
-
 	auto ec_req = std::make_unique<CECPacket>(EC_OP_SHARED_FILE_SEARCH_KAD_NOTES);
 	ec_req->AddTag(CECTag(EC_TAG_KNOWNFILE, file_hash));
 	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
@@ -9675,6 +9694,17 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 		return ErrorResponse(400, "amuled_rejected", ec_err.c_str());
 	}
 	delete ec_resp;
+
+	// Refresh AFTER the lookup has been started, for the same reason the GET
+	// refreshes at all: a finished search is otherwise frozen, and the flag
+	// this POST turns on would never be observed turning off again.
+	//
+	// Order matters. Refreshing first cached a pre-lookup snapshot and spent
+	// the one-second ClaimSearchRefresh token on it, so a GET issued straight
+	// afterwards fell inside the TTL and reported
+	// `kad_comment_search_running: false` for a lookup that had just begun --
+	// breaking the poll-until-false loop the docs prescribe.
+	RefreshSearchIfStale(owner_search_id);
 
 	CHttpServer::Response r;
 	r.status = 202;

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -133,7 +133,9 @@ private:
 		const CHttpServer::Request &, const std::string &key);
 	// source-reported filenames + counts. `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleDownloadFilenames(const CHttpServer::Request &, const std::string &key);
-	// A4AF source list (GET) + swap actions (POST). `key` = 32-char MD4 hash.
+	// A4AF swap action (POST). `key` = 32-char MD4 hash. The GET that once
+	// listed the sources is retired -- the rows now come from
+	// GET /downloads/{hash}/clients, which flags each one with `a4af`.
 	CHttpServer::Response HandleDownloadA4afAction(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);
@@ -277,8 +279,8 @@ private:
 	CHttpServer::Response HandleKnownClients(const CHttpServer::Request &);
 	// POST /clients/{ecid}/shared_files — browse a peer's shared file list
 	// ("View Files", #399). Returns a search_id addressed like any search:
-	// results via GET /search/results?search_id=, progress + SSE via the
-	// standard search machinery.
+	// results via GET /search/{id}/results, progress + SSE via the standard
+	// search machinery. (The old ?search_id= query form is a 404 since #996.)
 	CHttpServer::Response HandleClientBrowse(const CHttpServer::Request &, const std::string &ecid_str);
 	// Shared by the /clients and /friends browse routes; `by_friend` selects
 	// which sub-tag addresses the target.

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include <type_traits>
 
 namespace webapi
 {
@@ -121,7 +122,7 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	  << "\"total\":" << f.download.sources_total << ",\"not_current\":" << f.download.sources_not_current
 	  << ",\"transferring\":" << f.download.sources_transferring
 	  << ",\"a4af\":" << f.download.sources_a4af << "}"
-	  << ",\"progress\":{\"percent\":" << f.download.percent << "}"
+	  << ",\"progress\":{\"percent\":" << JsonDoubleToString(f.download.percent) << "}"
 	  << ",\"kad_comment_search_running\":" << (f.download.kad_comment_searching ? "true" : "false")
 	  << "}";
 	return o.str();
@@ -238,8 +239,12 @@ std::string ToJson(const ClientSnapshot &c)
 	  << ",\"view_shared_disabled\":" << (c.view_shared_disabled ? "true" : "false");
 	// Omitted, not sent as the negative sentinel, exactly as the REST row
 	// does it: the field only exists for a peer we are downloading from.
+	// Formatted through the shared writer, not `<<`: the stream default is 6
+	// significant digits (so SSE read 33.3333 where REST read
+	// 33.333333333333336) and it honours LC_NUMERIC, which on an it/de/fr
+	// locale would emit a comma and break the frame's JSON outright.
 	if (c.part_progress_percent >= 0.0) {
-		o << ",\"part_progress_percent\":" << c.part_progress_percent;
+		o << ",\"part_progress_percent\":" << JsonDoubleToString(c.part_progress_percent);
 	}
 	o << "}";
 	return o.str();
@@ -475,6 +480,14 @@ std::string RemovedHashPayload(const FileSnapshot &f)
 // spelled.
 template <class Snapshot> std::string RemovedEcidPayload(const Snapshot &item)
 {
+	// The per-type overloads this replaced could only be called with an
+	// ECID-keyed snapshot; an unconstrained template accepts anything with
+	// an `.ecid` member, and FileSnapshot has one (State.h) while its
+	// collections are hash-keyed and their consumers expect {"hash":...}.
+	// Wiring one through DiffMap would otherwise compile and emit the wrong
+	// shape at runtime.
+	static_assert(!std::is_same<Snapshot, FileSnapshot>::value,
+		"file collections are hash-keyed -- use RemovedHashPayload");
 	std::ostringstream o;
 	o << "{\"ecid\":" << item.ecid << "}";
 	return o.str();

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -908,18 +908,51 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 	// file_hash_by_ecid snapshot the caller built from m_files this
 	// tick. Empty hash if the ECID isn't in the map — file may have
 	// been removed between the file walkers and this client walker.
+	//
+	// A zero ECID is the core saying "no file", not "unchanged":
+	// ECSpecialCoreTags.cpp:438-443 emits `file->ECID()` or a literal 0 for
+	// both tags. Reading 0 as absent left the last hash cached forever, so a
+	// peer that finished downloading kept its `role: "source"` row in
+	// /downloads/{hash}/clients for as long as it stayed in clientlist.
+	//
+	// Whenever the hash moves, the matching per-part bitmap has to go with
+	// it. CUpDownClient::SetReqFile clears m_downPartStatus without
+	// repopulating it (DownloadClient.cpp:1683) and the core then sends no
+	// PART_STATUS until the peer answers for the new file, so a bitmap kept
+	// across the change describes the OLD file -- reported either as "holds
+	// every part" or as the old bitmap truncated to the new part count.
+	// amulegui re-zeroes its bitvector on the same transition; this decoder
+	// now does too.
 	{
 		std::uint32_t v = 0;
-		if (c->AssignIfExist(EC_TAG_CLIENT_UPLOAD_FILE, v) && v != 0) {
-			const auto it = file_hash_by_ecid.find(v);
-			cs.upload_file_hash = (it != file_hash_by_ecid.end()) ? it->second : std::string();
+		if (c->AssignIfExist(EC_TAG_CLIENT_UPLOAD_FILE, v)) {
+			std::string next;
+			if (v != 0) {
+				const auto it = file_hash_by_ecid.find(v);
+				next = (it != file_hash_by_ecid.end()) ? it->second : std::string();
+			}
+			if (next != cs.upload_file_hash) {
+				cs.upload_file_hash = std::move(next);
+				cs.upload_part_status.clear();
+				cs.upload_part_status_all = false;
+				cs.has_upload_part_status = false;
+			}
 		}
 	}
 	{
 		std::uint32_t v = 0;
-		if (c->AssignIfExist(EC_TAG_CLIENT_REQUEST_FILE, v) && v != 0) {
-			const auto it = file_hash_by_ecid.find(v);
-			cs.download_file_hash = (it != file_hash_by_ecid.end()) ? it->second : std::string();
+		if (c->AssignIfExist(EC_TAG_CLIENT_REQUEST_FILE, v)) {
+			std::string next;
+			if (v != 0) {
+				const auto it = file_hash_by_ecid.find(v);
+				next = (it != file_hash_by_ecid.end()) ? it->second : std::string();
+			}
+			if (next != cs.download_file_hash) {
+				cs.download_file_hash = std::move(next);
+				cs.part_status.clear();
+				cs.part_status_all = false;
+				cs.has_part_status = false;
+			}
 		}
 	}
 	{

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -50,11 +50,12 @@ void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli)
 	if (!cli.has_available_parts || cli.download_file_hash.empty()) {
 		return;
 	}
-	FileSnapshot f;
-	if (!state.FindDownload(cli.download_file_hash, f) || f.size == 0) {
-		return;
-	}
-	const std::uint64_t part_count = PartCountForSize(f.size);
+	// DownloadPartCount, not FindDownload: this runs once per source per
+	// tick on the SSE path and once per row on two REST paths, and the part
+	// count is the only thing wanted. FindDownload would deep-copy the whole
+	// FileSnapshot each time, repeating the identical copy for every source
+	// of the same file.
+	const std::uint64_t part_count = state.DownloadPartCount(cli.download_file_hash);
 	if (part_count == 0) {
 		return;
 	}
@@ -602,6 +603,18 @@ bool CState::FindDownload(const std::string &hash_hex, FileSnapshot &out) const
 		return false;
 	out = it->second;
 	return true;
+}
+
+std::uint64_t CState::DownloadPartCount(const std::string &hash_hex) const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	std::uint32_t ecid = 0;
+	if (!m_files.FindEcidByHash(hash_hex, ecid))
+		return 0;
+	const auto it = m_files.find(ecid);
+	if (it == m_files.end() || !it->second.is_downloading)
+		return 0;
+	return PartCountForSize(it->second.size);
 }
 
 bool CState::FindDownloadByEcid(std::uint32_t ecid, FileSnapshot &out) const

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -368,11 +368,12 @@ struct ClientSnapshot
 					// "disabled" | "unknown"
 	bool friend_slot = false;
 
-	// --- Detail-only fields (issue #422) -----------------------------
-	// Captured from EC tags already on the INC_UPDATE wire but not
-	// surfaced by the /clients list. Serialized only by the
-	// GET /clients/{ecid} detail endpoint; the list object and the SSE
-	// client_* payloads are unchanged.
+	// --- Extra fields decoded off the INC_UPDATE wire (issue #422) ----
+	// Originally detail-only. Five of them -- source_origin,
+	// available_parts, mod_version, view_shared_disabled and the derived
+	// part_progress_percent -- were since promoted to the /clients list row
+	// and the SSE client_* payloads (#995, #1015); the rest are still
+	// serialized only by GET /clients/{ecid}.
 	std::uint32_t user_id_hybrid = 0; // EC_TAG_CLIENT_USER_ID (hybrid eD2k id)
 	bool high_id = false;             // derived: !IsLowID(user_id_hybrid)
 	std::string server_ip;            // dotted-quad; "" when unknown/0
@@ -386,7 +387,10 @@ struct ClientSnapshot
 	bool view_shared_disabled = false; // peer forbids viewing its shared files
 	// Completeness of the linked download for this peer, as a percent
 	// (available_parts / file part count). < 0 => not computable (no
-	// linked file / no part count); populated by the detail handler.
+	// linked file / no part count). Derived rather than decoded: filled in
+	// by ComputePartProgressPercent at every site that serializes a client
+	// -- the list, the per-file rows, the detail object and the SSE
+	// payload -- since it needs a second snapshot to resolve.
 	double part_progress_percent = -1.0;
 
 	// Per-part bitmaps, one bit per chunk of the file the relation names:
@@ -408,6 +412,13 @@ struct ClientSnapshot
 	bool has_upload_part_status = false;
 	// Indices into the download bitmap; absent from the wire means unchanged,
 	// so the has_ flags distinguish "never reported" from "reported as 0".
+	//
+	// Decoded but not yet surfaced: no endpoint serializes these and no
+	// comparator sorts on them. Kept because the decode is already paid for
+	// on every INC_UPDATE tick and they are the natural companions of the
+	// bitmaps above -- a client wanting to show which chunk a peer is
+	// feeding needs them. Delete them rather than leave them rotting if
+	// that never materialises.
 	std::uint16_t next_requested_part = 0;
 	std::uint16_t last_downloading_part = 0;
 	bool has_next_requested_part = false;
@@ -780,8 +791,6 @@ struct SearchProgressSnapshot
 	std::uint64_t generation = 0;
 };
 
-// One concurrent search's cached state: its results (keyed by result ECID)
-// and its lifecycle progress. CState holds a map of these keyed by the
 // The byte width of one partfile chunk. Authoritative copy is PARTSIZE in
 // `protocol/ed2k/Constants.h`, which is deliberately NOT included here: that
 // header is written against amule's legacy `uint64`/`uint32` typedefs from
@@ -814,6 +823,8 @@ std::uint64_t PartCountForSize(std::uint64_t size);
 class CState;
 void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli);
 
+// One concurrent search's cached state: its results (keyed by result ECID)
+// and its lifecycle progress. CState holds a map of these keyed by the
 // daemon-allocated search_id (see m_searches).
 struct SearchSlot
 {
@@ -1457,6 +1468,11 @@ public:
 	// is left untouched. Used by /downloads/{hash} (download role) and
 	// /shared/{hash} (shared role) — both inspect the same m_files map.
 	bool FindDownload(const std::string &hash_hex, FileSnapshot &out) const;
+	// Part count of the download with this hash, or 0 when there is none (or
+	// it has no size yet). Exists so a per-client loop can ask the cheap
+	// question without FindDownload's full FileSnapshot copy -- strings plus
+	// the gap / source / comment vectors, per source, per tick.
+	std::uint64_t DownloadPartCount(const std::string &hash_hex) const;
 	bool FindShared(const std::string &hash_hex, FileSnapshot &out) const;
 
 	// ECID-keyed counterparts. Used internally — there is no

--- a/unittests/tests/JsonWriterTest.cpp
+++ b/unittests/tests/JsonWriterTest.cpp
@@ -22,6 +22,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 //
 
+#include <clocale>
 #include <muleunit/test.h>
 #include "JsonWriter.h"
 
@@ -255,4 +256,43 @@ TEST(JsonWriter, LargeString)
 	expected += big;
 	expected += wxT("\"");
 	ASSERT_EQUALS(expected, w.GetBuffer());
+}
+
+// JsonDoubleToString is the one formatting both the REST writer and the SSE
+// payload builders go through. It exists because `ostream << double` differs
+// from it in two ways that matter on the wire.
+TEST(JsonWriter, DoubleToStringIsRoundTrippableNotSixDigits)
+{
+	// The stream default is 6 significant digits, which turns 1-of-3 parts
+	// into "33.3333" -- a different number from the one REST reports for the
+	// same value.
+	const double third = 100.0 / 3.0;
+	ASSERT_EQUALS(std::string("33.333333333333336"), JsonDoubleToString(third));
+	// Whole values stay short; %.17g does not pad.
+	ASSERT_EQUALS(std::string("87.5"), JsonDoubleToString(87.5));
+	ASSERT_EQUALS(std::string("100"), JsonDoubleToString(100.0));
+	ASSERT_EQUALS(std::string("0"), JsonDoubleToString(0.0));
+}
+
+TEST(JsonWriter, DoubleToStringUsesACLocaleDecimalPoint)
+{
+	// snprintf and ostream both honour LC_NUMERIC, which amuleapi inherits
+	// from --locale. A comma separator would make the frame invalid JSON, so
+	// the formatter normalises it. Skipped where the locale is unavailable,
+	// which is normal in a minimal container.
+	const char *prev = std::setlocale(LC_NUMERIC, nullptr);
+	const std::string saved = prev ? prev : "C";
+	if (std::setlocale(LC_NUMERIC, "de_DE.UTF-8") == nullptr &&
+		std::setlocale(LC_NUMERIC, "it_IT.UTF-8") == nullptr) {
+		return;
+	}
+	const std::string got = JsonDoubleToString(87.5);
+	std::setlocale(LC_NUMERIC, saved.c_str());
+	ASSERT_EQUALS(std::string("87.5"), got);
+}
+
+TEST(JsonWriter, DoubleToStringSpellsNonFiniteAsNull)
+{
+	ASSERT_EQUALS(std::string("null"), JsonDoubleToString(std::nan("")));
+	ASSERT_EQUALS(std::string("null"), JsonDoubleToString(std::numeric_limits<double>::infinity()));
 }

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1533,6 +1533,106 @@ TEST(Refresher, ClientPartStatusIsDecodedLsbFirst)
 	ASSERT_TRUE(!cache[12].part_status[7]);
 }
 
+// Same helper plus a REQUEST_FILE ECID, for the swap tests below. The core
+// always sends that tag when the request file changes (AddDiffTag), and sends
+// it as a literal 0 when the peer stops requesting anything
+// (ECSpecialCoreTags.cpp:443).
+static void PutClientWithReqFileAndPartStatus(CECPacket &resp,
+	std::uint32_t ecid,
+	std::uint32_t req_file_ecid,
+	const std::uint8_t *buf /* nullptr = no part-status tag at all */,
+	std::size_t len)
+{
+	CECTag container(EC_TAG_CLIENT, static_cast<std::uint32_t>(0));
+	CECTag cli(EC_TAG_CLIENT, ecid);
+	cli.AddTag(CECTag(EC_TAG_CLIENT_REQUEST_FILE, req_file_ecid));
+	if (buf) {
+		cli.AddTag(CECTag(EC_TAG_CLIENT_PART_STATUS, len, buf));
+	}
+	container.AddTag(cli);
+	resp.AddTag(container);
+}
+
+TEST(Refresher, ClientPartStatusIsDroppedWhenTheRequestFileChanges)
+{
+	// An A4AF swap. CUpDownClient::SetReqFile clears m_downPartStatus without
+	// repopulating it, and the core then sends no PART_STATUS until the peer
+	// answers for the new file -- so a bitmap kept across the change would
+	// describe the OLD file and report the peer as holding parts of a file it
+	// has never sent a status for.
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> files;
+	files[70] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+	files[71] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+	const std::uint8_t buf[] = { 0x05 };
+	CECPacket first(EC_OP_SHARED_FILES);
+	PutClientWithReqFileAndPartStatus(first, 20, 70, buf, sizeof(buf));
+	ApplyGetUpdateToClients(&first, cache, files);
+	ASSERT_TRUE(cache[20].has_part_status);
+	ASSERT_EQUALS(std::string("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), cache[20].download_file_hash);
+
+	// Second tick: same peer, different file, and no PART_STATUS with it.
+	CECPacket second(EC_OP_SHARED_FILES);
+	PutClientWithReqFileAndPartStatus(second, 20, 71, nullptr, 0);
+	ApplyGetUpdateToClients(&second, cache, files);
+
+	ASSERT_EQUALS(std::string("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), cache[20].download_file_hash);
+	ASSERT_TRUE(!cache[20].has_part_status);
+	ASSERT_TRUE(!cache[20].part_status_all);
+	ASSERT_TRUE(cache[20].part_status.empty());
+}
+
+TEST(Refresher, ClientPartStatusInTheSameTickSurvivesTheFileChange)
+{
+	// The invalidation must not eat a bitmap the same packet carries: the
+	// hash is merged before the PART_STATUS decode, so a peer that swaps and
+	// reports its new status in one tick keeps the new status.
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> files;
+	files[70] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+	files[71] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+	const std::uint8_t old_buf[] = { 0x05 };
+	CECPacket first(EC_OP_SHARED_FILES);
+	PutClientWithReqFileAndPartStatus(first, 21, 70, old_buf, sizeof(old_buf));
+	ApplyGetUpdateToClients(&first, cache, files);
+
+	const std::uint8_t new_buf[] = { 0x02 };
+	CECPacket second(EC_OP_SHARED_FILES);
+	PutClientWithReqFileAndPartStatus(second, 21, 71, new_buf, sizeof(new_buf));
+	ApplyGetUpdateToClients(&second, cache, files);
+
+	ASSERT_EQUALS(std::string("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), cache[21].download_file_hash);
+	ASSERT_TRUE(cache[21].has_part_status);
+	ASSERT_TRUE(!cache[21].part_status[0]);
+	ASSERT_TRUE(cache[21].part_status[1]);
+}
+
+TEST(Refresher, ClientRequestFileZeroClearsTheDownloadHash)
+{
+	// The core spells "no request file" as the tag carrying 0, not as an
+	// absent tag. Reading that as "unchanged" left a finished peer listed as
+	// a source of the file it had just completed, bitmap and all.
+	std::map<std::uint32_t, ClientSnapshot> cache;
+	std::map<std::uint32_t, std::string> files;
+	files[70] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+	const std::uint8_t buf[] = { 0x05 };
+	CECPacket first(EC_OP_SHARED_FILES);
+	PutClientWithReqFileAndPartStatus(first, 22, 70, buf, sizeof(buf));
+	ApplyGetUpdateToClients(&first, cache, files);
+	ASSERT_EQUALS(std::string("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), cache[22].download_file_hash);
+
+	CECPacket second(EC_OP_SHARED_FILES);
+	PutClientWithReqFileAndPartStatus(second, 22, 0, nullptr, 0);
+	ApplyGetUpdateToClients(&second, cache, files);
+
+	ASSERT_TRUE(cache[22].download_file_hash.empty());
+	ASSERT_TRUE(!cache[22].has_part_status);
+	ASSERT_TRUE(cache[22].part_status.empty());
+}
+
 TEST(Refresher, ClientAbsentPartStatusLeavesCachedBitmap)
 {
 	// Tagmap convention: a tick that does not carry the tag says nothing


### PR DESCRIPTION
Review of #995 and its follow-ups (#996, #1004, #1015) turned up nine correctness defects plus a tail of stale comments and docs. Ordered most severe first.

## 1. Per-part bitmaps were never invalidated when a peer's request file changed

`CUpDownClient::SetReqFile` clears `m_downPartStatus` without repopulating it ([DownloadClient.cpp:1683](https://github.com/amule-org/amule/blob/master/src/DownloadClient.cpp#L1683)) and the core then sends no `PART_STATUS` until the peer answers for the new file. So a peer A4AF-swapped from file A to B was reported as holding **every chunk of B**, or as holding A's bitmap truncated to B's part count. amulegui re-zeroes its bitvector on that transition; this decoder now does too.

The clear runs before the `PART_STATUS` decode, so a swap that reports its new status in the same tick keeps the new status — covered by its own test.

## 2. A finished peer never left `GET /downloads/{hash}/clients`

Row membership keys on `download_file_hash` / `upload_file_hash`, and the core spells "no file" as the tag carrying `0` ([ECSpecialCoreTags.cpp:438-443](https://github.com/amule-org/amule/blob/master/src/ECSpecialCoreTags.cpp#L438-L443)) while the merge guarded on `v != 0`. The last hash therefore stayed cached forever and the peer kept its `role: "source"` row — stale bitmap included — for as long as it lived in `clientlist`.

## 3. A friend browse looked its nickname up in the client list

`CECID` hands out one global counter, so a `CFriend`'s ECID never matches a client. Every `POST /friends/{ecid}/shared_files` stored an empty query while `GET /search` reported the real nick for the same id.

## 4. The Kad-notes POST refreshed before sending its packet

That cached a pre-lookup snapshot and spent the one-second `ClaimSearchRefresh` token on it, so a `GET` issued straight afterwards fell inside the TTL and answered `kad_comment_search_running: false` for a lookup that had just begun — breaking the poll-until-false loop the docs prescribe. The refresh now happens after the lookup is started.

## 5. `GET /clients` never computed `part_progress_percent`

The list row omitted it while the SSE payload always carried it — the inverse of the parity #1015 set out to establish, and it made that PR's own two EVENTS.md sentences false in the other direction.

## 6. A dropped search result answered 200 from a stale copy

The comments `GET` discarded the post-refresh lookup result, so when the refresh had dropped the hit it answered 200 from the pre-refresh copy. It now 404s.

## 7. Both SSE doubles bypassed the JSON number formatting

`ostream <<` is 6 significant digits against the REST writer's `%.17g` (one-of-three parts read `33.3333` on SSE and `33.333333333333336` on REST), and it honours `LC_NUMERIC` — which amuleapi inherits from `--locale`. On an it/de/fr locale the frame would carry `"33,3333"` and **stop being valid JSON**. The REST writer already normalised the separator; that formatting is now one shared `JsonDoubleToString` rather than a second hand-rolled copy.

This also covers `download.percent`, which had the same exposure and predates the reviewed PRs.

## 8. A whole `FileSnapshot` was deep-copied per source per tick

`ComputePartProgressPercent` called `FindDownload`, copying strings plus the gap / source / comment vectors once per source per 1 s tick on the app thread, repeating the identical copy for every source of the same file. Replaced by `CState::DownloadPartCount`, which reads the one number under the lock — fixing the cost at every call site rather than only the SSE one.

## 9. The `RemovedEcidPayload` template lost its compile-time guard

It accepts anything with an `.ecid` member, and `FileSnapshot` has one while its collections are hash-keyed. Wiring one through `DiffMap` would compile and emit `{"ecid":…}` where consumers expect `{"hash":…}`. A `static_assert` restores what the three overloads gave for free.

## Docs and comments

The promoted fields are no longer described as detail-only, with the `/clients` example updated to actually carry them; the a4af `POST` reply shape is written out rather than pointing at a retired `GET`; the `ClientSnapshot` block comment, the A4AF handler comment and the browse handler comment all say what the code does now; a doc block orphaned by a deleted function is gone, as is a stray `;`; the two decoded-but-unread part indices say why they are kept; and the `kPartSizeBytes` block that had been inserted into the middle of the `SearchSlot` doc comment is out of it.

## Testing

**35/35 unit tests pass, including six new ones.** Three in `RefresherTest` cover the bitmap invalidation, the same-tick swap that must *keep* its new bitmap, and the zero-ECID clear. Three in `JsonWriterTest` cover `%.17g` precision, the `LC_NUMERIC` normalisation, and non-finite → `null`.

Live against a daemon: `04-read-downloads-shared` 65/65, `19-search` 137/138 (the one failure is cross-run state pollution — searches accumulate in the daemon between runs — not a regression).

The `/clients` percent fix is verified by construction rather than live: it is a three-line loop over a function two other handlers already call and the unit tests cover, and a throwaway rig attracts no real peers to render.

clang-format clean; both clang-tidy tiers clean with 0 compiler errors.
