### PR TITLE
fix(gui): grey the search category label with its selector

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -1585,8 +1585,11 @@ void CSearchDlg::UpdateCatChoice()
 	// With only Main configured there is nothing to choose, so the selector is
 	// noise. Same gate the context menu applies to its own category submenu
 	// (SearchListCtrl.cpp), and it lifts as soon as a second category exists --
-	// this runs on every category change, so no restart is needed.
-	c_cat->Enable(theApp->glob_prefs->GetCatCount() > 1);
+	// this runs on every category change, so no restart is needed. The label
+	// greys out with it, or it reads as live beside a dead dropdown.
+	const bool haveChoice = theApp->glob_prefs->GetCatCount() > 1;
+	c_cat->Enable(haveChoice);
+	FindWindow(ID_AUTOCATASSIGN_LABEL)->Enable(haveChoice);
 }
 
 void CSearchDlg::UpdateProgress(uint32 new_value)

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -366,7 +366,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     // hidden and then silently ignored. Here it is always visible and its
     // meaning is positional. Same wording as the right-click action that does
     // the same thing (SearchListCtrl.cpp), so the two cannot drift.
-    wxStaticText *item17 = new wxStaticText( parent, -1, _("Download in category"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item17 = new wxStaticText( parent, ID_AUTOCATASSIGN_LABEL, _("Download in category"), wxDefaultPosition, wxDefaultSize, 0 );
     item43->Add( item17, wxSizerFlags().Center().Border(wxALL, 5) );
     // Empty item list: UpdateCatChoice() fills it and keeps it in step with the
     // configured categories. nullptr, not the file's usual (wxString*) NULL --

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -71,6 +71,9 @@ extern wxSizer *s_search_sizer;
 extern wxSizer *s_extended_sizer;
 #define IDC_TypeSearch 10006
 #define ID_AUTOCATASSIGN 10007
+// Label of the category selector: has an id so UpdateCatChoice() can grey it
+// out with the choice. Numbered out of block like ID_FILTER_RESET.
+#define ID_AUTOCATASSIGN_LABEL 10509
 #define IDC_EDITSEARCHEXTENSION 10008
 #define IDC_SPINSEARCHMIN 10009
 #define IDC_SEARCHMINSIZE 10010


### PR DESCRIPTION
UpdateCatChoice() disables the download-category choice while Main is the only category, but its "Download in category" label kept its normal colour, so the pair read as half-live. One category is the default configuration, so that is the state most users see all the time.

The label now carries an id and is disabled alongside the choice.

Follow-up to #979, GUI only.