### PR TITLE
fix(gui): act on a column resize when it ends, not on every pixel of it

### DIFF
--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -504,7 +504,17 @@ void CMuleDataViewCtrl::OnIdle(wxIdleEvent &event)
 			changed = true;
 		}
 	}
+
+	// Act when the drag ends, not on every step of it. Idle fires as long as
+	// the mouse moves, so a change on this tick means the pointer is still
+	// dragging and a further change is coming; the width that matters is the
+	// one it stops at. Firing per observed change instead ran a wxConfig write
+	// and, for a search list, a full column-sync across every other open tab
+	// for each pixel of travel -- the flicker and CPU spike of issue #1022.
 	if (changed) {
+		m_widthsSettling = true;
+	} else if (m_widthsSettling) {
+		m_widthsSettling = false;
 		OnColumnWidthsChanged();
 	}
 

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -164,6 +164,15 @@ protected:
 	 * user happened to sort or toggle a column afterwards -- SaveColumnSettings'
 	 * only other callers. An override must call the base, or resizing stops
 	 * being remembered for that list.
+	 *
+	 * Fired once per drag, when the widths stop moving -- not once per pixel.
+	 * The poll runs on idle, which fires continuously while the mouse does, so
+	 * acting on every observed change made a single drag do its work hundreds
+	 * of times: a wxConfig write each time here, and in CSearchListCtrl a
+	 * width-set on every column of every other open search tab, each forcing a
+	 * header relayout and repaint. That is what made resizing flicker and spike
+	 * the CPU, the more so the more tabs were open (issue #1022). Only the
+	 * final width matters, so only the final width is acted on.
 	 */
 	virtual void OnColumnWidthsChanged() { SaveColumnSettings(); }
 
@@ -367,6 +376,11 @@ private:
 
 	//! Last-seen widths, for detecting a drag-resize (no portable event).
 	std::vector<int> m_lastKnownWidths;
+
+	//! Whether the widths moved since the last idle, i.e. a drag is still in
+	//! progress. OnColumnWidthsChanged() fires when this goes back to false,
+	//! not while it is true -- see OnIdle().
+	bool m_widthsSettling = false;
 
 	//! True once AppendSpacerColumn() has run (macOS only).
 	bool m_hasSpacer = false;


### PR DESCRIPTION
Found while investigating #1022, but **it does not fix that issue** - the reporter confirmed the flicker
survives this change, so it deliberately does not close it. What follows is real waste this removes on
its own merits.

Resizing a column ran the width-changed handler once per pixel of drag.

## Cause

`wxDataViewCtrl` has no portable end-of-drag event (unlike `wxListCtrl`'s `EVT_LIST_COL_END_DRAG`), so `CMuleDataViewCtrl::OnIdle` detects a resize by polling every column's width and comparing against the last seen values. Idle fires for as long as the mouse moves, and during a drag the width changes on essentially every one, so `OnColumnWidthsChanged()` ran **once per pixel of travel**.

Each of those calls does real work:

- the base writes every column into `wxConfig`
- `CSearchListCtrl` additionally mirrors the widths onto **every other open search tab**, setting each column and forcing a header relayout and repaint there

So a single drag costs O(pixels × tabs × columns) repaints. That is the flicker and the CPU spike, and it explains why it is worse with several tabs open - the cross-tab mirror is the part that scales.

Distinct from #951 / #953, which was `CMuleNotebook` repainting tabs on mouse-move. This is the column-width poller, in a different file.

## Fix

Only the width the drag stops at matters, so only that one is acted on. A change on this tick means the pointer is still moving and another is coming; the hook fires on the first idle that sees nothing move.

In the base class, so every list gets it. `CMuleVirtualDataViewCtrl` inherits the poll rather than repeating it, so the single change covers all nine derived controls (Search, Shared Files, Downloads, Servers, Friends, GenericClient, ClientRow, FileDetail). `CSearchListCtrl` is the only override of the hook and needs no change - it simply stops being called hundreds of times per drag.

## Note

The save is one idle tick later than before. Nothing flushes column settings at shutdown (the base destructor is `= default`), so a resize followed instantly by quitting could in principle lose the width - but releasing the button empties the event queue and the settled idle follows within microseconds.

## Testing

Builds clean, `clang-format` clean, unit suite 35/35.

The per-pixel firing is read directly from the code, not inferred. What is *not* established is that it caused the flicker in #1022: the reporter tried this build and still sees flickering, and a second tester could not reproduce the symptom at all on wxGTK3 with ten search tabs. The evidence now points at GTK toggling the horizontal scrollbar as the column total crosses the viewport width, which is a different mechanism and is being pursued separately on the issue.

So this stands on being less wasteful - one `wxConfig` write and one cross-tab sync per drag instead of per pixel - rather than on fixing a user-visible symptom.

