### PR TITLE
fix(amuleapi): seed the percent when adopting a finished search

### DIFF
--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -322,6 +322,15 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 	// ships no timestamp to borrow.
 	slot.progress.active = active;
 	slot.progress.complete = complete;
+	// Seeded here or never. A slot discovered as finished is not in
+	// ActiveSearchIds(), so the tick never polls it and WriteSearchProgress
+	// is never called for it -- the percent would sit at its 0 default for
+	// the life of the slot, contradicting the "finished" state in the very
+	// same envelope. A finished search is 100 by definition, so there is
+	// nothing to ask the daemon for. A discovered *running* slot keeps 0 and
+	// is corrected by the next tick, which is why only the finished case was
+	// stuck.
+	slot.progress.percent = complete ? 100 : 0;
 	slot.progress.kind = kind;
 	slot.query = query;
 	slot.seq = ++m_search_seq;

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -274,6 +274,18 @@ if [ -n "$SECOND_TOKEN" ] && [ "$SECOND_TOKEN" != "null" ]; then
 	# The adopted slot also learns the query from the SEARCH_LIST entry,
 	# so a client that discovered an id can label it without guessing.
 	_assert_json_eq '.query' "$TEST_QUERY" 'second amuleapi instance reports the discovered query'
+	# A slot discovered as finished is never polled by the tick, so its
+	# percent has to be seeded at discovery or it stays 0 forever and
+	# contradicts the "finished" state carried in this same envelope. Only
+	# meaningful once the search has actually finished; a still-running one
+	# reports the daemon's real ramp and is checked elsewhere.
+	ADOPTED_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
+	if [ "$ADOPTED_STATE" = "finished" ]; then
+		_assert_json_eq '.progress.percent' 100 \
+			'an adopted finished search reports percent 100, not 0'
+	else
+		echo "    info: adopted search still $ADOPTED_STATE; skipping the finished-percent check"
+	fi
 else
 	_fail "second amuleapi instance: admin login" "could not obtain a token; log: $(tail -c 300 "$SECOND_LOG")"
 fi

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -26,6 +26,7 @@
 
 #include "State.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -602,6 +603,57 @@ TEST(State, DiscoveredSearchKeepsTheDaemonsLifecycleState)
 	// finished search would show an empty result list forever.
 	ASSERT_TRUE(s.ClaimSearchRefresh(42, std::chrono::milliseconds(1000)));
 	ASSERT_FALSE(s.ClaimSearchRefresh(43, std::chrono::milliseconds(1000)));
+}
+
+TEST(State, DiscoveredFinishedSearchReportsFullPercent)
+{
+	// A slot discovered as finished is never polled -- it is not in
+	// ActiveSearchIds() -- so the percent has to be seeded at discovery or it
+	// stays 0 for the life of the slot, contradicting the "finished" state
+	// carried in the same envelope. A finished search is 100 by definition.
+	CState s;
+	s.MarkSearchDiscovered(2147483660u, "kad", "harry", /*active=*/false, /*complete=*/true);
+	const auto finished = s.SearchProgress(2147483660u);
+	ASSERT_TRUE(finished.complete);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(100), finished.percent);
+}
+
+TEST(State, DiscoveredRunningSearchKeepsZeroPercentAndIsPolled)
+{
+	// The running case must not be faked to 100: it is in ActiveSearchIds(),
+	// so the very next tick overwrites the percent with the daemon's real
+	// one. Seeding anything but 0 here would flash a wrong number for a tick.
+	CState s;
+	s.MarkSearchDiscovered(44, "kad", "ubuntu", /*active=*/true, /*complete=*/false);
+	const auto running = s.SearchProgress(44);
+	ASSERT_TRUE(!running.complete);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), running.percent);
+
+	const auto active = s.ActiveSearchIds();
+	ASSERT_TRUE(std::find(active.begin(), active.end(), 44u) != active.end());
+}
+
+TEST(State, DiscoveryDoesNotStompAnAlreadyKnownSearchsPercent)
+{
+	// Re-discovery of a slot this session already tracks must leave its
+	// accumulated progress alone; only the query is filled in. Seeding the
+	// percent must not have opened a path that overwrites a real one.
+	// The slot has to exist first: WriteSearchProgress only updates a slot
+	// that is already there, so seeding it needs MarkSearchStarted (this
+	// session started the search) before the progress write.
+	CState s;
+	s.MarkSearchStarted(45, "kad", "ubuntu");
+	SearchProgressSnapshot p;
+	p.active = true;
+	p.complete = false;
+	p.percent = 37;
+	p.kind = "kad";
+	s.WriteSearchProgress(45, p);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(37), s.SearchProgress(45).percent);
+
+	// Re-discovery of that same id must leave the real percent alone.
+	s.MarkSearchDiscovered(45, "kad", "named-later", /*active=*/false, /*complete=*/true);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(37), s.SearchProgress(45).percent);
 }
 
 TEST(State, SearchRefreshIsClaimedOncePerTtlAndOnlyWhenIdle)


### PR DESCRIPTION
Closes #1026.

`GET /api/v0/search/{id}/results` for a search this amuleapi process did not start reported `"state": "finished"` alongside `"percent": 0`, and never corrected itself — two fields contradicting each other in the one response that carries both. A client rendering a progress bar off that field showed a completed search as stalled at 0 %.

## Root cause

`MarkSearchDiscovered` seeds `active`, `complete`, `kind` and `query` but left `progress.percent` at its `0` default, and nothing repairs it afterwards:

- the refresher tick only asks about `ActiveSearchIds()`, and a slot seeded as **finished** is not in that set, so `WriteSearchProgress` is never called for it;
- `RefreshSearchIfStale`, the on-read refresh added for finished searches, fetches results and not progress.

A slot seeded as **running** self-corrects on the next tick, which is why only the finished case stuck.

## The fix

Seed the percent where the lifecycle state it derives from is seeded. A finished search is 100 by definition, so there is nothing to ask the daemon for: no new EC tag, no extra roundtrip on any path, and it behaves identically against an older amuled.

The running case is deliberately left at `0` rather than faked. That slot **is** in `ActiveSearchIds()`, so the next tick overwrites it with the daemon's real ramp — seeding anything else would flash a wrong number for a tick.

## Note on the issue's reasoning

The issue rules out "add percent to `EC_OP_SEARCH_LIST`" partly on the grounds that the list "carries no percent to read even if we wanted to". The tag itself does exist — `EC_TAG_SEARCH_LIFECYCLE_PERCENT` at `0x070C`+1 — it is simply not among the five tags `Get_EC_Response_Search_List` emits. That does not change the conclusion (a finished search needs no wire data to be known as 100), but it is worth recording, because #1029 proposes adding a different existing tag to that same builder: if it does, carrying the percent along would give discovered *running* searches a real number immediately rather than one tick later. This fix would still be wanted either way, since it costs nothing and works against daemons that send neither tag.

## Testing

Three new `StateTest` cases:

- a slot discovered as finished reports `percent == 100`;
- a slot discovered as running keeps `0` **and** appears in `ActiveSearchIds()`, pinning the reason the running case is not seeded;
- re-discovering a slot this session already tracks leaves its accumulated percent alone (guarding against the seed opening a path that stomps a real value).

Plus an assertion in `19-search.sh`'s existing second-instance discovery block, guarded on the adopted search having actually reached `finished` — a still-running one reports the daemon's ramp and is covered elsewhere.

35/35 unit tests pass; clang-format clean; both clang-tidy tiers report 0 findings with 0 compiler errors.
