### PR TITLE
test(amuleapi): fix the jq that made the status_changed parity check always fail

### DIFF
--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -409,9 +409,13 @@ kill $SSE_PID 2>/dev/null
 wait $SSE_PID 2>/dev/null
 if [ -n "$STATUS_JSON" ]; then
 	REST_JSON=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/status")
+	# The two subtractions need their own parentheses: inside object
+	# construction jq parses `k: a - b` as `k: a` and then chokes on the `-`,
+	# so the expression failed to compile and this check reported a failure
+	# on every run that actually captured a frame.
 	DIFF=$(jq -n --argjson a "$REST_JSON" --argjson b "$STATUS_JSON" \
 		'def keys_: [paths | join(".")] | sort;
-		 {rest_only: ($a|keys_) - ($b|keys_), sse_only: ($b|keys_) - ($a|keys_)}')
+		 {rest_only: (($a|keys_) - ($b|keys_)), sse_only: (($b|keys_) - ($a|keys_))}')
 	if [ "$(echo "$DIFF" | jq -c '.')" = '{"rest_only":[],"sse_only":[]}' ]; then
 		_pass "status_changed payload keys match GET /status exactly"
 	else


### PR DESCRIPTION
The `status_changed` / `GET /status` key-parity check added in #1002 has never actually run. Inside jq object construction, `{k: a - b}` parses as `{k: a}` and then chokes on the `-`:

```
jq: error: syntax error, unexpected '-', expecting '}' (Unix shell quoting issues?)
jq: 2 compile errors
```

jq then produces no output, the comparison against the expected empty-diff object cannot match, and the check reports a **failure** - it does not skip. So the suite is red whenever a run actually captures a `status_changed` frame.

It stayed unnoticed because that only happens on a daemon busy enough to emit one inside the capture window. An idle one takes the "not emitted this run" path and the suite passes, which is how it got through review - mine, on #1002.

Parenthesising each subtraction is the whole fix.

## Verification

Against a live `amuled` + `amuleapi` that does emit a frame, the same check on the same daemon:

```
before:  FAIL  status_changed / GET /status key parity
after:   PASS  status_changed payload keys match GET /status exactly
```

and `22-sse-diff-emission.sh` goes from `FAIL: 1/21 failed` to `OK: 21/21 passed`.

Both runs genuinely reached the check rather than skipping it, which matters here - a green run that skipped would prove nothing.

The corrected expression still detects a real divergence rather than merely compiling. Dropping a nested key from one side:

```
{"rest_only":["n","n.a"],"sse_only":[]}
```
