### PR TITLE
fix(core): clear the shared-file path index with the map it mirrors

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -396,6 +396,23 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 	{
 		wxMutexLocker lock(list_mut);
 		m_Files_map.clear();
+		// The index goes with the map it mirrors. AddFile writes a key only on
+		// a fresh insert and RemoveFile erases only the one key it recomputes,
+		// so any path this walk does not re-add -- a file deleted while its
+		// root was unshared, a DELETE lost to a watcher backend overflow, a
+		// remote deletion on a network share -- would keep an entry that makes
+		// NotifyPathAdded treat the path as already shared and silently refuse
+		// to share it again, with nothing logged at any level. Clearing here
+		// cannot heal that on its own; leaving the key behind is what creates
+		// it (issue #1028).
+		//
+		// Same locked scope on purpose: this puts the index under the invariant
+		// the map already has -- neither may be observed between here and the
+		// end of the walk. That is not a new constraint, it is the one that
+		// already rules out pumping the event loop during a walk (see
+		// SharedFilesReloadProgress.h). Keeping the two containers on one rule
+		// is why they are cleared together rather than separately.
+		m_pathIndex.clear();
 		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 	}
 
@@ -623,14 +640,38 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 
 	CKnownFile *toadd = filelist->FindKnownFile(fname, fdate, fsize);
 	if (toadd) {
+		// Ask before stamping. SetFilePath is not a plain assignment -- it
+		// calls MarkECChanged(), which hands the file a new EC generation and
+		// so pushes it into the next INC_UPDATE. Stamping and then rolling
+		// back on a decline did that twice for a net-zero path change, sending
+		// every duplicate-content file to every EC client as "changed" on each
+		// reload, which is precisely what the generation counter exists to
+		// avoid (issue #1028).
+		//
+		// Note the obvious guard -- stamp only when the path differs -- would
+		// not have helped: a decline with previousPath == directory is close to
+		// unreachable, because the watcher route returns on an index hit before
+		// reaching here and the bulk walk clears the map up front and visits
+		// each root once. Every decline that happens in practice has a
+		// different path, so that guard skips nothing.
+		{
+			wxMutexLocker lock(list_mut);
+			if (m_Files_map.find(toadd->GetFileHash()) != m_Files_map.end()) {
+				AddDebugLogLineN(
+					logKnownFiles, CFormat("File already shared, skipping: %s") % fname);
+				return kAddPathAlreadyShared;
+			}
+		}
+
 		// Set the path BEFORE AddFile so the path index that AddFile
 		// maintains keys off the file's current GetFilePath() rather
 		// than whatever stale path was stamped on the CKnownFile by
 		// a previous shared-list membership.
 		//
-		// Kept so the decline below can undo it: that reasoning only holds
-		// when AddFile actually inserts, because AddFile writes m_pathIndex
-		// only on a fresh insert.
+		// The rollback below still stands as the fallback for the
+		// check-then-insert race: the membership test above drops the lock
+		// before AddFile retakes it, so a hashing task completing through
+		// SafeAddKFile in between can still make AddFile decline.
 		const CPath previousPath = toadd->GetFilePath();
 		toadd->SetFilePath(directory);
 		if (AddFile(toadd)) {
@@ -915,7 +956,13 @@ void CSharedFileList::RemoveFile(CKnownFile *toremove)
 	const wxString key =
 		NormalizePathKey(toremove->GetFilePath().JoinPaths(toremove->GetFileName()).GetRaw());
 	const size_t erasedFromIndex = m_pathIndex.erase(key);
-	if (erasedFromIndex == 0 && !m_pathIndex.empty()) {
+	// `reloading` suppresses the check for the duration of a walk. The index is
+	// cleared at the start of one and refilled as the walk proceeds, so a
+	// removal that lands mid-walk -- CUploadDiskIOThread calls RemoveFile from
+	// a worker thread -- legitimately finds nothing to erase. Without this the
+	// hardening would cry wolf on every such removal, which is worse than not
+	// having it (issue #1028).
+	if (erasedFromIndex == 0 && !m_pathIndex.empty() && !reloading) {
 		// Not fatal on its own -- the older-snapshot case above is legitimate
 		// -- but it is the signature of a desynchronised index, so say so
 		// rather than leaking an entry in silence.

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -263,9 +263,10 @@ private:
 		kAddPathExcluded,
 		//! Matched a CKnownFile and was newly attached.
 		kAddPathKnown,
-		// Matched a CKnownFile that was *already* in the share set, so AddFile
-		// declined -- the same content reachable from a second shared
-		// directory, or a repeated watcher event. Split out from
+		// Matched a CKnownFile that was *already* in the share set, so the add
+		// was declined -- the same content reachable from a second shared
+		// directory. (Not a repeated watcher event: NotifyPathAdded returns on
+		// an index hit before it ever reaches AddPathToShares.) Split out from
 		// kAddPathKnown because callers that announce a file becoming shared
 		// must not claim a share that did not happen.
 		//
@@ -354,6 +355,20 @@ private:
 	// RemoveFile(); both insertion and erase happen under list_mut so
 	// the two stay consistent. Key is the file's current
 	// GetFilePath().JoinPaths(GetFileName()) raw string.
+	//
+	// The invariant is "if and only if": an entry exists for a path exactly
+	// when a file currently in m_Files_map lives there. NotifyPathAdded,
+	// NotifyPathModified and NotifyDirRemoved all read a hit as proof the
+	// file is already shared, so an entry that outlives its file makes the
+	// watcher silently refuse to share that path -- it returns before its
+	// first log statement, so nothing is reported at any level.
+	//
+	// This is why FindSharedFiles clears it in the same locked scope as
+	// m_Files_map rather than leaving it to accumulate: the keys a reload
+	// cannot heal are exactly the ones whose files the walk no longer finds
+	// (issue #1028). Both containers are therefore empty from that clear
+	// until the walk refills them, and neither may be observed in between --
+	// one rule covering the two, not two rules that can drift apart.
 	std::unordered_map<wxString, CKnownFile *> m_pathIndex;
 	mutable wxMutex list_mut;
 


### PR DESCRIPTION
Closes #1028. Both parts.

## Part 1 — the index outlived the map

`m_pathIndex` is written only on a fresh `AddFile` insert and erased only one key at a time in `RemoveFile`, while `FindSharedFiles` rebuilds `m_Files_map` from scratch on every reload. For a path the walk visits again that is harmless — the insert overwrites the same key. **The leak is the path the walk cannot re-add**, and nothing then erases the key it left behind.

That key makes `NotifyPathAdded` treat the path as already shared, and it returns *before the function's first log statement* — so a file copied into a shared directory is silently never shared, with nothing reported at any level, even with `logKnownFiles` enabled.

### Reproduced both ways

Route (c) from the issue, driven through `PUT /api/v0/shared/directories`: share a root, un-share it, delete the file while unwatched, re-share it, then restore the file with its mtime intact so the watcher sees a CREATE with no MODIFY delta.

| | pre-fix | post-fix |
|---|---|---|
| shared initially | 1 | 1 |
| shared after restoring the file | **0** | **1** |

### The fix, and why it is in that exact scope

Clearing `m_pathIndex` in the same locked scope as `m_Files_map` puts the index under the invariant the map already has — neither may be observed between the clear and the end of the walk — rather than adding a second rule that can drift.

That is worth being explicit about, because it looks at first like it introduces a new hazard. It does not: "nothing may observe the transiently-empty container mid-walk" is already documented as the reason pumping the event loop during a walk is ruled out (`SharedFilesReloadProgress.h`). The index now shares that rule instead of having its own lifetime.

It also does not complicate the incremental-scan work in #969. That already has to solve mid-walk observability for `m_Files_map` — its own issue says answering `EC_OP_GET_SHARED_FILES` mid-walk would emit thousands of spurious `shared_removed` events. Whatever solves it for the map covers the index for free, precisely because the two are now cleared and rebuilt together. That is also the case against the build-and-swap alternative the issue offers: it would make the index safe to observe while the map still is not, buying nothing for #969 and costing a second index in peak memory.

### The #1020 diagnostic

Suppressed while `reloading`. The index is empty at the start of a walk, so a `RemoveFile` landing mid-walk — `CUploadDiskIOThread` calls it from its own thread — legitimately finds nothing to erase. A critical line on every such removal would be worse than no hardening at all.

## Part 2 — no-op EC generation bumps

`SetFilePath` calls `MarkECChanged`, so stamping and then rolling back did it twice for a net-zero path change, pushing every duplicate-content file to every EC client as changed on each reload — the exact thing #713's generation counter exists to avoid.

Taken as the issue's option 1: check `m_Files_map` membership first and return without touching the path. The stamp-and-rollback stays as the fallback for the check-then-insert race, since the membership test drops the lock before `AddFile` retakes it.

Recording the part worth not re-deriving: the obvious guard, `if (previousPath != directory)`, **would skip nothing**. The watcher route returns on an index hit before reaching `AddPathToShares`, and the bulk walk clears the map up front and visits each root once, so every decline that happens in practice already has a different path.

## Verification

Watcher routes exercised on the fixed build, all intact:

```
Discovered 5 new shared files
Stopped sharing removed file: .../shareC/f1.bin            (NotifyPathRemoved)
Stopped sharing 2 files under removed directory: .../sub/  (NotifyDirRemoved)
Hashing file: .../shareC/f2.bin                            (NotifyPathModified -> re-add)
Hashing file: .../shareC/new.bin                           (NotifyPathAdded, queued)
```

with **zero** false-positive "no entry to erase" lines.

One thing checked rather than assumed, because it would have been severe: `AddPathToShares` now takes `list_mut`, which is a plain non-recursive `wxMutex`. `NotifyPathAdded` releases its lock before the switch and the bulk walk holds none, so there is no deadlock.

Both header comments corrected as the issue asks — the `m_pathIndex` invariant stated explicitly, and the unreachable "repeated watcher event" case dropped from the `kAddPathAlreadyShared` doc.

Two files, no new strings, `check-potfiles.sh` passes, both clang-tidy tiers and clang-format clean.
