### PR TITLE
feat(amuleapi): report each search's result count and percent in GET /search

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2382,9 +2382,9 @@ Lists every search amuled currently holds — including ones started by a **diff
 ```json
 {
   "searches": [
-    { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished", "started_at": 1751000000 },
-    { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running",  "started_at": 1751000042 },
-    { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running",  "client_ecid": 621 }
+    { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished", "started_at": 1751000000, "result_count": 182 },
+    { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running",  "started_at": 1751000042, "result_count": 57  },
+    { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running",  "client_ecid": 621,       "result_count": 237 }
   ]
 }
 ```
@@ -2396,6 +2396,10 @@ Lists every search amuled currently holds — including ones started by a **diff
 `started_at` is the Unix second amuleapi started the search, and it is the **only recency signal on this list**: entries arrive ordered by `search_id`, and id order is not start order — Kad search ids carry a high-bit mask and therefore always sort above eD2k ones. Sort on `started_at` when you need "the newest search".
 
 It is **omitted** for any search this `amuleapi` process did not start itself — one begun by another client, by the desktop GUI, or restored from the daemon's on-disk ring after a restart. The daemon ships no timestamp of its own, so there is nothing to report for those; treat a missing `started_at` as *unknown*, not as oldest.
+
+`result_count` is how many results the daemon currently holds for that search. It matches the `total` that [`GET /search/{id}/results`](#get-apiv0searchidresults) reports for the same id once the search has finished; while one is still running the two can differ by a fetch, because this number comes straight off the daemon's live index and `total` counts what amuleapi last pulled into its cache. It counts top-level hits only: grouped alternative filenames ride their parent's `children[]` and are not counted separately. On a `"browse"` entry it is the files received from the peer so far. Like every other field on this listing it is a snapshot at request time, so a running search's count climbs between calls.
+
+It exists so a client that adopts the whole list and fetches each search's results lazily — on first activation of a tab, rather than all at once at load — has a number to label an unopened tab with. It is **omitted**, not zeroed, when the daemon does not report it: a daemon older than this field sends nothing, and "does not report counts" has to stay distinguishable from "this search found nothing". Same rule as `client_ecid` and `started_at` above.
 
 amuled only tracks multiple concurrent searches for clients that advertise multi-search support; `amuleapi` does, so this always reflects the full live set. `searches` is an empty array when amuled holds no searches, never an error.
 

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2889,6 +2889,21 @@ static CECPacket *Get_EC_Response_Search_List()
 		entry.AddTag(EC_TAG_SEARCH_LIFECYCLE_STATE,
 			static_cast<uint64_t>(
 				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleStateById(sid))));
+		// How many hits this search is holding. A client that adopts the whole
+		// listing and fetches results per tab on activation has no other way to
+		// label a tab it has not opened yet -- and eagerly fetching every
+		// search's results to learn one integer each is the thing the lazy
+		// fetch exists to avoid. Same tag, same number, as the progress and
+		// results replies already carry (an O(1) map lookup on the index).
+		entry.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
+			static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
+		// And the percent, so a client discovering a *running* search reports
+		// the daemon's real ramp from first sight rather than 0 until the next
+		// poll. Both tags are already allocated and already emitted on the
+		// per-id progress reply; this listing was simply the one reply that
+		// left them out.
+		entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT,
+			theApp->searchlist->GetSearchLifecyclePercentById(sid)));
 		response->AddTag(entry);
 	}
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -6700,13 +6700,19 @@ bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
 		// into a no-op. 1 = running, 2 = finished (SearchLifecycleStateToString).
 		const CECTag *stateTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
 		const std::uint8_t state_val = stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0;
+		// ...and the percent, when the daemon reports one. -1 means it did
+		// not, which is what an older daemon looks like; the seed then falls
+		// back to deriving it from the lifecycle state.
+		const CECTag *pctTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT);
+		const int reported_pct = pctTag ? static_cast<int>(pctTag->GetInt()) : -1;
 		m_state.MarkSearchDiscovered(search_id,
 			SearchKindToString(
 				kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : EC_SEARCH_GLOBAL)
 				.ToStdString(),
 			nameTag ? std::string(nameTag->GetStringData().utf8_str()) : std::string(),
 			state_val == 1,
-			state_val == 2);
+			state_val == 2,
+			reported_pct);
 		found = true;
 		break;
 	}
@@ -6779,6 +6785,19 @@ CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Reques
 		if (const std::time_t started = m_state.SearchStartedAt(sid); started != 0) {
 			w.Key("started_at");
 			w.ValueInt(static_cast<int64_t>(started));
+		}
+		// How many hits the daemon holds for this search -- the same number
+		// GET /search/{id}/results reports as `total`. A client that adopts
+		// the listing and fetches results lazily per tab has nothing else to
+		// label an unopened tab with.
+		//
+		// Omitted, not zeroed, when the tag is absent: a daemon older than
+		// this change reports no counts, and "does not report" has to stay
+		// distinguishable from "found nothing". Same rule client_ecid and
+		// started_at already follow above.
+		if (const CECTag *countTag = entry.GetTagByName(EC_TAG_SEARCH_RESULT_COUNT)) {
+			w.Key("result_count");
+			w.ValueInt(static_cast<int64_t>(countTag->GetInt()));
 		}
 		w.EndObject();
 	}

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -298,7 +298,8 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 	const std::string &kind,
 	const std::string &query,
 	bool active,
-	bool complete)
+	bool complete,
+	int reported_percent)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	auto known = m_searches.find(search_id);
@@ -326,11 +327,14 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 	// ActiveSearchIds(), so the tick never polls it and WriteSearchProgress
 	// is never called for it -- the percent would sit at its 0 default for
 	// the life of the slot, contradicting the "finished" state in the very
-	// same envelope. A finished search is 100 by definition, so there is
-	// nothing to ask the daemon for. A discovered *running* slot keeps 0 and
-	// is corrected by the next tick, which is why only the finished case was
-	// stuck.
-	slot.progress.percent = complete ? 100 : 0;
+	// same envelope.
+	//
+	// Prefer the daemon's own number when the listing carried one. Without it
+	// (an older daemon) derive: 100 for a finished search, true by
+	// definition; 0 for a running one, which IS polled and is corrected
+	// within a tick, where inventing a number would flash a wrong one.
+	slot.progress.percent =
+		reported_percent >= 0 ? static_cast<std::uint32_t>(reported_percent) : (complete ? 100u : 0u);
 	slot.progress.kind = kind;
 	slot.query = query;
 	slot.seq = ++m_search_seq;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1548,11 +1548,19 @@ public:
 	// or so it took to be corrected. A slot seeded inactive is not polled by
 	// the tick, which is fine -- the read paths refresh an inactive slot on
 	// demand (ClaimSearchRefresh).
+	//
+	// `reported_percent` is the daemon's own percent for this search when the
+	// EC_OP_SEARCH_LIST entry carried one, and -1 when it did not. A daemon
+	// older than that tag reports nothing, and the fallback then has to be
+	// derived: 100 for a finished search (true by definition), 0 for a
+	// running one (the tick corrects it within a second, and inventing a
+	// number would flash a wrong one meanwhile).
 	void MarkSearchDiscovered(std::uint32_t search_id,
 		const std::string &kind,
 		const std::string &query,
 		bool active,
-		bool complete);
+		bool complete,
+		int reported_percent = -1);
 	// Refresher-side write path for one search's progress snapshot.
 	void WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s);
 	// Drop a search's slot entirely: DELETE /search/{id}, or the refresher

--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -36,10 +36,11 @@ let lastAdopt = 0;
 let offs = [];
 let lastResult = null, lastProgress = null, lastClosed = null;
 
-function newTab({ id, query = "", label = "", kind = "global", state = "running", startedAt = 0 }) {
+function newTab({ id, query = "", label = "", kind = "global", state = "running", startedAt = 0,
+                 percent = 0, count = 0 }) {
   return {
-    id, query, label: label || query, kind, state, percent: 0, startedAt,
-    results: new Map(), count: 0, fetching: false,
+    id, query, label: label || query, kind, state, percent, startedAt,
+    results: new Map(), count, fetching: false,
     // Per-tab UI state: switching tabs and coming back must restore it, so it
     // cannot live in the view's component state.
     ui: { selection: new Set(), filter: "", filterHave: "all", cat: 0, rowCat: {}, rowEcid: {} },
@@ -56,9 +57,14 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 function tabList() {
   return Array.from(tabs.values()).map((x) => ({
     id: x.id, query: x.query, label: x.label, kind: x.kind, state: x.state,
-    // Only meaningful while running: an adopted search that already finished
-    // reports 0 forever (amuleapi seeds a discovered slot's state, not its
-    // percent), which is why the view keys its progress text off `state`.
+    // An adopted search now arrives with a real percent -- amuleapi seeds a
+    // discovered slot from the daemon's own number, and falls back to 100 for
+    // a finished one. The view still keys its progress text off `state`,
+    // which is the authoritative signal.
+    //
+    // count is the larger of the daemon's reported total and what this tab
+    // has actually pulled: a tab whose results are loaded knows better than
+    // the listing snapshot, and an unopened one has only the listing.
     percent: x.percent, count: Math.max(x.count || 0, x.results.size),
   }));
 }
@@ -130,11 +136,23 @@ async function adopt() {
     const known = tabs.get(s.search_id);
     if (known) {
       if (!known.query && s.query) { known.query = s.query; known.label = known.label || s.query; }
+      // Keep an unopened tab's badge current. Only while it holds no results
+      // of its own -- once fetched, its own map is the better number and the
+      // listing snapshot must not walk it back.
+      if (typeof s.result_count === "number" && !known.results.size &&
+          s.result_count !== known.count) {
+        known.count = s.result_count;
+        added = true;
+      }
       continue;
     }
+    // result_count is what makes an unopened tab show a real badge instead of
+    // 0 after a reload; it is omitted by a daemon that does not report counts,
+    // in which case the badge stays 0 until the tab is opened and fetched.
     tabs.set(s.search_id, newTab({
       id: s.search_id, query: s.query || "", kind: s.kind || "global",
       state: s.state || "finished", startedAt: s.started_at || 0,
+      count: typeof s.result_count === "number" ? s.result_count : 0,
     }));
     added = true;
   }

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -219,6 +219,25 @@ _assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].started_at 
 	'GET /search stamps started_at on a search this session started'
 _assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].started_at > 1700000000" \
 	true 'started_at is a plausible recent unix second, not 0'
+# result_count lets a client label a tab it has not opened yet, instead of
+# fetching every search's results just to learn one integer each.
+_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].result_count | type" number \
+	'GET /search entry carries a numeric result_count'
+# ...and it agrees with what the results endpoint reports as `total` -- but only
+# once the search has settled. While it runs, result_count is the daemon's live
+# index and `total` is whatever amuleapi last pulled into its cache, so the two
+# legitimately differ by a fetch.
+LIST_COUNT=$(printf '%s' "$CURL_BODY" \
+	| jq -r "[.searches[] | select(.search_id == $FIRST_SID)][0].result_count")
+LIST_STATE=$(printf '%s' "$CURL_BODY" \
+	| jq -r "[.searches[] | select(.search_id == $FIRST_SID)][0].state")
+if [ "$LIST_STATE" = "finished" ]; then
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+	_assert_json_eq '.total' "$LIST_COUNT" \
+		'result_count equals the results endpoint total for a finished search'
+else
+	echo "    info: search still $LIST_STATE; skipping the result_count/total comparison"
+fi
 
 if [ "$HAVE_GUEST" = "1" ]; then
 	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/search"

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -633,6 +633,34 @@ TEST(State, DiscoveredRunningSearchKeepsZeroPercentAndIsPolled)
 	ASSERT_TRUE(std::find(active.begin(), active.end(), 44u) != active.end());
 }
 
+TEST(State, DiscoveredSearchPrefersTheDaemonsReportedPercent)
+{
+	// Once the daemon reports a percent on its listing, that number wins over
+	// the one derived from the lifecycle state -- which is the whole point of
+	// carrying it: a running search adopted mid-ramp shows its real progress
+	// from first sight instead of 0 until the next tick.
+	CState s;
+	s.MarkSearchDiscovered(50, "kad", "ubuntu", /*active=*/true, /*complete=*/false, 62);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(62), s.SearchProgress(50).percent);
+
+	// A finished one likewise takes what the daemon says rather than assuming.
+	s.MarkSearchDiscovered(51, "kad", "debian", /*active=*/false, /*complete=*/true, 100);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(100), s.SearchProgress(51).percent);
+}
+
+TEST(State, DiscoveredSearchFallsBackWhenTheDaemonReportsNoPercent)
+{
+	// -1 is "the listing carried no percent", i.e. a daemon older than the
+	// tag. The derived fallback has to survive: finished is 100, running is 0
+	// and gets corrected by the tick.
+	CState s;
+	s.MarkSearchDiscovered(52, "kad", "harry", /*active=*/false, /*complete=*/true, -1);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(100), s.SearchProgress(52).percent);
+
+	s.MarkSearchDiscovered(53, "kad", "potter", /*active=*/true, /*complete=*/false, -1);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchProgress(53).percent);
+}
+
 TEST(State, DiscoveryDoesNotStompAnAlreadyKnownSearchsPercent)
 {
 	// Re-discovery of a slot this session already tracks must leave its


### PR DESCRIPTION
Closes #1029.

`GET /api/v0/search` listed every search the daemon holds but said nothing about how many hits any of them had. A client that adopts the whole list and fetches results lazily per tab — which is what the bundled Web UI's tab strip does since #1030 — had no number to label an unopened tab with, so every tab rendered a `0` badge after a reload. That reads as "this search found nothing" rather than "not loaded yet". Eagerly fetching every search's results to learn one integer each is precisely what the lazy fetch exists to avoid.

## Core

Two lines in `Get_EC_Response_Search_List`, both using tags that already exist and accessors the adjacent lines already call:

- `EC_TAG_SEARCH_RESULT_COUNT` — an O(1) lookup on the result index, the same number the progress and results replies already carry;
- `EC_TAG_SEARCH_LIFECYCLE_PERCENT` — the rider discussed on #1026, so a discovered **running** search reports the daemon's real ramp from first sight rather than 0 until the next tick.

No new tag allocation, no new opcode, no preference.

## amuleapi

`result_count` on each listing entry, and the percent threaded into `MarkSearchDiscovered`. Both follow the same rule: **absent is not zero**. A daemon older than these tags reports neither — `result_count` is omitted entirely, and the percent falls back to the derivation #1032 added. That fallback is load-bearing rather than dead code: a new amuleapi against an older amuled is a supported pairing, and without it that combination would go straight back to reporting `finished` with `percent: 0`.

## Web UI

Tab badges seed from `result_count` at adoption, and an unopened tab's badge is kept current on re-adoption — but only while it holds no results of its own, since a fetched tab knows better than the listing snapshot and must not be walked back by it. Also removes a comment that #1032 made stale.

## Docs

`result_count` documented with the honest caveat rather than a claim of exact equality: it matches the results endpoint's `total` once a search has finished, but the two can differ by a fetch while one is running, because this number comes off the daemon's live index and `total` counts what amuleapi last pulled into its cache.

## Testing

35/35 unit tests, including two new `StateTest` cases — the reported percent wins over the derived one, and `-1` (no tag) still falls back to 100/0 correctly.

Live against a daemon:

```
GET /api/v0/search            → result_count: 86
GET /api/v0/search/1/results  → total: 86, progress.percent: 100
```

`19-search.sh` passes 113/115; both failures are `Kad search can't be done if Kad is not running` on a rig with no `nodes.dat` to bootstrap from, and this change touches no Kad search path.

Incidental confirmation of the compatibility rule: an earlier run accidentally pointed the suite's second amuleapi instance at an **older** daemon, and its listing entries carried no `result_count` key at all — omitted, not zeroed, exactly as specified.

clang-format clean; both clang-tidy tiers report 0 findings with 0 compiler errors.
