### PR TITLE
feat(gui): one row for the extended search filters, and fix the Download button never arming

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -737,9 +737,32 @@ void CSearchDlg::OnIdle(wxIdleEvent &evt)
 	m_pendingHitCount.clear();
 }
 
+// The Download button acts on the selection, so one place answers whether it
+// is available and both routes here ask it: the selection changing, and a tab
+// switch bringing a different list to the front. They disagreed before -- the
+// selection route only ever enabled, so deselecting the last row left an armed
+// button that did nothing until a tab switch corrected it.
+void CSearchDlg::UpdateDownloadButtonState()
+{
+	bool enable = false;
+	const int selection = m_notebook->GetSelection();
+	if (selection != wxNOT_FOUND) {
+		// A page that is not a result list (or a half-built tab) leaves the
+		// button off rather than dereferencing a failed cast.
+		if (const CSearchListCtrl *ctrl =
+				dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(selection))) {
+			enable = ctrl->GetSelectedItemCount() > 0;
+		}
+	}
+	FindWindow(IDC_SDOWNLOAD)->Enable(enable);
+}
+
 void CSearchDlg::OnListItemSelected(wxDataViewEvent &event)
 {
-	FindWindow(IDC_SDOWNLOAD)->Enable(true);
+	// Recompute rather than Enable(true): wxDataViewCtrl sends this same event
+	// when the last selected row is deselected, and the button has to go back
+	// off with it.
+	UpdateDownloadButtonState();
 
 	event.Skip();
 }
@@ -946,12 +969,10 @@ void CSearchDlg::OnSearchPageChanged(wxBookCtrlEvent &WXUNUSED(evt))
 		selection = m_notebook->GetPageCount() - 1;
 	}
 
-	// Only enable the Download button for pages where files have been selected
+	// Whether Download is available follows the newly-visible list's selection.
+	UpdateDownloadButtonState();
 	if (selection != -1) {
 		CSearchListCtrl *ctrl = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(selection));
-
-		bool enable = (ctrl->GetSelectedItemCount() > 0);
-		FindWindow(IDC_SDOWNLOAD)->Enable(enable);
 
 		// Refresh the bottom bar instantly for the newly-visible tab so it
 		// tracks the selected search rather than the last one that updated it.

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -313,6 +313,9 @@ private:
 	// Persists the chosen search type so it survives a restart (amule-org/amule#608).
 	void OnSearchTypeChanged(wxCommandEvent &evt);
 
+	// Recomputes the Download button from the visible list's selection; see
+	// the definition for why both callers go through it.
+	void UpdateDownloadButtonState();
 	void OnListItemSelected(wxDataViewEvent &ev);
 	void OnBnClickedReset(wxCommandEvent &ev);
 	void OnBnClickedClear(wxCommandEvent &ev);

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -55,7 +55,6 @@
 wxBEGIN_EVENT_TABLE(CSearchListCtrl, CMuleDataViewCtrl)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CSearchListCtrl::OnRightClick)
 	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CSearchListCtrl::OnItemActivated)
-	EVT_DATAVIEW_SELECTION_CHANGED(wxID_ANY, CSearchListCtrl::OnSelectionChanged)
 
 	EVT_MENU(MP_GETED2KLINK, CSearchListCtrl::OnPopupGetUrl)
 	EVT_MENU(MP_RAZORSTATS, CSearchListCtrl::OnRazorStatsCheck)
@@ -815,13 +814,6 @@ void CSearchListCtrl::OnItemActivated(wxDataViewEvent &event)
 	} else {
 		DownloadSelected();
 	}
-}
-
-void CSearchListCtrl::OnSelectionChanged(wxDataViewEvent &WXUNUSED(event))
-{
-	// Bubbles up like the old EVT_LIST_ITEM_SELECTED so
-	// CSearchDlg::OnListItemSelected can enable the Download button; bound
-	// separately on CSearchDlg for wxEVT_DATAVIEW_SELECTION_CHANGED.
 }
 
 void CSearchListCtrl::OnPopupGetUrl(wxCommandEvent &WXUNUSED(event))

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -361,7 +361,6 @@ protected:
 
 	void OnRightClick(wxDataViewEvent &event);
 	void OnItemActivated(wxDataViewEvent &event);
-	void OnSelectionChanged(wxDataViewEvent &event);
 
 	void OnPopupGetUrl(wxCommandEvent &event);
 	void OnRazorStatsCheck(wxCommandEvent &event);

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -232,8 +232,11 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item3->Add( item6, 0, wxALIGN_CENTER, 0 );
 
     item1->Add( item3, wxSizerFlags().Expand().CenterVertical() );
-    wxFlexGridSizer *item13 = new wxFlexGridSizer( 8, 0, 0 );
-    item13->AddGrowableRow( 1 );
+    // One row: the five filters sit side by side, each preceded by a separator
+    // from the second onwards -- 14 cells. They were split across two rows of
+    // eight while Category lived here; #979 took Category out and left Min Size
+    // stranded at the end of the first row, away from Max Size (issue #1035).
+    wxFlexGridSizer *item13 = new wxFlexGridSizer( 14, 0, 0 );
     s_extended_sizer = item13;
 
     wxStaticText *item14 = new wxStaticText( parent, -1, _("File Type"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -280,8 +283,8 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item23->Add( item25, wxSizerFlags().Center().Border(wxALL, 5) );
     item13->Add( item23, wxSizerFlags().Center().Border(wxALL, 5) );
 
-    // Min Size closes the first row and Max Size opens the second, so the
-    // separator that used to divide them would now sit on the row break.
+    wxStaticLine *item26 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
+    item13->Add( item26, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item27 = new wxStaticText( parent, -1, _("Max Size"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item27, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item28 = new wxBoxSizer( wxHORIZONTAL );
@@ -305,13 +308,6 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item32, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxSpinCtrl *item33 = new wxSpinCtrl( parent, IDC_SPINSEARCHAVAILABILITY, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000, 0 );
     item13->Add( item33, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    // Five filters no longer divide evenly into the 8-column grid: the first row
-    // takes three (File Type, Extension, Min Size) and the second two, so the
-    // second is padded out to a full row. Without this the sizer pulls cells up
-    // from the next row and the two rows stop lining up.
-    for (int pad = 0; pad < 3; ++pad) {
-        item13->Add( 0, 0, wxSizerFlags().Border(wxALL, 5) );
-    }
     item1->Add( item13, wxSizerFlags().Center() );
 
     wxFlexGridSizer *item34 = new wxFlexGridSizer( 1, 0, 0, 0 );


### PR DESCRIPTION
Closes #1035, and fixes the Download button while in the same panel.

## One row for the extended filters (#1035)

#979 took the Category selector out of this grid — it is not a search filter, nothing about it travels with the query — which left five filters in an eight-column sizer: File Type, Extension and Min Size on the first row, Max Size and Availability on the second. So Min Size ended up stranded at the end of a row with Max Size directly *below* it rather than beside it, and the second row needed three padding cells to stop the sizer pulling cells up into it.

Five filters fit one row of fourteen cells, so the grid becomes that. Min Size and Max Size sit next to each other where a reader expects them, the separator between them comes back — it was dropped only because it would have landed on the row break — the padding goes, and the panel hands a row of height back to the results list.

No control, id or handler changes: the same widgets in the same order, one row instead of two.

## The Download button never armed on selection

Noticed while looking at the panel. The button is meant to enable when a result is selected, and `CSearchDlg` binds `EVT_DATAVIEW_SELECTION_CHANGED` to do exactly that. It never ran: `CSearchListCtrl` binds the same event on itself with `wxID_ANY` and handled it with an empty function that does not `Skip()`, so the event stopped at the control. The comment there says it bubbles up like the old `EVT_LIST_ITEM_SELECTED` — which is precisely what the code prevented. It came in with the wxDataViewCtrl port; the old `wxListCtrl` had no such handler and the event reached the dialog on its own.

That left `OnSearchPageChanged` as the only code that ever enabled the button, which is why it looked erratic rather than simply broken: select a row and nothing happens, switch tabs and back and the button is suddenly live, because the tab switch recomputes from `GetSelectedItemCount()`.

The empty handler is dropped rather than given a `Skip()` — a handler whose only job is to not interfere reads like a hook and will be re-added by the next person.

The two routes also disagreed in the other direction: the selection route only ever *enabled*, so deselecting the last row left the button armed over an empty selection until a tab switch corrected it. Both now go through one `UpdateDownloadButtonState()`, which asks the visible list how many rows are selected — and which declines on a failed cast instead of dereferencing it, as the old inline copy did.

## Testing

Built and looked at on macOS: the merged filter row comes out the same width as the action-button row above it, so it costs no extra window width — the risk worth checking, since `wxFlexGridSizer` does not wrap and would have forced the window wider rather than reflowing. Selecting a result now arms Download immediately, deselecting disarms it, and switching tabs still agrees with the selection in the tab being shown.

clang-format and both clang-tidy tiers clean; no new translatable strings, so no catalog churn.
