### PR TITLE
feat(kad,ec,amuleapi): report whether a Kad search can still be widened

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2525,13 +2525,21 @@ Freeing a search delivers a [`search_closed`](EVENTS.md#search_closed) event to 
 
 **Auth:** `ADMIN`
 
-Widens a running **Kad** search — the desktop's **"More"** button. It re-asks the Kad peers already queried for a wider result frontier; amuled caps this at 4 reasks per search and logs the outcome itself, so this is fire-and-forget. No body.
+Widens a running **Kad** search — the desktop's **"More"** button. It re-asks the Kad peers already queried for a wider result frontier. No body.
 
 Kad-only and running-only, matching what the desktop button allows rather than what the core tolerates: amuled turns a `more` on a non-Kad or finished search into a silent no-op, so both are rejected here instead of being answered with a misleading `202`.
 
-**Response:** `202 Accepted` → `{ "ok": true }`.
+**Response:** `202 Accepted` → `{ "ok": true }` — the reask was performed, or could not be performed *yet* but may be on a later press.
 
-**Errors:** `400 bad_request` (bad `{id}`, a non-Kad search, or one that has already finished), `400 amuled_rejected`, `403 forbidden` (guest), `404 not_found` (no such search), `405`, `503 ec_unavailable`.
+**When it can no longer be widened:** `409 Conflict`, code `kad_more_exhausted`. Kad allows at most **4** reasks per search, and stops accepting them entirely once the search enters its stopping window — which begins 20 s before a keyword search's 45 s life ends, or as soon as it has collected 300 answers. In practice that means `more` only does something during roughly the first half of a search; past that, this is the answer. Disable the control for that search when you see it: nothing about that search will make it widenable again, and re-running the query is the way to get more (a fresh `POST /search` succeeds immediately and returns a new `search_id`).
+
+A `202` does **not** promise a reask went out. A press made while no already-responded peer is left un-reasked also answers `202`, because that clears the moment another peer answers and retrying is the right next action. The distinction the status carries is *terminal* versus *not terminal*, which is what a UI acts on; the daemon's log line distinguishes all the individual outcomes for anyone debugging.
+
+Note that a successful reask changes neither `progress.percent` nor `progress.state` — the Kad percent is a wall-clock ramp off the search's own start time. The response is the only signal; do not try to infer the outcome from the progress envelope.
+
+**Older daemons.** A daemon predating this reports nothing, and amuleapi keeps answering `202` for every press rather than guessing. Absent is *unknown*, never *exhausted*.
+
+**Errors:** `400 bad_request` (bad `{id}`, a non-Kad search, or one that has already finished), `400 amuled_rejected`, `403 forbidden` (guest), `404 not_found` (no such search), `405`, `409 kad_more_exhausted`, `503 ec_unavailable`.
 
 #### Related-files search
 
@@ -2636,6 +2644,7 @@ Every error code emitted by `/api/v0/*`, sorted by what triggered it. The matchi
 | `forbidden` | 403 | Authenticated as `guest` but the endpoint requires `admin`. |
 | `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name). |
 | `partfile_unsupported` | 409 | Verify Local Data requested on a file that is still an incomplete partfile. |
+| `kad_more_exhausted` | 409 | `POST /search/{id}/more` on a Kad search that can no longer be widened — its 4-reask budget is spent, or it has entered the stopping window Kad begins 20 s before a keyword search ends. Terminal for that search; re-run the query for more. |
 | `rate_limited` | 429 | Per-IP failure bucket full. `Retry-After: <seconds>` accompanies the response. |
 | `login_disabled` | 503 | `/auth/login` reached but no admin AND no guest password configured. |
 | `ec_unavailable` | 503 | EC connection not ready yet (cold start, transient amuled restart). |

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -3119,9 +3119,11 @@ static CECPacket *Get_EC_Response_Search_Stop(const CECPacket *request, bool mul
 static CECPacket *Get_EC_Response_Search_Request_More(const CECPacket *request, bool multiSearch)
 {
 	// "More" button (Kad-only): re-ask already-queried peers for a wider result
-	// frontier for one search. RequestMoreResults logs the outcome itself (the
-	// single source of truth shared with the monolithic GUI); that line is
-	// forwarded back to amuleGUI over EC, so the reply here is a plain ack.
+	// frontier for one search. RequestMoreResults logs what actually happened
+	// (the single source of truth shared with the monolithic GUI) and that line
+	// is forwarded back to amuleGUI over EC; the reply carries the other half,
+	// whether a LATER press could still widen the search, which is what a
+	// client greys its control on.
 	CECPacket *reply = new CECPacket(EC_OP_MISC_DATA);
 	// Per-ID. No ID => the most-recently-started search. Gate on the core's
 	// own knowledge (CSearchList::IsKnownSearchId), not s_ecSearches -- see
@@ -3131,8 +3133,22 @@ static CECPacket *Get_EC_Response_Search_Request_More(const CECPacket *request, 
 	const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 	uint32 sid =
 		idTag ? static_cast<uint32>(idTag->GetInt()) : (multiSearch ? s_ecSearches.Current() : 0);
+	bool reaskable = false;
 	if (sid != 0 && (!multiSearch || theApp->searchlist->IsKnownSearchId(sid))) {
-		theApp->searchlist->RequestMoreResults(sid);
+		reaskable = theApp->searchlist->RequestMoreResults(sid);
+	}
+	// Emitted on BOTH paths, including the unknown-id early-out above (which
+	// leaves it false -- a search the core does not hold is terminal by
+	// definition). That way an absent tag means exactly one thing to the
+	// client: a daemon older than this reply, whose answer is unknown rather
+	// than "exhausted".
+	reply->AddTag(CECTag(EC_TAG_SEARCH_MORE_REASKABLE, static_cast<uint8>(reaskable ? 1 : 0)));
+	// Echo which search the verdict is about. The request may not have named
+	// one (a client without multi-search leaves it to s_ecSearches.Current()),
+	// and a client with several tabs open cannot attribute a bare reply to any
+	// of them -- the replies are not correlated any other way.
+	if (sid != 0) {
+		reply->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
 	}
 	return reply;
 }

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -663,7 +663,7 @@ void CSearchDlg::RefreshVisibleTabProgress()
 	// (IsKadSearch goes false when the Kad search ends). Refreshing it on the
 	// same tick the bar updates is what makes it grey out on completion instead
 	// of lingering until the next tab switch.
-	FindWindow(IDC_SEARCHMORE)->Enable(sid && theApp->searchlist->IsKadSearch((uint32_t)sid));
+	FindWindow(IDC_SEARCHMORE)->Enable(MoreAllowed((uint32_t)sid));
 }
 #endif
 
@@ -686,7 +686,7 @@ void CSearchDlg::UpdateSearchProgress(uint32 searchID, uint32 status)
 		// the daemon just reported: IsKadSearch reads the remote cache that
 		// CSearchListRem::HandlePacket updated immediately before this call.
 		// (Monolithic drives the button from the local Kad layer on tab change.)
-		FindWindow(IDC_SEARCHMORE)->Enable(theApp->searchlist->IsKadSearch((uint32_t)searchID));
+		FindWindow(IDC_SEARCHMORE)->Enable(MoreAllowed((uint32_t)searchID));
 #endif
 	}
 }
@@ -810,6 +810,10 @@ void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 	// Zero to avoid results added while destructing.
 	ctrl->ShowResults(0);
 	m_searchProgress.erase(searchID);
+	// The "More"-is-spent memo dies with the tab: a re-run gets a fresh
+	// searchID anyway, and leaving entries behind would grow this set for the
+	// life of the session.
+	m_moreExhausted.erase((uint32_t)searchID);
 #ifdef CLIENT_GUI
 	// Remote multi-search: closing a tab stops *and* frees that specific
 	// search on the daemon (leaving other tabs' searches running). On a
@@ -976,8 +980,7 @@ void CSearchDlg::OnSearchPageChanged(wxBookCtrlEvent &WXUNUSED(evt))
 
 		// "More" is Kad-only — enable when this tab's searchID still
 		// corresponds to an active Kad search.
-		FindWindow(IDC_SEARCHMORE)
-			->Enable(theApp->searchlist->IsKadSearch((uint32_t)ctrl->GetSearchId()));
+		FindWindow(IDC_SEARCHMORE)->Enable(MoreAllowed((uint32_t)ctrl->GetSearchId()));
 	} else {
 		FindWindow(IDC_SEARCHMORE)->Enable(false);
 	}
@@ -1139,7 +1142,7 @@ void CSearchDlg::CreateNewTab(const wxString &searchString, wxUIntPtr nSearchID,
 		// AddPage above made the new tab the selected one; defer to
 		// IsKadSearch on its searchID so a freshly-created ED2K tab leaves
 		// the button disabled.
-		FindWindow(IDC_SEARCHMORE)->Enable(theApp->searchlist->IsKadSearch((uint32_t)nSearchID));
+		FindWindow(IDC_SEARCHMORE)->Enable(MoreAllowed((uint32_t)nSearchID));
 	}
 }
 
@@ -1250,6 +1253,29 @@ void CSearchDlg::OnBnClickedStop(wxCommandEvent &WXUNUSED(evt))
 	ResetControls();
 }
 
+void CSearchDlg::MarkMoreExhausted(uint32_t searchID)
+{
+	m_moreExhausted.insert(searchID);
+	// Only touch the button when the exhausted search is the one on screen --
+	// the verdict arrives asynchronously and the user may have switched tabs
+	// meanwhile. Every other path recomputes through MoreAllowed anyway, so a
+	// tab switch back to it finds the button correctly disabled.
+	const int sel = m_notebook->GetSelection();
+	if (sel == -1) {
+		return;
+	}
+	CSearchListCtrl *page = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(sel));
+	if (page && (uint32_t)page->GetSearchId() == searchID) {
+		FindWindow(IDC_SEARCHMORE)->Enable(false);
+	}
+}
+
+bool CSearchDlg::MoreAllowed(uint32_t searchID) const
+{
+	return searchID && theApp->searchlist->IsKadSearch(searchID) &&
+	       m_moreExhausted.find(searchID) == m_moreExhausted.end();
+}
+
 void CSearchDlg::OnBnClickedSearchMore(wxCommandEvent &WXUNUSED(evt))
 {
 	// "More" button: ask the currently-selected Kad search for more
@@ -1273,10 +1299,15 @@ void CSearchDlg::OnBnClickedSearchMore(wxCommandEvent &WXUNUSED(evt))
 		return;
 	}
 	const uint32_t searchID = (uint32_t)page->GetSearchId();
-	// RequestMoreResults logs the outcome itself (single source of truth) — and
-	// on amuleGUI that log is the daemon's, forwarded over EC, so the remote GUI
-	// shows the real result rather than an optimistic guess.
-	theApp->searchlist->RequestMoreResults(searchID);
+	// RequestMoreResults logs what actually happened (single source of truth) —
+	// and on amuleGUI that log is the daemon's, forwarded over EC. What it
+	// RETURNS is the other question: whether a later press could still widen
+	// this search. False is terminal (the search is in its final seconds, or
+	// its reask budget is spent), so the button goes away for this search only.
+	if (!theApp->searchlist->RequestMoreResults(searchID)) {
+		m_moreExhausted.insert(searchID);
+		FindWindow(IDC_SEARCHMORE)->Enable(false);
+	}
 }
 
 void CSearchDlg::ResetControls()
@@ -1312,8 +1343,7 @@ void CSearchDlg::KadSearchEnd(uint32 id)
 	if (sel != -1) {
 		CSearchListCtrl *page = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(sel));
 		if (page) {
-			FindWindow(IDC_SEARCHMORE)
-				->Enable(theApp->searchlist->IsKadSearch((uint32_t)page->GetSearchId()));
+			FindWindow(IDC_SEARCHMORE)->Enable(MoreAllowed((uint32_t)page->GetSearchId()));
 		}
 	}
 }

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -401,6 +401,27 @@ private:
 	 */
 	std::set<CSearchListCtrl *> m_pendingHitCount;
 
+	// Kad searches whose "More" budget is spent, by searchID. The daemon
+	// reports this once per press and it never un-spends, so it is remembered
+	// here rather than re-asked: the button's enabled state is recomputed on
+	// every tab switch and progress tick, and without this a switch away and
+	// back would silently re-enable a control that can no longer do anything.
+	// Entries die with the tab (see the erase in the close path); re-running a
+	// search yields a new searchID and so starts clean.
+	std::set<uint32_t> m_moreExhausted;
+
+	// Whether the "More" button should be live for this search: Kad-only, and
+	// not already reported as un-widenable. Single home for a predicate that
+	// five separate sites otherwise have to keep in step.
+	bool MoreAllowed(uint32_t searchID) const;
+
+public:
+	// The daemon says this search can no longer be widened. Called from the
+	// remote GUI's reply handler (amuleGUI); the monolithic build reaches the
+	// same state straight from RequestMoreResults' return value.
+	void MarkMoreExhausted(uint32_t searchID);
+
+private:
 	void OnIdle(wxIdleEvent &evt);
 
 	/**

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -1257,11 +1257,19 @@ bool CSearchList::RequestMoreResults(uint32_t searchID)
 	// (for a remote-GUI request over EC) both reach this one path, and the
 	// daemon forwards the line to amuleGUI — so the remote GUI shows the real
 	// result rather than an optimistic guess.
-	const bool ok = Kademlia::CSearchManager::RequestMoreResults(searchID);
-	AddLogLineN(ok ? _("Kad search: requested wider results from one more peer.")
-		       : _("Kad search: no peer left to reask for more results (cap reached or no "
-			   "responses yet)."));
-	return ok;
+	//
+	// Two different answers come back, and they are not interchangeable. The
+	// log line reports what actually happened on THIS press; the return value
+	// reports whether a LATER press could still do something, which is what a
+	// caller greys its control on. A reask that spends the last of the budget
+	// fires (so it is logged as a success) and leaves the search un-widenable
+	// (so it returns false).
+	bool fired = false;
+	const bool reaskable = Kademlia::CSearchManager::RequestMoreResults(searchID, &fired);
+	AddLogLineN(fired ? _("Kad search: requested wider results from one more peer.")
+			  : _("Kad search: no peer left to reask for more results (cap reached or no "
+			      "responses yet)."));
+	return reaskable;
 }
 
 void CSearchList::StopSearch(bool globalOnly)

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3452,15 +3452,21 @@ bool CSearchListRem::RequestMoreResults(uint32_t searchID)
 	if (searchID == 0) {
 		return false;
 	}
-	// Ask the daemon to widen this Kad search (KADEMLIA_FIND_VALUE_MORE). Fire-
-	// and-forget, like StopSearchById: the daemon performs the re-ask; the rare
-	// "no peer left" outcome is not surfaced over EC, so the caller logs the
-	// request optimistically.
+	// Ask the daemon to widen this Kad search (KADEMLIA_FIND_VALUE_MORE).
+	// SendRequest, not SendPacket: the daemon answers with EC_OP_MISC_DATA
+	// carrying EC_TAG_SEARCH_MORE_REASKABLE, and HandlePacket below greys the
+	// button for that search when it says the reasking is over for good. This
+	// used to be fire-and-forget and returned an optimistic true, so a user
+	// could press "More" repeatedly against a daemon that was doing nothing.
+	//
+	// Still returns true here: the verdict arrives asynchronously, and this
+	// return only says the request went out. The greying happens in the reply
+	// handler.
 	CECPacket req(EC_OP_SEARCH_REQUEST_MORE);
 	if (m_conn->ServerSupportsMultiSearch()) {
 		req.AddTag(CECTag(EC_TAG_SEARCH_ID, (uint32)searchID));
 	}
-	m_conn->SendPacket(&req);
+	m_conn->SendRequest(this, &req);
 	return true;
 }
 
@@ -3610,6 +3616,21 @@ void CSearchListRem::ApplySearchProgress(const CECTag *src)
 
 void CSearchListRem::HandlePacket(const CECPacket *packet)
 {
+	if (packet->GetOpCode() == EC_OP_MISC_DATA) {
+		// Reply to EC_OP_SEARCH_REQUEST_MORE. The tag is absent on a daemon
+		// older than it, which means "unknown", never "exhausted" -- leave the
+		// button alone in that case and keep the previous optimistic
+		// behaviour. Present and false is terminal for this search: its reask
+		// budget is spent, or it is inside the stopping window Kad enters 20 s
+		// before a keyword search ends.
+		const CECTag *reaskable = packet->GetTagByName(EC_TAG_SEARCH_MORE_REASKABLE);
+		const CECTag *idTag = packet->GetTagByName(EC_TAG_SEARCH_ID);
+		if (reaskable && idTag && reaskable->GetInt() == 0 && theApp->amuledlg &&
+			theApp->amuledlg->m_searchwnd) {
+			theApp->amuledlg->m_searchwnd->MarkMoreExhausted((uint32)idTag->GetInt());
+		}
+		return;
+	}
 	if (packet->GetOpCode() == EC_OP_SEARCH_PROGRESS) {
 		if (m_conn->ServerSupportsMultiSearch()) {
 			if (m_conn->ServerSupportsSearchProgressUnion()) {

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -3616,17 +3616,28 @@ void CSearchListRem::ApplySearchProgress(const CECTag *src)
 
 void CSearchListRem::HandlePacket(const CECPacket *packet)
 {
-	if (packet->GetOpCode() == EC_OP_MISC_DATA) {
-		// Reply to EC_OP_SEARCH_REQUEST_MORE. The tag is absent on a daemon
-		// older than it, which means "unknown", never "exhausted" -- leave the
-		// button alone in that case and keep the previous optimistic
-		// behaviour. Present and false is terminal for this search: its reask
-		// budget is spent, or it is inside the stopping window Kad enters 20 s
-		// before a keyword search ends.
-		const CECTag *reaskable = packet->GetTagByName(EC_TAG_SEARCH_MORE_REASKABLE);
+	// Reply to EC_OP_SEARCH_REQUEST_MORE. Claimed by the TAG, not by the
+	// opcode alone: EC_OP_MISC_DATA is a generic envelope (search stop and
+	// GET_CONNSTATE use it too), and consuming every packet carrying that
+	// opcode would silently swallow any future request that both answers
+	// MISC_DATA and routes its handler here. Only a packet that actually
+	// carries the reaskable bit is ours; anything else falls through.
+	//
+	// The tag is absent on a daemon older than it, which means "unknown",
+	// never "exhausted" -- so that case falls through too and keeps the
+	// previous optimistic behaviour. Present and false is terminal for this
+	// search: its reask budget is spent, or it is inside the stopping window
+	// Kad enters 20 s before a keyword search ends.
+	//
+	// The id has to come off the packet rather than from the selected tab.
+	// The EC FIFO pairs replies to requests positionally, with no request id
+	// on the wire, so with two "More" presses in flight on different tabs the
+	// arrival order is the only thing distinguishing them -- and the user may
+	// have switched tabs meanwhile. The daemon echoes EC_TAG_SEARCH_ID for
+	// exactly this.
+	if (const CECTag *reaskable = packet->GetTagByName(EC_TAG_SEARCH_MORE_REASKABLE)) {
 		const CECTag *idTag = packet->GetTagByName(EC_TAG_SEARCH_ID);
-		if (reaskable && idTag && reaskable->GetInt() == 0 && theApp->amuledlg &&
-			theApp->amuledlg->m_searchwnd) {
+		if (idTag && reaskable->GetInt() == 0 && theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
 			theApp->amuledlg->m_searchwnd->MarkMoreExhausted((uint32)idTag->GetInt());
 		}
 		return;

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -1410,6 +1410,16 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 	}
 }
 
+// The terminal half of RequestMoreResults()'s guards -- everything that will
+// still be true on the next press. Deliberately does NOT walk m_responded: "no
+// un-reasked peer right now" is transient, clears when another peer answers,
+// and must not read as "never again".
+bool CSearch::CanReaskMore() const
+{
+	return !m_stopping && GetRequestContactCount() == KADEMLIA_FIND_VALUE &&
+	       m_requestedMoreNodes.size() < KADEMLIA_FIND_VALUE_MORE_REASKS;
+}
+
 bool CSearch::RequestMoreResults()
 {
 	// Walk m_responded (sorted by distance to target) for the closest

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -113,6 +113,21 @@ public:
 	// dispatched, false if no eligible candidate remains.
 	bool RequestMoreResults();
 
+	// Whether this search could still be widened by a future reask, ignoring
+	// whether one is dispatchable right now.
+	//
+	// The distinction is the point. RequestMoreResults() returns false both
+	// when the search is finished with reasking for good (it is stopping, or
+	// the reask budget is spent) and when it simply has no un-reasked peer to
+	// send to *yet* -- and those want opposite answers from a UI. The first
+	// is terminal, so the "More" control should go away; the second clears as
+	// soon as another peer responds, so the control must stay.
+	//
+	// Callers pair the two as `fired || CanReaskMore()`. The `fired ||` is
+	// not optional: the reask that consumes the last of the budget really
+	// happens, and this predicate is already false by the time it returns.
+	bool CanReaskMore() const;
+
 	enum
 	{
 		NODE,

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -74,16 +74,29 @@ bool CSearchManager::IsSearching(uint32_t searchID) noexcept
 	return false;
 }
 
-bool CSearchManager::RequestMoreResults(uint32_t searchID)
+bool CSearchManager::RequestMoreResults(uint32_t searchID, bool *out_fired)
 {
+	if (out_fired) {
+		*out_fired = false;
+	}
 	// Linear scan because m_searches is keyed by target hash, not
 	// searchID.  CSearch counts at any one time are tiny (one per active
 	// user search plus internal lookups), so the scan cost is negligible.
 	for (SearchMap::iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
 		if (it->second->GetSearchID() == searchID) {
-			return it->second->RequestMoreResults();
+			const bool fired = it->second->RequestMoreResults();
+			if (out_fired) {
+				*out_fired = fired;
+			}
+			// Evaluated AFTER the attempt, and or-ed with it: the reask that
+			// consumes the last of the budget really happened, but leaves
+			// CanReaskMore() false. Reporting that as a refusal would have
+			// every client disable its control on a success.
+			return fired || it->second->CanReaskMore();
 		}
 	}
+	// No live search carries that id -- it finished and was deleted, taking
+	// m_responded / m_tried / m_requestedMoreNodes with it. Terminal.
 	return false;
 }
 

--- a/src/kademlia/kademlia/SearchManager.h
+++ b/src/kademlia/kademlia/SearchManager.h
@@ -94,11 +94,21 @@ public:
 	}
 
 	// Find a CSearch by searchID (m_searches is keyed by target hash;
-	// this iterates) and invoke its RequestMoreResults().  Returns true
-	// if a reask was dispatched, false if no matching search was found
-	// or RequestMoreResults declined (cap reached / no eligible peer).
-	// Wired up on the search dialog "More" button.
-	static bool RequestMoreResults(uint32_t searchID);
+	// this iterates) and invoke its RequestMoreResults().
+	//
+	// Returns whether the search can still be widened by a later press --
+	// `fired || CanReaskMore()`, i.e. false only when reasking is over for
+	// good (the search is stopping, its reask budget is spent, or no live
+	// search carries that id at all). NOT "did a reask go out": a press made
+	// while no responded peer is left to reask *yet* still returns true,
+	// because that clears as soon as another peer answers and a UI must keep
+	// its control.
+	//
+	// `out_fired`, when given, receives whether a reask actually went out on
+	// this call. The two genuinely differ -- the reask that spends the last
+	// of the budget fires and leaves the search un-widenable -- and a log
+	// line wants the second, a control's enabled state the first.
+	static bool RequestMoreResults(uint32_t searchID, bool *out_fired = nullptr);
 
 	// True if the given searchID corresponds to an active Kad search.
 	// Used by the search dialog to gate "More" button enable state on

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -420,6 +420,12 @@ EC_TAG_SEARCHFILE                         0x0700
 	EC_TAG_SEARCHFILE_CLIENT_PORT             0x0713
 	EC_TAG_SEARCHFILE_DIRECTORY               0x0714
 	EC_TAG_SEARCH_BROWSE_STATUS               0x0715
+## Whether a Kad search can still be widened by a later "More" press --
+## `fired || CanReaskMore()`, not "did a reask go out". Emitted on every
+## EC_OP_SEARCH_REQUEST_MORE reply, including the unknown-id path. A peer
+## predating it sends nothing, and absent must read as "this daemon does not
+## report it", never as "exhausted".
+	EC_TAG_SEARCH_MORE_REASKABLE              0x0716
 
 EC_TAG_FRIEND                             0x0800
 	EC_TAG_FRIEND_NAME                        0x0801

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -9380,7 +9380,7 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 // opcode, the optional close flag and the success shape differ, so the
 // exchange itself lives here rather than three times over.
 CHttpServer::Response CApiDispatcher::SendSearchOp(
-	ec_opcode_t opcode, std::uint32_t search_id, bool close, int success_status)
+	ec_opcode_t opcode, std::uint32_t search_id, bool close, int success_status, int *out_more_reaskable)
 {
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(opcode));
 	// Always addressed. The old no-id form let the daemon decide what "stop"
@@ -9398,6 +9398,13 @@ CHttpServer::Response CApiDispatcher::SendSearchOp(
 	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
 		delete ec_resp;
 		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	if (out_more_reaskable) {
+		// Left at its caller-set -1 when the tag is absent: that is a daemon
+		// older than it, whose answer is unknown rather than negative.
+		if (const CECTag *t = ec_resp->GetTagByName(EC_TAG_SEARCH_MORE_REASKABLE)) {
+			*out_more_reaskable = t->GetInt() != 0 ? 1 : 0;
+		}
 	}
 	delete ec_resp;
 
@@ -9485,9 +9492,28 @@ CHttpServer::Response CApiDispatcher::HandleSearchMore(
 			400, "bad_request", "`more` applies to a running search; this one has finished");
 	}
 
-	// Fire-and-forget: the daemon acks with a plain EC_OP_MISC_DATA and logs
-	// the real outcome itself, so there is nothing to report but acceptance.
-	return SendSearchOp(EC_OP_SEARCH_REQUEST_MORE, search_id, /*close=*/false, 202);
+	// The daemon logs what actually happened and answers with the other half:
+	// whether a LATER press could still widen this search. False is terminal --
+	// the reask budget of 4 is spent, or the search is inside the stopping
+	// window Kad enters 20 s before a keyword search ends, which is most of the
+	// second half of its life. Reporting that as 202 is what let a client press
+	// "More" five times while the daemon did nothing.
+	//
+	// A press that simply has no responded peer left to reask *yet* still gets
+	// 202: it clears as soon as another peer answers, and retrying is genuinely
+	// the right next action.
+	int reaskable = -1;
+	CHttpServer::Response r =
+		SendSearchOp(EC_OP_SEARCH_REQUEST_MORE, search_id, /*close=*/false, 202, &reaskable);
+	// Only reinterpret a success. An error from the exchange is its own answer,
+	// and -1 means the daemon never reported -- keep today's 202 for it.
+	if (r.status == 202 && reaskable == 0) {
+		return ErrorResponse(409,
+			"kad_more_exhausted",
+			"this Kad search cannot be widened any further (reask budget spent, or the "
+			"search is in its final seconds)");
+	}
+	return r;
 }
 
 CHttpServer::Response CApiDispatcher::HandleSearchDownload(

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -264,8 +264,15 @@ private:
 	// One addressed EC exchange for stop / close / more: they differ only in
 	// opcode, the close flag and the success status, so the packet build,
 	// the EC_OP_FAILED mapping and the `{ok:true}` body live in one place.
-	CHttpServer::Response SendSearchOp(
-		ec_opcode_t opcode, std::uint32_t search_id, bool close, int success_status);
+	// `out_more_reaskable`, when given, receives the EC_TAG_SEARCH_MORE_REASKABLE
+	// bit from the reply as 1 or 0, or stays -1 when the daemon sent no such
+	// tag. Only EC_OP_SEARCH_REQUEST_MORE carries it; -1 is what an older
+	// daemon looks like and must never be read as "exhausted".
+	CHttpServer::Response SendSearchOp(ec_opcode_t opcode,
+		std::uint32_t search_id,
+		bool close,
+		int success_status,
+		int *out_more_reaskable = nullptr);
 	CHttpServer::Response HandleSearchDownload(const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleSearchComments(const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleSearchCommentsKadSearch(

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -419,6 +419,36 @@ if [ "$CURL_STATUS" = "202" ]; then
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$KAD_SID/more"
 	_assert_status 202 "POST /search/{id}/more on a running Kad search → 202"
 	_assert_json_eq '.ok' true 'more response.ok==true'
+
+	# The timing edge, which is deterministic where the reask cap is not.
+	# Kad calls PrepareToStop on a keyword search 20 s before its 45 s life
+	# ends, and RequestMoreResults refuses from that moment on -- so a press
+	# made past roughly 55% of the ramp can never widen the search again and
+	# must answer 409 instead of a misleading 202.
+	#
+	# Deliberately NOT trying to exhaust the 4-reask budget: that needs four
+	# distinct responded peers inside the first 25 s and is not reproducible
+	# on a test daemon.
+	MORE_PCT=0
+	for _ in $(seq 1 40); do
+		sleep 2
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$KAD_SID/results"
+		MORE_PCT=$(printf '%s' "$CURL_BODY" | jq -r '.progress.percent // 0')
+		MORE_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
+		[ "$MORE_STATE" = "finished" ] && break
+		# 65 is comfortably past the ~55% PrepareToStop point without waiting
+		# for the search to finish (which a finished search rejects with 400).
+		awk -v p="$MORE_PCT" 'BEGIN { exit !(p > 65) }' && break
+	done
+	if [ "$MORE_STATE" = "running" ] && awk -v p="$MORE_PCT" 'BEGIN { exit !(p > 65) }'; then
+		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$KAD_SID/more"
+		_assert_status 409 "POST /search/{id}/more past the stopping window → 409"
+		_assert_json_eq '.error.code' kad_more_exhausted \
+			'a search that can no longer be widened reports kad_more_exhausted'
+	else
+		echo "    info: Kad search reached state=$MORE_STATE percent=$MORE_PCT;" \
+			"skipping the stopping-window 409 check"
+	fi
 	if [ "$HAVE_GUEST" = "1" ]; then
 		_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
 			"$HOST/api/v0/search/$KAD_SID/more"


### PR DESCRIPTION
Closes #1027.

`POST /api/v0/search/{id}/more` answered `202` unconditionally, and amuleGUI's **More** button returned an optimistic `true` of its own. The daemon knew better — `CSearchList::RequestMoreResults` has always returned a bool and logged the real outcome — but the EC reply threw that bool away, so no client could act on it. A user could press *More* five times on the same search and get five successes while the daemon performed none of them. That is the common case rather than a corner one: Kad stops accepting reasks 20 s before a keyword search's 45 s life ends, so the control is dead for most of the second half of every search.

## The bit is "can this still be widened", not "did a reask go out"

`CSearch::CanReaskMore()` is the terminal half of `RequestMoreResults`' guards — stopping window, reask budget, wrong search kind — and deliberately excludes the transient "no un-reasked peer *right now*", which clears as soon as another peer answers. Callers pair the two as `fired || CanReaskMore()`.

The `fired ||` is load-bearing: the reask that consumes the last of the budget really happens, and reporting it as a refusal would have every client disable its control on a success.

## Two answers, two consumers

`CSearchManager::RequestMoreResults` grows an out-param so `CSearchList` can keep its log line driven by **what actually fired** while returning **what is still possible**. They are not interchangeable and both have consumers: the log is the human-readable source of truth, the return value is what a UI greys a control on.

## EC

`EC_TAG_SEARCH_MORE_REASKABLE` (`0x0716`), emitted on **both** reply paths — including the unknown-id early-out — so an absent tag means exactly one thing: a daemon older than this change.

The reply also echoes `EC_TAG_SEARCH_ID`. **This goes beyond the issue's plan** and is worth review: without it a client with several tabs open cannot attribute a bare reply to any of them, and the request does not always name the id (a client without multi-search leaves it to `s_ecSearches.Current()`). amuleGUI cannot act on the bit at all without it.

## Clients

amuleapi maps `false` → `409 kad_more_exhausted` and leaves an absent tag as today's `202`. Both GUIs grey the button for that search only.

amuleGUI stops being fire-and-forget and handles the reply through `SendRequest`/`HandlePacket`, which is what it needed to act on this at all — its stale "not surfaced over EC" comment is gone with it. The per-search memo lives in `CSearchDlg` rather than being re-derived, because the button's enabled state is recomputed on every tab switch and progress tick and would otherwise silently re-enable itself; the memo dies with the tab, and a re-run gets a fresh `search_id`.

## Verified against a Kad-connected daemon

Four presses returned `202`, each logging `Kad search: requested wider results from one more peer` — **including the fourth, which spent the last of the reask budget** — and the fifth returned `409 kad_more_exhausted` alongside the daemon's `no peer left to reask` line:

```
11:11:33  requested wider results from one more peer.   → 202
11:11:35  requested wider results from one more peer.   → 202
11:11:37  requested wider results from one more peer.   → 202
11:11:39  requested wider results from one more peer.   → 202   (spends the budget)
11:11:41  no peer left to reask for more results...     → 409 kad_more_exhausted
```

So the 4-reask cap that the issue expected to be unreproducible on a test daemon turns out to be the *easiest* path to the refusal. The curl test still targets the timing edge as specified, guarded and skippable when Kad is down.

35/35 unit tests, clang-format clean, both clang-tidy tiers 0 findings with 0 compiler errors. No catalog churn — the two touched strings keep their msgids.

## Not covered by CI

The button greying in both GUIs is verified by construction only; the core, EC and REST layers are covered by tests. I can run the monolithic and amuleGUI on the VMs before this merges if you'd rather see it confirmed.

No new opcode, no preference, and no change to Kad's reask policy.

