### PR TITLE
fix(gui): re-flow only the status strip, not the content area behind it

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -679,6 +679,37 @@ bool SetLabelIfChanged(wxStaticText *label, const wxString &text)
 	label->SetLabel(text);
 	return true;
 }
+
+// Re-flow the strip a status label sits in, not its parent.
+//
+// These labels are children of a horizontal bar that shares its parent sizer
+// with the main content area, so laying the parent out re-flowed everything
+// under it -- on the main window that includes the search page and its results
+// notebook -- to make room for a few characters of text. On wxMSW that
+// invalidation erases the notebook whenever no page covers it, which is the
+// flicker reported in issue #1037. The containing sizer is the bar alone,
+// which is the only thing that ever has to move.
+void RelayoutLabelStrip(wxWindow *label)
+{
+	if (wxSizer *strip = label->GetContainingSizer()) {
+		strip->Layout();
+	} else {
+		label->GetParent()->Layout();
+	}
+}
+
+// Set a status label and re-flow its strip, both only when the text changed.
+// The strip scope is what fixes the flicker: these run on every stats update --
+// once per 500 ms EC reply in the remote GUI -- and at that rate the text
+// usually has changed, so the guard alone would rarely spare the work.
+bool UpdateStatusLabel(wxStaticText *label, const wxString &text)
+{
+	if (!SetLabelIfChanged(label, text)) {
+		return false;
+	}
+	RelayoutLabelStrip(label);
+	return true;
+}
 } // namespace
 
 void CamuleDlg::SetFreeSpaceLabel(
@@ -704,7 +735,7 @@ void CamuleDlg::SetFreeSpaceLabel(
 			relayout = true;
 		}
 		if (relayout) {
-			label->GetParent()->Layout();
+			RelayoutLabelStrip(label);
 		}
 		return;
 	}
@@ -729,7 +760,7 @@ void CamuleDlg::SetFreeSpaceLabel(
 	relayout =
 		SetLabelIfChanged(label, CFormat(_("Free space: %s")) % CastItoXBytes(freeSpace)) || relayout;
 	if (relayout) {
-		label->GetParent()->Layout();
+		RelayoutLabelStrip(label);
 	}
 }
 
@@ -1098,8 +1129,7 @@ void CamuleDlg::ResetLog(int id)
 	if (id == ID_LOGVIEW) {
 		// Also clear the log line
 		wxStaticText *text = CastChild("infoLabel", wxStaticText);
-		text->SetLabel("");
-		text->GetParent()->Layout();
+		UpdateStatusLabel(text, wxEmptyString);
 	}
 }
 
@@ -1141,10 +1171,9 @@ void CamuleDlg::AddLogLineToView(const wxString &line, int viewId)
 		// Escape "&"s, which would otherwise not show up
 		bufferline.Replace("&", "&&");
 		wxStaticText *text = CastChild("infoLabel", wxStaticText);
-		// Only show the first line if multiple lines
-		text->SetLabel(bufferline.BeforeFirst('\n'));
 		text->SetToolTip(bufferline);
-		text->GetParent()->Layout();
+		// Only show the first line if multiple lines
+		UpdateStatusLabel(text, bufferline.BeforeFirst('\n'));
 	}
 }
 
@@ -1297,8 +1326,7 @@ void CamuleDlg::ShowConnectionState()
 		labelMsg = msgED2K + msgKad;
 	}
 
-	connLabel->SetLabel(labelMsg);
-	connLabel->GetParent()->Layout();
+	UpdateStatusLabel(connLabel, labelMsg);
 
 	////////////////////////////////////////////////////////////
 	// Update the globe-icon in the lower-right corner.
@@ -1376,8 +1404,7 @@ void CamuleDlg::ShowUserCount(const wxString &info)
 	// Update Kad tab
 	m_serverwnd->UpdateKadInfo();
 
-	label->SetLabel(info);
-	label->GetParent()->Layout();
+	UpdateStatusLabel(label, info);
 }
 
 void CamuleDlg::ShowTransferRate()
@@ -1404,32 +1431,10 @@ void CamuleDlg::ShowTransferRate()
 	}
 	buffer.Truncate(50); // Max size 50
 
-	// Only touch the label when the text it shows actually changes. SetLabel
-	// plus a Layout of the enclosing strip runs on every stats update -- once
-	// per 500 ms EC reply in the remote GUI, every 5 s on the core timer in
-	// monolithic -- and the Layout invalidates the area behind the strip even
-	// when nothing moved. With no search tab open there is no page covering
-	// the results notebook, so on wxMSW each invalidation erases and repaints
-	// that empty area: the flicker in issue #1037, at exactly those two rates.
-	//
-	// An idle node now lays out never, and a busy one only when the rendered
-	// string changes rather than ten times for the same "Up: 0.0 | Down: 0.0".
+	// The status labels all share one strip, and updating any of them used to
+	// re-flow the whole content area behind it -- see UpdateStatusLabel().
 	wxStaticText *label = CastChild("speedLabel", wxStaticText);
-	if (label->GetLabel() != buffer) {
-		label->SetLabel(buffer);
-		// Re-flow the strip the label sits in, not its parent. The parent here
-		// is the main content panel, which the search page and its results
-		// notebook also hang off, so laying that out re-flowed the whole
-		// content area to make room for a few characters of speed text -- and
-		// on a busy node the text changes on nearly every update, so the guard
-		// above would rarely spare it. The containing sizer covers the status
-		// strip alone, which is the only thing that has to move.
-		if (wxSizer *strip = label->GetContainingSizer()) {
-			strip->Layout();
-		} else {
-			label->GetParent()->Layout();
-		}
-	}
+	UpdateStatusLabel(label, buffer);
 
 	// Show upload/download speed in title
 	if (thePrefs::GetShowRatesOnTitle()) {

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1404,9 +1404,32 @@ void CamuleDlg::ShowTransferRate()
 	}
 	buffer.Truncate(50); // Max size 50
 
+	// Only touch the label when the text it shows actually changes. SetLabel
+	// plus a Layout of the enclosing strip runs on every stats update -- once
+	// per 500 ms EC reply in the remote GUI, every 5 s on the core timer in
+	// monolithic -- and the Layout invalidates the area behind the strip even
+	// when nothing moved. With no search tab open there is no page covering
+	// the results notebook, so on wxMSW each invalidation erases and repaints
+	// that empty area: the flicker in issue #1037, at exactly those two rates.
+	//
+	// An idle node now lays out never, and a busy one only when the rendered
+	// string changes rather than ten times for the same "Up: 0.0 | Down: 0.0".
 	wxStaticText *label = CastChild("speedLabel", wxStaticText);
-	label->SetLabel(buffer);
-	label->GetParent()->Layout();
+	if (label->GetLabel() != buffer) {
+		label->SetLabel(buffer);
+		// Re-flow the strip the label sits in, not its parent. The parent here
+		// is the main content panel, which the search page and its results
+		// notebook also hang off, so laying that out re-flowed the whole
+		// content area to make room for a few characters of speed text -- and
+		// on a busy node the text changes on nearly every update, so the guard
+		// above would rarely spare it. The containing sizer covers the status
+		// strip alone, which is the only thing that has to move.
+		if (wxSizer *strip = label->GetContainingSizer()) {
+			strip->Layout();
+		} else {
+			label->GetParent()->Layout();
+		}
+	}
 
 	// Show upload/download speed in title
 	if (thePrefs::GetShowRatesOnTitle()) {


### PR DESCRIPTION
Addresses #1037. Not marked as `Fixes` — still needs @ghysler's confirmation on the remaining half before this closes.

## What his test established

He tested the first build (3.0.1-638) and reported: **monolithic no longer flashes**, while amuleGUI still does — but at a *stable* ~2/second, having lost the extra flash every ~5 seconds.

That is a clean result. It confirms the mechanism and it locates what was missed.

`ShowTransferRate()` ended with:

```cpp
label->SetLabel(buffer);
label->GetParent()->Layout();
```

and `speedLabel`'s parent sizer holds the **main content area** as well as the status strip — the same content area the search page and its results notebook hang off. So a few characters of speed text re-flowed everything under it. With a search tab open the page repaints over that; with no tabs nothing covers the notebook, so on wxMSW the erase shows as a flash of empty results space. That is why it stops the moment a tab exists, and why a larger window makes it worse.

Monolithic calls that function from the five-second block of the GUI timer, so fixing it removed monolithic's only repeating relayout — hence "gone". The remote GUI calls it once per 500 ms EC poll, so the same fix removed the 5 s component he saw there too. What was left flashing at the poll rate had to be something else on that same poll.

## The rest of it

It was the same two lines, three more times. `speedLabel` was one of four labels in that strip, and every one of them re-flowed the parent:

| Label | Updated from | Rate in amuleGUI |
|---|---|---|
| `speedLabel` | `ShowTransferRate()` | every stats reply |
| `userLabel` | `ShowUserCount()` | every stats reply |
| `connLabel` | `ShowConnectionState()` | every stats reply |
| `infoLabel` | `AddLogLineToView()` | every log line |

All three of the first are called from the *same* `CStatsUpdaterRem::HandlePacket()`, once per poll — which is exactly the steady ~2/second he is still seeing.

## The change

Fold the pattern into `UpdateStatusLabel()`, built on the `SetLabelIfChanged()` this file already had, and lay out the label's **containing sizer** — the strip alone — rather than its parent. `SetFreeSpaceLabel()`'s two batched relayouts get the same narrower scope, so the pattern is not left in the tree to be copied again. No call site now lays out a content area to update a label.

The guard is not the fix. At 2 Hz the rate and user counts genuinely change, so it would rarely skip; narrowing the layout scope is what stops the invalidation. The guard just avoids pointless work on an idle node.

## Testing

Built monolithic and amulegui on macOS, GUI runs, all four labels still update and the strip still lays out correctly.

The flicker itself **cannot be verified here** — it is a wxMSW erase-then-paint artifact and Cocoa composites instead. I instrumented the notebook on macOS to count repaints while forcing the label width to change, and got zero, which is consistent with it being wxMSW-specific rather than evidence against the mechanism. @ghysler's monolithic result is what actually confirmed it.

clang-format and both clang-tidy tiers clean. Rebased onto current master (picks up #1044).
