### PR TITLE
fix(gui): grey out Verify Local Data on partially obtained files

### DIFF
--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -235,6 +235,14 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->Enable(MP_GETAICHED2KLINKSRC, file->HasProperAICHHashSet());
 		m_menu->Enable(MP_GETHOSTNAMESOURCEED2KLINK, !thePrefs::GetYourHostname().IsEmpty());
 		m_menu->Enable(MP_GETHOSTNAMECRYPTSOURCEED2KLINK, !thePrefs::GetYourHostname().IsEmpty());
+		// Verifying a partfile is not supported: the hashset covers the
+		// finished file, and CVerifyLocalDataTask bails on one anyway. Greyed
+		// out rather than silently refused, so the state is visible before the
+		// click instead of only in the log afterwards (amule-org/amule#1039).
+		// IsPartFile() is answered correctly in both binaries: amulegui files a
+		// shared partfile into its shared list as the very CPartFile the
+		// download queue holds (amule-remote-gui.cpp), not a plain CKnownFile.
+		m_menu->Enable(MP_VERIFY, !file->IsPartFile());
 
 		int priority = file->IsAutoUpPriority() ? PR_AUTO : file->GetUpPriority();
 
@@ -315,6 +323,11 @@ void CSharedFilesCtrl::OnVerifyLocalData(wxCommandEvent &WXUNUSED(event))
 {
 	for (wxUIntPtr data : GetSelectedItemData()) {
 		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
+		// Still reachable with the menu item greyed out for partfiles: the
+		// menu is built from the row that was right-clicked, while this acts
+		// on the whole selection. Right-click a completed file with a
+		// partfile also selected and the entry is enabled, but the partfile
+		// still has to be turned away here.
 		if (file->IsPartFile()) {
 			AddLogLineN(
 				CFormat(_("Verify Local Data on PartFile is currently not supported: %s")) %


### PR DESCRIPTION
Closes #1039.

Verifying a partfile has never done anything. The menu handler turns it away before the verifier is reached, and `CVerifyLocalDataTask::Entry()` bails on a partfile as well - the stored MD4/AICH hashset describes the *finished* file, so there is nothing meaningful to check against while parts are still missing.

The problem is that both refusals happen after the click, and one of them is invisible.

| Layer | How it refuses | Visible? |
|---|---|---|
| `CSharedFilesCtrl::OnVerifyLocalData` | `AddLogLineN("Verify Local Data on PartFile is currently not supported: …")` | yes, in the aMule log |
| `CVerifyLocalDataTask::Entry()` | `AddDebugLogLineC(logVerifyLocalData, "…file is a part file, skipping…")` | **no** by default |

The second is gated by `CLogger::IsEnabled`, which requires both the debug category to be enabled *and* verbose logging. So a user driving the daemon from **amulegui** clicks the entry and sees nothing happen at all, which is exactly what was reported.

## The change

Disable the menu entry for a partfile, so the state is visible before the click rather than only in a log afterwards:

```cpp
m_menu->Enable(MP_VERIFY, !file->IsPartFile());
```

`IsPartFile()` is the right test in **both** binaries, which is the part worth checking before relying on it. amulegui does not construct a separate shared-list object for a shared partfile - `CDownQueueRem::ProcessItemUpdate` files the very `CPartFile` the download queue holds into `theApp->sharedfiles`:

```cpp
if (file->IsShared() && !theApp->sharedfiles->count(file->ECID())) {
    (*theApp->sharedfiles)[file->ECID()] = file;
```

so the virtual resolves to `CPartFile::IsPartFile` there too. Had the remote list stored a plain `CKnownFile`, this fix would have done nothing for the reporter.

## What stays

The handler's guard is kept deliberately, and commented so it is not removed later as newly unreachable: the context menu is built from the row that was right-clicked, while `OnVerifyLocalData` acts on the whole selection. Right-click a completed file with a partfile also selected and the entry is enabled, so a partfile still has to be turned away there.

The core-side `CVerifyLocalDataTask` guard is untouched. It is defence in depth for the EC path and does not need promoting to a default-level log line now that the UI no longer offers the action.

## Verification

Built and confirmed by hand in **both** binaries: right-clicking a partially obtained file in the Shared Files panel shows *Verify Local Data* greyed out, and a completed file still offers it and verifies as before.

clang-format and both clang-tidy tiers clean on the diff, 0 compiler errors. No new translatable strings, so no catalog regeneration.
