### PR TITLE
fix(gui): stop the Searches button toggling the eD2k links handler

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -539,17 +539,6 @@ void CamuleDlg::ShowED2KLinksHandler(bool show)
 	s_dlgcnt->Layout();
 }
 
-// Toogles ed2k link handler.
-void CamuleDlg::ToogleED2KLinksHandler()
-{
-	// Errorchecking in case the pointer becomes invalid ...
-	if (s_fed2klh == NULL) {
-		wxLogWarning("Unable to find Fast ED2K Links handler sizer! Toogling FED2KLH aborted.");
-		return;
-	}
-	ShowED2KLinksHandler(!s_dlgcnt->IsShown(s_fed2klh));
-}
-
 void CamuleDlg::SetActiveDialog(DialogType type, wxWindow *dlg)
 {
 	m_nActiveDialog = type;
@@ -817,14 +806,16 @@ void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 	// Kry - just if the GUI is ready for it
 	if (m_is_safe_state) {
 
-		// Rehide the handler if needed
-		if (lastbutton == ID_BUTTONSEARCH && !thePrefs::GetFED2KLH()) {
-			if (ev.GetId() != ID_BUTTONSEARCH) {
-				ShowED2KLinksHandler(false);
-			} else {
-				// Toogle ED2K handler.
-				ToogleED2KLinksHandler();
-			}
+		// Leaving the search page hides the handler again, since without
+		// GetFED2KLH() it belongs to that page only. Re-clicking the search
+		// button while already on the page used to toggle the handler
+		// instead -- a 2005 shortcut that no other toolbar button has, that
+		// nothing advertises, and that did nothing at all once
+		// "show in every window" was enabled. Clicking the page you are
+		// already on now simply stays put (amule-org/amule#1041).
+		if (lastbutton == ID_BUTTONSEARCH && !thePrefs::GetFED2KLH() &&
+			ev.GetId() != ID_BUTTONSEARCH) {
+			ShowED2KLinksHandler(false);
 		}
 
 		if (lastbutton != ev.GetId()) {

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -426,7 +426,6 @@ private:
 	void Apply_Toolbar_Skin(wxToolBar *wndToolbar);
 	bool Check_and_Init_Skin();
 	void Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon, bool useSkins);
-	void ToogleED2KLinksHandler();
 	void SetMessagesTool();
 	void OnKeyPressed(wxKeyEvent &evt);
 


### PR DESCRIPTION
Closes #1041.

With **"Show Fast eD2k Links Handler in every window"** off, the handler belongs to the search page. Clicking the **Searches** toolbar button while already on that page toggled it off, clicking again brought it back, so every extra click flipped it. Switching away and back restored it, which made the flipping read as a glitch rather than as an action.

It was deliberate. [amuleDlg.cpp](../blob/master/src/amuleDlg.cpp) carried a 2005 shortcut that reused the navigation button as a show/hide for the bar:

```cpp
if (lastbutton == ID_BUTTONSEARCH && !thePrefs::GetFED2KLH()) {
    if (ev.GetId() != ID_BUTTONSEARCH) {
        ShowED2KLinksHandler(false);   // leaving the page -> hide
    } else {
        // Toogle ED2K handler.
        ToogleED2KLinksHandler();      // re-clicking the page -> toggle
    }
}
```

Nothing advertises it, no other toolbar button behaves that way, and it did nothing at all with the preference **enabled**, because the whole branch sits inside the `!GetFED2KLH()` guard. That asymmetry between the two preference states, rather than the toggle itself, is what the report is about.

## Change

Clicking the page you are already on now stays put. Leaving the search page still hides the handler and returning still shows it, unchanged.

`ToogleED2KLinksHandler()` had exactly this one caller, so it goes with it, along with its declaration and the comment that outlived the function it described.

## Verification

Built and checked by hand in both `amule` and `amulegui`, with the preference off:

- Searches page, clicking Searches repeatedly: the handler stays put (was flipping)
- Switching to another page hides it, returning to Searches shows it again (unchanged)

and with the preference on, the handler stays visible everywhere and repeated clicks do nothing (unchanged).

clang-format and both clang-tidy tiers clean on the diff, 0 compiler errors. No string changes, so no catalog regeneration.
