### PR TITLE
feat(search): ask before a new eD2k search stops the running one

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6259,6 +6259,19 @@ msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Search in progress"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6361,6 +6361,20 @@ msgstr ""
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
+msgstr "بحث"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
 msgstr "بحث"
 
 #: src/SearchDlg.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6477,6 +6477,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Guetar"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "En progresu"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6336,6 +6336,20 @@ msgstr ""
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
+msgstr "Търсене"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
 msgstr "Търсене"
 
 #: src/SearchDlg.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6258,6 +6258,19 @@ msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Search in progress"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6449,6 +6449,20 @@ msgstr "És impossible cercar quan l'eD2k i el Kademlia estan inhabilitats."
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Error en la cerca"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Progrés de la cerca: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6437,6 +6437,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Vyhledávání"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Probíhá"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6379,6 +6379,20 @@ msgstr ""
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
+msgstr "Søg"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
 msgstr "Søg"
 
 #: src/SearchDlg.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6445,6 +6445,20 @@ msgstr "Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia deakti
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Suchfehler"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Vergleichsfortschritt: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6490,6 +6490,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Αναζητήσεις"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Σε εξέλιξη"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6259,6 +6259,19 @@ msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Search in progress"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6404,6 +6404,20 @@ msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Error de búsqueda"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Progreso de la búsqueda: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6452,6 +6452,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Otsingud"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Otsing : %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6451,6 +6451,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Bilaketak"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Bilaketa aurrerapena: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6451,6 +6451,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Haut"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Haun edistyminen: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6399,6 +6399,20 @@ msgstr "Lorsque eD2k et Kademlia sont désactivés tous les deux, il est impossi
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Erreur de recherche"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "État d'avancement de la recherche : %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6459,6 +6459,20 @@ msgstr "Non se pode buscar se tanto eD2k coma Kademlia están desactivados."
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Erro na busca"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Progreso da busca: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6417,6 +6417,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "חיפושים"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "בתהליך"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6404,6 +6404,20 @@ msgstr ""
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 #, fuzzy
 msgid "Search error"
+msgstr "Pretrage"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
 msgstr "Pretrage"
 
 #: src/SearchDlg.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6423,6 +6423,20 @@ msgstr "Nem lehet keresni, ha az eD2k és a Kademlia hálózat is le van tiltva.
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Keresési hiba"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Keresés haladása: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6406,6 +6406,20 @@ msgstr "Impossibile avviare ricerche con eD2k e Kademlia entrambi disabilitati."
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Errore di ricerca"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Avanzamento ricerca: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6446,6 +6446,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "検索"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "途中です"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6481,6 +6481,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "검색"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "진행중"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6508,6 +6508,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Paieška"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Dirbama"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6301,6 +6301,19 @@ msgstr "Meklēšana nav iespējama, ja gan eD2k, gan Kademlia ir atspējoti."
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Search in progress"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6397,6 +6397,20 @@ msgstr "Er kan niet gezocht worden wanneer eD2k en Kademlia uitgeschakeld zijn."
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Fout tijdens zoeken"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Voortgang zoeken: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6483,6 +6483,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Søk"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "I framdrift"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6486,6 +6486,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Szukaj"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "W trakcie"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6400,6 +6400,20 @@ msgstr "É impossível realizar busca quando ambas eD2K e Kademlia estão desabi
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Erro na busca"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Progresso da busca: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6459,6 +6459,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Pesquisas"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Progresso da pesquisa: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6469,6 +6469,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Căutări"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Progres căutare: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6450,6 +6450,20 @@ msgstr "Поиск невозможен, если отключены и eD2k, и
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Ошибка поиска"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Состояние поиска: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6507,6 +6507,20 @@ msgstr "Iskanje ni mogoče, ko sta tako eD2k kot tudi Kademlia onemogočena."
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Napaka iskanja"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Napredek iskanja: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6473,6 +6473,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Kerkimet"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Ne vazhdim"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6447,6 +6447,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Sökningar"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Sökets framstigande: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6258,6 +6258,19 @@ msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Search in progress"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6392,6 +6392,20 @@ msgstr "Hem eD2k hem de Kademlia devre dışı bırakıldığında arama yapmak 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "Arama hatası"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "Arama süreci: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6511,6 +6511,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "Пошук"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "В дії"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6255,6 +6255,19 @@ msgstr ""
 
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+msgid "Search in progress"
 msgstr ""
 
 #: src/SearchDlg.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6396,6 +6396,20 @@ msgstr "同时禁用 eD2k 和 Kademlia 时将无法搜索。"
 #: src/SearchDlg.cpp src/SearchListCtrl.cpp
 msgid "Search error"
 msgstr "搜索错误"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "搜索进度: %u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 00:01+0200\n"
+"POT-Creation-Date: 2026-08-22 12:11+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6431,6 +6431,20 @@ msgstr ""
 #, fuzzy
 msgid "Search error"
 msgstr "搜尋"
+
+#: src/SearchDlg.cpp
+msgid ""
+"An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.\n"
+"\n"
+"Results already found are kept; only new ones stop arriving.\n"
+"\n"
+"Start the new search anyway?"
+msgstr ""
+
+#: src/SearchDlg.cpp
+#, fuzzy
+msgid "Search in progress"
+msgstr "搜尋進度：%u %% \n"
 
 #: src/SearchDlg.cpp
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -691,6 +691,50 @@ void CSearchDlg::UpdateSearchProgress(uint32 searchID, uint32 status)
 	}
 }
 
+bool CSearchDlg::HasRunningEd2kSearch() const
+{
+	for (size_t i = 0; i < m_notebook->GetPageCount(); ++i) {
+		const CSearchListCtrl *ctrl = dynamic_cast<const CSearchListCtrl *>(m_notebook->GetPage(i));
+		// A browse tab is not an ed2k search, and the placeholder tab that
+		// exists before the first search has no id yet.
+		if (!ctrl || ctrl->IsBrowse()) {
+			continue;
+		}
+		const wxUIntPtr sid = ctrl->GetSearchId();
+		if (!sid) {
+			continue;
+		}
+		// Kad searches carry their own IDs and run in parallel, so a running
+		// one is not in the way of a new ed2k search.
+		if (theApp->searchlist->IsKadSearch((uint32_t)sid)) {
+			continue;
+		}
+
+		// 0xffff / 0xfffe are the finished sentinels; anything else is a
+		// running percent. Same vocabulary in both builds, different source.
+		uint32 status;
+#ifdef CLIENT_GUI
+		// Remote GUI: the daemon pushes the sentinel through
+		// UpdateSearchProgress, which caches it per tab. A tab with no entry
+		// is one nothing has reported on this session -- a search restored
+		// from disk at startup -- so it is finished, not running. Treating
+		// the absence as "running" would prompt on every first search of a
+		// session that had stored results.
+		const std::map<wxUIntPtr, uint32>::const_iterator it = m_searchProgress.find(sid);
+		if (it == m_searchProgress.end()) {
+			continue;
+		}
+		status = it->second;
+#else
+		status = theApp->searchlist->GetSearchBarStatusById(sid);
+#endif
+		if (status != 0xffff && status != 0xfffe) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void CSearchDlg::AddResult(CSearchFile *toadd)
 {
 	CSearchListCtrl *outputwnd = GetSearchList(toadd->GetSearchID());
@@ -1014,6 +1058,29 @@ void CSearchDlg::OnBnClickedStart(wxCommandEvent &WXUNUSED(evt))
 			_("Search error"),
 			wxOK | wxCENTRE | wxICON_ERROR);
 		return;
+	}
+
+	// Starting a second ed2k search finalises the one in flight (see
+	// HasRunningEd2kSearch for why the protocol forces that), and until now it
+	// happened silently: the first tab's progress bar simply cleared, which
+	// reads exactly like a search that finished normally. Ask first, so
+	// stopping it is the user's decision rather than a surprise.
+	//
+	// Only ed2k-over-ed2k. Starting a Kad search alongside a running ed2k one
+	// is fine, and so is the reverse -- Kad results carry their own search ID.
+	const int newType = GetSelectedSearchTypeCanonical();
+	if ((newType == LocalSearch || newType == GlobalSearch) && HasRunningEd2kSearch()) {
+		const int answer =
+			wxMessageBox(_("An eD2k search is still running. Starting a new one will stop it, "
+				       "because the eD2k protocol allows only one search at a time.\n\n"
+				       "Results already found are kept; only new ones stop arriving.\n\n"
+				       "Start the new search anyway?"),
+				_("Search in progress"),
+				wxYES_NO | wxCENTRE | wxICON_QUESTION,
+				this);
+		if (answer != wxYES) {
+			return;
+		}
 	}
 
 	// Debounce accidental double-clicks, but keep it short so multi-search

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -237,6 +237,26 @@ public:
 	// tab only, so each search's lifecycle is tracked independently.
 	void UpdateSearchProgress(uint32 searchID, uint32 status);
 
+	/**
+	 * Is one of the open tabs an ed2k search that is still running?
+	 *
+	 * eD2k replies carry no search identifier -- neither the server's TCP
+	 * reply nor the global UDP results -- so a client can only attribute
+	 * incoming results to the query it sent most recently. Starting a second
+	 * ed2k search therefore finalises the one in flight, and the user gets no
+	 * say. This answers whether there is such a search to warn about.
+	 *
+	 * Kad tabs and "View Files" browse tabs are excluded: Kad results carry
+	 * their own search ID so those genuinely run in parallel, and a browse is
+	 * not an ed2k search at all.
+	 *
+	 * Where the running/finished answer comes from differs between the two
+	 * builds -- the local search list monolithically, the sentinel the daemon
+	 * pushes in the remote GUI -- so it is resolved here and every caller asks
+	 * the same question.
+	 */
+	bool HasRunningEd2kSearch() const;
+
 	void UpdateProgress(uint32 new_value);
 
 #ifndef CLIENT_GUI


### PR DESCRIPTION
Closes #967.

Starting a second eD2k search finalises the one in flight. That is a protocol limit rather than a choice: eD2k replies carry no search identifier — neither the server's TCP reply nor the global UDP results — so a client can only attribute incoming results to the query it sent most recently, and two at once would file each other's hits into the wrong tab. Kad is unaffected; its results carry their own search ID, so those genuinely run in parallel.

The problem was that it happened **silently**. The first tab's progress bar simply cleared, which reads exactly like a search that finished normally, so the user had no way to tell it had been cut short — which is why #967 was filed as a suspected bug rather than noticed as a limitation.

## The change

When the new search is eD2k **and** an eD2k search is still running, a Yes/No dialog says what will happen:

> An eD2k search is still running. Starting a new one will stop it, because the eD2k protocol allows only one search at a time.
>
> Results already found are kept; only new ones stop arriving.
>
> Start the new search anyway?

**No** leaves the running search alone; **Yes** proceeds exactly as before. Only eD2k over eD2k — starting Kad alongside a running eD2k search, or the reverse, is unaffected and never prompts.

## Working in both binaries

`SearchDlg.cpp` compiles into monolithic aMule and amulegui, but the two do not share a state source: monolithic reads `GetSearchBarStatusById()` from the local search list, while the remote GUI only has the sentinel the daemon pushes into `m_searchProgress`. `CSearchListRem` is not a `CSearchList` subclass, so there is no common accessor to call.

`HasRunningEd2kSearch()` resolves that in one place behind an `#ifdef`, so the handler asks a single question. Kad tabs and "View Files" browse tabs are skipped — neither is an eD2k search standing in the way.

Two judgement calls worth a reviewer's eye:

- **Browse tabs excluded.** A peer's shared-file listing is not an eD2k search and must not block one.
- **In the remote GUI, a tab with no cached sentinel counts as finished, not running.** The absent case is a search restored from disk at startup, never a live one; treating it as running would prompt on the first search of every session that had stored results. The cost is a sub-second window right after starting a search in which a second start would not prompt.

## Testing

Monolithic, remote GUI and daemon all build clean — the remote-GUI build exercises the `CLIENT_GUI` branch. `clang-format` (18.1.8, the CI version) clean. Catalogs regenerated with `scripts/update-po.sh` for the two new strings.

**Not exercised by hand**: it needs two live searches against a real server, which I have not run. The manual plan is in the comment below.

## Not included

#967 also suggests the progress bar should stop where it was cancelled rather than clearing, as a second signal that the search was cut short. That is a separate change to the bar's sentinel handling and is left out deliberately — this PR is the confirmation step.
