### PR TITLE
fix(gui): give the search row's first two separators a height

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -258,14 +258,14 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     // It is not a search filter -- nothing about it travels with the query --
     // so it moved to the button row next to Download, whose destination it is
     // (issue #979). Five filters remain: three on this row, two on the next.
-    wxStaticLine *item16 = new wxStaticLine( parent, -1, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
-    item13->Add( item16, wxSizerFlags(1).CenterHorizontal().Border(wxALL, 5) );
+    wxStaticLine *item16 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
+    item13->Add( item16, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item20 = new wxStaticText( parent, -1, _("Extension"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item20, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     CMuleTextCtrl *item21 = new CMuleTextCtrl( parent, IDC_EDITSEARCHEXTENSION, "", wxDefaultPosition, wxSize(60,-1), wxTE_PROCESS_ENTER );
     item13->Add( item21, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    wxStaticLine *item19 = new wxStaticLine( parent, -1, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
-    item13->Add( item19, wxSizerFlags().CenterHorizontal().Border(wxALL, 5) );
+    wxStaticLine *item19 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
+    item13->Add( item19, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item22 = new wxStaticText( parent, -1, _("Min Size"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item22, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item23 = new wxBoxSizer( wxHORIZONTAL );


### PR DESCRIPTION
Reported at #1035.

The dividers between **File Type**, **Extension** and **Min Size** were in the layout already — they simply never drew.

Both were constructed with `wxDefaultSize`, and a `wxLI_VERTICAL` `wxStaticLine` has no intrinsic height, so inside a horizontal sizer it collapses to nothing. They were the **only two** vertical separators in `muuli_wdr.cpp` without an explicit size; every other one — including the Min Size / Max Size divider a few lines below, which renders correctly — passes `wxSize(-1,20)`. That is what identifies the cause rather than merely matching the symptom.

```diff
-    wxStaticLine *item16 = new wxStaticLine( parent, -1, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
-    item13->Add( item16, wxSizerFlags(1).CenterHorizontal().Border(wxALL, 5) );
+    wxStaticLine *item16 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
+    item13->Add( item16, wxSizerFlags().Center().Border(wxALL, 5) );
```

The first one also carried `wxSizerFlags(1)`. Proportion 1 let the line stretch horizontally and take space from the filters instead of sitting between them as a divider, so that goes too — both separators now match the house pattern exactly.

## Testing

Monolithic and remote GUI both build clean; `clang-format` (18.1.8, the CI version) clean. Verified visually by @got3nks: the two dividers now appear at the same height as the existing Min Size / Max Size one, and the row is otherwise unchanged.
