### PR TITLE
fix(core): stop a no-op path stamp pushing every shared file over EC

### DIFF
--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -626,6 +626,12 @@ CKnownFile::~CKnownFile()
 
 void CKnownFile::SetFilePath(const CPath &filePath)
 {
+	// Only on a real change: MarkECChanged() below pushes the file into the next
+	// INC_UPDATE, and the shared-files walk re-stamps every known file on every
+	// reload (issue #1028).
+	if (m_filePath == filePath) {
+		return;
+	}
 	m_filePath = filePath;
 	// EC exports the path printable for non-partfiles (EC_TAG_KNOWNFILE_FILENAME).
 	MarkECChanged();

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -27,7 +27,7 @@
 #define SHAREDFILELIST_H
 
 #include "SharedFilesReloadLatch.h" // Needed for CSharedFilesReloadLatch
-#include <atomic>                   // Needed for std::atomic (m_listGeneration)
+#include <atomic>                   // Needed for std::atomic (m_listGeneration, reloading)
 #include <functional>
 #include <list>
 #include <map>
@@ -293,7 +293,8 @@ private:
 		size_t &excluded,
 		bool &aborted);
 	void FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborted);
-	bool reloading;
+	// Atomic: RemoveFile() reads it off the upload worker thread (issue #1028).
+	std::atomic<bool> reloading;
 	// Set by RequestReload(), drained by Process(). The rules it enforces --
 	// coalescing, a mid-walk request belonging to the next walk, and an
 	// aborted walk giving its request back -- live in the latch so they can be


### PR DESCRIPTION
SetFilePath() always called MarkECChanged(), which hands the file a new EC generation and so pushes it into the next INC_UPDATE. AddPathToShares() re-stamps every already-known file on every reload, and the path is not persisted in known.met, so from the second walk of a session onwards those stamps are all no-ops -- and each one still sent the file to every connected EC client as changed. On a large shareset a reload that changed nothing pushed the whole shareset, which is the O(N) per-INC_UPDATE cost the generation counter was added to avoid (#713).

Guard the bump on an actual change, the way SetUpPriority() and SetAutoUpPriority() already do. Comparison is CPath::operator== (exact match, not IsSameDir): equal here has to mean the path exports identically, since EC exports it printable. This covers every caller, so the rollback in the declined branch of AddPathToShares() no longer bumps the generation either.

Also make CSharedFileList::reloading atomic. It stopped being main-thread-only when RemoveFile() started reading it to suppress the path-index diagnostic mid-walk, because CUploadDiskIOThread calls RemoveFile() from its own thread while Reload() writes the flag outside list_mut. A torn bool is not a practical hazard, but the unsynchronised pair is a data race and the only unguarded shared state left in the class.

Follow-up to #1034 / issue #1028.