### PR TITLE
fix(core): recompute complete sources when uploaders leave, not only when they arrive

### DIFF
--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1649,6 +1649,21 @@ void CKnownFile::UpdatePartsInfo()
 	uint16 partcount = GetPartCount();
 	bool flag = (time(NULL) - m_nCompleteSourcesTime > 0);
 
+	// One transition must not wait out the throttle: the upload list going
+	// empty. Every caller here is driven by a peer event, and there is no
+	// periodic sweep -- so if the last requesting peer leaves inside the 60 s
+	// window, the throttled call is the final one this file will ever get and
+	// the count would keep its last value for the life of the process. That is
+	// the staleness this whole path is about, so the answer that is both
+	// certain and free -- no peers, no complete sources -- is not worth
+	// deferring.
+	//
+	// Guarded on the value actually being non-zero, so a file that has already
+	// settled at 0 does not re-enter the recompute on every later call.
+	if (!flag && m_ClientUploadList.empty() && m_nCompleteSourcesCount != 0) {
+		flag = true;
+	}
+
 	// Ensure the frequency-list is ready
 	if (m_AvailPartFrequency.size() != GetPartCount()) {
 		m_AvailPartFrequency.clear();

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -247,16 +247,25 @@ void CUpDownClient::ProcessExtendedInfo(const CMemFile *data, CKnownFile *tempre
 		}
 
 		if (GetExtendedRequestsVersion() > 1) {
-			uint16 nCompleteCountLast = GetUpCompleteSourcesCount();
-			uint16 nCompleteCountNew = data->ReadUInt16();
-			SetUpCompleteSourcesCount(nCompleteCountNew);
-			if (nCompleteCountLast != nCompleteCountNew) {
-				tempreqfile->UpdatePartsInfo();
-			}
+			// Still guarded, because this is where the count is read off the
+			// wire. The recompute it used to gate has moved below: the peer's
+			// self-reported total staying put says nothing about its part
+			// bitmap, which may well have changed in the same message.
+			SetUpCompleteSourcesCount(data->ReadUInt16());
 		}
 	}
 
 	m_uploadingfile->UpdateUpPartsFrequency(this, true); // Increment
+	// Unconditional now, where it used to be gated on the peer's self-reported
+	// complete-source total having changed -- which says nothing about its part
+	// bitmap, so the frequency vector could move without the count following
+	// (issue #1050). UpdatePartsInfo() is throttled to one real recompute a
+	// minute per file, so the extra calls cost a comparison.
+	//
+	// On tempreqfile, as before: the UDP/v3 callers pass a reqfile that is not
+	// necessarily this client's m_uploadingfile, and this change is about when
+	// the recompute happens, not which file it runs on.
+	tempreqfile->UpdatePartsInfo();
 
 	Notify_SharedCtrlRefreshClient(ECID(), AVAILABLE_SOURCE);
 }
@@ -268,6 +277,11 @@ void CUpDownClient::SetUploadFileID(CKnownFile *newreqfile)
 	} else if (m_uploadingfile) {
 		m_uploadingfile->RemoveUploadingClient(this);
 		m_uploadingfile->UpdateUpPartsFrequency(this, false); // Decrement
+		// The decrement side never recomputed, so the count was a high-water
+		// mark that only ever rose (issue #1050). This one call covers both the
+		// peer disconnecting (Safe_Delete -> SetUploadFileID(NULL)) and the peer
+		// switching to a different file.
+		m_uploadingfile->UpdatePartsInfo();
 	}
 
 	if (newreqfile) {
@@ -280,6 +294,7 @@ void CUpDownClient::SetUploadFileID(CKnownFile *newreqfile)
 		} else {
 			// this is the same file we already had assigned. Only update data.
 			newreqfile->UpdateUpPartsFrequency(this, true); // Increment
+			newreqfile->UpdatePartsInfo();
 		}
 
 		m_uploadingfile = newreqfile;


### PR DESCRIPTION
Closes #1050.

`m_nCompleteSourcesCount` is derived from `m_AvailPartFrequency`, but only the *increment* side of that vector ever recomputed it. Every path that decrements updated the vector and left the scalar alone, so the reported figure was a high-water mark: as requesting peers disconnected the vector decayed toward zero while the count kept its last value, for the life of the process.

The desktop **Complete Sources** column and `complete_sources` on `GET /api/v0/shared` both read it, and #1045's availability bar renders the vector directly — so the same file could show an all-red bar beside a non-zero count. The bar was right.

## Recomputes added

| Path | Why it was missing |
|---|---|
| `SetUploadFileID` decrement | Both the peer disconnecting (`Safe_Delete` → `SetUploadFileID(NULL)`) and the peer switching away |
| `SetUploadFileID` same-file re-assignment | Increment with no recompute |
| `ProcessExtendedInfo` increment | Was gated on the peer's self-reported complete-source total having changed — which says nothing about its part bitmap, so the vector could move without the count following |

Adding call sites is cheap: `UpdatePartsInfo()` throttles itself to one real recompute a minute per file, so the extra calls cost a comparison.

## The throttle bypass is not optional

The issue lists this as item 3, "consider". It is required for the case the issue leads with.

Every caller of `UpdatePartsInfo()` is peer-event driven and there is no periodic sweep. So if the last requesting peer leaves inside the 60 s window, `flag` is false, the throttled call does nothing — and being the last peer, no further call will ever arrive for that file. The count keeps its stale value indefinitely: the same bug with a narrower entry condition, and acceptance criterion 1 would not hold.

An empty upload list therefore bypasses the throttle. No peers means no complete sources — an answer both certain and free. Guarded on the count actually being non-zero, so a file already settled at `0` does not re-enter the recompute on every later call.

## Two deliberate non-changes

**The `ProcessExtendedInfo` recompute stays on `tempreqfile`, not `m_uploadingfile`.** `ClientTCPSocket.cpp:400` sets the two equal, but the UDP/v3 callers (`ClientUDPSocket.cpp:236`, `ClientTCPSocket.cpp:1846`) pass a `reqfile` that is not necessarily that client's upload file. This changes *when* the recompute happens, not which file it runs on.

**`Notify_SharedFilesUpdateItem` stays outside the throttle branch.** The issue floats moving it inside if redraws storm, but that would change behaviour for the four existing callers too. The added notifies are bounded by peer count rather than share size — one per disconnecting peer, on its own file.

## Testing

Monolithic, remote GUI and daemon build clean; 35/35 unit tests; `clang-format` (18.1.8, the CI version) clean.

**Not verified against live peers.** Acceptance criteria 1 (count reaching `0` after the last uploader leaves) and 6 (no CPU regression during mass disconnects on a large share) need real uploaders disconnecting, which I have not staged. The reasoning above is from the code paths.

Partfiles are unaffected — `CPartFile::UpdatePartsInfo` is a separate override and already runs on source removal.
