### PR TITLE
feat(chat): full chat parity over EC and REST — list, read, receive and send

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -10,6 +10,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		kademlia/routing/RoutingZone.cpp
 		amule.cpp
 		BaseClient.cpp
+		ChatSessionStore.cpp
 		ClientCreditsList.cpp
 		ClientList.cpp
 		ClientTCPSocket.cpp

--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -301,6 +301,7 @@ EC_OP_AUTH_REQ (0x02)
     +-- EC_TAG_CAN_CHAT               (0x16) (optional, advertises capability)
     +-- EC_TAG_CAN_SHAREDDIRS_CONFIG  (0x17) (optional, advertises capability)
     +-- EC_TAG_CAN_SEARCH_LIST        (0x1a) (optional, advertises capability)
+    +-- EC_TAG_CAN_CHAT_SESSIONS      (0x27) (optional, advertises capability)
 ```
 
 Each `EC_TAG_CAN_*` is an empty tag advertising support for one
@@ -320,8 +321,9 @@ confirmation — the server does not echo those two tags.
 
 **Feature capabilities** gate whole operations rather than the framing:
 `EC_TAG_CAN_PARTIAL_UPDATE`, `EC_TAG_CAN_MULTI_SEARCH`,
-`EC_TAG_CAN_CHAT`, `EC_TAG_CAN_SHAREDDIRS_CONFIG`,
-`EC_TAG_CAN_SEARCH_LIST`, `EC_TAG_CAN_SEARCH_PROGRESS_UNION`. The server
+`EC_TAG_CAN_CHAT`, `EC_TAG_CAN_CHAT_SESSIONS`,
+`EC_TAG_CAN_SHAREDDIRS_CONFIG`, `EC_TAG_CAN_SEARCH_LIST`,
+`EC_TAG_CAN_SEARCH_PROGRESS_UNION`. The server
 echoes each of these in its `EC_OP_AUTH_OK` response when it supports it,
 so the client learns what is negotiated for this connection.
 
@@ -512,7 +514,13 @@ isn't immediately obvious or has changed across protocol versions.
 
 Peer chat is served from a session store in the core, shared by the
 built-in GUI and every EC client, so all of them see one transcript.
-Gated by `EC_TAG_CAN_CHAT` (`0x16`).
+
+Gated by `EC_TAG_CAN_CHAT_SESSIONS` (`0x27`), which is **not** the older
+`EC_TAG_CAN_CHAT` (`0x16`). The two are deliberately distinct: `0x16`
+predates these operations and is echoed by servers that implement none
+of them, so a client gating on it would send `EC_OP_GET_CHAT_SESSIONS`
+to a server whose dispatcher only knows how to assert on it. A client
+must send none of the operations below unless it saw `0x27` echoed.
 
 | Tag                     | Code     | Type     | Description |
 | ----------------------- | -------- | -------- | ----------- |

--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -325,6 +325,13 @@ confirmation — the server does not echo those two tags.
 echoes each of these in its `EC_OP_AUTH_OK` response when it supports it,
 so the client learns what is negotiated for this connection.
 
+For a feature capability the echo is **load-bearing, not informational**.
+A client that does not see one echoed must not send the operations it
+gates: an opcode the server does not know reaches the unknown-opcode
+branch of its request dispatcher, which asserts before it can answer
+`EC_OP_FAILED`. Asking an older server takes it down rather than
+receiving a polite refusal.
+
 `EC_TAG_CAN_SEARCH_PROGRESS_UNION` changes the reply shape of
 `EC_OP_SEARCH_PROGRESS`, so it is advertised only alongside
 `EC_TAG_CAN_MULTI_SEARCH` — a single-search client has one search and no
@@ -500,6 +507,91 @@ Hopefully these examples clarified opcodes, tags, and nested tags.
 
 This section documents the data types of selected tags where the type
 isn't immediately obvious or has changed across protocol versions.
+
+### Chat (`EC_TAG_CHAT = 0x0900`)
+
+Peer chat is served from a session store in the core, shared by the
+built-in GUI and every EC client, so all of them see one transcript.
+Gated by `EC_TAG_CAN_CHAT` (`0x16`).
+
+| Tag                     | Code     | Type     | Description |
+| ----------------------- | -------- | -------- | ----------- |
+| `EC_TAG_CHAT`           | `0x0900` | `string` | Message text |
+| `EC_TAG_CHAT_CLIENT_ID` | `0x0901` | `uint64` | Peer GUI_ID, `(ip << 16) \| port` |
+| `EC_TAG_CHAT_SESSION`   | `0x0902` | `uint64` | Session container; value is the GUI_ID |
+| `EC_TAG_CHAT_MESSAGE`   | `0x0903` | `string` | Message container; value is the text |
+| `EC_TAG_CHAT_MSG_ID`    | `0x0904` | `uint32` | Monotonic message id, also used as a resume cursor |
+| `EC_TAG_CHAT_DIRECTION` | `0x0905` | `uint8`  | `0` = incoming, `1` = outgoing |
+| `EC_TAG_CHAT_TIMESTAMP` | `0x0906` | `uint32` | Unix seconds, stamped by the core |
+| `EC_TAG_CHAT_PEER_NAME` | `0x0907` | `string` | Peer display name; may be empty |
+
+The IP inside a GUI_ID uses the same byte order as
+`EC_TAG_CLIENT_USER_IP`.
+
+#### `EC_OP_GET_CHAT_SESSIONS` (`0x63`) → `EC_OP_CHAT_SESSIONS` (`0x64`)
+
+The polling workhorse: one roundtrip returns the session list *and*
+every message newer than the client's cursor, so an idle connection
+costs one small packet and a busy one needs no follow-up query.
+
+**Request:** optional `EC_TAG_CHAT_MSG_ID` — the highest id the client
+already holds. Absent or `0` means "everything you still have".
+
+**Reply:** a top-level `EC_TAG_CHAT_MSG_ID` carrying the store's current
+last id, then one `EC_TAG_CHAT_SESSION` per session. Each session
+container carries `EC_TAG_CHAT_PEER_NAME`, its own
+`EC_TAG_CHAT_MSG_ID`, an `EC_TAG_CLIENT` when the peer is online, an
+`EC_TAG_FRIEND` when the peer is a friend, and one
+`EC_TAG_CHAT_MESSAGE` per message past the cursor.
+
+The top-level cursor is present even when no messages come back, so a
+client can advance past ids that were evicted rather than requesting
+them forever.
+
+The reply is the server's **complete** session set. A session the client
+is tracking that is absent from it was closed — by another client, or by
+eviction — which is the only signal a close produces. No expiry tag is
+needed, and a client must drop such a session rather than assume it
+still exists.
+
+#### `EC_OP_GET_CHAT_MESSAGES` (`0x5B`) → `EC_OP_CHAT_MESSAGES` (`0x5C`)
+
+Non-destructive backfill of **one** session, for a client opening a
+conversation it has no transcript for. Takes a required
+`EC_TAG_CHAT_CLIENT_ID` and an optional `EC_TAG_CHAT_MSG_ID` cursor, and
+replies with the same shape as above containing a single session
+container.
+
+#### `EC_OP_CHAT_SEND` (`0x65`)
+
+Takes `EC_TAG_CHAT` (the text, non-empty) plus exactly one target:
+
+| Target tag              | Addresses |
+| ----------------------- | --------- |
+| `EC_TAG_CHAT_CLIENT_ID` | A GUI_ID — replying needs no lookup, it is the id messages arrive with |
+| `EC_TAG_CLIENT`         | A live peer by ECID |
+| `EC_TAG_FRIEND`         | A friend by ECID — resolved through the friend's stored address, so an **offline** friend is reachable |
+
+The server creates the session when it does not exist, so this doubles
+as "start a chat with this address".
+
+**Reply:** `EC_OP_NOOP` with `EC_TAG_CHAT_CLIENT_ID` (the resolved
+GUI_ID) and `EC_TAG_CHAT_MSG_ID` (the id assigned), so the sender can
+correlate without waiting for the next poll. `EC_OP_FAILED` with an
+`EC_TAG_STRING` on an unknown target or empty text.
+
+Note that the core's own send returning `false` means *queued while
+connecting*, not *failed*, and does not produce an `EC_OP_FAILED`.
+
+#### `EC_OP_CHAT_CLOSE_SESSION` (`0x66`)
+
+Takes `EC_TAG_CHAT_CLIENT_ID`; drops the session from the store and
+resets the peer's chat state. Replies `EC_OP_NOOP`, or `EC_OP_FAILED`
+when there is no such session.
+
+Closing is **global**, matching the semantics search tabs already have:
+the core state is destroyed for every client, and the others learn of it
+from the session's absence in the next `EC_OP_CHAT_SESSIONS` reply.
 
 ### Connection preferences (`EC_TAG_PREFS_CONNECTIONS = 0x1300`)
 

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -161,6 +161,7 @@ Every event belongs to a single channel. The full set, prefix-mapped from the ev
 | `status` | `status_*` | Connection state + headline counters |
 | `logs` | `log_*` | amuled log buffer (live tail; serverinfo is poll-only) |
 | `search` | `search_*` | Result deltas, completion, and the freeing of a search |
+| `chats` | `chat_*` | Peer chat messages, and conversations being closed |
 
 By default every channel is delivered. To subscribe to a subset, pass `?channels=` with a comma-separated list:
 
@@ -372,6 +373,38 @@ One `PATCH /api/v0/friends/{ecid}` can produce **two** `friend_updated` events. 
 ```json
 { "ecid": 12 }
 ```
+
+### `chats` channel
+
+Backed by the chat session store in `amuled`, which is shared by every client — so these events carry messages sent from the desktop GUI and amulegui too, not only ones this API sent.
+
+#### `chat_message`
+
+One event per message, **inbound and outbound alike**. An outbound one is how a message sent from amulegui, or from another browser tab, reaches every other viewer.
+
+```json
+{
+  "peer":        "203.0.113.42:4662",
+  "ip":          "203.0.113.42",
+  "port":        4662,
+  "name":        "alice",
+  "client_ecid": 4382,
+  "friend_ecid": 12,
+  "message":     { "id": 91, "direction": "in", "text": "thanks!", "timestamp": 1786652714 }
+}
+```
+
+`message` is identical to a `messages[]` entry on [`GET /api/v0/chats/{peer}/messages`](REFERENCE.md#get-apiv0chatspeermessages), and `name` uses the same `"IP: <ip> Port: <port>"` fallback the REST list does.
+
+There is no separate "conversation started" event: a conversation that did not exist yet is implied by the first message carrying its `peer`.
+
+#### `chat_session_closed`
+
+```json
+{ "peer": "203.0.113.42:4662" }
+```
+
+Closing is global — see [`DELETE /api/v0/chats/{peer}`](REFERENCE.md#delete-apiv0chatspeer). This fires whichever client closed it, including the desktop GUI, so a viewer should drop the conversation rather than assume it still exists.
 
 ### `clients` channel
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -70,6 +70,12 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`DELETE /api/v0/friends/{ecid}`](#delete-apiv0friendsecid) — remove a friend
 - [`PATCH /api/v0/friends/{ecid}`](#patch-apiv0friendsecid) — grant or clear the friend slot
 - [`POST /api/v0/friends/{ecid}/shared_files`](#post-apiv0friendsecidshared_files) — browse a friend's shared files
+- [`POST /api/v0/friends/{ecid}/messages`](#post-apiv0friendsecidmessages) — message a friend, online or offline
+- [`GET /api/v0/chats`](#get-apiv0chats) — list chat conversations
+- [`GET /api/v0/chats/{peer}/messages`](#get-apiv0chatspeermessages) — read a conversation's history
+- [`POST /api/v0/chats/{peer}/messages`](#post-apiv0chatspeermessages) — send a message to a peer address
+- [`DELETE /api/v0/chats/{peer}`](#delete-apiv0chatspeer) — close a conversation
+- [`POST /api/v0/clients/{ecid}/messages`](#post-apiv0clientsecidmessages) — message a connected peer
 
 **Categories**
 - [`GET /api/v0/categories`](#get-apiv0categories) — list categories
@@ -232,6 +238,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 | `GET /shared`         | `name`, `size` |
 | `GET /servers`        | `name`, `users`, `ping`, `files` |
 | `GET /friends`        | `name`, `online` |
+| `GET /chats`          | `last_message_at`, `name` |
 | `GET /search/{id}/results` | `name`, `size`, `sources`, `rating`, `directory` |
 
 ### Bulk mutations and the `results` envelope
@@ -2637,6 +2644,131 @@ The response is never `Content-Encoding: gzip` — a PNG is already entropy-code
 Peers whose country could not be resolved — GeoIP disabled, unsupported by the build, or a private/unmatched address — come back with `country_code: ""`. There is no per-country image to request in that case; draw nothing, or `unknown.png` for parity with the desktop list.
 
 ---
+
+### Chat
+
+Conversations with peers, backed by the chat session store in `amuled`. The store is shared: a message sent from the desktop GUI, from amulegui or through this API lands in the same transcript, and every client sees the same conversation.
+
+A conversation is keyed on `{peer}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across peer reconnects — unlike an ECID — and it needs no identifier of its own. A `{peer}` that is not four dotted octets plus a port is a `400`.
+
+The store is **in memory**: an `amuled` restart empties every conversation, exactly as the desktop's own transcript dies with its notebook tab. Retention is bounded at 200 messages per conversation and 50 conversations, evicting the least recently active first.
+
+Message `id` is monotonic per `amuled` process and never reused, which makes it a safe polling cursor: `since_id` never returns a duplicate and never skips a message. It resets when the daemon restarts, which also empties the store.
+
+Every endpoint here answers `503 ec_unsupported` when the connected `amuled` does not serve chat.
+
+#### `GET /api/v0/chats`
+
+**Auth:** `GUEST`
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
+```
+
+```json
+{
+  "chats": [
+    {
+      "peer":            "203.0.113.42:4662",
+      "ip":              "203.0.113.42",
+      "port":            4662,
+      "name":            "alice",
+      "client_ecid":     4382,
+      "friend_ecid":     12,
+      "online":          true,
+      "message_count":   14,
+      "last_msg_id":     91,
+      "last_message_at": 1786652714,
+      "last_message":    { "id": 91, "direction": "in", "text": "thanks!", "timestamp": 1786652714 }
+    }
+  ],
+  "total": 1, "offset": 0, "limit": 1
+}
+```
+
+`name` falls back to `"IP: <ip> Port: <port>"` when the core has no nickname for the peer, matching what the desktop shows; the same string appears in the SSE payload. `client_ecid` is `0` when the peer is offline, `friend_ecid` is `0` when the peer is not a friend — join against [`GET /clients`](#get-apiv0clients) and [`GET /friends`](#get-apiv0friends). `online` is simply `client_ecid != 0`.
+
+`last_message` is omitted for a conversation that holds none. The full transcript is deliberately **not** on the list: 50 conversations at 200 messages each would be 10 000 objects per read. Use the messages endpoint below.
+
+Served from the refresher snapshot — no EC roundtrip per request. Standard [list envelope](#list-pagination-and-sorting); sortable on `last_message_at` and `name`.
+
+**Errors:** `503 ec_unsupported`, `503 ec_unavailable`.
+
+#### `GET /api/v0/chats/{peer}/messages`
+
+**Auth:** `GUEST`
+
+**Query:** `since_id=N` (only messages with `id > N`), `limit=N` (the last N of that window).
+
+```json
+{
+  "peer": "203.0.113.42:4662",
+  "messages": [
+    { "id": 90, "direction": "out", "text": "hi",      "timestamp": 1786652700 },
+    { "id": 91, "direction": "in",  "text": "thanks!", "timestamp": 1786652714 }
+  ],
+  "total": 14,
+  "last_msg_id": 91
+}
+```
+
+`direction` is `"in"` (from the peer) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `timestamp` is stamped by the core when the message was received or sent. `total` counts everything the store holds for this conversation, not the returned window.
+
+**Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{peer}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
+
+#### `POST /api/v0/chats/{peer}/messages`
+
+**Auth:** `ADMIN`
+
+**Body:** `{ "text": "hello" }` — non-empty, at most 1024 bytes.
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"text":"hello"}' "http://$HOST/api/v0/chats/203.0.113.42:4662/messages"
+```
+
+```json
+{ "ok": true, "peer": "203.0.113.42:4662",
+  "message": { "id": 92, "direction": "out", "text": "hello" } }
+```
+
+The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{peer}` is not a `404` here.
+
+Returns `202 Accepted`, not `200`: the core acknowledges that it queued the message on the peer connection, not that the peer received it. An unreachable peer is not an error — the desktop behaves the same, optimistically showing `*** Connecting to Client ***`.
+
+**Errors:** `400 bad_request`, `503 ec_unsupported`, `503 ec_unavailable`.
+
+#### `POST /api/v0/friends/{ecid}/messages`
+
+**Auth:** `ADMIN`
+
+Message a friend by friend ECID. This is the form that reaches an **offline** friend: the daemon resolves the ECID to the friend's stored address, so no live connection is needed.
+
+**Body:** `{ "text": "hello" }`
+
+**Response:** `202 Accepted` → `{ "ok": true, "peer": "203.0.113.42:4662", "message": { … } }`, so the caller learns the conversation key to read back.
+
+**Errors:** `404 not_found` (no friend with that ECID), plus the set above.
+
+#### `POST /api/v0/clients/{ecid}/messages`
+
+**Auth:** `ADMIN`
+
+The peer-addressed form, for a caller holding a peer row that should not have to compose an `ip:port` key. Same body and response as above.
+
+**Errors:** `404 not_found` (no live peer with that ECID), plus the set above.
+
+#### `DELETE /api/v0/chats/{peer}`
+
+**Auth:** `ADMIN`
+
+Closes the conversation: drops it from the core store and resets the peer's chat state.
+
+**Response:** `200 OK` → `{ "ok": true, "peer": "203.0.113.42:4662" }`
+
+Closing is **global**, the same way closing a search tab frees the search for every client. A connected amulegui drops its tab on the next poll, and the desktop GUI closes its own; no client is left showing a conversation the core no longer has.
+
+**Errors:** `404 not_found`, `400 bad_request`, `503 ec_unsupported`, `503 ec_unavailable`.
 
 ## Error code catalog
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2130,6 +2130,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:02+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2169,6 +2169,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2196,6 +2196,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Aniciada Nueva sesión de charra"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Zarrar esta sesión de charra"
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nome desconocíu)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:03+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2164,6 +2164,23 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Неизвестно име)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2129,6 +2129,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2189,6 +2189,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Inici d'una nova sessió de xat"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Tanca aquesta sessió de xat."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nom desconegut)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2182,6 +2182,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Nepodařilo se uložit heslo amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Zahájeno nové sezení v chatu"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Zavře tento chat."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(neznámý název)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2174,6 +2174,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2194,6 +2194,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Neue Chat-Sitzung gestartet."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Schließe diese Chat-Sitzung."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Unbekannter Name)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2206,6 +2206,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Ξεκίνησε καινούρια περίοδος συνομιλίας"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Κλείσιμο της συνομιλίας."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Άγνωστο όνομα)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2130,6 +2130,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2181,6 +2181,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "No se pudo guardar la contraseña amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Nueva sesión de chat iniciada"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Cerrar esta sesión de chat."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nombre desconocido)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2189,6 +2189,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Uus vestlussession alustatud"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Sulge see vestlus-seanss."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Tundmatu nimi)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2190,6 +2190,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Elkarrizketa saio berria hasia"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Itxi elkarrizketa saio hau."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Izen ezezaguna)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2190,6 +2190,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Uusi keskustelu aloitettu"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Sulje tämä keskustelu."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Tuntematon nimi)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2180,6 +2180,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Impossible d’enregistrer le mot de passe d’amuleapi : %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Nouvelle session de chat démarrée"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Ferme cette session de discussion."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nom inconnu)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2207,6 +2207,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Comezada nova sesión da conversa"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Pechar esta conversa."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nome descoñecido)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2185,6 +2185,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "צ'אט חדש החל."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "סגור את הצ'אט הנוכחי."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(שם לא ידוע)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2182,6 +2182,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2181,6 +2181,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Új beszélgetés kezdődött"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Csevegési folyamat bezárása."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Ismeretlen név)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2187,6 +2187,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Impossibile salvare la password di amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Nuova sessione chat iniziata"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Chiude questa sessione di chat."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(nome sconosciuto)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2192,6 +2192,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "新しいチャットセッションの開始"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "チャット・セションを閉じます。"
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "（不明な名前）"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2203,6 +2203,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "프로토콜 버젼 태그 없음"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "이 채팅세션을 닫습니다."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(알수없는 이름)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:11+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2213,6 +2213,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Pradėtas naujas pokalbis"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(pavadinimas nežinomas)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2153,6 +2153,23 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Trūkst protokola versijas birka."
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2177,6 +2177,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Kon het amuleapi-wachtwoord niet opslaan: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Nieuwe chatsessie begonnen"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Sluit deze chat-sessie."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Onbekende naam)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:12+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2204,6 +2204,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Ny lynmeldingsøkt starta"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Stengje denne lynmeldingsøkta."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Ukjent namn)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2199,6 +2199,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Rozpoczęto nową sesję czatu"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Zamknij tę sesję czata."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nieznana nazwa)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:13+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2181,6 +2181,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Não foi possível salvar a senha da amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Nova sessão de chat iniciada"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Encerrar sessão de Chat."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nome Desconhecido)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2196,6 +2196,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Nova sessão de conversa iniciada"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Fechar esta conversa."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nome desconhecido)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:14+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2196,6 +2196,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "O nouă sesiune chat este pornită"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Închide această sesiune de chat."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Nume necunoscut)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2197,6 +2197,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Не удалось сохранить пароль amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Начата новая беседа"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Закрыть данный чат."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Неизвестное имя)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:15+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2210,6 +2210,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Začeta je bila nova seja klepeta."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Zapri to pogovorno sejo."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(neznano ime)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2199,6 +2199,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Sesion i ri chati filloi"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Mbylle kete sesion chati."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Emer i panjohur)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:16+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2188,6 +2188,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Ny chatt startad"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Stäng denna chat-session."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Okänt namn)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2129,6 +2129,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2173,6 +2173,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "amuleapi parolası kaydedilemedi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Yeni sohbet oturumu başladı"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Bu sohbet oturumunu kapatır."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(Bilinmeyen ad)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:17+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2209,6 +2209,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "Розпочато нову розмову"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "Закрити цю розмову."
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(невідома назва)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2128,6 +2128,22 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Missing chat session id"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Unknown chat target"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2177,6 +2177,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "无法保存 amuleapi 密码：%s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "新的聊天对话已启动"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "结束本次聊天。"
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(未知名称)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 12:11+0200\n"
+"POT-Creation-Date: 2026-08-22 15:15+0200\n"
 "PO-Revision-Date: 2026-08-21 19:18+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2186,6 +2186,25 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Missing chat session id"
+msgstr "已開始新的交談"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such chat session"
+msgstr "結束本次交談。"
+
+#: src/ExternalConn.cpp
+msgid "Empty chat message"
+msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Unknown chat target"
+msgstr "(不明名稱)"
 
 #: src/ExternalConn.cpp
 msgid "Kad is disabled in preferences."

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -59,6 +59,7 @@
 #include "Packet.h"            // Needed for CPacket
 #include "Friend.h"            // Needed for CFriend
 #include "ClientList.h"        // Needed for CClientList
+#include "ChatSessionStore.h"  // Needed for CChatSessionStore
 #ifndef AMULE_DAEMON
 #include "amuleDlg.h"      // Needed for CamuleDlg
 #include "CaptchaDialog.h" // Needed for CCaptchaDialog
@@ -3007,6 +3008,15 @@ void CUpDownClient::ProcessChatMessage(wxString message)
 	}
 	AddLogLineC(logMsg);
 	IncMessagesReceived();
+
+	// Record in the core store BEFORE the GUI notify. Both builds reach this
+	// line -- it is the single inbound choke point -- so this is what gives
+	// amulegui and amuleapi a transcript at all, and what lets the local GUI
+	// and every EC client agree on one. Placed after the filter / spammer
+	// branches above so a filtered message is not stored.
+	if (theApp->chatsessions) {
+		theApp->chatsessions->AddIncoming(GUI_ID(GetIP(), GetUserPort()), GetUserName(), message);
+	}
 
 	Notify_ChatProcessMsg(GUI_ID(GetIP(), GetUserPort()), GetUserName() + "|" + message);
 }

--- a/src/ChatSelector.cpp
+++ b/src/ChatSelector.cpp
@@ -190,9 +190,7 @@ bool CChatSelector::ProcessMessage(uint64 sender_id, const wxString &message)
 			// Core did not send us the name.
 			// This must NOT happen.
 			// Build a client name based on the ID
-			uint32 ip = IP_FROM_GUI_ID(sender_id);
-			client_name = CFormat("IP: %s Port: %u") % Uint32toStringIP(ip) %
-				      PORT_FROM_GUI_ID(sender_id);
+			client_name = ChatPeerFallbackName(sender_id);
 		}
 
 		session = StartSession(sender_id, client_name, true);

--- a/src/ChatSelector.cpp
+++ b/src/ChatSelector.cpp
@@ -212,6 +212,25 @@ bool CChatSelector::ProcessMessage(uint64 sender_id, const wxString &message)
 	return newtab;
 }
 
+void CChatSelector::AppendStoredMessage(
+	uint64 gui_id, const wxString &name, const wxString &text, bool outgoing)
+{
+	CChatSession *session = GetPageByClientID(gui_id);
+	if (!session) {
+		// show=false: a session can appear on its own -- opened by another
+		// client, or by a peer messaging us -- and must not pull the
+		// selection away from whatever the local user is doing.
+		session = StartSession(gui_id, name, false);
+		if (!session) {
+			return;
+		}
+	}
+	session->m_active = true;
+	session->AddText(
+		outgoing ? thePrefs::GetUserNick() : name, outgoing ? COLOR_GREEN : COLOR_BLUE, false);
+	session->AddText(": " + text, COLOR_BLACK);
+}
+
 bool CChatSelector::SendMessage(const wxString &message, const wxString &client_name, uint64 to_id)
 {
 	// Dont let the user send empty messages
@@ -238,9 +257,17 @@ bool CChatSelector::SendMessage(const wxString &message, const wxString &client_
 
 	ci->m_active = true;
 
-	// #warning EC needed here.
-
-#ifndef CLIENT_GUI
+#ifdef CLIENT_GUI
+	// amulegui sends through the daemon and deliberately does NOT echo the
+	// line locally: the core records every outbound message in the chat
+	// session store, so the next EC_OP_GET_CHAT_SESSIONS poll returns it and
+	// renders it here. Echoing as well would print it twice, and printing it
+	// from the poll is also what keeps the ordering the core sees.
+	CECPacket req(EC_OP_CHAT_SEND);
+	req.AddTag(CECTag(EC_TAG_CHAT, message));
+	req.AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, ci->m_client_id));
+	theApp->m_connect->SendPacket(&req);
+#else
 	if (theApp->clientlist->SendChatMessage(ci->m_client_id, message)) {
 		ci->AddText(thePrefs::GetUserNick(), COLOR_GREEN, false);
 		ci->AddText(": " + message, COLOR_BLACK);

--- a/src/ChatSelector.h
+++ b/src/ChatSelector.h
@@ -76,6 +76,17 @@ public:
 	CChatSession *GetPageByClientID(uint64 client_id);
 	int GetTabByClientID(uint64 client_id);
 	bool ProcessMessage(uint64 sender_id, const wxString &message);
+
+	/**
+	 * Render one message the core's session store already holds.
+	 *
+	 * Distinct from ProcessMessage, which parses the "name|text" wire form
+	 * and always announces the message. This takes an already-decoded
+	 * message with its direction, and does NOT touch the new-message blink --
+	 * the caller decides that, because replaying history on connect must not
+	 * light the Messages button up for messages already read elsewhere.
+	 */
+	void AppendStoredMessage(uint64 gui_id, const wxString &name, const wxString &text, bool outgoing);
 	bool SendMessage(const wxString &message, const wxString &client_name = "", uint64 to_id = 0);
 	void ConnectionResult(bool success, const wxString &message, uint64 id);
 	void RefreshFriend(uint64 toupdate_id, const wxString &new_name);

--- a/src/ChatSessionStore.cpp
+++ b/src/ChatSessionStore.cpp
@@ -1,0 +1,135 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ChatSessionStore.h"
+
+#include "OtherFunctions.h" // IP_FROM_GUI_ID / PORT_FROM_GUI_ID
+
+#include <algorithm>
+#include <ctime>
+
+CChatSessionStore::Session &CChatSessionStore::Touch(uint64 gui_id, const wxString &name)
+{
+	const uint32 now = static_cast<uint32>(time(NULL));
+
+	for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
+		if (it->gui_id != gui_id) {
+			continue;
+		}
+		// Only overwrite the name when the caller actually has one. An
+		// outbound message carries none, and a peer that has not sent its
+		// nick yet reports empty -- neither should erase a name we already
+		// learnt from an earlier inbound message.
+		if (!name.IsEmpty()) {
+			it->name = name;
+		}
+		it->last_activity = now;
+		// Move to front: activity order is what Sessions() returns and what
+		// eviction walks backwards through.
+		if (it != m_sessions.begin()) {
+			m_sessions.splice(m_sessions.begin(), m_sessions, it);
+		}
+		return m_sessions.front();
+	}
+
+	Session s;
+	s.gui_id = gui_id;
+	s.name = name;
+	s.ip = static_cast<uint32>(IP_FROM_GUI_ID(gui_id));
+	s.port = static_cast<uint16>(PORT_FROM_GUI_ID(gui_id));
+	s.last_activity = now;
+	m_sessions.push_front(std::move(s));
+	EvictSessionsIfNeeded();
+	return m_sessions.front();
+}
+
+uint32 CChatSessionStore::Append(Session &s, uint8 direction, const wxString &text)
+{
+	Message m;
+	// Pre-increment: id 0 is reserved as the "no cursor / nothing yet"
+	// sentinel every reader uses, so the first real message is 1.
+	m.id = ++m_lastMsgId;
+	m.direction = direction;
+	m.timestamp = static_cast<uint32>(time(NULL));
+	m.text = text;
+	s.messages.push_back(std::move(m));
+	while (s.messages.size() > MAX_MESSAGES_PER_SESSION) {
+		s.messages.pop_front();
+	}
+	return m_lastMsgId;
+}
+
+uint32 CChatSessionStore::AddIncoming(uint64 gui_id, const wxString &name, const wxString &text)
+{
+	return Append(Touch(gui_id, name), DIR_IN, text);
+}
+
+uint32 CChatSessionStore::AddOutgoing(uint64 gui_id, const wxString &text)
+{
+	return Append(Touch(gui_id, wxEmptyString), DIR_OUT, text);
+}
+
+bool CChatSessionStore::CloseSession(uint64 gui_id)
+{
+	for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
+		if (it->gui_id == gui_id) {
+			m_sessions.erase(it);
+			return true;
+		}
+	}
+	return false;
+}
+
+const CChatSessionStore::Session *CChatSessionStore::Find(uint64 gui_id) const
+{
+	for (const Session &s : m_sessions) {
+		if (s.gui_id == gui_id) {
+			return &s;
+		}
+	}
+	return NULL;
+}
+
+std::vector<const CChatSessionStore::Session *> CChatSessionStore::Sessions() const
+{
+	std::vector<const Session *> out;
+	out.reserve(m_sessions.size());
+	for (const Session &s : m_sessions) {
+		out.push_back(&s);
+	}
+	return out;
+}
+
+void CChatSessionStore::EvictSessionsIfNeeded()
+{
+	// Least recently active first, i.e. from the back. Note this drops a
+	// conversation whole rather than trimming it: a client tracking that
+	// GUI_ID sees it vanish from the session list and closes its tab, which
+	// is the same rule a session closed by another client follows.
+	while (m_sessions.size() > MAX_SESSIONS) {
+		m_sessions.pop_back();
+	}
+}
+
+// File_checked_for_headers

--- a/src/ChatSessionStore.cpp
+++ b/src/ChatSessionStore.cpp
@@ -31,7 +31,7 @@
 
 CChatSessionStore::Session &CChatSessionStore::Touch(uint64 gui_id, const wxString &name)
 {
-	const uint32 now = static_cast<uint32>(time(NULL));
+	const uint32 now = static_cast<uint32>(time(nullptr));
 
 	for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
 		if (it->gui_id != gui_id) {
@@ -71,7 +71,7 @@ uint32 CChatSessionStore::Append(Session &s, uint8 direction, const wxString &te
 	// sentinel every reader uses, so the first real message is 1.
 	m.id = ++m_lastMsgId;
 	m.direction = direction;
-	m.timestamp = static_cast<uint32>(time(NULL));
+	m.timestamp = static_cast<uint32>(time(nullptr));
 	m.text = text;
 	s.messages.push_back(std::move(m));
 	while (s.messages.size() > MAX_MESSAGES_PER_SESSION) {
@@ -108,7 +108,7 @@ const CChatSessionStore::Session *CChatSessionStore::Find(uint64 gui_id) const
 			return &s;
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 std::vector<const CChatSessionStore::Session *> CChatSessionStore::Sessions() const

--- a/src/ChatSessionStore.h
+++ b/src/ChatSessionStore.h
@@ -1,0 +1,128 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef CHATSESSIONSTORE_H
+#define CHATSESSIONSTORE_H
+
+#include "Types.h" // uint64 / uint32 / uint8
+
+#include <deque>
+#include <list>
+#include <vector>
+
+#include <wx/string.h>
+
+// The core's record of who we are chatting with and what was said.
+//
+// Chat used to exist only inside the monolithic GUI's notebook tabs, which
+// left nothing for EC to serve and no way for two clients to agree on the
+// transcript. This store moves the model into the core so the local GUI,
+// amulegui and amuleapi are three views of one conversation rather than three
+// private ones.
+//
+// Compiled into both `amule` and `amuled` -- no GUI dependency. Owned by
+// CamuleApp, fed at the two existing choke points (CUpDownClient::
+// ProcessChatMessage inbound, CClientList::SendChatMessage outbound).
+//
+// In-memory only: an amuled restart empties it, which is the behaviour the
+// monolithic GUI already has (the transcript dies with the notebook page).
+// Persisting it is a self-contained follow-up that needs no EC change.
+//
+// **Threading:** every mutator runs on the main thread, from the packet
+// handlers and the EC request handlers, exactly like CClientList. No locking,
+// deliberately -- adding a mutex here would imply off-thread callers that do
+// not exist and would have to be audited into existence.
+class CChatSessionStore
+{
+public:
+	enum Direction : uint8
+	{
+		DIR_IN = 0,  //!< received from the peer
+		DIR_OUT = 1, //!< sent by us, from any client
+	};
+
+	struct Message
+	{
+		uint32 id = 0; //!< monotonic across the whole store, never reused
+		uint8 direction = DIR_IN;
+		uint32 timestamp = 0; //!< unix seconds, stamped by the core
+		wxString text;
+	};
+
+	struct Session
+	{
+		uint64 gui_id = 0; //!< GUI_ID(ip, port) -- the key
+		wxString name;     //!< peer display name; may be empty
+		uint32 ip = 0;
+		uint16 port = 0;
+		uint32 last_activity = 0; //!< unix seconds, drives session eviction
+		std::deque<Message> messages;
+
+		//! Highest message id in this session, 0 when it holds none.
+		uint32 LastMsgId() const { return messages.empty() ? 0 : messages.back().id; }
+	};
+
+	// Bounded so a chatty peer cannot grow the daemon without limit. Plain
+	// constants rather than preferences: nobody has asked to tune them, and a
+	// pref would need EC prefs plumbing to be reachable from a remote client.
+	static const size_t MAX_MESSAGES_PER_SESSION = 200;
+	static const size_t MAX_SESSIONS = 50;
+
+	// Record one message, creating the session when it is the first. `name`
+	// updates the stored display name when non-empty, so a peer that only
+	// reveals its nick later still ends up named. Returns the id assigned.
+	uint32 AddIncoming(uint64 gui_id, const wxString &name, const wxString &text);
+	uint32 AddOutgoing(uint64 gui_id, const wxString &text);
+
+	// Drop one session. Returns false when there was none, so the EC handler
+	// can answer 404-equivalent rather than silently succeeding.
+	bool CloseSession(uint64 gui_id);
+
+	const Session *Find(uint64 gui_id) const;
+
+	// Sessions in most-recently-active-first order -- the order a client wants
+	// to render, and the order eviction walks backwards through.
+	std::vector<const Session *> Sessions() const;
+
+	//! Store-wide highest id, so a client resumes with one cursor rather than one per session.
+	uint32 LastMsgId() const { return m_lastMsgId; }
+
+	size_t SessionCount() const { return m_sessions.size(); }
+
+private:
+	Session &Touch(uint64 gui_id, const wxString &name);
+	uint32 Append(Session &s, uint8 direction, const wxString &text);
+	void EvictSessionsIfNeeded();
+
+	// A list, not a map: the working set is at most MAX_SESSIONS, and the
+	// dominant operations are "walk in activity order" and "move to front",
+	// both O(1) here and both awkward on a map keyed by GUI_ID. Front is the
+	// most recently active session.
+	std::list<Session> m_sessions;
+	uint32 m_lastMsgId = 0;
+};
+
+#endif // CHATSESSIONSTORE_H
+
+// File_checked_for_headers

--- a/src/ChatWnd.cpp
+++ b/src/ChatWnd.cpp
@@ -308,7 +308,7 @@ void CChatWnd::OnChatClosing(wxBookCtrlEvent &evt)
 	const uint64 gui_id = session->m_client_id;
 	CScopedFlag closingGuard(m_inChatClosing);
 #ifdef CLIENT_GUI
-	if (theApp->m_connect && theApp->m_connect->ServerSupportsChat()) {
+	if (theApp->m_connect && theApp->m_connect->ServerSupportsChatSessions()) {
 		CECPacket req(EC_OP_CHAT_CLOSE_SESSION);
 		req.AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, gui_id));
 		theApp->m_connect->SendPacket(&req);

--- a/src/ChatWnd.cpp
+++ b/src/ChatWnd.cpp
@@ -36,8 +36,14 @@
 #include "FriendList.h"     // Needed for CFriendList
 #include "Friend.h"         // Needed for CFriend
 #include "ChatSelector.h"   // Needed for CChatSelector
-#include "muuli_wdr.h"      // Needed for messagePage
+#ifndef CLIENT_GUI
+#include "ChatSessionStore.h" // Needed for CChatSessionStore
+#include "ClientList.h"       // Needed for CClientList
+#endif
+#include "muuli_wdr.h" // Needed for messagePage
 #include "OtherFunctions.h"
+#include "ScopedPtr.h" // Needed for CScopedFlag
+#include "Constants.h" // Needed for MS_NONE
 
 wxBEGIN_EVENT_TABLE(CChatWnd, wxPanel)
 	EVT_RIGHT_DOWN(CChatWnd::OnNMRclickChatTab)
@@ -50,6 +56,7 @@ wxBEGIN_EVENT_TABLE(CChatWnd, wxPanel)
 	EVT_TEXT_ENTER(IDC_CMESSAGE, CChatWnd::OnBnClickedCsend)
 	EVT_BUTTON(IDC_CSEND, CChatWnd::OnBnClickedCsend)
 	EVT_BUTTON(IDC_CCLOSE, CChatWnd::OnBnClickedCclose)
+	EVT_MULENOTEBOOK_PAGE_CLOSING(IDC_CHATSELECTOR, CChatWnd::OnChatClosing)
 	EVT_MULENOTEBOOK_ALL_PAGES_CLOSED(IDC_CHATSELECTOR, CChatWnd::OnAllPagesClosed)
 wxEND_EVENT_TABLE()
 
@@ -216,16 +223,8 @@ void CChatWnd::SendMessage(const wxString &message, const wxString &client_name,
 
 void CChatWnd::CheckNewButtonsState()
 {
-#ifdef CLIENT_GUI
-	// amulegui is receive-only: sending a chat message isn't wired over EC
-	// (CChatSelector::SendMessage is compiled out under CLIENT_GUI), so the
-	// compose box and Send button stay permanently disabled. Close still
-	// tracks whether there's an open session to close.
-	const bool hasSession = chatselector->GetPageCount() > 0;
-	GetParent()->FindWindow(IDC_CSEND)->Enable(false);
-	GetParent()->FindWindow(IDC_CMESSAGE)->Enable(false);
-	GetParent()->FindWindow(IDC_CCLOSE)->Enable(hasSession);
-#else
+	// Both builds take this path now: amulegui sends over EC_OP_CHAT_SEND,
+	// so the compose box and Send button are no longer disabled for it.
 	switch (chatselector->GetPageCount()) {
 	case 0:
 		GetParent()->FindWindow(IDC_CSEND)->Enable(false);
@@ -244,7 +243,6 @@ void CChatWnd::CheckNewButtonsState()
 		wxASSERT(GetParent()->FindWindow(IDC_CMESSAGE)->IsEnabled());
 		break;
 	}
-#endif
 }
 
 bool CChatWnd::IsIdValid(uint64 id)
@@ -260,6 +258,66 @@ void CChatWnd::ShowCaptchaResult(uint64 id, bool ok)
 void CChatWnd::EndSession(uint64 id)
 {
 	chatselector->EndSession(id);
+}
+
+void CChatWnd::StartSessionByID(uint64 gui_id, const wxString &name)
+{
+	// show=false: a session can appear on its own, opened by another client
+	// or by a peer messaging us, and must not pull the selection away from
+	// whatever the local user is doing.
+	chatselector->StartSession(gui_id, name, false);
+	CheckNewButtonsState();
+}
+
+void CChatWnd::AppendStoredMessage(
+	uint64 gui_id, const wxString &name, const wxString &text, bool outgoing, bool blink)
+{
+	chatselector->AppendStoredMessage(gui_id, name, text, outgoing);
+	// `blink` is false while replaying history on connect: a reconnect must
+	// not light the Messages button up for messages the user already read on
+	// another client. Only arrivals past the connect-time cursor blink.
+	if (blink && !theApp->amuledlg->IsDialogVisible(CamuleDlg::DT_CHAT_WND)) {
+		theApp->amuledlg->SetMessageBlink(true);
+	}
+	CheckNewButtonsState();
+}
+
+void CChatWnd::EndSessionFromCore(uint64 gui_id)
+{
+	// The core has already forgotten this session, so the tab must go without
+	// originating a close of its own. The guard keeps OnChatClosing from
+	// sending one when this DeletePage fires the page-closing event.
+	CScopedFlag closingGuard(m_inChatClosing);
+	chatselector->EndSession(gui_id);
+	CheckNewButtonsState();
+}
+
+void CChatWnd::OnChatClosing(wxBookCtrlEvent &evt)
+{
+	if (m_inChatClosing) {
+		// Re-entry from EndSessionFromCore (or from the notify that a close
+		// we just performed fired): the core already knows.
+		evt.Skip();
+		return;
+	}
+	CChatSession *session = static_cast<CChatSession *>(chatselector->GetPage(evt.GetSelection()));
+	if (!session || !session->m_client_id) {
+		evt.Skip();
+		return;
+	}
+	const uint64 gui_id = session->m_client_id;
+	CScopedFlag closingGuard(m_inChatClosing);
+#ifdef CLIENT_GUI
+	if (theApp->m_connect && theApp->m_connect->ServerSupportsChat()) {
+		CECPacket req(EC_OP_CHAT_CLOSE_SESSION);
+		req.AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, gui_id));
+		theApp->m_connect->SendPacket(&req);
+	}
+#else
+	theApp->chatsessions->CloseSession(gui_id);
+	theApp->clientlist->SetChatState(gui_id, MS_NONE);
+#endif
+	evt.Skip();
 }
 
 // File_checked_for_headers

--- a/src/ChatWnd.h
+++ b/src/ChatWnd.h
@@ -55,6 +55,41 @@ public:
 	void ShowCaptchaResult(uint64 id, bool ok);
 	void EndSession(uint64 id);
 
+	// --- Driven by the core's chat session store, over EC -------------------
+	// Open (or reuse) a tab for a session the core reports, without stealing
+	// the selection: a session can appear on its own, started by another
+	// client, while the user is doing something else.
+	void StartSessionByID(uint64 gui_id, const wxString &name);
+
+	// Render one message the core already holds. `blink` is false while
+	// replaying history on connect -- a reconnect must not light the Messages
+	// button up for messages the user has already read -- and true for
+	// anything that arrives afterwards.
+	void AppendStoredMessage(
+		uint64 gui_id, const wxString &name, const wxString &text, bool outgoing, bool blink);
+
+	// The core no longer has this session (closed by another client, or
+	// evicted). Closes the tab WITHOUT sending a close back: distinct from
+	// EndSession, which is the user's own close.
+	void EndSessionFromCore(uint64 gui_id);
+
+protected:
+	/**
+	 * The user closed a chat tab: tell the core to drop the session.
+	 *
+	 * Closing is global, exactly as it is for a search tab -- the core state
+	 * goes away for every client, which is why this is the only place that
+	 * originates a close. `m_inChatClosing` guards the re-entry: dropping the
+	 * session fires MuleNotify::Chat_SessionRemoved, which routes straight
+	 * back into this tab's close path.
+	 */
+	void OnChatClosing(wxBookCtrlEvent &evt);
+
+	//! True while OnChatClosing is tearing a tab down; see EndSessionFromCore.
+	bool m_inChatClosing = false;
+
+public:
+
 protected:
 	/**
 	 * Event-handler for displaying the chat-popup menu.

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -31,14 +31,15 @@
 #include <protocol/kad/Constants.h>
 #include <protocol/kad2/Client2Client/TCP.h>
 
-#include "amule.h"           // Needed for theApp
-#include "ClientTCPSocket.h" // Needed for CClientTCPSocket
-#include "DownloadQueue.h"   // Needed for CDownloadQueue
-#include "UploadQueue.h"     // Needed for CUploadQueue
-#include "IPFilter.h"        // Needed for CIPFIlter
-#include "updownclient.h"    // Needed for CUpDownClient
-#include "Preferences.h"     // Needed for thePrefs
-#include "Statistics.h"      // Needed for theStats
+#include "amule.h"            // Needed for theApp
+#include "ChatSessionStore.h" // Needed for CChatSessionStore
+#include "ClientTCPSocket.h"  // Needed for CClientTCPSocket
+#include "DownloadQueue.h"    // Needed for CDownloadQueue
+#include "UploadQueue.h"      // Needed for CUploadQueue
+#include "IPFilter.h"         // Needed for CIPFIlter
+#include "updownclient.h"     // Needed for CUpDownClient
+#include "Preferences.h"      // Needed for thePrefs
+#include "Statistics.h"       // Needed for theStats
 #include "Logger.h"
 #include "GuiEvents.h" // Needed for Notify_*
 #include "Packet.h"
@@ -823,6 +824,15 @@ bool CClientList::SendChatMessage(uint64 client_id, const wxString &message)
 		client = new CUpDownClient(
 			PORT_FROM_GUI_ID(client_id), IP_FROM_GUI_ID(client_id), 0, 0, NULL, true, true);
 		AddClient(client);
+	}
+	// Record before sending, and record regardless of the result: a false
+	// return from CUpDownClient::SendChatMessage means "queued while
+	// connecting", not "failed" (the desktop optimistically prints
+	// *** Connecting to Client *** and keeps the line in the transcript), so
+	// gating the store on it would drop exactly the messages a slow peer
+	// receives a moment later.
+	if (theApp->chatsessions) {
+		theApp->chatsessions->AddOutgoing(client_id, message);
 	}
 	return client->SendChatMessage(message);
 }

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1207,12 +1207,13 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// amulecmd's `search progress` with no argument expects.
 					m_searchProgressUnionActive = true;
 				}
-				if (request->GetTagByName(EC_TAG_CAN_CHAT)) {
-					// Client speaks the chat session ops. The daemon always
-					// supports them, so echo the capability in AUTH_OK; the
-					// client then polls EC_OP_GET_CHAT_SESSIONS with a
-					// cursor. A client that omits the tag never sees the
-					// echo and must never send those opcodes.
+				if (request->GetTagByName(EC_TAG_CAN_CHAT_SESSIONS)) {
+					// Client speaks the chat session ops. Its own tag, NOT
+					// EC_TAG_CAN_CHAT: that one is echoed by daemons which
+					// predate these opcodes, so a client gating on it would
+					// send EC_OP_GET_CHAT_SESSIONS to a core that asserts on
+					// it. A client that omits this tag never sees the echo
+					// and must never send those opcodes.
 					m_chatActive = true;
 				}
 				m_haveNotificationSupport = request->GetTagByName(EC_TAG_CAN_NOTIFY) != NULL;
@@ -1425,7 +1426,7 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				if (m_chatActive) {
 					// Confirm the chat session ops so the client starts
 					// polling EC_OP_GET_CHAT_SESSIONS.
-					response->AddTag(CECEmptyTag(EC_TAG_CAN_CHAT));
+					response->AddTag(CECEmptyTag(EC_TAG_CAN_CHAT_SESSIONS));
 				}
 				if (m_multiSearchActive) {
 					// Confirm multi-search mode so the client addresses

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -51,6 +51,7 @@
 #include "amule.h"      // Needed for theApp
 #include "SearchList.h" // Needed for GetSearchResults
 #include "ClientList.h"
+#include "ChatSessionStore.h"
 #include "ClientCreditsList.h" // Needed for CClientCreditsList
 #include "ClientCredits.h"     // Needed for CClientCredits, ClientMetaStruct
 #ifdef ENABLE_IP2COUNTRY
@@ -443,22 +444,9 @@ public:
 
 	void ResetLog() { m_LoggerAccess.Reset(); }
 
-	// True once this connection advertised EC_TAG_CAN_CHAT — used by
-	// ExternalConn::QueueChatMessage to fan an incoming peer message out only
-	// to clients that asked for the chat relay.
+	// True once this connection advertised EC_TAG_CAN_CHAT — it speaks the
+	// chat session ops and may be sent EC_OP_CHAT_SESSIONS replies.
 	bool ChatActive() const { return m_chatActive; }
-
-	// Append one incoming peer chat message to THIS connection's own queue
-	// (per-client, like the partial-update valuemaps — each EC client drains
-	// its own copy). Bounded so a slow-polling client can't grow it without
-	// limit; oldest dropped first.
-	void QueueChatMessage(uint64 sender_id, const wxString &message)
-	{
-		m_chatQueue.emplace_back(sender_id, message);
-		while (m_chatQueue.size() > MAX_CHAT_MESSAGES) {
-			m_chatQueue.pop_front();
-		}
-	}
 
 private:
 	ECNotifier *m_ec_notifier;
@@ -574,16 +562,11 @@ private:
 	// `m_multiSearchActive` — a single-search client's id-less request keeps
 	// meaning "the current search" (amulecmd's `search progress`).
 	bool m_searchProgressUnionActive;
-	// Set when the client advertised EC_TAG_CAN_CHAT: it wants incoming peer
-	// chat messages relayed over EC and polls EC_OP_GET_CHAT_MESSAGES. The
-	// daemon always supports this, so the flag just mirrors the client tag.
+	// Set when the client advertised EC_TAG_CAN_CHAT: it speaks the chat
+	// session ops (EC_OP_GET_CHAT_SESSIONS and friends). A client that omits
+	// the tag never sees the capability echoed and must never send those
+	// opcodes — an unknown opcode asserts before the EC_OP_FAILED path.
 	bool m_chatActive;
-	// This connection's own queue of incoming peer chat messages, drained on
-	// EC_OP_GET_CHAT_MESSAGES. Per-client (not global) so several GUIs each
-	// get their own independent copy — like the partial-update valuemaps.
-	// <sender GUI_ID, "name|message">.
-	std::list<std::pair<uint64, wxString>> m_chatQueue;
-	static const size_t MAX_CHAT_MESSAGES = 100;
 	// File ECIDs sent in the previous response for each EC request path.
 	// Diffed against the current snapshot to compute the removal list emitted
 	// to partial-update-capable clients. Tracked per-path because amulegui
@@ -1064,19 +1047,6 @@ void ExternalConn::ResetAllLogs()
 	}
 }
 
-void ExternalConn::QueueChatMessage(uint64 sender_id, const wxString &message)
-{
-	// Fan the incoming peer message out to every connected EC client that
-	// asked for the chat relay. Each keeps its own queue (per-client, like
-	// the partial-update valuemaps), so multiple GUIs get independent copies
-	// and one draining its queue doesn't steal messages from another.
-	for (CECServerSocket *s : socket_list) {
-		if (s->ChatActive()) {
-			s->QueueChatMessage(sender_id, message);
-		}
-	}
-}
-
 CExternalConnListener::CExternalConnListener(const amuleIPV4Address &adr, int flags, ExternalConn *conn)
 : CLibSocketServer(adr, flags, thePrefs::GetECNetworkInterface())
 , m_conn(conn)
@@ -1238,11 +1208,11 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					m_searchProgressUnionActive = true;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_CHAT)) {
-					// Client (amulegui) wants incoming peer chat messages
-					// relayed over EC. The daemon always supports this, so
-					// echo the capability in AUTH_OK; the client then polls
-					// EC_OP_GET_CHAT_MESSAGES. Old clients omit the tag and
-					// simply never poll — see the client-side login packet.
+					// Client speaks the chat session ops. The daemon always
+					// supports them, so echo the capability in AUTH_OK; the
+					// client then polls EC_OP_GET_CHAT_SESSIONS with a
+					// cursor. A client that omits the tag never sees the
+					// echo and must never send those opcodes.
 					m_chatActive = true;
 				}
 				m_haveNotificationSupport = request->GetTagByName(EC_TAG_CAN_NOTIFY) != NULL;
@@ -1453,8 +1423,8 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				// opcode asserts before the EC_OP_FAILED path.
 				response->AddTag(CECEmptyTag(EC_TAG_CAN_CLIENT_HISTORY));
 				if (m_chatActive) {
-					// Confirm chat relay so the client starts polling
-					// EC_OP_GET_CHAT_MESSAGES for incoming peer messages.
+					// Confirm the chat session ops so the client starts
+					// polling EC_OP_GET_CHAT_SESSIONS.
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_CHAT));
 				}
 				if (m_multiSearchActive) {
@@ -1690,6 +1660,81 @@ static CECPacket *Get_EC_Response_GetSharedDirs()
 // (EC_TAG_SHAREDDIR_REJECTED + a numeric reason the client translates, so the
 // daemon's locale never leaks into the user's UI); every path that *did*
 // validate is still applied, so one bad entry doesn't discard the whole edit.
+namespace
+{
+
+// The client's resume cursor: it already holds everything up to this id.
+// Absent or 0 means "everything you still have".
+uint32 ChatCursorFrom(const CECPacket *request)
+{
+	const CECTag *tag = request->GetTagByName(EC_TAG_CHAT_MSG_ID);
+	return tag ? static_cast<uint32>(tag->GetInt()) : 0;
+}
+
+// One EC_TAG_CHAT_SESSION container: identity, plus every message newer than
+// `cursor`. A session with nothing new still encodes (with no message
+// children) — that is how a late-connecting client learns it exists.
+CECTag EncodeChatSession(const CChatSessionStore::Session &session, uint32 cursor)
+{
+	CECTag tag(EC_TAG_CHAT_SESSION, session.gui_id);
+	tag.AddTag(CECTag(EC_TAG_CHAT_PEER_NAME, session.name));
+	tag.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, session.LastMsgId()));
+
+	// Link the live peer and the friend entry when they exist, so a client
+	// can join against its own /clients and /friends views without a lookup
+	// of its own. Both are omitted when absent rather than sent as 0.
+	if (const CUpDownClient *client = theApp->clientlist->FindClientByIP(session.ip, session.port)) {
+		tag.AddTag(CECTag(EC_TAG_CLIENT, client->ECID()));
+	}
+	if (const CFriend *f = theApp->friendlist->FindFriend(CMD4Hash(), session.ip, session.port)) {
+		tag.AddTag(CECTag(EC_TAG_FRIEND, f->ECID()));
+	}
+
+	for (const CChatSessionStore::Message &msg : session.messages) {
+		if (msg.id <= cursor) {
+			continue;
+		}
+		CECTag msgTag(EC_TAG_CHAT_MESSAGE, msg.text);
+		msgTag.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, msg.id));
+		msgTag.AddTag(CECTag(EC_TAG_CHAT_DIRECTION, msg.direction));
+		msgTag.AddTag(CECTag(EC_TAG_CHAT_TIMESTAMP, msg.timestamp));
+		tag.AddTag(msgTag);
+	}
+	return tag;
+}
+
+// Resolve an EC_OP_CHAT_SEND target to a GUI_ID. Three addressing modes so a
+// caller can reply without a lookup (CHAT_CLIENT_ID), address a live peer it
+// already has (CLIENT), or reach a friend who is currently OFFLINE (FRIEND) —
+// the last one resolves through the friend's stored ip:port, which is what
+// makes messaging an offline friend work at all.
+bool ResolveChatTarget(const CECPacket *request, uint64 &out_gui_id)
+{
+	if (const CECTag *tag = request->GetTagByName(EC_TAG_CHAT_CLIENT_ID)) {
+		out_gui_id = tag->GetInt();
+		return out_gui_id != 0;
+	}
+	if (const CECTag *tag = request->GetTagByName(EC_TAG_CLIENT)) {
+		const CUpDownClient *client = theApp->clientlist->FindClientByECID(tag->GetInt());
+		if (!client) {
+			return false;
+		}
+		out_gui_id = GUI_ID(client->GetIP(), client->GetUserPort());
+		return true;
+	}
+	if (const CECTag *tag = request->GetTagByName(EC_TAG_FRIEND)) {
+		CFriend *f = theApp->friendlist->FindFriend(tag->GetInt());
+		if (!f || !f->GetIP() || !f->GetPort()) {
+			return false;
+		}
+		out_gui_id = GUI_ID(f->GetIP(), f->GetPort());
+		return true;
+	}
+	return false;
+}
+
+} // namespace
+
 static CECPacket *Get_EC_Response_SetSharedDirs(const CECPacket *request)
 {
 	CECPacket *response = new CECPacket(EC_OP_SET_SHARED_DIRS);
@@ -4167,17 +4212,89 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = new CECPacket(EC_OP_NOOP);
 		break;
 	case EC_OP_GET_CHAT_MESSAGES: {
-		// Drain buffered incoming peer chat messages for a polling EC
-		// client (amulegui). Each EC_TAG_CHAT carries the "name|message"
-		// string, with the sender's GUI_ID as an EC_TAG_CHAT_CLIENT_ID
-		// child — the format CChatWnd::ProcessMessage already expects.
-		response = new CECPacket(EC_OP_CHAT_MESSAGES);
-		for (const auto &msg : m_chatQueue) {
-			CECTag chatTag(EC_TAG_CHAT, msg.second);
-			chatTag.AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, msg.first));
-			response->AddTag(chatTag);
+		// Non-destructive backfill of ONE session's history, for a client
+		// opening a conversation it has no transcript for. The polling path
+		// is EC_OP_GET_CHAT_SESSIONS; this exists so opening an old tab does
+		// not have to replay the whole store.
+		const CECTag *idTag = request->GetTagByName(EC_TAG_CHAT_CLIENT_ID);
+		if (!idTag) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Missing chat session id")));
+			break;
 		}
-		m_chatQueue.clear();
+		const CChatSessionStore::Session *session = theApp->chatsessions->Find(idTag->GetInt());
+		if (!session) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("No such chat session")));
+			break;
+		}
+		response = new CECPacket(EC_OP_CHAT_MESSAGES);
+		response->AddTag(CECTag(EC_TAG_CHAT_MSG_ID, theApp->chatsessions->LastMsgId()));
+		response->AddTag(EncodeChatSession(*session, ChatCursorFrom(request)));
+		break;
+	}
+	case EC_OP_GET_CHAT_SESSIONS: {
+		// The per-tick workhorse: the session list AND every message newer
+		// than the client's cursor in one roundtrip, so an idle connection
+		// costs one small packet and a busy one needs no follow-up query.
+		const uint32 cursor = ChatCursorFrom(request);
+		response = new CECPacket(EC_OP_CHAT_SESSIONS);
+		// Top-level cursor even when nothing came back, so a client can
+		// advance past messages that were evicted rather than re-asking for
+		// them forever.
+		response->AddTag(CECTag(EC_TAG_CHAT_MSG_ID, theApp->chatsessions->LastMsgId()));
+		for (const CChatSessionStore::Session *session : theApp->chatsessions->Sessions()) {
+			// Sessions with nothing new are still listed, with no message
+			// children: that is how a client that connected late learns the
+			// session exists, and how every client learns a session it is
+			// tracking was closed elsewhere (absence from this reply).
+			response->AddTag(EncodeChatSession(*session, cursor));
+		}
+		break;
+	}
+	case EC_OP_CHAT_SEND: {
+		const CECTag *textTag = request->GetTagByName(EC_TAG_CHAT);
+		const wxString text = textTag ? textTag->GetStringData() : wxString();
+		if (text.IsEmpty()) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Empty chat message")));
+			break;
+		}
+		uint64 gui_id = 0;
+		if (!ResolveChatTarget(request, gui_id)) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Unknown chat target")));
+			break;
+		}
+		// Deliberately ignoring the bool: a false return means "queued while
+		// connecting", not "failed" — the desktop optimistically prints
+		// *** Connecting to Client *** — so turning it into EC_OP_FAILED
+		// would report an error for a message that arrives moments later.
+		theApp->clientlist->SendChatMessage(gui_id, text);
+		response = new CECPacket(EC_OP_NOOP);
+		response->AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, gui_id));
+		response->AddTag(CECTag(EC_TAG_CHAT_MSG_ID, theApp->chatsessions->LastMsgId()));
+		break;
+	}
+	case EC_OP_CHAT_CLOSE_SESSION: {
+		const CECTag *idTag = request->GetTagByName(EC_TAG_CHAT_CLIENT_ID);
+		if (!idTag) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Missing chat session id")));
+			break;
+		}
+		const uint64 gui_id = idTag->GetInt();
+		if (!theApp->chatsessions->CloseSession(gui_id)) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("No such chat session")));
+			break;
+		}
+		theApp->clientlist->SetChatState(gui_id, MS_NONE);
+		// Closing is global, matching how closing a search tab destroys the
+		// core bucket for every client: the next EC_OP_CHAT_SESSIONS reply
+		// simply omits the session and each client drops its tab.
+		Notify_Chat_SessionRemoved(gui_id);
+		response = new CECPacket(EC_OP_NOOP);
 		break;
 	}
 	//

--- a/src/ExternalConn.h
+++ b/src/ExternalConn.h
@@ -126,15 +126,6 @@ public:
 	void KillAllSockets();
 	void ResetAllLogs();
 
-	// Read-only chat bridge for EC clients (amulegui): incoming peer chat
-	// messages are dropped on a headless daemon (no chat window), so relay
-	// them to any connected EC client that asked for the chat feed. Fans the
-	// message out to each chat-capable CECServerSocket's own per-client queue,
-	// which the client drains via EC_OP_GET_CHAT_MESSAGES. The pair carried is
-	// <sender GUI_ID, "name|message"> — the same encoding the built-in GUI's
-	// CChatWnd::ProcessMessage already parses.
-	void QueueChatMessage(uint64 sender_id, const wxString &message);
-
 	// Brute-force protection for the password exchange, shared by every
 	// connection. It lives here rather than on CECServerSocket because a
 	// socket dies with its connection: per-socket buckets would reset on

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -460,7 +460,7 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 		m_ECClient->SetForceZlib(m_forceZLIB);
 		m_ECClient->SetCanAEAD(m_ECEncryption);
 		m_ECClient->SetCanMultiSearch(m_canMultiSearch);
-		m_ECClient->SetCanChat(m_canChat);
+		m_ECClient->SetCanChatSessions(m_canChat);
 		// Bound the blocking EC connect so a wrong or unreachable host
 		// fails fast instead of hanging on the OS TCP connect timeout
 		// (which can be minutes). The GUI clients have their own async

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -258,6 +258,7 @@ CaMuleExternalConnector::CaMuleExternalConnector()
 , m_forceZLIB(false)
 , m_ECEncryption(true)
 , m_canMultiSearch(false)
+, m_canChat(false)
 , m_KeepQuiet(false)
 , m_Verbose(false)
 , m_noLogFile(false)
@@ -459,6 +460,7 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 		m_ECClient->SetForceZlib(m_forceZLIB);
 		m_ECClient->SetCanAEAD(m_ECEncryption);
 		m_ECClient->SetCanMultiSearch(m_canMultiSearch);
+		m_ECClient->SetCanChat(m_canChat);
 		// Bound the blocking EC connect so a wrong or unreachable host
 		// fails fast instead of hanging on the OS TCP connect timeout
 		// (which can be minutes). The GUI clients have their own async

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -230,6 +230,11 @@ public:
 	{
 		return m_ECClient && m_ECClient->ServerSupportsClientHistory();
 	}
+	// True when amuled serves the chat session ops (EC_OP_GET_CHAT_SESSIONS
+	// and friends). Same null-check-is-load-bearing reasoning as above: a
+	// daemon predating them asserts on the unknown opcode instead of
+	// answering EC_OP_FAILED, so every chat request must be gated on this.
+	bool IsServerChatActive() const { return m_ECClient && m_ECClient->ServerSupportsChat(); }
 	// Version string of the connected core, from the EC AUTH_OK handshake.
 	// Empty when not connected (m_ECClient null) or when the daemon is old
 	// enough to omit the EC_TAG_SERVER_VERSION tag.
@@ -282,6 +287,10 @@ protected:
 	// default; only a connector that reads EC_TAG_SEARCH_ID back and handles
 	// per-ID results (amulecmd) sets it true. amuleweb stays single-search.
 	bool m_canMultiSearch;
+	// Advertise the chat capability (EC_TAG_CAN_CHAT) so the daemon echoes it
+	// and this connector may use the chat session ops. Off by default; a
+	// connector that never reads chat leaves the daemon free of the work.
+	bool m_canChat;
 	bool m_KeepQuiet;
 	bool m_Verbose;
 	// --log-file / --no-log-file. Parsed for every connector; only amuleapi

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -234,7 +234,7 @@ public:
 	// and friends). Same null-check-is-load-bearing reasoning as above: a
 	// daemon predating them asserts on the unknown opcode instead of
 	// answering EC_OP_FAILED, so every chat request must be gated on this.
-	bool IsServerChatActive() const { return m_ECClient && m_ECClient->ServerSupportsChat(); }
+	bool IsServerChatActive() const { return m_ECClient && m_ECClient->ServerSupportsChatSessions(); }
 	// Version string of the connected core, from the EC AUTH_OK handshake.
 	// Empty when not connected (m_ECClient null) or when the daemon is old
 	// enough to omit the EC_TAG_SERVER_VERSION tag.
@@ -287,9 +287,9 @@ protected:
 	// default; only a connector that reads EC_TAG_SEARCH_ID back and handles
 	// per-ID results (amulecmd) sets it true. amuleweb stays single-search.
 	bool m_canMultiSearch;
-	// Advertise the chat capability (EC_TAG_CAN_CHAT) so the daemon echoes it
-	// and this connector may use the chat session ops. Off by default; a
-	// connector that never reads chat leaves the daemon free of the work.
+	// Advertise EC_TAG_CAN_CHAT_SESSIONS so the daemon echoes it and this
+	// connector may use the chat session ops. Off by default; a connector
+	// that never reads chat leaves the daemon free of the work.
 	bool m_canChat;
 	bool m_KeepQuiet;
 	bool m_Verbose;

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -712,7 +712,13 @@ void Chat_SessionRemoved(uint64 NOT_ON_DAEMON(gui_id))
 {
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg && theApp->amuledlg->m_chatwnd) {
-		theApp->amuledlg->m_chatwnd->EndSession(gui_id);
+		// EndSessionFromCore, not EndSession: the core has already dropped
+		// this session, so the tab must close WITHOUT its page-closing
+		// handler originating a close of its own. Without the distinction a
+		// close from one client makes every other client echo a redundant
+		// close back -- which the daemon answers EC_OP_FAILED, the session
+		// being gone already.
+		theApp->amuledlg->m_chatwnd->EndSessionFromCore(gui_id);
 	}
 #endif
 }

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -708,6 +708,15 @@ void Browse_Status(uint64 NOT_ON_DAEMON(searchID), uint32 NOT_ON_DAEMON(status))
 // so a const-ref parameter would dangle. This mirrors every other wxString
 // notify handler here.
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
+void Chat_SessionRemoved(uint64 NOT_ON_DAEMON(gui_id))
+{
+#ifndef AMULE_DAEMON
+	if (theApp->amuledlg && theApp->amuledlg->m_chatwnd) {
+		theApp->amuledlg->m_chatwnd->EndSession(gui_id);
+	}
+#endif
+}
+
 void Search_Removed(wxUIntPtr NOT_ON_DAEMON(searchID))
 {
 #ifndef AMULE_DAEMON
@@ -764,14 +773,10 @@ void ChatConnResult(bool NOT_ON_DAEMON(success), uint64 NOT_ON_DAEMON(id), wxStr
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ChatProcessMsg(uint64 sender, wxString message)
 {
-	// Relay the incoming peer message to any polling EC client (amulegui):
-	// the daemon has no chat window of its own, and even a monolithic aMule
-	// with EC enabled should surface friend messages on a connected remote
-	// GUI. Buffered here and drained via EC_OP_GET_CHAT_MESSAGES; the
-	// built-in GUI below still handles its own local display.
-	if (theApp->ECServerHandler) {
-		theApp->ECServerHandler->QueueChatMessage(sender, message);
-	}
+	// No EC relay here any more: CUpDownClient::ProcessChatMessage records
+	// the message in the core store before this notify fires, and every EC
+	// client reads it from there. The built-in GUI below still handles its
+	// own local display.
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg->m_chatwnd) {
 		theApp->amuledlg->m_chatwnd->ProcessMessage(sender, message);

--- a/src/GuiEvents.h
+++ b/src/GuiEvents.h
@@ -144,6 +144,14 @@ void SearchFileBeingDestroyed(CSearchFile *file);
 // close, rather than two mechanisms for one idea.
 void Search_Removed(wxUIntPtr searchID);
 
+// A chat session was dropped from the core store, by whichever client asked.
+// The mirror of Search_Removed, and closing follows the same rule searches
+// already do: the core state is destroyed for everyone and each client is
+// TOLD, rather than left showing a tab the core no longer has. The monolithic
+// GUI closes its notebook page here; EC clients learn it from the session's
+// absence in the next EC_OP_CHAT_SESSIONS reply.
+void Chat_SessionRemoved(uint64 gui_id);
+
 // Fired from CSearchList::StartNewSearch, once per search the core begins,
 // whoever asked for it. The mirror of Search_Removed: it lets the monolithic
 // GUI show a tab for a search started by an EC client (amulegui, amulecmd,
@@ -605,6 +613,8 @@ typedef void (wxEvtHandler::*MuleNotifyEventFunction)(CMuleGUIEvent &);
 #define Notify_ChatRemoveFriend(ptr) MuleNotify::DoNotify(&MuleNotify::ChatRemoveFriend, ptr)
 #define Notify_ChatConnResult(val0, val1, s) MuleNotify::DoNotify(&MuleNotify::ChatConnResult, val0, val1, s)
 #define Notify_ChatProcessMsg(val0, s) MuleNotify::DoNotify(&MuleNotify::ChatProcessMsg, val0, s)
+// A chat session was closed — see MuleNotify::Chat_SessionRemoved above.
+#define Notify_Chat_SessionRemoved(id) MuleNotify::DoNotify(&MuleNotify::Chat_SessionRemoved, id)
 #define Notify_ChatSendCaptcha(val0, s) MuleNotify::DoNotify(&MuleNotify::ChatSendCaptcha, val0, s)
 
 // misc

--- a/src/OtherFunctions.h
+++ b/src/OtherFunctions.h
@@ -26,8 +26,10 @@
 #ifndef OTHERFUNCTIONS_H
 #define OTHERFUNCTIONS_H
 
-#include <wx/datetime.h> // Needed for wxDateTime
-#include <wx/intl.h>     // Needed for wxLANGUAGE_ constants
+#include <common/Format.h>    // Needed for CFormat
+#include "NetworkFunctions.h" // Needed for Uint32toStringIP
+#include <wx/datetime.h>      // Needed for wxDateTime
+#include <wx/intl.h>          // Needed for wxLANGUAGE_ constants
 
 #include "Types.h"       // Needed for uint16, uint32 and uint64
 #include "Preferences.h" // Needed for AllCategoryFilter enumeration
@@ -329,6 +331,18 @@ void DumpMem_DW(const uint32 *ptr, int count);
 // And so...
 #define PORT_FROM_GUI_ID(x) (x & 0xFFFF)
 #define IP_FROM_GUI_ID(x) (x >> 16)
+
+// Label for a chat peer the core has no nickname for, built from its GUI_ID.
+//
+// Deliberately NOT translated: the same label is rendered by the monolithic
+// chat selector, by amulegui and by amuleapi's /chats, and the API contract
+// fixes it as English. Translating the GUI copies alone would show the same
+// conversation under two different names depending on which client you opened.
+inline wxString ChatPeerFallbackName(uint64 gui_id)
+{
+	return CFormat(wxT("IP: %s Port: %u")) % Uint32toStringIP(IP_FROM_GUI_ID(gui_id)) %
+	       PORT_FROM_GUI_ID(gui_id);
+}
 
 inline long int make_full_ed2k_version(int a, int b, int c)
 {

--- a/src/ScopedPtr.h
+++ b/src/ScopedPtr.h
@@ -29,6 +29,31 @@
 #include "OtherFunctions.h" // Needed for DeleteContents()
 
 /**
+ * Sets a bool for the lifetime of the scope.
+ *
+ * Both users are notebook page-closing handlers whose own teardown fires a
+ * MuleNotify that routes straight back into the close path for the same tab:
+ * the flag makes the re-entry a no-op instead of a recursive close. It lived
+ * privately in SearchDlg.cpp while there was one such handler; chat's is the
+ * second, so it moved here rather than being copied.
+ */
+class CScopedFlag
+{
+public:
+	explicit CScopedFlag(bool &flag)
+	: m_flag(flag)
+	{
+		m_flag = true;
+	}
+	~CScopedFlag() { m_flag = false; }
+	CScopedFlag(const CScopedFlag &) = delete;
+	CScopedFlag &operator=(const CScopedFlag &) = delete;
+
+private:
+	bool &m_flag;
+};
+
+/**
  * CScopedPtr is a simple smart pointer.
  *
  * This class is a replacement for std::auto_ptr, with simpler

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -47,6 +47,7 @@
 #include "GetTickCount.h"
 #include "Preferences.h"
 #include "amule.h"        // Needed for theApp
+#include "ScopedPtr.h"    // Needed for CScopedFlag
 #include "SearchList.h"   // Needed for CSearchList
 #include "updownclient.h" // Needed for EBrowseStatus (browse tab lifecycle)
 #include <common/Format.h>
@@ -833,28 +834,6 @@ void CSearchDlg::OnFilterCheckChange(wxCommandEvent &event)
 		UpdateHitCount(page);
 	}
 }
-
-namespace
-{
-// Sets a bool for the lifetime of the scope. Local to this file: the one
-// use is OnSearchClosing's re-entrancy guard, which is not worth a shared
-// utility header.
-class CScopedFlag
-{
-public:
-	explicit CScopedFlag(bool &flag)
-	: m_flag(flag)
-	{
-		m_flag = true;
-	}
-	~CScopedFlag() { m_flag = false; }
-	CScopedFlag(const CScopedFlag &) = delete;
-	CScopedFlag &operator=(const CScopedFlag &) = delete;
-
-private:
-	bool &m_flag;
-};
-} // namespace
 
 void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 {

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -464,7 +464,7 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 		// children. Gated on the capability; a daemon that never echoes
 		// EC_TAG_CAN_CHAT does not know these opcodes, and sending one
 		// asserts on the daemon before it can answer EC_OP_FAILED.
-		if (m_connect->ServerSupportsChat()) {
+		if (m_connect->ServerSupportsChatSessions()) {
 			CECPacket chat_req(EC_OP_GET_CHAT_SESSIONS);
 			if (m_chatmsg_handler.Cursor()) {
 				chat_req.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, m_chatmsg_handler.Cursor()));
@@ -625,8 +625,8 @@ bool CamuleRemoteGuiApp::OnInit()
 	m_connect->SetCanMultiSearch(true);
 	// amulegui shows incoming friend/chat messages read-only; ask the daemon
 	// to relay them (polled via EC_OP_GET_CHAT_MESSAGES). An old daemon won't
-	// echo the capability and amulegui simply never polls (ServerSupportsChat()).
-	m_connect->SetCanChat(true);
+	// echo the capability and amulegui simply never polls (ServerSupportsChatSessions()).
+	m_connect->SetCanChatSessions(true);
 	// The ForceZLIB override is read from the connection dialog
 	// (see ShowConnectionDialog) so the user's checkbox choice in this
 	// session overrides the persisted /EC/ForceZLIB value.
@@ -757,7 +757,7 @@ void CamuleRemoteGuiApp::ResetEcConnect()
 	wxConfig::Get()->Read("/EC/ZLIB", &enableZLIB, 1);
 	m_connect->SetCapabilities(enableZLIB != 0, true, false);
 	m_connect->SetCanMultiSearch(true);
-	m_connect->SetCanChat(true);
+	m_connect->SetCanChatSessions(true);
 }
 
 void CamuleRemoteGuiApp::OnECConnection(wxEvent &event)

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1334,9 +1334,7 @@ void CChatMsgHandlerRem::HandlePacket(const CECPacket *packet)
 			name = nameTag->GetStringData();
 		}
 		if (name.IsEmpty()) {
-			// Same fallback the desktop uses when the core has no name.
-			name = CFormat(_("IP: %s Port: %u")) % Uint32toStringIP(IP_FROM_GUI_ID(gui_id)) %
-			       PORT_FROM_GUI_ID(gui_id);
+			name = ChatPeerFallbackName(gui_id);
 		}
 
 		// Open the tab even when the session has no new messages: that is

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -456,15 +456,19 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			}
 			statgraphs->DoRequery();
 		}
-		// Incoming friend/chat messages are relayed by the daemon over EC
-		// (amulegui is receive-only). Poll unconditionally — like stats
-		// above, and unlike the per-tab data — so a message that arrives
-		// while the user is on another tab still triggers the new-message
-		// blink in CChatWnd::ProcessMessage. Cheap: an empty reply when
-		// nothing is pending. Gated on the daemon supporting the relay;
-		// old daemons never echo EC_TAG_CAN_CHAT and we never poll.
+		// Chat sessions + every message newer than our cursor, in one
+		// roundtrip. Poll unconditionally — like stats above, and unlike
+		// the per-tab data — so a message that arrives while the user is
+		// on another tab still triggers the new-message blink. Cheap: an
+		// idle daemon answers with the session list and no message
+		// children. Gated on the capability; a daemon that never echoes
+		// EC_TAG_CAN_CHAT does not know these opcodes, and sending one
+		// asserts on the daemon before it can answer EC_OP_FAILED.
 		if (m_connect->ServerSupportsChat()) {
-			CECPacket chat_req(EC_OP_GET_CHAT_MESSAGES);
+			CECPacket chat_req(EC_OP_GET_CHAT_SESSIONS);
+			if (m_chatmsg_handler.Cursor()) {
+				chat_req.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, m_chatmsg_handler.Cursor()));
+			}
 			m_connect->SendRequest(&m_chatmsg_handler, &chat_req);
 		}
 		// Back to the roots
@@ -1303,24 +1307,71 @@ void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
 
 void CChatMsgHandlerRem::HandlePacket(const CECPacket *packet)
 {
-	// amuled answers EC_OP_GET_CHAT_MESSAGES with one EC_TAG_CHAT tag per
-	// buffered incoming message (empty reply if none). Feed each through the
-	// same CChatWnd::ProcessMessage the monolithic GUI uses — that both opens
-	// / updates the sender's chat tab and fires the new-message blink when the
-	// chat window isn't the visible one.
+	// EC_OP_CHAT_SESSIONS: a top-level EC_TAG_CHAT_MSG_ID carrying the store's
+	// current last id, then one EC_TAG_CHAT_SESSION per session with only the
+	// messages newer than the cursor we sent.
 	if (!theApp->amuledlg || !theApp->amuledlg->m_chatwnd) {
 		return;
 	}
-	for (const CECTag &tag : *packet) {
-		if (tag.GetTagName() != EC_TAG_CHAT) {
+	CChatWnd *chatwnd = theApp->amuledlg->m_chatwnd;
+
+	// First reply of a connection backfills history rather than announcing
+	// it: replay must not light the Messages toolbar button up for messages
+	// the user already read on another client. Only what arrives after we
+	// have a cursor is genuinely new.
+	const bool backfill = (m_cursor == 0);
+
+	std::set<uint64> present;
+	for (const CECTag &sessionTag : *packet) {
+		if (sessionTag.GetTagName() != EC_TAG_CHAT_SESSION) {
 			continue;
 		}
-		uint64 sender = 0;
-		const CECTag *idTag = tag.GetTagByName(EC_TAG_CHAT_CLIENT_ID);
-		if (idTag) {
-			sender = idTag->GetInt();
+		const uint64 gui_id = sessionTag.GetInt();
+		present.insert(gui_id);
+
+		wxString name;
+		if (const CECTag *nameTag = sessionTag.GetTagByName(EC_TAG_CHAT_PEER_NAME)) {
+			name = nameTag->GetStringData();
 		}
-		theApp->amuledlg->m_chatwnd->ProcessMessage(sender, tag.GetStringData());
+		if (name.IsEmpty()) {
+			// Same fallback the desktop uses when the core has no name.
+			name = CFormat(_("IP: %s Port: %u")) % Uint32toStringIP(IP_FROM_GUI_ID(gui_id)) %
+			       PORT_FROM_GUI_ID(gui_id);
+		}
+
+		// Open the tab even when the session has no new messages: that is
+		// how a session started before we connected becomes visible at all.
+		// Unfocused, so a session appearing on its own cannot steal the
+		// selection from whatever the user is doing.
+		chatwnd->StartSessionByID(gui_id, name);
+
+		for (const CECTag &msgTag : sessionTag) {
+			if (msgTag.GetTagName() != EC_TAG_CHAT_MESSAGE) {
+				continue;
+			}
+			const CECTag *dirTag = msgTag.GetTagByName(EC_TAG_CHAT_DIRECTION);
+			const bool outgoing = dirTag && dirTag->GetInt() != 0;
+			chatwnd->AppendStoredMessage(
+				gui_id, name, msgTag.GetStringData(), outgoing, /*blink=*/!backfill);
+		}
+	}
+
+	// A session we are tracking that is absent from the reply was closed by
+	// another client (or evicted). Drop the tab without sending a close of
+	// our own — the core has already forgotten it. Snapshot first: closing a
+	// tab mutates the set being iterated.
+	const std::set<uint64> tracked = m_sessions;
+	for (uint64 gui_id : tracked) {
+		if (!present.count(gui_id)) {
+			chatwnd->EndSessionFromCore(gui_id);
+		}
+	}
+	m_sessions = present;
+
+	if (const CECTag *cursorTag = packet->GetTagByName(EC_TAG_CHAT_MSG_ID)) {
+		// Advance even when nothing came back, so evicted ids are not asked
+		// for forever.
+		m_cursor = cursorTag->GetInt();
 	}
 }
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -26,6 +26,7 @@
 #define AMULE_REMOTE_GUI_H
 
 #include <functional>             // std::function for the CSharedFilesRem
+#include <set>                    // std::set for CChatMsgHandlerRem's tracked sessions
 				  // Reload(yieldCb) shim — matches the daemon-side
 				  // signature added in PrefsUnifiedDlg's commit path.
 #include <ec/cpp/RemoteConnect.h> // Needed for CRemoteConnect
@@ -871,16 +872,27 @@ public:
 	virtual void HandlePacket(const CECPacket *);
 };
 
-// Polls the daemon for incoming peer chat/friend messages relayed over EC
-// (EC_OP_GET_CHAT_MESSAGES -> EC_OP_CHAT_MESSAGES). amulegui can't send
-// chat (the compose box and Send button are disabled), but surfaces received
-// messages read-only through the same CChatWnd::ProcessMessage path the
-// monolithic GUI uses. Each EC_TAG_CHAT tag carries the "name|message" text
-// with the sender GUI_ID in an EC_TAG_CHAT_CLIENT_ID child.
+// Polls the daemon's chat session store (EC_OP_GET_CHAT_SESSIONS ->
+// EC_OP_CHAT_SESSIONS): one roundtrip returns every session plus the messages
+// newer than our cursor, so an idle connection costs one small packet.
+//
+// Holds two pieces of client state. `m_cursor` is the resume position -- the
+// highest message id we hold -- which the poll sends so the daemon replies
+// with only what is new; it starts at 0, and that first reply is history
+// replay rather than live arrivals. `m_sessions` is the set we currently show
+// tabs for, so a session missing from a reply can be recognised as closed
+// elsewhere and its tab dropped without echoing a close back.
 class CChatMsgHandlerRem : public CECPacketHandlerBase
 {
 public:
 	virtual void HandlePacket(const CECPacket *);
+
+	//! Resume cursor for the next poll; 0 until the first reply lands.
+	uint32 Cursor() const { return m_cursor; }
+
+private:
+	uint32 m_cursor = 0;
+	std::set<uint64> m_sessions;
 };
 
 class CStatTreeRem : public CECPacketHandlerBase

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -224,7 +224,7 @@ CamuleApp::CamuleApp()
 	theApp = &wxGetApp();
 
 	clientlist = NULL;
-	chatsessions = NULL;
+	chatsessions = nullptr;
 	searchlist = NULL;
 	knownfiles = NULL;
 	canceledfiles = NULL;
@@ -404,7 +404,7 @@ int CamuleApp::OnExit()
 	friendlist = NULL;
 
 	delete chatsessions;
-	chatsessions = NULL;
+	chatsessions = nullptr;
 
 	// Destroying CDownloadQueue calls destructor for CPartFile
 	// calling CSharedFileList::SafeAddKFile occasionally.

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -72,6 +72,7 @@
 #include "ExternalConn.h"         // Needed for ExternalConn & MuleConnection
 #include <common/FileFunctions.h> // Needed for CDirIterator
 #include "FriendList.h"           // Needed for CFriendList
+#include "ChatSessionStore.h"     // Needed for CChatSessionStore
 #include "HTTPDownload.h"         // Needed for CHTTPDownloadThread
 #include "InternalEvents.h"       // Needed for CMuleInternalEvent
 #include "IPFilter.h"             // Needed for CIPFilter
@@ -223,6 +224,7 @@ CamuleApp::CamuleApp()
 	theApp = &wxGetApp();
 
 	clientlist = NULL;
+	chatsessions = NULL;
 	searchlist = NULL;
 	knownfiles = NULL;
 	canceledfiles = NULL;
@@ -400,6 +402,9 @@ int CamuleApp::OnExit()
 
 	delete friendlist;
 	friendlist = NULL;
+
+	delete chatsessions;
+	chatsessions = NULL;
 
 	// Destroying CDownloadQueue calls destructor for CPartFile
 	// calling CSharedFileList::SafeAddKFile occasionally.
@@ -863,6 +868,7 @@ bool CamuleApp::OnInit()
 
 	clientlist = new CClientList();
 	friendlist = new CFriendList();
+	chatsessions = new CChatSessionStore();
 	searchlist = new CSearchList();
 	knownfiles = new CKnownFileList();
 	canceledfiles = new CCanceledFileList;

--- a/src/amule.h
+++ b/src/amule.h
@@ -78,6 +78,7 @@ class CCanceledFileList;
 class CSearchList;
 class CClientCreditsList;
 class CFriendList;
+class CChatSessionStore;
 class CClientUDPSocket;
 class CIPFilter;
 class UploadBandwidthThrottler;
@@ -460,6 +461,10 @@ public:
 	CSearchList *searchlist;
 	CClientCreditsList *clientcredits;
 	CFriendList *friendlist;
+	// The core's chat transcript, shared by the local GUI and every EC
+	// client so all three see one conversation rather than three private
+	// ones. In-memory; emptied by a restart.
+	CChatSessionStore *chatsessions;
 	CClientUDPSocket *clientudp;
 	CStatistics *m_statistics;
 	CIPFilter *ipfilter;

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -174,6 +174,14 @@ EC_OP_SEARCH_LIST                   0x60
 
 EC_OP_GET_CLIENT_HISTORY            0x61
 EC_OP_CLIENT_HISTORY                0x62
+
+## Chat session store (issue #971). The client asks for the session list and
+## everything newer than its cursor in one roundtrip, so an idle connection
+## costs one small packet and a busy one needs no follow-up query.
+EC_OP_GET_CHAT_SESSIONS             0x63
+EC_OP_CHAT_SESSIONS                 0x64
+EC_OP_CHAT_SEND                     0x65
+EC_OP_CHAT_CLOSE_SESSION            0x66
 [/Section]
 
 [Section Content]
@@ -438,8 +446,17 @@ EC_TAG_FRIEND                             0x0800
 	EC_TAG_FRIEND_FRIENDSLOT                  0x0808
 	EC_TAG_FRIEND_SHARED                      0x0809
 
+## EC_TAG_CHAT carries the message text as its value; EC_TAG_CHAT_CLIENT_ID is
+## the peer's GUI_ID, a uint64 packed as (ip << 16) | port, with the IP in the
+## same byte order as EC_TAG_CLIENT_USER_IP.
 EC_TAG_CHAT                               0x0900
 	EC_TAG_CHAT_CLIENT_ID                     0x0901
+	EC_TAG_CHAT_SESSION                       0x0902
+	EC_TAG_CHAT_MESSAGE                       0x0903
+	EC_TAG_CHAT_MSG_ID                        0x0904
+	EC_TAG_CHAT_DIRECTION                     0x0905
+	EC_TAG_CHAT_TIMESTAMP                     0x0906
+	EC_TAG_CHAT_PEER_NAME                     0x0907
 
 EC_TAG_SELECT_PREFS                       0x1000
 

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -230,6 +230,12 @@ EC_TAG_AEAD_SERVER_CONFIRM                0x0024
 EC_TAG_SESSION_ID                         0x0025
 EC_TAG_CAN_CLIENT_HISTORY                 0x0026
 
+## Client speaks the chat session ops (EC_OP_GET_CHAT_SESSIONS and friends).
+## Deliberately distinct from EC_TAG_CAN_CHAT: that tag shipped earlier, on
+## builds that echo it but know none of these opcodes, so reusing it would
+## make such a daemon look capable and earn it an unknown opcode.
+EC_TAG_CAN_CHAT_SESSIONS                  0x0027
+
 
 EC_TAG_CLIENT_NAME                        0x0100
 	EC_TAG_CLIENT_VERSION                     0x0101

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -65,6 +65,7 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	bool preferNoZlib,
 	bool canMultiSearch,
 	bool canChat,
+	bool canChatSessions,
 	bool canAEAD,
 	const std::vector<uint8_t> &clientNonce,
 	const std::vector<uint8_t> &clientPubKey)
@@ -148,6 +149,11 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	// window; old servers ignore the unknown tag and never relay.
 	if (canChat)
 		AddTag(CECEmptyTag(EC_TAG_CAN_CHAT));
+	// Separate from EC_TAG_CAN_CHAT above: a daemon that echoes that one may
+	// still know none of the session opcodes, so the client needs its own
+	// confirmation before sending any of them.
+	if (canChatSessions)
+		AddTag(CECEmptyTag(EC_TAG_CAN_CHAT_SESSIONS));
 	// Transport encryption: the ciphers we can do, in preference order, our
 	// half of the derivation salt, and our ephemeral public key. A daemon that
 	// does not know these tags ignores them and the session stays in clear.
@@ -212,6 +218,8 @@ m_req_fifo_thr(20)
 , m_serverMultiSearch(false)
 , m_canChat(false)
 , m_serverChat(false)
+, m_canChatSessions(false)
+, m_serverChatSessions(false)
 , m_serverSharedDirsConfig(false)
 , m_serverSearchList(false)
 , m_serverSearchProgressUnion(false)
@@ -333,6 +341,7 @@ bool CRemoteConnect::ConnectToCore(const wxString &host,
 			m_preferNoZlib,
 			m_canMultiSearch,
 			m_canChat,
+			m_canChatSessions,
 			m_canAEAD,
 			m_aeadClientNonce,
 			m_aeadEphPub);
@@ -395,6 +404,7 @@ void CRemoteConnect::OnConnect()
 			m_preferNoZlib,
 			m_canMultiSearch,
 			m_canChat,
+			m_canChatSessions,
 			m_canAEAD,
 			m_aeadClientNonce,
 			m_aeadEphPub);
@@ -790,6 +800,13 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			// daemons omit the echo and the client never polls for chat.
 			if (reply->GetTagByName(EC_TAG_CAN_CHAT)) {
 				m_serverChat = true;
+			}
+			// Server confirmed the chat session ops. Its own tag, because
+			// EC_TAG_CAN_CHAT above is echoed by daemons that predate them:
+			// gating on that one would send EC_OP_GET_CHAT_SESSIONS to a core
+			// whose dispatcher asserts on it.
+			if (reply->GetTagByName(EC_TAG_CAN_CHAT_SESSIONS)) {
+				m_serverChatSessions = true;
 			}
 			// Server confirmed it serves EC_OP_SEARCH_LIST. Old daemons omit
 			// the echo and the client must not send that opcode: they have no

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -68,6 +68,7 @@ public:
 		bool preferNoZlib = false,
 		bool canMultiSearch = false,
 		bool canChat = false,
+		bool canChatSessions = false,
 		bool canAEAD = false,
 		const std::vector<uint8_t> &clientNonce = std::vector<uint8_t>(),
 		const std::vector<uint8_t> &clientPubKey = std::vector<uint8_t>());
@@ -281,6 +282,15 @@ private:
 	// buffers incoming peer messages for polling via EC_OP_GET_CHAT_MESSAGES.
 	// Old daemons don't echo it; the client then never polls for chat.
 	bool m_serverChat;
+	// Client speaks the chat session ops (advertise `EC_TAG_CAN_CHAT_SESSIONS`).
+	bool m_canChatSessions;
+	// Set when the server echoed `EC_TAG_CAN_CHAT_SESSIONS` in AUTH_OK.
+	//
+	// Distinct from m_serverChat on purpose. `EC_TAG_CAN_CHAT` is echoed by
+	// daemons that predate the session ops entirely, so gating on it would
+	// send EC_OP_GET_CHAT_SESSIONS to a core with no case for it -- straight
+	// into the unknown-opcode branch, which asserts before answering.
+	bool m_serverChatSessions;
 
 	void WriteDoneAndQueueEmpty();
 
@@ -320,6 +330,9 @@ public:
 	// chat window (amulegui) should set this; others never poll for messages.
 	void SetCanChat(bool can) noexcept { m_canChat = can; }
 
+	// Opt into the chat session ops. Call BEFORE ConnectToCore().
+	void SetCanChatSessions(bool can) noexcept { m_canChatSessions = can; }
+
 	bool ServerSupportsPartialUpdate() const { return m_serverPartialUpdate; }
 	//! See m_serverClientHistory. False means: do not send the request at all.
 	bool ServerSupportsClientHistory() const { return m_serverClientHistory; }
@@ -330,6 +343,10 @@ public:
 	bool ServerSupportsMultiSearch() const { return m_serverMultiSearch; }
 
 	bool ServerSupportsChat() const { return m_serverChat; }
+
+	//! See m_serverChatSessions. False means: do not send the chat session
+	//! opcodes at all.
+	bool ServerSupportsChatSessions() const { return m_serverChatSessions; }
 
 	bool ServerSupportsSharedDirsConfig() const { return m_serverSharedDirsConfig; }
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -994,6 +994,66 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
+	if (path == "/api/v0/chats") {
+		if (req.method == "GET" || req.method == "HEAD") {
+			return HandleChats(req);
+		}
+		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD on /chats");
+	}
+
+	// One conversation, keyed on "<ip>:<port>". The messages sub-resource is
+	// matched first, same ordering rationale as the server / friend routes:
+	// the longer pattern would otherwise be shadowed.
+	{
+		static const auto chat_messages = web_api_path::ParsePattern("/api/v0/chats/{peer}/messages");
+		static const auto chat_one = web_api_path::ParsePattern("/api/v0/chats/{peer}");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(chat_messages, path_segs, caps)) {
+			if (req.method == "GET" || req.method == "HEAD") {
+				return HandleChatMessages(req, caps["peer"]);
+			}
+			if (req.method == "POST") {
+				return HandleChatSend(req, caps["peer"]);
+			}
+			return ErrorResponse(405,
+				"method_not_allowed",
+				"only GET / HEAD / POST on /chats/{peer}/messages");
+		}
+		if (web_api_path::Match(chat_one, path_segs, caps)) {
+			if (req.method == "DELETE") {
+				return HandleChatClose(req, caps["peer"]);
+			}
+			return ErrorResponse(405, "method_not_allowed", "only DELETE on /chats/{peer}");
+		}
+	}
+
+	// Address a conversation by ECID instead of ip:port, for a caller holding
+	// a peer or friend row and no wish to compose the key. The friend form is
+	// the one that reaches an OFFLINE friend.
+	{
+		static const auto friend_messages =
+			web_api_path::ParsePattern("/api/v0/friends/{ecid}/messages");
+		static const auto client_messages =
+			web_api_path::ParsePattern("/api/v0/clients/{ecid}/messages");
+		const auto path_segs = web_api_path::SplitPath(path);
+		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(friend_messages, path_segs, caps)) {
+			if (req.method != "POST") {
+				return ErrorResponse(
+					405, "method_not_allowed", "only POST on /friends/{ecid}/messages");
+			}
+			return HandleFriendMessageSend(req, caps["ecid"]);
+		}
+		if (web_api_path::Match(client_messages, path_segs, caps)) {
+			if (req.method != "POST") {
+				return ErrorResponse(
+					405, "method_not_allowed", "only POST on /clients/{ecid}/messages");
+			}
+			return HandleClientMessageSend(req, caps["ecid"]);
+		}
+	}
+
 	if (path == "/api/v0/servers/update") {
 		if (req.method != "POST") {
 			return ErrorResponse(405, "method_not_allowed", "only POST on /servers/update");
@@ -5075,6 +5135,107 @@ bool FindFriendByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::F
 // one peer: every list field plus the detail-only B fields. Bare
 // object (no list envelope), mirroring HandleDownloadDetail. 404 when
 // the ecid isn't in the current snapshot.
+// --- Chat (issue #971) -------------------------------------------------
+//
+// Conversations are keyed on "<ip>:<port>", the readable form of the GUI_ID
+// the wire already uses. Stable across peer reconnects (unlike an ECID),
+// needs no invented identifier, and converts straight back to the GUI_ID the
+// EC ops want.
+
+namespace
+{
+
+// Parse "<ip>:<port>" back into a GUI_ID. Strict on purpose: anything that is
+// not four dotted octets plus a port is a client bug, and accepting it would
+// address some other conversation.
+bool ParseChatPeerKey(const std::string &peer, std::uint64_t &out_gui_id)
+{
+	const std::size_t colon = peer.rfind(':');
+	if (colon == std::string::npos || colon == 0 || colon + 1 >= peer.size())
+		return false;
+
+	unsigned a = 0, b = 0, c = 0, d = 0;
+	char extra = 0;
+	if (std::sscanf(peer.substr(0, colon).c_str(), "%u.%u.%u.%u%c", &a, &b, &c, &d, &extra) != 4)
+		return false;
+	if (a > 255 || b > 255 || c > 255 || d > 255)
+		return false;
+
+	const std::string port_str = peer.substr(colon + 1);
+	if (port_str.find_first_not_of("0123456789") != std::string::npos)
+		return false;
+	const unsigned long port = std::strtoul(port_str.c_str(), nullptr, 10);
+	if (port == 0 || port > 65535)
+		return false;
+
+	// LSB-first, matching IPv4ToDotted and EC_TAG_CLIENT_USER_IP.
+	const std::uint32_t ip = static_cast<std::uint32_t>(a) | (static_cast<std::uint32_t>(b) << 8) |
+				 (static_cast<std::uint32_t>(c) << 16) |
+				 (static_cast<std::uint32_t>(d) << 24);
+	out_gui_id = (static_cast<std::uint64_t>(ip) << 16) | static_cast<std::uint64_t>(port);
+	return true;
+}
+
+void WriteChatMessageObject(CJsonWriter &w, const webapi::ChatMessageSnapshot &m)
+{
+	w.BeginObject();
+	w.Key("id");
+	w.ValueInt(static_cast<int64_t>(m.id));
+	w.Key("direction");
+	// "in" = from the peer, "out" = sent by us from ANY client: this API,
+	// amulegui, or the local GUI.
+	w.ValueString(wxString::FromAscii(m.outgoing ? "out" : "in"));
+	w.Key("text");
+	w.ValueString(wxString::FromUTF8(m.text.c_str()));
+	w.Key("timestamp");
+	w.ValueInt(static_cast<int64_t>(m.timestamp));
+	w.EndObject();
+}
+
+void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
+{
+	w.BeginObject();
+	w.Key("peer");
+	w.ValueString(wxString::FromUTF8(s.PeerKey().c_str()));
+	w.Key("ip");
+	w.ValueString(wxString::FromUTF8(s.ip.c_str()));
+	w.Key("port");
+	w.ValueInt(static_cast<int64_t>(s.port));
+	w.Key("name");
+	w.ValueString(wxString::FromUTF8(s.DisplayName().c_str()));
+	w.Key("client_ecid");
+	w.ValueInt(static_cast<int64_t>(s.client_ecid));
+	w.Key("friend_ecid");
+	w.ValueInt(static_cast<int64_t>(s.friend_ecid));
+	w.Key("online");
+	w.ValueBool(s.client_ecid != 0);
+	w.Key("message_count");
+	w.ValueInt(static_cast<int64_t>(s.messages.size()));
+	w.Key("last_msg_id");
+	w.ValueInt(static_cast<int64_t>(s.LastMsgId()));
+	w.Key("last_message_at");
+	w.ValueInt(static_cast<int64_t>(s.messages.empty() ? 0 : s.messages.back().timestamp));
+	// The transcript itself is deliberately NOT on the list: a 50-session
+	// store at 200 messages each would be 10 000 objects per list read.
+	if (!s.messages.empty()) {
+		w.Key("last_message");
+		WriteChatMessageObject(w, s.messages.back());
+	}
+	w.EndObject();
+}
+
+const webapi::ChatSessionSnapshot *FindChat(
+	const std::vector<webapi::ChatSessionSnapshot> &chats, std::uint64_t gui_id)
+{
+	for (const webapi::ChatSessionSnapshot &s : chats) {
+		if (s.gui_id == gui_id)
+			return &s;
+	}
+	return nullptr;
+}
+
+} // namespace
+
 CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -5208,6 +5369,300 @@ CHttpServer::Response CApiDispatcher::HandleClientDetail(
 	r.content_type = "application/json";
 	CJsonWriter w;
 	WriteClientDetailObject(w, cli);
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleChats(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (!m_app.IsServerChatActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
+	}
+	// RequireSnapshot is ListResponse's job; params first so a malformed
+	// query is a 400 rather than a 503 while EC is still warming up.
+	ListParams params;
+	if (auto err = ParseListParams(QueryOf(req), params))
+		return *err;
+
+	// Served straight from the refresher snapshot -- no EC roundtrip per
+	// request. The daemon's own order is most-recently-active first, which is
+	// the order a client wants by default.
+	const std::vector<webapi::ChatSessionSnapshot> chats = m_state.Chats();
+
+	static const ListComparators<webapi::ChatSessionSnapshot> kComps = {
+		{ "last_message_at",
+			[](const webapi::ChatSessionSnapshot &x, const webapi::ChatSessionSnapshot &y) {
+				const std::uint32_t xa = x.messages.empty() ? 0 : x.messages.back().timestamp;
+				const std::uint32_t ya = y.messages.empty() ? 0 : y.messages.back().timestamp;
+				return xa < ya;
+			} },
+		{ "name",
+			[](const webapi::ChatSessionSnapshot &x, const webapi::ChatSessionSnapshot &y) {
+				return x.DisplayName() < y.DisplayName();
+			} },
+	};
+	return ListResponse(m_state, "chats", chats, WriteChatObject, params, kComps);
+}
+
+CHttpServer::Response CApiDispatcher::HandleChatMessages(
+	const CHttpServer::Request &req, const std::string &peer)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (!m_app.IsServerChatActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
+	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
+	std::uint64_t gui_id = 0;
+	if (!ParseChatPeerKey(peer, gui_id)) {
+		return ErrorResponse(400, "bad_request", "path `{peer}` must be `<ip>:<port>`");
+	}
+
+	const std::vector<webapi::ChatSessionSnapshot> chats = m_state.Chats();
+	const webapi::ChatSessionSnapshot *session = FindChat(chats, gui_id);
+	if (!session) {
+		return ErrorResponse(404, "not_found", "no chat session with that peer");
+	}
+
+	// `since_id` is a safe polling cursor: ids are monotonic per daemon
+	// process, so a client never sees a duplicate and never skips one. They
+	// reset when the daemon restarts, which also empties the store.
+	std::uint32_t since_id = 0;
+	std::size_t limit = 0;
+	const auto qmap = web_api_path::ParseQuery(QueryOf(req));
+	{
+		const auto it = qmap.find("since_id");
+		if (it != qmap.end()) {
+			if (it->second.find_first_not_of("0123456789") != std::string::npos) {
+				return ErrorResponse(
+					400, "bad_request", "`since_id` must be a non-negative integer");
+			}
+			since_id = static_cast<std::uint32_t>(std::strtoul(it->second.c_str(), nullptr, 10));
+		}
+	}
+	{
+		const auto it = qmap.find("limit");
+		if (it != qmap.end()) {
+			if (it->second.find_first_not_of("0123456789") != std::string::npos) {
+				return ErrorResponse(
+					400, "bad_request", "`limit` must be a non-negative integer");
+			}
+			limit = static_cast<std::size_t>(std::strtoul(it->second.c_str(), nullptr, 10));
+		}
+	}
+
+	std::vector<const webapi::ChatMessageSnapshot *> selected;
+	for (const webapi::ChatMessageSnapshot &m : session->messages) {
+		if (m.id > since_id)
+			selected.push_back(&m);
+	}
+	// `limit` means the LAST n, matching "show me the tail of this
+	// conversation"; combined with since_id it trims the same window from the
+	// front, so the newest are always the ones kept.
+	if (limit && selected.size() > limit) {
+		selected.erase(selected.begin(), selected.end() - static_cast<std::ptrdiff_t>(limit));
+	}
+
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("peer");
+	w.ValueString(wxString::FromUTF8(session->PeerKey().c_str()));
+	w.Key("messages");
+	w.BeginArray();
+	for (const webapi::ChatMessageSnapshot *m : selected)
+		WriteChatMessageObject(w, *m);
+	w.EndArray();
+	w.Key("total");
+	w.ValueInt(static_cast<int64_t>(session->messages.size()));
+	w.Key("last_msg_id");
+	w.ValueInt(static_cast<int64_t>(session->LastMsgId()));
+	w.EndObject();
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+// Shared by all three send forms. `target` is the already-built EC tag naming
+// the recipient -- a GUI_ID, a live peer's ECID, or a friend's ECID. The
+// friend form is the one that reaches an OFFLINE friend, resolved by the
+// daemon through the friend's stored ip:port.
+CHttpServer::Response CApiDispatcher::SendChatMessageTo(const CHttpServer::Request &req, const CECTag &target)
+{
+	picojson::value root;
+	std::string parse_err;
+	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
+		return ErrorResponse(400, "bad_request", parse_err.c_str());
+	}
+	const auto &obj = root.get<picojson::object>();
+	const auto it = obj.find("text");
+	if (it == obj.end() || !it->second.is<std::string>()) {
+		return ErrorResponse(400, "bad_request", "required string field `text` is missing");
+	}
+	const std::string text = it->second.get<std::string>();
+	if (text.empty()) {
+		return ErrorResponse(400, "bad_request", "`text` must be a non-empty string");
+	}
+	const std::size_t kMaxChatText = 1024;
+	if (text.size() > kMaxChatText) {
+		return ErrorResponse(400, "bad_request", "`text` exceeds 1024 bytes");
+	}
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_CHAT_SEND));
+	ec_req->AddTag(CECTag(EC_TAG_CHAT, wxString::FromUTF8(text.c_str())));
+	ec_req->AddTag(target);
+
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for chat send");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(404, "not_found", ec_err_msg.c_str());
+	}
+	std::uint64_t gui_id = 0;
+	std::uint32_t msg_id = 0;
+	if (const CECTag *t = ec_resp->GetTagByName(EC_TAG_CHAT_CLIENT_ID))
+		gui_id = t->GetInt();
+	if (const CECTag *t = ec_resp->GetTagByName(EC_TAG_CHAT_MSG_ID))
+		msg_id = static_cast<std::uint32_t>(t->GetInt());
+	delete ec_resp;
+
+	// 202, not 200: the core acknowledges that it queued the message on the
+	// peer connection, not that the peer received it. An unreachable peer is
+	// not an error -- the desktop behaves the same, optimistically printing
+	// *** Connecting to Client ***.
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.Key("peer");
+	w.ValueString(wxString::FromUTF8(webapi::ChatPeerKeyFromGuiId(gui_id).c_str()));
+	w.Key("message");
+	w.BeginObject();
+	w.Key("id");
+	w.ValueInt(static_cast<int64_t>(msg_id));
+	w.Key("direction");
+	w.ValueString(wxString::FromAscii("out"));
+	w.Key("text");
+	w.ValueString(wxString::FromUTF8(text.c_str()));
+	w.EndObject();
+	w.EndObject();
+	CHttpServer::Response r;
+	r.status = 202;
+	r.content_type = "application/json";
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleChatSend(const CHttpServer::Request &req, const std::string &peer)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_app.IsServerChatActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
+	}
+	std::uint64_t gui_id = 0;
+	if (!ParseChatPeerKey(peer, gui_id)) {
+		return ErrorResponse(400, "bad_request", "path `{peer}` must be `<ip>:<port>`");
+	}
+	// No 404 for an unknown peer here: the core creates the session if it does
+	// not exist, so this doubles as "start a chat with this address".
+	return SendChatMessageTo(req, CECTag(EC_TAG_CHAT_CLIENT_ID, gui_id));
+}
+
+CHttpServer::Response CApiDispatcher::HandleFriendMessageSend(
+	const CHttpServer::Request &req, const std::string &ecid_str)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_app.IsServerChatActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
+	}
+	std::uint32_t ecid = 0;
+	if (!ParseEcidPath(ecid_str, ecid)) {
+		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
+	}
+	return SendChatMessageTo(req, CECTag(EC_TAG_FRIEND, ecid));
+}
+
+CHttpServer::Response CApiDispatcher::HandleClientMessageSend(
+	const CHttpServer::Request &req, const std::string &ecid_str)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_app.IsServerChatActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
+	}
+	std::uint32_t ecid = 0;
+	if (!ParseEcidPath(ecid_str, ecid)) {
+		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
+	}
+	return SendChatMessageTo(req, CECTag(EC_TAG_CLIENT, ecid));
+}
+
+CHttpServer::Response CApiDispatcher::HandleChatClose(
+	const CHttpServer::Request &req, const std::string &peer)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	if (!m_app.IsServerChatActive()) {
+		return ErrorResponse(
+			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
+	}
+	std::uint64_t gui_id = 0;
+	if (!ParseChatPeerKey(peer, gui_id)) {
+		return ErrorResponse(400, "bad_request", "path `{peer}` must be `<ip>:<port>`");
+	}
+
+	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_CHAT_CLOSE_SESSION));
+	ec_req->AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, gui_id));
+	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for chat close");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		delete ec_resp;
+		return ErrorResponse(404, "not_found", ec_err_msg.c_str());
+	}
+	delete ec_resp;
+
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.Key("peer");
+	w.ValueString(wxString::FromUTF8(peer.c_str()));
+	w.EndObject();
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
 	FinalizeJsonBody(w, r);
 	return r;
 }
@@ -9954,6 +10409,11 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 			return "logs";
 		if (prefix == "search")
 			return "search";
+		// Plural, matching the /chats collection: the bootstrap advice is to
+		// GET the collections matching your subscribed channels, which only
+		// works if the two names line up.
+		if (prefix == "chat")
+			return "chats";
 		return prefix;
 	};
 	auto event_passes_filter = [&](const std::string &name) {

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -40,6 +40,7 @@
 #include <map>
 #include <utility>
 
+class CECTag;
 class CAmuleApiConfig;
 class CamuleapiApp;
 class CJsonWriter;
@@ -284,6 +285,24 @@ private:
 		const CHttpServer::Request &, const std::string &key, bool require_downloading);
 	CHttpServer::Response HandleClientDetail(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleKnownClients(const CHttpServer::Request &);
+
+	// --- Chat (issue #971) -------------------------------------------------
+	// All six gate on m_app.IsServerChatActive() and answer 503
+	// ec_unsupported otherwise: a daemon predating the chat ops asserts on
+	// the unknown opcode rather than answering EC_OP_FAILED, so the request
+	// must never go out.
+	CHttpServer::Response HandleChats(const CHttpServer::Request &);
+	CHttpServer::Response HandleChatMessages(const CHttpServer::Request &, const std::string &peer);
+	CHttpServer::Response HandleChatSend(const CHttpServer::Request &, const std::string &peer);
+	CHttpServer::Response HandleChatClose(const CHttpServer::Request &, const std::string &peer);
+	// Shared body of all three send forms; `target` is the EC tag naming the
+	// recipient (GUI_ID, client ECID or friend ECID).
+	CHttpServer::Response SendChatMessageTo(const CHttpServer::Request &, const CECTag &target);
+	// Address a conversation by friend / peer ECID instead of ip:port. The
+	// friend form is the one that reaches an OFFLINE friend, through their
+	// stored address.
+	CHttpServer::Response HandleFriendMessageSend(const CHttpServer::Request &, const std::string &ecid);
+	CHttpServer::Response HandleClientMessageSend(const CHttpServer::Request &, const std::string &ecid);
 	// POST /clients/{ecid}/shared_files — browse a peer's shared file list
 	// ("View Files", #399). Returns a search_id addressed like any search:
 	// results via GET /search/{id}/results, progress + SSE via the standard

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -410,7 +410,8 @@ int CamuleapiApp::OnRun()
 	m_canMultiSearch = true;
 
 	// Chat: amuleapi serves /chats from the daemon's session store, so it
-	// advertises EC_TAG_CAN_CHAT at login and the daemon echoes it back. The
+	// advertises EC_TAG_CAN_CHAT_SESSIONS at login and the daemon echoes it
+	// back when it serves those ops. The
 	// echo is what every chat endpoint gates on -- against a daemon that
 	// predates the ops, an unknown opcode asserts rather than failing, so
 	// they must answer 503 ec_unsupported instead of asking.

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -409,6 +409,13 @@ int CamuleapiApp::OnRun()
 	// single-search fallback to maintain.
 	m_canMultiSearch = true;
 
+	// Chat: amuleapi serves /chats from the daemon's session store, so it
+	// advertises EC_TAG_CAN_CHAT at login and the daemon echoes it back. The
+	// echo is what every chat endpoint gates on -- against a daemon that
+	// predates the ops, an unknown opcode asserts rather than failing, so
+	// they must answer 503 ec_unsupported instead of asking.
+	m_canChat = true;
+
 	// ConnectAndRun does the EC bring-up (CRemoteConnect, ConnectToCore)
 	// and then calls TextShell — which we've overridden so the daemon's
 	// main loop runs there. On EC failure ConnectAndRun returns without
@@ -634,6 +641,12 @@ bool CamuleapiApp::IsServerClientHistoryActive()
 	// Same shape as IsServerPartialUpdateActive(): a const bool snapshot
 	// taken at login, so no mutex.
 	return CaMuleExternalConnector::IsServerClientHistoryActive();
+}
+
+bool CamuleapiApp::IsServerChatActive()
+{
+	// Same shape again: a const bool snapshot taken at login, so no mutex.
+	return CaMuleExternalConnector::IsServerChatActive();
 }
 
 wxString CamuleapiApp::GetDaemonVersion()

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -100,6 +100,9 @@ public:
 	// i.e. it answers EC_OP_GET_CLIENT_HISTORY. /known_clients returns 503
 	// rather than sending a request an older core would assert on.
 	bool IsServerClientHistoryActive();
+	// True when the connected amuled serves the chat session ops; every
+	// /chats route answers 503 ec_unsupported when this is false.
+	bool IsServerChatActive();
 
 	// Version string of the connected amuled, captured from the
 	// EC_TAG_SERVER_VERSION tag of the AUTH_OK handshake. Empty string

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -538,6 +538,45 @@ void EnforceSinglePublisher()
 
 } // namespace
 
+// One chat message as the `message` object both the SSE payload and
+// GET /chats/{peer}/messages expose. Written here in the same string-building
+// style as the other event payloads in this file; the REST side renders the
+// identical shape through CJsonWriter.
+std::string ChatMessageJson(const ChatMessageSnapshot &msg)
+{
+	return "{\"id\":" + std::to_string(msg.id) + ",\"direction\":\"" + (msg.outgoing ? "out" : "in") +
+	       "\",\"text\":\"" + EscJson(msg.text) + "\",\"timestamp\":" + std::to_string(msg.timestamp) +
+	       "}";
+}
+
+void PublishChatEvents(CEventBus &bus,
+	const std::vector<ChatSessionSnapshot> &new_messages,
+	const std::vector<std::uint64_t> &closed)
+{
+	if (new_messages.empty() && closed.empty())
+		return;
+
+	std::vector<std::pair<std::string, std::string>> batch;
+	for (const ChatSessionSnapshot &session : new_messages) {
+		const std::string peer = session.PeerKey();
+		for (const ChatMessageSnapshot &msg : session.messages) {
+			std::string payload = "{\"peer\":\"" + EscJson(peer) + "\",\"ip\":\"" +
+					      EscJson(session.ip) +
+					      "\",\"port\":" + std::to_string(session.port) + ",\"name\":\"" +
+					      EscJson(session.DisplayName()) +
+					      "\",\"client_ecid\":" + std::to_string(session.client_ecid) +
+					      ",\"friend_ecid\":" + std::to_string(session.friend_ecid) +
+					      ",\"message\":" + ChatMessageJson(msg) + "}";
+			batch.emplace_back("chat_message", std::move(payload));
+		}
+	}
+	for (std::uint64_t gui_id : closed) {
+		const std::string peer = ChatPeerKeyFromGuiId(gui_id);
+		batch.emplace_back("chat_session_closed", "{\"peer\":\"" + EscJson(peer) + "\"}");
+	}
+	bus.PublishBatch(batch);
+}
+
 void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state)
 {
 	EnforceSinglePublisher();

--- a/src/webapi/EventDiff.h
+++ b/src/webapi/EventDiff.h
@@ -109,6 +109,19 @@ struct LastSeenState
 // three pieces stay consistent within a tick.
 void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state);
 
+// Chat events, published straight from the refresher's chat roundtrip rather
+// than by diffing a prior snapshot: the walker already knows exactly what is
+// new (only messages past the cursor come back) and which sessions vanished,
+// so a diff would re-derive what the wire just told us.
+//
+// One `chat_message` per message, inbound AND outbound alike -- an outbound
+// one is how a message sent from amulegui, or from another web tab, reaches
+// every other viewer. A session that did not exist is implied by the first
+// message carrying its `peer`; there is no separate "session started" event.
+void PublishChatEvents(CEventBus &bus,
+	const std::vector<ChatSessionSnapshot> &new_messages,
+	const std::vector<std::uint64_t> &closed);
+
 } // namespace webapi
 
 #endif // WEBAPI_EVENT_DIFF_H

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -171,22 +171,6 @@ const char *KadStateString(const CEC_ConnState_Tag *conn)
 	return "connecting";
 }
 
-// Renders an IPv4 address that arrives LSB-first — the layout
-// EC_TAG_CLIENT_USER_IP, the Kad address tags and the eD2k id all share,
-// and what Uint32toStringIP() renders on the desktop side.
-std::string IPv4ToDotted(std::uint32_t ip_lsb_first)
-{
-	char buf[16];
-	std::snprintf(buf,
-		sizeof(buf),
-		"%u.%u.%u.%u",
-		static_cast<unsigned>((ip_lsb_first) & 0xFFu),
-		static_cast<unsigned>((ip_lsb_first >> 8) & 0xFFu),
-		static_cast<unsigned>((ip_lsb_first >> 16) & 0xFFu),
-		static_cast<unsigned>((ip_lsb_first >> 24) & 0xFFu));
-	return std::string(buf);
-}
-
 // As above, but an unset address formats as empty rather than "0.0.0.0".
 // The peer and server fields use 0 for "not known" and omit the key on it,
 // whereas the Kad fields report the quad verbatim — which is the only
@@ -1866,6 +1850,106 @@ static void MergeFriendTag(const CEC_Friend_Tag *ft, FriendSnapshot &f, bool is_
 		if (ft->FriendSlot(slot))
 			f.friend_slot = slot;
 	}
+}
+
+void ApplyChatSessions(const CECPacket *resp,
+	std::vector<ChatSessionSnapshot> &cache,
+	std::uint32_t &cursor,
+	std::vector<ChatSessionSnapshot> &out_new_messages,
+	std::vector<std::uint64_t> &out_closed)
+{
+	if (!resp)
+		return;
+
+	// Index what we already hold so the incremental messages can be carried
+	// over: the reply only contains what is newer than the cursor we sent.
+	std::map<std::uint64_t, ChatSessionSnapshot> previous;
+	for (ChatSessionSnapshot &s : cache) {
+		previous.emplace(s.gui_id, std::move(s));
+	}
+
+	std::vector<ChatSessionSnapshot> fresh;
+	std::set<std::uint64_t> present;
+
+	for (const CECTag &tag : *resp) {
+		const CECTag *t = &tag;
+		if (t->GetTagName() != EC_TAG_CHAT_SESSION)
+			continue;
+
+		ChatSessionSnapshot session;
+		session.gui_id = t->GetInt();
+		present.insert(session.gui_id);
+		// GUI_ID is (ip << 16) | port, with the IP in the same byte order
+		// EC_TAG_CLIENT_USER_IP uses, so it renders with the peer formatter
+		// every other address on this surface goes through.
+		session.ip = FormatClientIpv4(static_cast<std::uint32_t>(session.gui_id >> 16));
+		session.port = static_cast<std::uint16_t>(session.gui_id & 0xFFFFu);
+
+		if (const CECTag *nameTag = t->GetTagByName(EC_TAG_CHAT_PEER_NAME))
+			session.name = std::string(nameTag->GetStringData().utf8_str());
+		if (const CECTag *clientTag = t->GetTagByName(EC_TAG_CLIENT))
+			session.client_ecid = static_cast<std::uint32_t>(clientTag->GetInt());
+		if (const CECTag *friendTag = t->GetTagByName(EC_TAG_FRIEND))
+			session.friend_ecid = static_cast<std::uint32_t>(friendTag->GetInt());
+
+		// Carry over the history this tick's reply did not repeat.
+		auto prev = previous.find(session.gui_id);
+		if (prev != previous.end()) {
+			session.messages = std::move(prev->second.messages);
+			// A name the daemon stops sending must not blank one we have.
+			if (session.name.empty())
+				session.name = prev->second.name;
+		}
+
+		ChatSessionSnapshot arrivals;
+		arrivals.gui_id = session.gui_id;
+		arrivals.ip = session.ip;
+		arrivals.port = session.port;
+		arrivals.name = session.name;
+		arrivals.client_ecid = session.client_ecid;
+		arrivals.friend_ecid = session.friend_ecid;
+
+		for (const CECTag &child : *t) {
+			const CECTag *m = &child;
+			if (m->GetTagName() != EC_TAG_CHAT_MESSAGE)
+				continue;
+			ChatMessageSnapshot msg;
+			msg.text = std::string(m->GetStringData().utf8_str());
+			if (const CECTag *idTag = m->GetTagByName(EC_TAG_CHAT_MSG_ID))
+				msg.id = static_cast<std::uint32_t>(idTag->GetInt());
+			if (const CECTag *dirTag = m->GetTagByName(EC_TAG_CHAT_DIRECTION))
+				msg.outgoing = dirTag->GetInt() != 0;
+			if (const CECTag *tsTag = m->GetTagByName(EC_TAG_CHAT_TIMESTAMP))
+				msg.timestamp = static_cast<std::uint32_t>(tsTag->GetInt());
+			session.messages.push_back(msg);
+			arrivals.messages.push_back(msg);
+		}
+
+		// Mirror the daemon's own retention so a long-lived amuleapi does
+		// not accumulate what the core has already dropped.
+		const std::size_t kMaxPerSession = 200;
+		if (session.messages.size() > kMaxPerSession) {
+			session.messages.erase(session.messages.begin(),
+				session.messages.end() - static_cast<std::ptrdiff_t>(kMaxPerSession));
+		}
+
+		if (!arrivals.messages.empty())
+			out_new_messages.push_back(std::move(arrivals));
+		fresh.push_back(std::move(session));
+	}
+
+	// Absent from the reply == closed on the daemon. Reported so the event
+	// layer can emit chat_session_closed; the vector is replaced wholesale
+	// below, which is what actually drops it.
+	for (const auto &kv : previous) {
+		if (!present.count(kv.first))
+			out_closed.push_back(kv.first);
+	}
+
+	cache = std::move(fresh);
+
+	if (const CECTag *cursorTag = resp->GetTagByName(EC_TAG_CHAT_MSG_ID))
+		cursor = static_cast<std::uint32_t>(cursorTag->GetInt());
 }
 
 void ApplyGetUpdateToFriends(const CECPacket *resp, std::map<std::uint32_t, FriendSnapshot> &cache)

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -89,6 +89,7 @@ struct StatusSnapshot;
 struct FileSnapshot;
 struct ClientSnapshot;
 struct FriendSnapshot;
+struct ChatSessionSnapshot;
 struct ServerSnapshot;
 struct KadSnapshot;
 struct CategorySnapshot;
@@ -200,6 +201,21 @@ void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, Serv
 // EC_OP_GET_UPDATE reply (ExternalConn.cpp, "Add friends"), so /friends is
 // served from the tick we already run rather than a roundtrip of its own.
 void ApplyGetUpdateToFriends(const CECPacket *resp, std::map<std::uint32_t, FriendSnapshot> &cache);
+
+// EC_OP_CHAT_SESSIONS -> the /chats snapshot. `cursor` is read as the value
+// sent with the request and written back with the store's current last id.
+//
+// The reply is the daemon's COMPLETE session set, so this replaces the vector
+// rather than merging into it: a session missing from a reply was closed (by
+// another client, or evicted), and that absence is the only signal a close
+// produces. Messages, by contrast, arrive incrementally -- only those newer
+// than the cursor -- so they are appended to the session they belong to,
+// carrying over what the previous tick already held.
+void ApplyChatSessions(const CECPacket *resp,
+	std::vector<ChatSessionSnapshot> &cache,
+	std::uint32_t &cursor,
+	std::vector<ChatSessionSnapshot> &out_new_messages,
+	std::vector<std::uint64_t> &out_closed);
 
 // ed2k server priority, both directions. The SRV_PR_* wire values are not
 // monotone (NORMAL=0, HIGH=1, LOW=2), so callers must never assume a name's

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -197,6 +197,32 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		state.ReconcileKnownClients();
 	}
 
+	// /chats — one roundtrip carrying the cursor from the previous tick, so
+	// the daemon replies with the session list plus only the messages we do
+	// not have. Gated on the capability and skipped entirely otherwise: a
+	// daemon predating the chat ops reaches the unknown-opcode branch of
+	// ProcessRequest2(), which asserts rather than answering EC_OP_FAILED.
+	if (app.IsServerChatActive()) {
+		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_GET_CHAT_SESSIONS));
+		const std::uint32_t cursor = state.ChatCursor();
+		if (cursor) {
+			req->AddTag(CECTag(EC_TAG_CHAT_MSG_ID, cursor));
+		}
+		const CECPacket *resp = app.SendRecvSerialized(req.get());
+		if (!resp)
+			return false;
+		// Collected under the write lock, published after it: emitting SSE
+		// frames from inside the lambda would hold CState exclusively across
+		// the event bus.
+		std::vector<webapi::ChatSessionSnapshot> new_messages;
+		std::vector<std::uint64_t> closed;
+		state.MutateChats([&](std::vector<webapi::ChatSessionSnapshot> &cache, std::uint32_t &cur) {
+			ApplyChatSessions(resp, cache, cur, new_messages, closed);
+		});
+		delete resp;
+		PublishChatEvents(app.EventBus(), new_messages, closed);
+	}
+
 	// /logs/serverinfo, /stats/tree, /stats/graphs/{graph} are NOT
 	// fetched per-tick — they're lazy-fetched on first GET via
 	// CTtlCache (1 s TTL coalesces burst reads). HTTP handlers in

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -24,6 +24,7 @@
 
 #include "State.h"
 
+#include <cstdio>
 #include <ctime>
 
 #include <mutex>
@@ -442,6 +443,44 @@ void CState::MutateFriends(const std::function<void(std::map<std::uint32_t, Frie
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_friends);
+}
+
+std::string IPv4ToDotted(std::uint32_t ip_lsb_first)
+{
+	char buf[16];
+	std::snprintf(buf,
+		sizeof(buf),
+		"%u.%u.%u.%u",
+		static_cast<unsigned>((ip_lsb_first) & 0xFFu),
+		static_cast<unsigned>((ip_lsb_first >> 8) & 0xFFu),
+		static_cast<unsigned>((ip_lsb_first >> 16) & 0xFFu),
+		static_cast<unsigned>((ip_lsb_first >> 24) & 0xFFu));
+	return std::string(buf);
+}
+
+std::string ChatPeerKeyFromGuiId(std::uint64_t gui_id)
+{
+	const std::uint32_t ip = static_cast<std::uint32_t>(gui_id >> 16);
+	const std::uint16_t port = static_cast<std::uint16_t>(gui_id & 0xFFFFu);
+	return IPv4ToDotted(ip) + ":" + std::to_string(port);
+}
+
+std::vector<ChatSessionSnapshot> CState::Chats() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	return m_chats;
+}
+
+std::uint32_t CState::ChatCursor() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	return m_chat_cursor;
+}
+
+void CState::MutateChats(const std::function<void(std::vector<ChatSessionSnapshot> &, std::uint32_t &)> &fn)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	fn(m_chats, m_chat_cursor);
 }
 
 std::vector<FileSnapshot> CState::Downloads() const

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -504,6 +504,59 @@ struct FriendSnapshot
 	bool friend_slot = false;
 };
 
+// /chats endpoints. One conversation with one peer, mirrored from the
+// daemon's CChatSessionStore over EC_OP_GET_CHAT_SESSIONS.
+//
+// Keyed on the GUI_ID the wire already uses -- (ip << 16) | port -- which the
+// REST layer renders as the readable "<ip>:<port>" conversation key. Stable
+// across peer reconnects, unlike an ECID, and converts straight back to the
+// GUI_ID the EC ops want.
+struct ChatMessageSnapshot
+{
+	std::uint32_t id = 0; //!< monotonic per daemon process; a safe `since_id` cursor
+	bool outgoing = false;
+	std::uint32_t timestamp = 0; //!< unix seconds, stamped by the core
+	std::string text;
+};
+
+struct ChatSessionSnapshot
+{
+	std::uint64_t gui_id = 0;
+	std::string ip; //!< dotted quad, rendered in the walker like ClientSnapshot::ip
+	std::uint16_t port = 0;
+	std::string name;              //!< peer display name; "" when the core has none
+	std::uint32_t client_ecid = 0; //!< live peer, 0 when offline
+	std::uint32_t friend_ecid = 0; //!< friend entry, 0 when not a friend
+	std::vector<ChatMessageSnapshot> messages;
+
+	//! Highest id held here, 0 when empty.
+	std::uint32_t LastMsgId() const { return messages.empty() ? 0 : messages.back().id; }
+
+	//! The REST conversation key, "<ip>:<port>".
+	std::string PeerKey() const { return ip + ":" + std::to_string(port); }
+
+	//! Display name, falling back to the desktop's own rendering when the
+	//! core has no nick for the peer (CChatSelector builds the same string).
+	//! Shared by the list, the detail read and the SSE payload so a client
+	//! never sees a blank name from one and a real one from another.
+	std::string DisplayName() const
+	{
+		return name.empty() ? ("IP: " + ip + " Port: " + std::to_string(port)) : name;
+	}
+};
+
+// Renders an IPv4 address that arrives LSB-first -- the layout
+// EC_TAG_CLIENT_USER_IP, the Kad address tags and the eD2k id all share, and
+// what Uint32toStringIP() renders on the desktop side. Lives here rather than
+// in the refresher because the snapshot layer needs it too (a chat peer key
+// is built from a GUI_ID, with no walker involved).
+std::string IPv4ToDotted(std::uint32_t ip_lsb_first);
+
+// The same key built straight from a GUI_ID, for paths that only have the id
+// (a session that was closed is gone from the snapshot, so there is no
+// ChatSessionSnapshot left to ask). GUI_ID is (ip << 16) | port.
+std::string ChatPeerKeyFromGuiId(std::uint64_t gui_id);
+
 // /kad endpoint. Single composite snapshot pulled from the STAT_REQ
 // response we're already fetching for /status — saves a roundtrip
 // since amuled's `EC_OP_STAT_REQ` at `EC_DETAIL_CMD` ships every
@@ -1432,6 +1485,12 @@ public:
 
 	std::vector<ServerSnapshot> Servers() const;
 	std::vector<FriendSnapshot> Friends() const;
+	// Chat sessions, most-recently-active first (the daemon's own order).
+	std::vector<ChatSessionSnapshot> Chats() const;
+	// The resume cursor for the next EC_OP_GET_CHAT_SESSIONS poll: the
+	// highest message id this snapshot holds. Advanced from the reply even
+	// when nothing came back, so evicted ids are not re-requested forever.
+	std::uint32_t ChatCursor() const;
 	// Results / progress for one search. Every caller names a concrete
 	// daemon-allocated id — there is no implicit "current search" — and an
 	// unknown id yields an empty list / idle progress. HasSearch
@@ -1514,6 +1573,12 @@ public:
 	void MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn);
 	void MutateServers(const std::function<void(std::map<std::uint32_t, ServerSnapshot> &)> &fn);
 	void MutateFriends(const std::function<void(std::map<std::uint32_t, FriendSnapshot> &)> &fn);
+	// The walker replaces the whole session vector each tick rather than
+	// merging: the daemon's reply IS the complete set, and a session missing
+	// from it was closed (that absence is exactly how every client learns of
+	// a close, so merging would resurrect closed conversations).
+	void MutateChats(
+		const std::function<void(std::vector<ChatSessionSnapshot> &, std::uint32_t &cursor)> &fn);
 	// Mutate one search's result map (the refresher's per-tick full-fetch
 	// overwrite). No-op if the id names no live slot.
 	void MutateSearch(std::uint32_t search_id,
@@ -1628,6 +1693,8 @@ private:
 	void ReconcileKnownClientsLocked();
 	std::map<std::uint32_t, ServerSnapshot> m_servers;
 	std::map<std::uint32_t, FriendSnapshot> m_friends;
+	std::vector<ChatSessionSnapshot> m_chats;
+	std::uint32_t m_chat_cursor = 0;
 	std::vector<std::string> m_amule_log_lines;
 	ServerInfoLog m_server_info;
 	StatsTreeNode m_stats_tree;

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# amuleapi 38-chat — the /chats surface (issue #971).
+#
+# Chat is served from a session store in amuled that every client shares,
+# so a message sent from the desktop GUI, from amulegui or through this
+# API lands in one transcript.
+#
+# Wire contract:
+#   GET    /chats                   → list envelope of conversations
+#   GET    /chats/{peer}/messages   → { peer, messages[], total, last_msg_id }
+#   POST   /chats/{peer}/messages   → 202 + the created message
+#   DELETE /chats/{peer}            → 200 { ok, peer }
+#   POST   /friends/{ecid}/messages → 202 (reaches an OFFLINE friend)
+#   POST   /clients/{ecid}/messages → 202
+#
+# `{peer}` is "<ip>:<port>". Every route answers 503 ec_unsupported when
+# the connected amuled predates the chat ops.
+#
+# The peer used below is in the RFC 5737 TEST-NET-3 documentation range,
+# which is not routable: the daemon creates the conversation and queues
+# the message without anything leaving the host. That is the point --
+# POST is 202 ("queued on the peer connection"), never a delivery
+# receipt, so an unreachable peer is a valid and deliberate test target.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+GUEST_PASS=${GUEST_PASS:-guestpass}
+
+# TEST-NET-3 (RFC 5737). Never routable, never a real peer.
+PEER_IP=203.0.113.42
+PEER_PORT=4662
+PEER="$PEER_IP:$PEER_PORT"
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_38_chat_body.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| _fail "$label" "body was not valid JSON" "body: $CURL_BODY"
+	if [ "$actual" = "$expected" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+command -v jq >/dev/null 2>&1 || _die "jq is required."
+curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null \
+	|| _die "amuleapi at $HOST is not reachable."
+
+echo "amuleapi 38-chat smoke @ $HOST"
+
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
+
+# --- 1. Capability gate. ------------------------------------------
+#
+# Against an amuled that predates the chat ops every route must answer
+# 503 ec_unsupported rather than sending an opcode the daemon would land
+# in its unknown-opcode branch (which asserts before it can answer).
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
+if [ "$CURL_STATUS" = "503" ]; then
+	CODE=$(printf '%s' "$CURL_BODY" | jq -r '.error.code')
+	if [ "$CODE" = "ec_unsupported" ]; then
+		_pass "GET /chats → 503 ec_unsupported (daemon predates the chat ops)"
+		echo "    info: connected amuled does not serve chat; remaining checks skipped"
+		echo
+		echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+		exit 0
+	fi
+	_fail "GET /chats 503 shape" "expected error.code=ec_unsupported, got $CODE"
+fi
+_assert_status 200 "GET /chats → 200"
+_assert_json_eq '.chats | type' array '/chats .chats is array'
+
+# --- 2. Send creates the conversation. ----------------------------
+#
+# No 404 for an unknown peer: the core creates the session, so POST
+# doubles as "start a chat with this address".
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+	-d '{"text":"curl-test hello"}' "$HOST/api/v0/chats/$PEER/messages"
+_assert_status 202 "POST /chats/{peer}/messages → 202 Accepted"
+_assert_json_eq '.ok'                  true    'send reports ok'
+_assert_json_eq '.peer'                "$PEER" 'send echoes the conversation key'
+_assert_json_eq '.message.direction'   out     'sent message is direction=out'
+_assert_json_eq '.message.text'        "curl-test hello" 'send echoes the text'
+FIRST_ID=$(printf '%s' "$CURL_BODY" | jq -r '.message.id')
+
+# The refresher mirrors the store on its next tick (1 s).
+sleep 3
+
+# --- 3. The conversation is now on the list. ----------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
+_assert_status 200 "GET /chats → 200 after send"
+FOUND=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.peer == $p)] | length')
+if [ "$FOUND" = "1" ]; then
+	_pass "/chats lists the new conversation"
+else
+	_fail "/chats conversation presence" "expected exactly 1 row for $PEER, got $FOUND"
+fi
+# Narrow the body to just this conversation's row for the field checks.
+ROW=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" -c '.chats[] | select(.peer == $p)')
+printf '%s' "$ROW" > "$CURL_BODY_FILE"; CURL_BODY=$ROW
+_assert_json_eq '.ip'                 "$PEER_IP"   'row carries the split ip'
+_assert_json_eq '.port'               "$PEER_PORT" 'row carries the split port'
+_assert_json_eq '.online'             false        'unrouted peer is offline'
+_assert_json_eq '.client_ecid'        0            'offline peer has client_ecid 0'
+_assert_json_eq '.last_message.text'  "curl-test hello" 'row carries last_message'
+# The core has no nickname for a peer that never answered, so the row must
+# fall back to the desktop's own rendering rather than an empty string.
+_assert_json_eq '.name' "IP: $PEER_IP Port: $PEER_PORT" 'name falls back to the address form'
+
+# --- 4. Reading the transcript. -----------------------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER/messages"
+_assert_status 200 "GET /chats/{peer}/messages → 200"
+_assert_json_eq '.peer'            "$PEER" 'messages echo the conversation key'
+_assert_json_eq '.messages | type' array   'messages is an array'
+_assert_json_eq '.messages[0].direction' out 'first message is direction=out'
+
+# Every message object is exactly {id, direction, text, timestamp}.
+WRONG=$(printf '%s' "$CURL_BODY" | jq \
+	'[.messages[] | select((keys | sort) != ["direction","id","text","timestamp"])] | length')
+if [ "$WRONG" = "0" ]; then
+	_pass "every message object is {id, direction, text, timestamp}"
+else
+	_fail "message object shape" "$WRONG messages carry unexpected keys"
+fi
+
+# --- 5. since_id is a safe cursor. --------------------------------
+#
+# ids are monotonic per daemon process, so a client polling with the
+# highest id it holds must never see a duplicate and never skip one.
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/chats/$PEER/messages?since_id=$FIRST_ID"
+_assert_status 200 "GET messages?since_id → 200"
+_assert_json_eq '.messages | length' 0 'since_id at the head returns nothing new'
+
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+	-d '{"text":"second message"}' "$HOST/api/v0/chats/$PEER/messages"
+_assert_status 202 "POST second message → 202"
+sleep 3
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/chats/$PEER/messages?since_id=$FIRST_ID"
+_assert_json_eq '.messages | length'   1                'since_id returns exactly the new message'
+_assert_json_eq '.messages[0].text'    "second message" 'since_id returns the right message'
+
+# --- 6. Input validation. -----------------------------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/notanaddress/messages"
+_assert_status 400 "GET messages with a malformed {peer} → 400"
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER_IP:99999/messages"
+_assert_status 400 "GET messages with an out-of-range port → 400"
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/198.51.100.7:4662/messages"
+_assert_status 404 "GET messages for an unknown conversation → 404"
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+	-d '{"text":""}' "$HOST/api/v0/chats/$PEER/messages"
+_assert_status 400 "POST with empty text → 400"
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+	-d '{}' "$HOST/api/v0/chats/$PEER/messages"
+_assert_status 400 "POST with no text field → 400"
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+	-d '{"text":"x"}' "$HOST/api/v0/clients/4294967290/messages"
+_assert_status 404 "POST to an unknown client ECID → 404"
+_curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+	-d '{"text":"x"}' "$HOST/api/v0/friends/4294967290/messages"
+_assert_status 404 "POST to an unknown friend ECID → 404"
+
+# --- 7. Method gating. --------------------------------------------
+_curl -X PUT -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
+_assert_status 405 "PUT /chats → 405"
+_curl -X PATCH -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
+_assert_status 405 "PATCH /chats/{peer} → 405"
+
+# --- 8. Guests read but do not write. -----------------------------
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$GUEST_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
+	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/chats"
+	_assert_status 200 "GET /chats as guest → 200 (read-only data)"
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
+		-d '{"text":"nope"}' "$HOST/api/v0/chats/$PEER/messages"
+	_assert_status 403 "POST as guest → 403 (sending is admin-only)"
+	_curl -X DELETE -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/chats/$PEER"
+	_assert_status 403 "DELETE as guest → 403"
+else
+	echo "    info: guest login unavailable; guest checks skipped"
+fi
+
+# --- 9. Closing is global and actually removes it. ----------------
+_curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
+_assert_status 200 "DELETE /chats/{peer} → 200"
+_assert_json_eq '.ok'   true    'close reports ok'
+_assert_json_eq '.peer' "$PEER" 'close echoes the conversation key'
+sleep 3
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
+GONE=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.peer == $p)] | length')
+if [ "$GONE" = "0" ]; then
+	_pass "closed conversation is gone from /chats"
+else
+	_fail "close removal" "conversation still listed after DELETE"
+fi
+_curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
+_assert_status 404 "DELETE an already-closed conversation → 404"
+
+# --- Summary. -----------------------------------------------------
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -217,6 +217,7 @@ PHASES=(
 	35-ipfilter-actions.sh
 	36-shared-reload.sh
 	37-shared-availability-parts.sh
+	38-chat.sh
 )
 
 # Override list from the command line if given.

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -482,6 +482,21 @@ target_link_libraries (SharedFilesReloadLatchTest
 	mulecommon
 )
 
+add_executable (ChatSessionStoreTest
+	ChatSessionStoreTest.cpp
+	${CMAKE_SOURCE_DIR}/src/ChatSessionStore.cpp
+)
+add_test (NAME ChatSessionStoreTest COMMAND ChatSessionStoreTest)
+target_include_directories (ChatSessionStoreTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+target_link_libraries (ChatSessionStoreTest
+	muleunit
+	mulecommon
+)
+
 add_executable (JsonWriterTest
 	JsonWriterTest.cpp
 )

--- a/unittests/tests/ChatSessionStoreTest.cpp
+++ b/unittests/tests/ChatSessionStoreTest.cpp
@@ -46,7 +46,7 @@ TEST(ChatSessionStore, StartsEmpty)
 	CChatSessionStore store;
 	ASSERT_EQUALS(static_cast<size_t>(0), store.SessionCount());
 	ASSERT_EQUALS(static_cast<uint32>(0), store.LastMsgId());
-	ASSERT_TRUE(store.Find(Peer(1)) == NULL);
+	ASSERT_TRUE(store.Find(Peer(1)) == nullptr);
 }
 
 TEST(ChatSessionStore, FirstMessageCreatesSessionWithIdOne)
@@ -60,7 +60,7 @@ TEST(ChatSessionStore, FirstMessageCreatesSessionWithIdOne)
 	ASSERT_EQUALS(static_cast<size_t>(1), store.SessionCount());
 
 	const CChatSessionStore::Session *s = store.Find(Peer(1));
-	ASSERT_TRUE(s != NULL);
+	ASSERT_TRUE(s != nullptr);
 	ASSERT_EQUALS(wxString("alice"), s->name);
 	ASSERT_EQUALS(static_cast<size_t>(1), s->messages.size());
 	ASSERT_EQUALS(wxString("hi"), s->messages[0].text);
@@ -139,9 +139,9 @@ TEST(ChatSessionStore, SessionCapEvictsLeastRecentlyActive)
 	// Peer(0) is the least recently active, so it is the one to go.
 	store.AddIncoming(Peer(9999), "newcomer", "hi");
 	ASSERT_EQUALS(cap, store.SessionCount());
-	ASSERT_TRUE(store.Find(Peer(0)) == NULL);
-	ASSERT_TRUE(store.Find(Peer(9999)) != NULL);
-	ASSERT_TRUE(store.Find(Peer(1)) != NULL);
+	ASSERT_TRUE(store.Find(Peer(0)) == nullptr);
+	ASSERT_TRUE(store.Find(Peer(9999)) != nullptr);
+	ASSERT_TRUE(store.Find(Peer(1)) != nullptr);
 }
 
 TEST(ChatSessionStore, ActivityRefreshRescuesASessionFromEviction)
@@ -156,8 +156,8 @@ TEST(ChatSessionStore, ActivityRefreshRescuesASessionFromEviction)
 	store.AddOutgoing(Peer(0), "still talking"); // moves Peer(0) to the front
 	store.AddIncoming(Peer(9999), "newcomer", "hi");
 
-	ASSERT_TRUE(store.Find(Peer(0)) != NULL);
-	ASSERT_TRUE(store.Find(Peer(1)) == NULL); // now the least recently active
+	ASSERT_TRUE(store.Find(Peer(0)) != nullptr);
+	ASSERT_TRUE(store.Find(Peer(1)) == nullptr); // now the least recently active
 }
 
 TEST(ChatSessionStore, SessionsAreMostRecentlyActiveFirst)
@@ -182,8 +182,8 @@ TEST(ChatSessionStore, CloseRemovesOnlyThatSession)
 	store.AddIncoming(Peer(2), "bob", "b");
 
 	ASSERT_TRUE(store.CloseSession(Peer(1)));
-	ASSERT_TRUE(store.Find(Peer(1)) == NULL);
-	ASSERT_TRUE(store.Find(Peer(2)) != NULL);
+	ASSERT_TRUE(store.Find(Peer(1)) == nullptr);
+	ASSERT_TRUE(store.Find(Peer(2)) != nullptr);
 	ASSERT_EQUALS(static_cast<size_t>(1), store.SessionCount());
 }
 
@@ -214,7 +214,7 @@ TEST(ChatSessionStore, SessionCarriesTheDecodedIpAndPort)
 	CChatSessionStore store;
 	store.AddIncoming(GUI_ID(0x0A000001u, 4662), "alice", "hi");
 	const CChatSessionStore::Session *s = store.Find(GUI_ID(0x0A000001u, 4662));
-	ASSERT_TRUE(s != NULL);
+	ASSERT_TRUE(s != nullptr);
 	ASSERT_EQUALS(static_cast<uint32>(0x0A000001u), s->ip);
 	ASSERT_EQUALS(static_cast<uint16>(4662), s->port);
 }

--- a/unittests/tests/ChatSessionStoreTest.cpp
+++ b/unittests/tests/ChatSessionStoreTest.cpp
@@ -1,0 +1,220 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include "ChatSessionStore.h"
+#include "OtherFunctions.h" // GUI_ID
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(ChatSessionStore)
+
+namespace
+{
+// Distinct peers that stay distinct as GUI_IDs, so a test asserting on
+// session count is not accidentally asserting on hash collisions.
+uint64 Peer(uint32 n)
+{
+	return GUI_ID(0xC0000000u + n, 4662);
+}
+} // namespace
+
+TEST(ChatSessionStore, StartsEmpty)
+{
+	CChatSessionStore store;
+	ASSERT_EQUALS(static_cast<size_t>(0), store.SessionCount());
+	ASSERT_EQUALS(static_cast<uint32>(0), store.LastMsgId());
+	ASSERT_TRUE(store.Find(Peer(1)) == NULL);
+}
+
+TEST(ChatSessionStore, FirstMessageCreatesSessionWithIdOne)
+{
+	// id 0 is the "no cursor yet" sentinel every reader uses, so the first
+	// real message must be 1 or a client starting at 0 would skip it.
+	CChatSessionStore store;
+	const uint32 id = store.AddIncoming(Peer(1), "alice", "hi");
+	ASSERT_EQUALS(static_cast<uint32>(1), id);
+	ASSERT_EQUALS(static_cast<uint32>(1), store.LastMsgId());
+	ASSERT_EQUALS(static_cast<size_t>(1), store.SessionCount());
+
+	const CChatSessionStore::Session *s = store.Find(Peer(1));
+	ASSERT_TRUE(s != NULL);
+	ASSERT_EQUALS(wxString("alice"), s->name);
+	ASSERT_EQUALS(static_cast<size_t>(1), s->messages.size());
+	ASSERT_EQUALS(wxString("hi"), s->messages[0].text);
+	ASSERT_EQUALS(static_cast<uint8>(CChatSessionStore::DIR_IN), s->messages[0].direction);
+}
+
+TEST(ChatSessionStore, IdsAreMonotonicAcrossSessions)
+{
+	// The store-wide counter is what makes a single `since_id` cursor safe.
+	// Per-session counters would let a client miss a message that landed in
+	// another session while it was polling this one.
+	CChatSessionStore store;
+	ASSERT_EQUALS(static_cast<uint32>(1), store.AddIncoming(Peer(1), "alice", "a"));
+	ASSERT_EQUALS(static_cast<uint32>(2), store.AddIncoming(Peer(2), "bob", "b"));
+	ASSERT_EQUALS(static_cast<uint32>(3), store.AddOutgoing(Peer(1), "c"));
+	ASSERT_EQUALS(static_cast<uint32>(3), store.LastMsgId());
+	ASSERT_EQUALS(static_cast<uint32>(3), store.Find(Peer(1))->LastMsgId());
+	ASSERT_EQUALS(static_cast<uint32>(2), store.Find(Peer(2))->LastMsgId());
+}
+
+TEST(ChatSessionStore, OutgoingDoesNotEraseAKnownPeerName)
+{
+	// An outbound message carries no name. Letting it overwrite would leave
+	// a session we already had a nick for rendering as a bare ip:port the
+	// moment the user replied.
+	CChatSessionStore store;
+	store.AddIncoming(Peer(1), "alice", "hi");
+	store.AddOutgoing(Peer(1), "hello back");
+	ASSERT_EQUALS(wxString("alice"), store.Find(Peer(1))->name);
+}
+
+TEST(ChatSessionStore, LaterNameFillsInAnEmptyOne)
+{
+	// The reverse case: a peer whose nick was unknown on the first message
+	// must pick it up when a later one carries it.
+	CChatSessionStore store;
+	store.AddIncoming(Peer(1), wxEmptyString, "hi");
+	ASSERT_TRUE(store.Find(Peer(1))->name.IsEmpty());
+	store.AddIncoming(Peer(1), "alice", "again");
+	ASSERT_EQUALS(wxString("alice"), store.Find(Peer(1))->name);
+}
+
+TEST(ChatSessionStore, MessageCapEvictsOldestKeepingIdsIntact)
+{
+	// The 201st message drops the 1st; ids are NOT renumbered, because a
+	// client holding a cursor into the evicted range must still advance past
+	// it rather than re-reading.
+	CChatSessionStore store;
+	const size_t cap = CChatSessionStore::MAX_MESSAGES_PER_SESSION;
+	for (size_t i = 0; i < cap; ++i) {
+		store.AddIncoming(Peer(1), "alice", wxString::Format("m%zu", i));
+	}
+	const CChatSessionStore::Session *s = store.Find(Peer(1));
+	ASSERT_EQUALS(cap, s->messages.size());
+	ASSERT_EQUALS(wxString("m0"), s->messages.front().text);
+	ASSERT_EQUALS(static_cast<uint32>(1), s->messages.front().id);
+
+	store.AddIncoming(Peer(1), "alice", "overflow");
+	s = store.Find(Peer(1));
+	ASSERT_EQUALS(cap, s->messages.size());
+	ASSERT_EQUALS(wxString("m1"), s->messages.front().text);
+	ASSERT_EQUALS(static_cast<uint32>(2), s->messages.front().id);
+	ASSERT_EQUALS(wxString("overflow"), s->messages.back().text);
+	ASSERT_EQUALS(static_cast<uint32>(cap + 1), s->messages.back().id);
+}
+
+TEST(ChatSessionStore, SessionCapEvictsLeastRecentlyActive)
+{
+	CChatSessionStore store;
+	const size_t cap = CChatSessionStore::MAX_SESSIONS;
+	for (size_t i = 0; i < cap; ++i) {
+		store.AddIncoming(Peer(static_cast<uint32>(i)), "peer", "hi");
+	}
+	ASSERT_EQUALS(cap, store.SessionCount());
+
+	// Peer(0) is the least recently active, so it is the one to go.
+	store.AddIncoming(Peer(9999), "newcomer", "hi");
+	ASSERT_EQUALS(cap, store.SessionCount());
+	ASSERT_TRUE(store.Find(Peer(0)) == NULL);
+	ASSERT_TRUE(store.Find(Peer(9999)) != NULL);
+	ASSERT_TRUE(store.Find(Peer(1)) != NULL);
+}
+
+TEST(ChatSessionStore, ActivityRefreshRescuesASessionFromEviction)
+{
+	// Eviction is by activity, not by creation order: a long-running
+	// conversation must not be dropped just because it started first.
+	CChatSessionStore store;
+	const size_t cap = CChatSessionStore::MAX_SESSIONS;
+	for (size_t i = 0; i < cap; ++i) {
+		store.AddIncoming(Peer(static_cast<uint32>(i)), "peer", "hi");
+	}
+	store.AddOutgoing(Peer(0), "still talking"); // moves Peer(0) to the front
+	store.AddIncoming(Peer(9999), "newcomer", "hi");
+
+	ASSERT_TRUE(store.Find(Peer(0)) != NULL);
+	ASSERT_TRUE(store.Find(Peer(1)) == NULL); // now the least recently active
+}
+
+TEST(ChatSessionStore, SessionsAreMostRecentlyActiveFirst)
+{
+	CChatSessionStore store;
+	store.AddIncoming(Peer(1), "alice", "a");
+	store.AddIncoming(Peer(2), "bob", "b");
+	store.AddIncoming(Peer(3), "carol", "c");
+	store.AddOutgoing(Peer(1), "reply to alice");
+
+	std::vector<const CChatSessionStore::Session *> list = store.Sessions();
+	ASSERT_EQUALS(static_cast<size_t>(3), list.size());
+	ASSERT_EQUALS(Peer(1), list[0]->gui_id);
+	ASSERT_EQUALS(Peer(3), list[1]->gui_id);
+	ASSERT_EQUALS(Peer(2), list[2]->gui_id);
+}
+
+TEST(ChatSessionStore, CloseRemovesOnlyThatSession)
+{
+	CChatSessionStore store;
+	store.AddIncoming(Peer(1), "alice", "a");
+	store.AddIncoming(Peer(2), "bob", "b");
+
+	ASSERT_TRUE(store.CloseSession(Peer(1)));
+	ASSERT_TRUE(store.Find(Peer(1)) == NULL);
+	ASSERT_TRUE(store.Find(Peer(2)) != NULL);
+	ASSERT_EQUALS(static_cast<size_t>(1), store.SessionCount());
+}
+
+TEST(ChatSessionStore, CloseOfUnknownSessionReportsFailure)
+{
+	// The EC handler answers "no such session" off this return rather than
+	// silently succeeding, so an unknown id must be distinguishable.
+	CChatSessionStore store;
+	ASSERT_TRUE(!store.CloseSession(Peer(1)));
+}
+
+TEST(ChatSessionStore, IdsKeepAdvancingAfterAClose)
+{
+	// Reopening a closed conversation must not reissue ids a client already
+	// holds: the counter is store-wide and never rewinds.
+	CChatSessionStore store;
+	store.AddIncoming(Peer(1), "alice", "a");
+	store.AddIncoming(Peer(1), "alice", "b");
+	store.CloseSession(Peer(1));
+	ASSERT_EQUALS(static_cast<uint32>(3), store.AddIncoming(Peer(1), "alice", "c"));
+	ASSERT_EQUALS(static_cast<size_t>(1), store.Find(Peer(1))->messages.size());
+}
+
+TEST(ChatSessionStore, SessionCarriesTheDecodedIpAndPort)
+{
+	// The REST layer keys conversations on "<ip>:<port>", so the split has
+	// to survive the GUI_ID round trip.
+	CChatSessionStore store;
+	store.AddIncoming(GUI_ID(0x0A000001u, 4662), "alice", "hi");
+	const CChatSessionStore::Session *s = store.Find(GUI_ID(0x0A000001u, 4662));
+	ASSERT_TRUE(s != NULL);
+	ASSERT_EQUALS(static_cast<uint32>(0x0A000001u), s->ip);
+	ASSERT_EQUALS(static_cast<uint16>(4662), s->port);
+}

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -299,6 +299,212 @@ void AddEncodedPartStatus(CECTag &parent, RLE_Data &enc, const ArrayOfUInts16 &s
 
 } // namespace
 
+// ----------------------------------------------------------------------
+// Chat sessions -- EC_OP_CHAT_SESSIONS (issue #971). The reply is the
+// daemon's COMPLETE session set plus only the messages newer than the
+// cursor the client sent, so the walker replaces the session vector
+// wholesale while appending messages incrementally. A session missing
+// from a reply is the ONLY signal a close produces.
+// ----------------------------------------------------------------------
+
+namespace
+{
+
+// Build one EC_TAG_CHAT_SESSION container the way the daemon does.
+CECTag MakeChatSession(std::uint64_t gui_id, const char *name)
+{
+	CECTag t(EC_TAG_CHAT_SESSION, gui_id);
+	t.AddTag(CECTag(EC_TAG_CHAT_PEER_NAME, wxString::FromAscii(name)));
+	return t;
+}
+
+void AddChatMessage(CECTag &session, std::uint32_t id, bool outgoing, std::uint32_t ts, const char *text)
+{
+	CECTag m(EC_TAG_CHAT_MESSAGE, wxString::FromUTF8(text));
+	m.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, id));
+	m.AddTag(CECTag(EC_TAG_CHAT_DIRECTION, static_cast<std::uint8_t>(outgoing ? 1 : 0)));
+	m.AddTag(CECTag(EC_TAG_CHAT_TIMESTAMP, ts));
+	session.AddTag(m);
+}
+
+// GUI_ID for 10.0.0.1:4662, LSB-first like the wire.
+const std::uint64_t kPeerA = (static_cast<std::uint64_t>(0x0100000Au) << 16) | 4662u;
+const std::uint64_t kPeerB = (static_cast<std::uint64_t>(0x0200000Au) << 16) | 4662u;
+
+} // namespace
+
+TEST(Refresher, ChatSessionDecodesIdentityAndMessages)
+{
+	std::vector<ChatSessionSnapshot> cache;
+	std::uint32_t cursor = 0;
+	std::vector<ChatSessionSnapshot> fresh;
+	std::vector<std::uint64_t> closed;
+
+	CECPacket resp(EC_OP_CHAT_SESSIONS);
+	resp.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, static_cast<std::uint32_t>(2)));
+	{
+		CECTag s = MakeChatSession(kPeerA, "alice");
+		s.AddTag(CECTag(EC_TAG_CLIENT, static_cast<std::uint32_t>(77)));
+		s.AddTag(CECTag(EC_TAG_FRIEND, static_cast<std::uint32_t>(12)));
+		AddChatMessage(s, 1, false, 1000, "hi");
+		AddChatMessage(s, 2, true, 1001, "hello back");
+		resp.AddTag(s);
+	}
+
+	ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	ASSERT_EQUALS(kPeerA, cache[0].gui_id);
+	// GUI_ID splits back into the REST conversation key.
+	ASSERT_EQUALS(std::string("10.0.0.1"), cache[0].ip);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(4662), cache[0].port);
+	ASSERT_EQUALS(std::string("10.0.0.1:4662"), cache[0].PeerKey());
+	ASSERT_EQUALS(std::string("alice"), cache[0].name);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(77), cache[0].client_ecid);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(12), cache[0].friend_ecid);
+	ASSERT_EQUALS(static_cast<size_t>(2), cache[0].messages.size());
+	ASSERT_TRUE(!cache[0].messages[0].outgoing);
+	ASSERT_TRUE(cache[0].messages[1].outgoing);
+	ASSERT_EQUALS(std::string("hello back"), cache[0].messages[1].text);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(2), cursor);
+	ASSERT_EQUALS(static_cast<size_t>(1), fresh.size());
+	ASSERT_TRUE(closed.empty());
+}
+
+TEST(Refresher, ChatMessagesAccumulateAcrossTicks)
+{
+	// Later replies carry only what is past the cursor, so the walker must
+	// carry the earlier messages over rather than replacing them -- otherwise
+	// every tick would shrink the transcript to whatever just arrived.
+	std::vector<ChatSessionSnapshot> cache;
+	std::uint32_t cursor = 0;
+	{
+		std::vector<ChatSessionSnapshot> fresh;
+		std::vector<std::uint64_t> closed;
+		CECPacket resp(EC_OP_CHAT_SESSIONS);
+		resp.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, static_cast<std::uint32_t>(1)));
+		CECTag s = MakeChatSession(kPeerA, "alice");
+		AddChatMessage(s, 1, false, 1000, "first");
+		resp.AddTag(s);
+		ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+	}
+	{
+		std::vector<ChatSessionSnapshot> fresh;
+		std::vector<std::uint64_t> closed;
+		CECPacket resp(EC_OP_CHAT_SESSIONS);
+		resp.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, static_cast<std::uint32_t>(2)));
+		CECTag s = MakeChatSession(kPeerA, "alice");
+		AddChatMessage(s, 2, true, 1001, "second");
+		resp.AddTag(s);
+		ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+		// Only the genuinely new one is reported for SSE.
+		ASSERT_EQUALS(static_cast<size_t>(1), fresh.size());
+		ASSERT_EQUALS(static_cast<size_t>(1), fresh[0].messages.size());
+		ASSERT_EQUALS(std::string("second"), fresh[0].messages[0].text);
+	}
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	ASSERT_EQUALS(static_cast<size_t>(2), cache[0].messages.size());
+	ASSERT_EQUALS(std::string("first"), cache[0].messages[0].text);
+	ASSERT_EQUALS(std::string("second"), cache[0].messages[1].text);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(2), cursor);
+}
+
+TEST(Refresher, ChatSessionAbsentFromReplyIsReportedClosed)
+{
+	// Absence IS the close signal -- there is no expiry tag -- so a session
+	// the previous tick held must be dropped AND reported, not merged
+	// forward. Merging would resurrect closed conversations forever.
+	std::vector<ChatSessionSnapshot> cache;
+	std::uint32_t cursor = 0;
+	{
+		std::vector<ChatSessionSnapshot> fresh;
+		std::vector<std::uint64_t> closed;
+		CECPacket resp(EC_OP_CHAT_SESSIONS);
+		CECTag a = MakeChatSession(kPeerA, "alice");
+		AddChatMessage(a, 1, false, 1000, "hi");
+		resp.AddTag(a);
+		resp.AddTag(MakeChatSession(kPeerB, "bob"));
+		ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+		ASSERT_EQUALS(static_cast<size_t>(2), cache.size());
+	}
+	{
+		std::vector<ChatSessionSnapshot> fresh;
+		std::vector<std::uint64_t> closed;
+		CECPacket resp(EC_OP_CHAT_SESSIONS);
+		resp.AddTag(MakeChatSession(kPeerB, "bob"));
+		ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+		ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+		ASSERT_EQUALS(kPeerB, cache[0].gui_id);
+		ASSERT_EQUALS(static_cast<size_t>(1), closed.size());
+		ASSERT_EQUALS(kPeerA, closed[0]);
+	}
+}
+
+TEST(Refresher, ChatSessionWithNoNewMessagesIsStillListed)
+{
+	// A session with nothing past the cursor still encodes, with no message
+	// children: that is how a client connecting late learns it exists at all.
+	std::vector<ChatSessionSnapshot> cache;
+	std::uint32_t cursor = 0;
+	std::vector<ChatSessionSnapshot> fresh;
+	std::vector<std::uint64_t> closed;
+
+	CECPacket resp(EC_OP_CHAT_SESSIONS);
+	resp.AddTag(CECTag(EC_TAG_CHAT_MSG_ID, static_cast<std::uint32_t>(9)));
+	resp.AddTag(MakeChatSession(kPeerA, "alice"));
+
+	ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
+	ASSERT_TRUE(cache[0].messages.empty());
+	// Nothing to emit an SSE frame for.
+	ASSERT_TRUE(fresh.empty());
+	// The cursor still advances, so ids evicted on the daemon are not
+	// requested forever.
+	ASSERT_EQUALS(static_cast<std::uint32_t>(9), cursor);
+}
+
+TEST(Refresher, ChatSessionKeepsAKnownNameWhenTheReplyOmitsIt)
+{
+	// The daemon suppresses an unchanged name; letting that blank the cached
+	// one would make an established conversation fall back to its ip:port
+	// label mid-stream.
+	std::vector<ChatSessionSnapshot> cache;
+	std::uint32_t cursor = 0;
+	{
+		std::vector<ChatSessionSnapshot> fresh;
+		std::vector<std::uint64_t> closed;
+		CECPacket resp(EC_OP_CHAT_SESSIONS);
+		resp.AddTag(MakeChatSession(kPeerA, "alice"));
+		ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+	}
+	{
+		std::vector<ChatSessionSnapshot> fresh;
+		std::vector<std::uint64_t> closed;
+		CECPacket resp(EC_OP_CHAT_SESSIONS);
+		resp.AddTag(CECTag(EC_TAG_CHAT_SESSION, kPeerA)); // no name child
+		ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+	}
+	ASSERT_EQUALS(std::string("alice"), cache[0].name);
+	ASSERT_EQUALS(std::string("alice"), cache[0].DisplayName());
+}
+
+TEST(Refresher, ChatSessionWithoutANameFallsBackToAddress)
+{
+	std::vector<ChatSessionSnapshot> cache;
+	std::uint32_t cursor = 0;
+	std::vector<ChatSessionSnapshot> fresh;
+	std::vector<std::uint64_t> closed;
+
+	CECPacket resp(EC_OP_CHAT_SESSIONS);
+	resp.AddTag(CECTag(EC_TAG_CHAT_SESSION, kPeerA));
+	ApplyChatSessions(&resp, cache, cursor, fresh, closed);
+
+	// The same string the desktop builds, and the one the SSE payload and
+	// the REST list must agree on.
+	ASSERT_EQUALS(std::string("IP: 10.0.0.1 Port: 4662"), cache[0].DisplayName());
+}
+
 TEST(Refresher, SharedKnownFileDecodesAvailability)
 {
 	std::map<std::uint32_t, PartFileEncoderData> rle_state;


### PR DESCRIPTION
Closes #971.

Chat worked only in the monolithic client. Over EC it was half-built — receiving was a destructive per-connection relay with no history, and sending did not exist at all (`CChatSelector::SendMessage` carried a literal `// #warning EC needed here.`). amuleapi got nothing.

This moves the chat model into the core as a session store that both builds feed, then serves it over EC and REST. The local GUI, amulegui and amuleapi become three views of one conversation instead of three private ones.

### Core

`CChatSessionStore`, owned by `CamuleApp`, built into amule + amuled with no GUI dependency. Fed at the two choke points that already exist and that both builds reach: `CUpDownClient::ProcessChatMessage` inbound (after the filter/spammer branches, so a filtered message is not stored) and `CClientList::SendChatMessage` outbound.

Outbound is recorded regardless of the send result on purpose: a `false` return means *queued while connecting*, not *failed*, so gating on it would drop exactly the messages a slow peer receives a moment later.

Message ids are monotonic across the whole store rather than per session, which is what makes a single resume cursor safe — a per-session counter would let a client miss a message that landed elsewhere while it polled. Ids are never renumbered on eviction, so a cursor into an evicted range still advances instead of re-reading. Bounded at 200 messages per session and 50 sessions, evicting the least recently *active* session so a long-running conversation is not dropped for having started first.

In memory only; a restart empties it, as the desktop's transcript already does. Persistence is a self-contained follow-up needing no EC change.

### EC

Four ops. `EC_OP_GET_CHAT_SESSIONS` (`0x63`) returns the session list **and** every message newer than the client's cursor in one roundtrip, so an idle connection costs one small packet and a busy one needs no follow-up. `EC_OP_CHAT_SEND` (`0x65`) and `EC_OP_CHAT_CLOSE_SESSION` (`0x66`) complete it. Six new `0x09xx` tags carry session identity, message id, direction and timestamp.

`EC_OP_GET_CHAT_MESSAGES` (`0x5B`) is re-specified as a non-destructive backfill of one session. Its previous form — a destructive drain of a per-connection queue — is gone along with the queue, the 100-message cap and the fan-out. That is safe because the entire chat-over-EC surface is post-3.0.1: no released client can issue any of these opcodes. It also fixes the root problem, that a message arriving while no EC client was attached was lost with nowhere to buffer it.

Sending resolves a target three ways: GUI\_ID to reply without a lookup, client ECID for a live peer, and friend ECID for a friend who may be **offline** — resolved through the stored address, which is what makes messaging an offline friend work.

Closing is global, matching how closing a search tab frees the search for every client. Clients learn of it from the session's absence in the next reply, so no expiry tag is needed.

**Capability.** The ops are gated on a new `EC_TAG_CAN_CHAT_SESSIONS` (`0x0027`), deliberately **not** the existing `EC_TAG_CAN_CHAT` (`0x0016`). Reusing `0x0016` looked free — it never shipped in a tagged release — but the echo direction is what a client reads to decide whether the opcodes exist, and daemons built from master since #517 echo it while implementing none of them. Such a daemon looks capable, receives `0x63`, and lands in the unknown-opcode branch: `wxFAIL` on a debug build; on release, `invalid opcode received: 0x63` once per refresher tick, forever. Reuse would also ship `0x0016` in a *new* meaning in 3.1.0 while master daemons echo the *old* one, leaving a released client unable to tell them apart. One tag number out of ~216 free in that block avoids both.

### amulegui

Polls with a resume cursor, so it now sees sessions that started before it connected, with their history, rather than an empty tab. History replay deliberately bypasses `ProcessMessage`: that path sets the new-message blink, and a reconnect must not light the Messages button up for messages already read elsewhere. Only arrivals past the connect-time cursor blink.

Sending works — the `#warning` is gone and the compose box and Send button enable for both builds. amulegui does not echo the sent line locally; the core records it and the next poll renders it, so echoing too would print it twice and in the wrong order.

Closing propagates both ways: a session absent from a reply drops its tab without echoing a close back, and a user-initiated close originates one from a single page-closing handler covering all four close paths.

### amuleapi

Six routes: `GET /chats`, `GET`+`POST /chats/{peer}/messages`, `DELETE /chats/{peer}`, and the ECID-addressed `POST /friends/{ecid}/messages` and `POST /clients/{ecid}/messages`. Conversations are keyed on `"<ip>:<port>"` — the readable form of the GUI\_ID the wire already uses, stable across peer reconnects unlike an ECID.

One gated roundtrip per tick carrying the previous cursor, skipped entirely without the capability; every route then answers `503 ec_unsupported` rather than sending an opcode that would assert on an older core. SSE gains `chat_message` and `chat_session_closed` on the existing stream, published straight from the walker's output rather than by diffing — the wire already said exactly what is new.

### Incidental fixes

- `MuleNotify::Chat_SessionRemoved` closed the tab via unguarded `EndSession`, so a close from one client made every other client echo a redundant close back. Now goes through a guarded path.
- `CScopedFlag` moves from a private class in `SearchDlg.cpp` to `ScopedPtr.h`. Its comment said one notebook close handler did not justify a shared header; chat's is the second, so it is shared rather than copied.
- `IPv4ToDotted` moves from the refresher's anonymous namespace into `State`, since building a peer key from a GUI\_ID needs it with no walker involved.
- The SSE payload was emitting an empty `name` where the REST list rendered the address fallback; both now use one `DisplayName()`.

### Verification

- **Real network, remote peer.** A message sent through `POST /chats/{peer}/messages` from a local node was received and logged by a separate aMule instance running a *different, older* build on another host.
- **Bidirectional, two daemons.** A→B then B→A; both transcripts show the same two messages with mirrored `direction`, and ids monotonic per process.
- **Capability gate.** Against a daemon echoing only the old tag — the deployed-master case — `/chats` answers `503 ec_unsupported` and **zero** unknown opcodes reach the daemon. The same daemon with the gate reverted to the old design answers `200`, i.e. it would proceed to send, confirming the test is not vacuous.
- **cctest** 36/36. 13 store cases and 6 walker cases, both negative-controlled: breaking activity-order eviction fails two store tests, and making the walker merge instead of replace fails close detection.
- **curl** new `38-chat.sh`, 42/42 — wire shapes, `since_id` cursor, name fallback, validation, method gating, guest read-but-not-write, close-then-404. Single-node by construction: it addresses an RFC 5737 TEST-NET-3 peer, so the whole local path runs with nothing leaving the host.
- clang-format clean on 39 files; clang-tidy Tier-1 and Tier-2 clean with 0 compiler errors.

### Not covered

The inbound direction and real peer delivery are verified by hand, not in CI — the curl harness has no way to stand up a second daemon pair. Worth a follow-up; right now the inbound path has no regression net, though the walker tests do pin the decode contract.

Web UI for chat is out of scope here, as the issue allows.
