### PR TITLE
fix(web-ui): refresh unopened tab badges by re-listing on view mount

### DIFF
--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -167,6 +167,7 @@ async function adopt() {
   if (added) publishTabs();
 }
 
+// Debounced adopt, so the first mount's own adopt() is not doubled.
 function nudgeAdopt() {
   if (!started || Date.now() - lastAdopt < ADOPT_DEBOUNCE_MS) return;
   adopt();
@@ -285,6 +286,7 @@ export const searches = {
   setActive,
   refresh,
   adopt,
+  nudgeAdopt,
 
   // Per-tab UI state. Read at render time; every write republishes the tab
   // list, which is what re-renders the view.

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -45,6 +45,9 @@ export default function Search({ isGuest }) {
     // already holds (this browser's searches, another client's, or ones
     // restored across a restart).
     searches.ensure();
+    // An unopened tab has no amuleapi slot, so no SSE refreshes its badge --
+    // re-list on every mount instead. Debounced, so the first one is free.
+    searches.nudgeAdopt();
     api.get("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
   }, []);
 

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -1055,6 +1055,10 @@ if [ -n "$PEER_ECID" ]; then
 			'GET /search reports the browse with kind=browse'
 		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].client_ecid" \
 			"$PEER_ECID" 'GET /search reports the browsed peer as client_ecid'
+		# Files received from the peer so far -- no total comparison, a browse
+		# is still running here.
+		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].result_count | type" \
+			number 'GET /search carries a numeric result_count on the browse'
 
 		# Give the peer a moment to answer, then check the browse-only
 		# folder field. An unreachable/denying peer returns nothing, which


### PR DESCRIPTION
#1036 seeded each tab's badge from the result_count that GET /search now reports, which fixed the reload case, and kept an unopened tab's badge current "on re-adoption". That second half almost never ran: adopt() fires once from searches.ensure(), which is idempotent, and otherwise only from nudgeAdopt() when an SSE frame arrives for an unknown search_id.

An unopened tab has no amuleapi slot either -- slots are seeded only by RequireSearch -> DiscoverSearchIfHeldByCore on a per-id request -- so the refresher never polls that search and no search_progress event ever reaches onProgress to move its count. A running search adopted at load therefore kept the badge from that snapshot until the user clicked its tab.

Re-list on every mount of the search view instead, reusing the existing nudgeAdopt() rather than adding a timer: navigating back to Search is when a stale badge is about to be looked at, and the 3 s debounce means the first mount's own adopt() is not doubled. Verified in the browser: one GET /search on load, and one more on returning to the view, badges unchanged.

Also adds the result_count assertion the issue asked for on the browse case in 19-search.sh, which #1036 only added for the search it starts itself. It sits with its neighbours inside the connected-peer branch, so it skips rather than fails with no peer, and asserts the type only -- a browse is still running there, and result_count is only guaranteed to equal the results endpoint's total once a search has finished.