### PR TITLE
feat(amuleapi): expose hashing progress on the shared side and on the downloads list

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -226,7 +226,7 @@ Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR
 
 #### `download_added` / `download_updated`
 
-Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) list-item shape. `_updated` fires on any field-level change including `size_done`, `size_xfer`, `speed_bps`, the source counters, and `kad_comment_search_running` — clients see live progress (and the Kad-notes lookup start → finish edge) without polling.
+Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) list-item shape. `_updated` fires on any field-level change including `size_done`, `size_xfer`, `speed_bps`, the source counters, `kad_comment_search_running` and `hashing_progress` — clients see live progress (and the Kad-notes lookup start → finish edge, and a running hash) without polling.
 
 ```json
 {
@@ -243,7 +243,8 @@ Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) lis
   "category":      0,
   "sources":  { "total": 217, "not_current": 23, "transferring": 8, "a4af": 4 },
   "progress": { "percent": 29.85 },
-  "kad_comment_search_running": false
+  "kad_comment_search_running": false,
+  "hashing_progress": 0
 }
 ```
 
@@ -278,7 +279,7 @@ Downloads only. It's kept separate from `download_updated` so the per-tick downl
 
 #### `shared_added` / `shared_updated`
 
-Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item shape. `_updated` fires on any field-level change including `priority`, `priority_auto`, `xfer.session`, `xfer.total`, `requests.*`, and `accepts.*` — clients see live upload counters (and priority changes) without polling.
+Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item shape. `_updated` fires on any field-level change including `priority`, `priority_auto`, `xfer.session`, `xfer.total`, `requests.*`, `accepts.*` and `hashing_progress` — clients see live upload counters (and priority changes, and a running hash) without polling.
 
 ```json
 {
@@ -291,9 +292,16 @@ Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item
   "complete_sources": 12,
   "xfer":     { "session": 5242880, "total": 314572800 },
   "requests": { "session": 42,      "total": 1837 },
-  "accepts":  { "session": 18,      "total": 921 }
+  "accepts":  { "session": 18,      "total": 921 },
+  "upload_speed_bps": 51200,
+  "uploading":        2,
+  "last_upload":      1700000500,
+  "shared_since":     1699000000,
+  "hashing_progress": 0
 }
 ```
+
+`hashing_progress` counts the parts hashed so far by a [`POST /shared/{hash}/verify`](REFERENCE.md#post-apiv0sharedhashverify) run or an AICH hashset rebuild, and is `0` when nothing is hashing — each advance pushes a `shared_updated`, so a progress bar can be driven straight off the stream. A file that is both downloading and shared reports the same value on both channels.
 
 #### `shared_removed`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -658,7 +658,8 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
       "category":      0,
       "sources":  { "total": 217, "not_current": 23, "transferring": 8, "a4af": 4 },
       "progress": { "percent": 29.85 },
-      "kad_comment_search_running": false
+      "kad_comment_search_running": false,
+      "hashing_progress": 0
     }
   ]
 }
@@ -671,6 +672,8 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
 The list shape omits `progress.parts` to keep large libraries compact. Use the detail endpoint for per-part state.
 
 `kad_comment_search_running` is `true` while an on-demand Kad notes lookup is in flight for the file (started by [`POST /downloads/{hash}/comments`](#post-apiv0downloadshashcomments)); it flips back to `false` when the lookup finishes. Because it lives on the download object, a client can watch the `download_updated` SSE event for the start → finish transition instead of polling.
+
+`hashing_progress` is the number of parts hashed so far by a pass running over the file — a `hashing` status, an [`AICH`](#post-apiv0sharedhashverify) hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `part_count`; divide by `part_count` (from the detail endpoint, or `ceil(size / 9728000)`) for a percentage.
 
 The SSE `download_added` / `download_updated` event payload matches this object byte-for-byte.
 
@@ -698,7 +701,6 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `available_part_count` | int | Number of parts available across the current sources. |
 | `part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
 | `remaining_time` | int | ETA in seconds; `-1` when stalled or paused (speed ≈ 0). |
-| `hashing_progress` | int | Index of the part currently being hashed (0 when idle). |
 | `lost_to_corruption` | int | Bytes discarded to corruption. |
 | `gained_by_compression` | int | Bytes saved by on-the-wire compression. |
 | `saved_by_ich` | int | Packets recovered by Intelligent Corruption Handling. |
@@ -1299,7 +1301,8 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
       "upload_speed_bps": 51200,
       "uploading":        2,
       "last_upload":      1700000500,
-      "shared_since":     1699000000
+      "shared_since":     1699000000,
+      "hashing_progress": 0
     }
   ]
 }
@@ -1310,6 +1313,10 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 `upload_speed_bps` is the file's current combined upload rate in bytes/sec (summed over the peers it is uploading to), and `uploading` is how many peers it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading` from the queued-client count (`queued_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload` is the unix timestamp of the last time data was sent for the file, and `shared_since` is when the file was completed or first shared; both are persisted in `known.met` and are `0` when unknown — a file that has never uploaded, or a `known.met` entry written before these fields existed.
 
 `priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`. For a file that is both downloading and shared this upload priority is independent of the download priority reported by [`GET /api/v0/downloads`](#get-apiv0downloads).
+
+`hashing_progress` is the number of parts hashed so far by a pass running over the file — a [`POST /shared/{hash}/verify`](#post-apiv0sharedhashverify) run, or an AICH hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `part_count` (see the detail endpoint, or compute `ceil(size / 9728000)`).
+
+A file that is both downloading and shared reports its progress here as well: amuled describes such a file as a partfile, so the value is read across from the download side and the two agree. That makes `hashing_progress` usable from either list without checking which one owns the file.
 
 The SSE `shared_added` / `shared_updated` event payload matches this object byte-for-byte, so a subscriber that received `shared_updated` does not need to re-GET to see the moved counters.
 
@@ -1339,6 +1346,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `comment` | string | The user's own comment on this file (`""` if none). |
 | `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). |
 | `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **Omitted entirely** when the file has no probed metadata. |
+
+`hashing_progress` comes through from the list item; pair it with `part_count` here for a percentage.
 
 `parts[].sources` is how many peers currently requesting this file hold that part — an **availability** measure, not a progress one. A shared file is fully local by definition, so a part with `"sources": 0` means no other peer has it and you are its only source. Counts saturate at `255`.
 
@@ -1486,6 +1495,8 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 ```
 
 Returns `202 Accepted`. amuled queues the hashing task and answers immediately, so the response confirms only that the re-hash was **scheduled** — it never carries the outcome, and a large file may take minutes to finish.
+
+**Watching it run.** While the task is hashing, `hashing_progress` on the file's [`GET /shared`](#get-apiv0shared) row counts the parts done so far, and each advance pushes a `shared_updated` SSE event — enough to drive a progress bar without polling. It returns to `0` when the task finishes or aborts, which is the signal that the log line below is available.
 
 **Reading the result.** The verdict is emitted as an amule log line when the task completes, so read it back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel:
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2471,6 +2471,11 @@ void WriteDownloadObject(
 	// clients can watch download_updated for the start -> finish transition.
 	w.Key("kad_comment_search_running");
 	w.ValueBool(f.download.kad_comment_searching);
+	// On the list, not detail-only: a client rendering a hashing indicator
+	// needs it wherever the file appears, and it only moves while a hash is
+	// actually running. Parts hashed so far, not an index -- 0 when idle.
+	w.Key("hashing_progress");
+	w.ValueInt(static_cast<int64_t>(f.download.hashing_progress));
 	if (detail) {
 		// Detail-only fields (GET /downloads/{hash}); omitted from the
 		// list. `part_count` and `remaining_time` are computed here from
@@ -2497,8 +2502,6 @@ void WriteDownloadObject(
 		w.ValueInt(part_count);
 		w.Key("remaining_time");
 		w.ValueInt(remaining_time);
-		w.Key("hashing_progress");
-		w.ValueInt(static_cast<int64_t>(f.download.hashing_progress));
 		w.Key("lost_to_corruption");
 		w.ValueInt(static_cast<int64_t>(f.download.lost_to_corruption));
 		w.Key("gained_by_compression");
@@ -2810,6 +2813,11 @@ void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.ValueInt(static_cast<int64_t>(f.shared.last_upload));
 	w.Key("shared_since");
 	w.ValueInt(static_cast<int64_t>(f.shared.shared_since));
+	// Parts hashed so far by a Verify Local Data or an AICH hashset rebuild
+	// over this share; 0 when idle. Goes through the accessor so a shared
+	// download, which amuled reports as a partfile, still reads correctly.
+	w.Key("hashing_progress");
+	w.ValueInt(static_cast<int64_t>(webapi::SharedHashingProgress(f)));
 }
 
 void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -124,7 +124,7 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	  << ",\"a4af\":" << f.download.sources_a4af << "}"
 	  << ",\"progress\":{\"percent\":" << JsonDoubleToString(f.download.percent) << "}"
 	  << ",\"kad_comment_search_running\":" << (f.download.kad_comment_searching ? "true" : "false")
-	  << "}";
+	  << ",\"hashing_progress\":" << f.download.hashing_progress << "}";
 	return o.str();
 }
 
@@ -168,7 +168,8 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << ",\"total\":" << f.shared.accepts_total << "}"
 	  << ",\"upload_speed_bps\":" << f.shared.upload_speed_bps
 	  << ",\"uploading\":" << f.shared.uploading_count << ",\"last_upload\":" << f.shared.last_upload
-	  << ",\"shared_since\":" << f.shared.shared_since << "}";
+	  << ",\"shared_since\":" << f.shared.shared_since
+	  << ",\"hashing_progress\":" << SharedHashingProgress(f) << "}";
 	return o.str();
 }
 
@@ -332,7 +333,8 @@ bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 	       a.download.sources_transferring == b.download.sources_transferring &&
 	       a.download.sources_a4af == b.download.sources_a4af &&
 	       a.download.percent == b.download.percent &&
-	       a.download.kad_comment_searching == b.download.kad_comment_searching;
+	       a.download.kad_comment_searching == b.download.kad_comment_searching &&
+	       a.download.hashing_progress == b.download.hashing_progress;
 }
 
 // Comment list equality (deliberately NOT part of EqualDownload — a comment
@@ -363,7 +365,12 @@ bool EqualShared(const FileSnapshot &a, const FileSnapshot &b)
 	       a.shared.accepts_total == b.shared.accepts_total &&
 	       a.shared.upload_speed_bps == b.shared.upload_speed_bps &&
 	       a.shared.uploading_count == b.shared.uploading_count &&
-	       a.shared.last_upload == b.shared.last_upload && a.shared.shared_since == b.shared.shared_since;
+	       a.shared.last_upload == b.shared.last_upload &&
+	       a.shared.shared_since == b.shared.shared_since &&
+	       // Through the accessor, not the raw field: a shared download's
+	       // progress lives on the download side, and comparing the raw
+	       // field would hold every tick of it back from shared_updated.
+	       SharedHashingProgress(a) == SharedHashingProgress(b);
 }
 bool Equal(const ServerSnapshot &a, const ServerSnapshot &b)
 {

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1173,6 +1173,14 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 			f.shared.complete_sources_low = v;
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_COMPLETE_SOURCES_HIGH, v))
 			f.shared.complete_sources_high = v;
+
+		// Parts hashed so far by a Verify Local Data or an AICH hashset
+		// rebuild over this complete share. Rides every update tick,
+		// CValueMap-suppressed when unchanged, so it moves only while a
+		// hash is actually running. The partfile equivalent is decoded
+		// into download.hashing_progress above.
+		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_HASHED_PART_COUNT, v))
+			f.shared.hashing_progress = v;
 	}
 	{
 		std::uint8_t pr = 0;

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -40,6 +40,11 @@ std::uint64_t PartCountForSize(std::uint64_t size)
 	return (size + kPartSizeBytes - 1) / kPartSizeBytes;
 }
 
+std::uint16_t SharedHashingProgress(const FileSnapshot &f)
+{
+	return f.shared.hashing_progress ? f.shared.hashing_progress : f.download.hashing_progress;
+}
+
 // Completeness of the file we download FROM this peer: parts the peer has over
 // that file's part count. Only the download link carries a meaningful
 // denominator -- a peer that merely downloads from us has no percent. Left at

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -251,6 +251,18 @@ struct FileSnapshot
 		// to 255 by the RLE encoder's uint8 buffer.
 		std::vector<std::uint16_t> decoded_part_sources;
 
+		// Parts hashed so far by a pass running over this complete share --
+		// Verify Local Data, or an AICH hashset rebuild -- decoded from
+		// EC_TAG_KNOWNFILE_HASHED_PART_COUNT on the EC_TAG_KNOWNFILE tag.
+		// A count, not an index: the tasks report part + 1. 0 means idle,
+		// which both tasks restore when they finish or abort.
+		//
+		// A download that is also shared arrives as EC_TAG_PARTFILE, so its
+		// progress lands in download.hashing_progress and this stays 0 --
+		// read both through SharedHashingProgress() rather than this field
+		// directly, the same fallback decoded_part_sources needs.
+		std::uint16_t hashing_progress = 0;
+
 		// Live upload activity (issue #466), the upload-side analogue of
 		// the download stats. `upload_speed_bps` + `uploading_count` are
 		// live (refresh every tick); `last_upload` / `shared_since` are
@@ -827,6 +839,17 @@ constexpr std::uint64_t kPartSizeBytes = 9728000ull;
 // multiple) -- worth knowing, because a mismatch here would silently trim
 // or pad every per-part bitmap.
 std::uint64_t PartCountForSize(std::uint64_t size);
+
+// Parts hashed so far by a pass running over `f` as a complete share -- Verify
+// Local Data, or an AICH hashset rebuild. 0 when no such pass is running.
+//
+// The fallback is why this is a function: amuled emits one tag kind per ECID,
+// so a download that is also shared arrives as EC_TAG_PARTFILE and its
+// progress lands on the download side. SharedPartSources in Api.cpp needs the
+// identical fallback for the identical reason. Every shared-side consumer --
+// the JSON writer, the SSE writer and the equality test -- goes through here,
+// so all three agree about which file is hashing.
+std::uint16_t SharedHashingProgress(const FileSnapshot &f);
 
 // Fill in ClientSnapshot::part_progress_percent, which is derived rather
 // than refreshed: it needs the part count of the file this peer is a source

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -132,6 +132,10 @@ if [ "$COUNT" -gt 0 ]; then
 		'/downloads[0].sources.total is numeric'
 	_assert_json_eq '.downloads[0].kad_comment_search_running | type' boolean \
 		'/downloads[0].kad_comment_search_running is boolean (issue #434)'
+	# Moved onto the list by issue #1054 — it used to be detail-only, which
+	# left a list-driven client with no way to see a hash running.
+	_assert_json_eq '.downloads[0].hashing_progress | type' number \
+		'/downloads[0].hashing_progress is numeric (#1054)'
 
 	# --- 4. /downloads/{hash} bare-object detail. -----------------
 	HASH=$(printf '%s' "$CURL_BODY" | jq -r '.downloads[0].hash')
@@ -349,6 +353,12 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared[0].last_upload is numeric (#466)'
 	_assert_json_eq '.shared[0].shared_since | type' number \
 		'/shared[0].shared_since is numeric (#466)'
+	# Hashing progress on the shared row (issue #1054). Parts hashed so far
+	# by a Verify Local Data / AICH rebuild, 0 when idle. Only the type is
+	# asserted: a smoke run has no hash in flight, and racing one would make
+	# the check flaky rather than stronger.
+	_assert_json_eq '.shared[0].hashing_progress | type' number \
+		'/shared[0].hashing_progress is numeric (#1054)'
 
 	# --- 6b. GET /shared/{hash} detail endpoint (issue #417 Part B). ---
 	SHASH=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].hash')
@@ -370,6 +380,8 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared/{hash} carries aich_hash'
 	_assert_json_eq '.part_count | type' number \
 		'/shared/{hash} carries part_count'
+	_assert_json_eq '.hashing_progress | type' number \
+		'/shared/{hash} carries hashing_progress (#1054)'
 	_assert_json_eq '.comment | type' string \
 		'/shared/{hash} carries comment'
 	_assert_json_eq '.rating | type' number \

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -159,6 +159,13 @@ if [ -n "$ADDED" ]; then
 	else
 		_fail "download_added .data.size" "not a number in $JSON"
 	fi
+	# Hashing progress rides the download event too (issue #1054), so a
+	# client watching the stream sees a Verify Local Data pass advance.
+	if echo "$JSON" | jq -e '.hashing_progress | type == "number"' >/dev/null 2>&1; then
+		_pass "download_added .data.hashing_progress is a number"
+	else
+		_fail "download_added .data.hashing_progress" "not a number in $JSON"
+	fi
 else
 	_fail "download_added missing" \
 		"no event with the Ubuntu ISO hash within 12 s; stream sample: $(head -30 "$SSE_OUT")"

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -669,3 +669,135 @@ TEST(EventDiff, ClientEventOmitsPartProgressPercentWithNoLinkedFile)
 	ASSERT_TRUE(payload.find("part_progress_percent") == std::string::npos);
 	ASSERT_TRUE(payload.find("-1") == std::string::npos);
 }
+
+// Hashing progress on the shared side (issue #1054). amuled emits one tag kind
+// per ECID, so a file that is both downloading and shared arrives only as
+// EC_TAG_PARTFILE and its hashing progress lands in the download sub-block.
+// SharedHashingProgress() is the fallback every shared-side consumer goes
+// through; these pin that the SSE payload and the equality test use it too,
+// since a shared row that never updates is the failure this hides behind.
+TEST(EventDiff, SharedEventCarriesHashingProgressFromTheSharedSide)
+{
+	CState state;
+	state.MutateShared([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 11;
+		f.hash = "1111111111111111111111111111aaaa";
+		f.name = "complete.iso";
+		f.size = kPartSizeBytes * 4;
+		f.is_shared = true;
+		f.shared.hashing_progress = 2;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "shared_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"hashing_progress\":2") != std::string::npos);
+}
+
+TEST(EventDiff, SharedEventFallsBackToTheDownloadSideHashingProgress)
+{
+	// The shared partfile case: shared.hashing_progress stays 0 because the
+	// tag never arrived on the KNOWNFILE variant, and the accessor reads
+	// across to the download sub-block.
+	CState state;
+	state.MutateShared([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 12;
+		f.hash = "2222222222222222222222222222bbbb";
+		f.name = "in-progress.iso";
+		f.size = kPartSizeBytes * 4;
+		f.is_shared = true;
+		f.is_downloading = true;
+		f.download.hashing_progress = 3;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "shared_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"hashing_progress\":3") != std::string::npos);
+}
+
+TEST(EventDiff, SharedUpdatedFiresWhenOnlyHashingProgressMoved)
+{
+	// EqualShared compares through the accessor, so a hash advancing on the
+	// download side of a shared partfile still pushes shared_updated. Comparing
+	// the raw shared field would hold every tick of it back.
+	CState state;
+	state.MutateShared([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 13;
+		f.hash = "3333333333333333333333333333cccc";
+		f.name = "verifying.iso";
+		f.size = kPartSizeBytes * 4;
+		f.is_shared = true;
+		f.is_downloading = true;
+		f.download.hashing_progress = 1;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // cold start: shared_added
+	DrainAll(bus);
+
+	state.MutateShared([](FileMap &files) { files.find(13)->second.download.hashing_progress = 2; });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "shared_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"hashing_progress\":2") != std::string::npos);
+}
+
+TEST(EventDiff, DownloadUpdatedFiresWhenOnlyHashingProgressMoved)
+{
+	// The download side needs the same treatment: hashing_progress used to be
+	// GET /downloads/{hash}-only and absent from EqualDownload, so a Verify
+	// Local Data pass produced no download_updated at all.
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 14;
+		f.hash = "4444444444444444444444444444dddd";
+		f.name = "checking.iso";
+		f.size = kPartSizeBytes * 4;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+	DrainAll(bus);
+
+	state.MutateDownloads([](FileMap &files) { files.find(14)->second.download.hashing_progress = 5; });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "download_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"hashing_progress\":5") != std::string::npos);
+}

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -680,6 +680,8 @@ TEST(Refresher, SharedDetailTagsDecodeIntoSnapshot)
 	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_UPLOADING_COUNT, static_cast<std::uint16_t>(3)));
 	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_LAST_UPLOAD, static_cast<std::uint32_t>(1700000500)));
 	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_SHARED_SINCE, static_cast<std::uint32_t>(1699000000)));
+	// Verify Local Data / AICH rebuild progress over a complete share.
+	kf.AddTag(CECTag(EC_TAG_KNOWNFILE_HASHED_PART_COUNT, static_cast<std::uint16_t>(4)));
 	resp.AddTag(kf);
 
 	ApplyGetUpdateToShared(&resp, cache, rle_state);
@@ -698,6 +700,7 @@ TEST(Refresher, SharedDetailTagsDecodeIntoSnapshot)
 	ASSERT_EQUALS(static_cast<std::uint32_t>(51200), s.shared.upload_speed_bps);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(3), s.shared.uploading_count);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1700000500), s.shared.last_upload);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(4), s.shared.hashing_progress);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1699000000), s.shared.shared_since);
 }
 


### PR DESCRIPTION
Backend half of #1054. The `PiecesBar` / Verify Local Data Web UI work stays with @ngosang — this only makes the data available on the REST + SSE surface.

## The gap

A Verify Local Data run or an AICH hashset rebuild over a shared file had no observable progress. amuled reports it on every update tick as `EC_TAG_KNOWNFILE_HASHED_PART_COUNT` (`ECSpecialCoreTags.cpp:284`, emitted ahead of the `EC_DETAIL_UPDATE` early-out), but `Refresher.cpp` only ever decoded the `EC_TAG_PARTFILE` variant, so the shared snapshot never carried it.

On the download side the field existed but was `GET /downloads/{hash}`-only and absent from `EqualDownload`, so a hash advancing produced no `download_updated` at all and a list-driven client could not see it either.

## What changed

- `SharedSide::hashing_progress`, decoded from the knownfile tag.
- `webapi::SharedHashingProgress()` — reads the shared field, falling back to the download field. The fallback is not optional: amuled emits one tag kind per ECID, so a file that is both downloading and shared arrives only as `EC_TAG_PARTFILE`. The JSON writer, the SSE writer and the equality test all go through the accessor, so all three agree about which file is hashing. `SharedPartSources` solves the identical problem the same way.
- `hashing_progress` on the `GET /shared` row, the `GET /shared/{hash}` detail, and `shared_added` / `shared_updated`; compared in `EqualShared` through the accessor.
- Download side: moved onto the `GET /downloads` list object and into `EqualDownload` and the `download_added` / `download_updated` payload.

The value is a **count of parts already hashed**, not the index of the part in flight — both tasks report `part + 1` and restore `0` when they finish or abort. `REFERENCE.md` described it as an index; corrected.

## Verified live

macOS, `amuled` + `amuleapi`, 1.6 GB fixture (173 parts), `POST /shared/{hash}/verify`:

```
t=1  hashing_progress=0     t=11 hashing_progress=94
t=2  hashing_progress=4     t=14 hashing_progress=116
t=4  hashing_progress=27    t=19 hashing_progress=159
t=7  hashing_progress=50    t=21 hashing_progress=0     <- task finished
```

The same run on `/events?channels=shared` produced 9 `shared_updated` frames, each driven solely by `hashing_progress` — nothing else in the payload moved.

## Tests + docs

- `RefresherTest` — the knownfile tag decodes into `shared.hashing_progress`.
- `EventDiffTest` — 4 new: shared-side value in the payload, download-side fallback, `shared_updated` fires when only hashing progress moved, same for `download_updated`. Full suite 35/35.
- curl suite: field-type assertions on `/shared[0]`, `/shared/{hash}` and `/downloads[0]`; `hashing_progress` on the `download_added` SSE frame.
- `REFERENCE.md` (both field tables, samples, and a "watching it run" note cross-linked from `POST /shared/{hash}/verify`) and `EVENTS.md`.

One drive-by in `EVENTS.md`: the `shared_added` sample had drifted from the list item since the upload-activity fields landed, so adding a field in order meant bringing it back in line.
