### PR TITLE
fix(gui): report why adding a collection failed, and resolve its path

### DIFF
--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -46,7 +46,6 @@
 #include "DataToText.h"       // Needed for PriorityToStr
 #include "Statistics.h"       // Needed for theStats (incoming free space)
 #include "GuiEvents.h"        // Needed for CoreNotify_*
-#include "MuleCollection.h"   // Needed for CMuleCollection
 #include "DownloadQueue.h"    // Needed for CDownloadQueue
 #include "TransferWnd.h"      // Needed for CTransferWnd
 #include "Logger.h"           // Needed for AddLogLine
@@ -194,7 +193,8 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->Append(MP_VERIFY, _("Verify Local Data"));
 		m_menu->AppendSeparator();
 
-		if (file->GetFileName().GetExt() == "emulecollection") {
+		const bool isCollection = file->GetFileName().GetExt() == "emulecollection";
+		if (isCollection) {
 			m_menu->Append(MP_ADDCOLLECTION, _("Add files in collection to transfer list"));
 			m_menu->AppendSeparator();
 		}
@@ -231,6 +231,13 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		FileLaunch::GetAvailability(file, canOpen, canReveal);
 		m_menu->Enable(MP_VIEW, previewable && canOpen);
 		m_menu->Enable(MP_SHOWINFOLDER, canReveal);
+		if (isCollection) {
+			// Reading a collection means reading its bytes on this host, so it
+			// needs the same reachability as opening the file. A part file is
+			// excluded on top of that: it is a truncated collection, not a
+			// usable one.
+			m_menu->Enable(MP_ADDCOLLECTION, canOpen && !file->IsPartFile());
+		}
 		m_menu->Enable(MP_GETAICHED2KLINK, file->HasProperAICHHashSet());
 		m_menu->Enable(MP_GETAICHED2KLINKSRC, file->HasProperAICHHashSet());
 		m_menu->Enable(MP_GETHOSTNAMESOURCEED2KLINK, !thePrefs::GetYourHostname().IsEmpty());
@@ -1198,22 +1205,33 @@ void CSharedFilesCtrl::OnAddCollection(wxCommandEvent &WXUNUSED(evt))
 		return;
 	}
 	CKnownFile *file = reinterpret_cast<CKnownFile *>(selected.front());
-	wxString CollectionFile = file->GetFilePath().JoinPaths(file->GetFileName()).GetRaw();
-	CMuleCollection my_collection;
-	if (my_collection.Open(CollectionFile)) {
-		wxArrayString links;
-		for (size_t e = 0; e < my_collection.size(); ++e) {
-			// eMule stores collection strings as UTF-8. Fall back to
-			// raw bytes rather than dropping the entry, since
-			// FromUTF8 yields an empty string on invalid input.
-			wxString link = wxString::FromUTF8(my_collection[e].c_str());
-			if (link.IsEmpty()) {
-				link = wxString::From8BitData(my_collection[e].c_str());
-			}
-			links.Add(link);
-		}
-		theApp->downloadqueue->AddLinks(links);
+
+	// The collection is parsed on this side, so its bytes have to be readable
+	// from this host. amulegui is shown the daemon's directory, which
+	// ResolvePath() rewrites through the user's configured mapping; in the
+	// monolithic build the path is already local and resolves unchanged.
+	//
+	// A part file is turned away rather than resolved: it resolves to the
+	// ".part" in the temp directory, which does exist, so a half-downloaded
+	// collection would parse and quietly queue whichever links happened to be
+	// on disk already. The menu entry is disabled for those, so this repeats
+	// that test only to keep the handler correct on its own.
+	CPath collection;
+	if (file->IsPartFile() || !FileLaunch::ResolvePath(file, collection)) {
+		return;
 	}
+
+	// The same expansion the command line and the macOS open-document path
+	// use: it reports a missing, malformed or empty collection itself, and
+	// runs every entry through CheckPassedLink() instead of forwarding the raw
+	// strings -- so magnet entries convert and invalid ones are named.
+	wxArrayString links;
+	if (theApp->ExpandPassedCollection(collection.GetRaw(), links, 0) !=
+		CamuleAppCommon::kCollectionExpanded) {
+		// Already logged by ExpandPassedCollection().
+		return;
+	}
+	theApp->downloadqueue->AddLinks(links);
 }
 
 // Both act on one file: the menu is opened over a row, and opening several

--- a/src/amule.h
+++ b/src/amule.h
@@ -147,31 +147,36 @@ private:
 
 	bool CheckPassedLink(const wxString &in, wxString &out, int cat);
 
-	// Outcome of trying to read a command-line argument as a collection.
+public:
+	// Outcome of trying to read a path as a collection.
 	enum CollectionExpansion
 	{
-		// The argument isn't a collection path; treat it as a link.
+		// The path isn't a collection; a command-line caller treats it
+		// as a link instead.
 		kNotACollection,
-		// The argument named a collection and its links were emitted.
+		// The path named a collection and its links were emitted.
 		kCollectionExpanded,
-		// The argument named a collection we could not read. Already
+		// The path named a collection we could not read. Already
 		// logged, and deliberately not retried as a link - doing so
 		// would emit a second, misleading "invalid eD2k link" error.
 		kCollectionFailed
 	};
 
 	/**
-	 * Expands a .emulecollection argument into its eD2k links.
+	 * Expands a .emulecollection into its eD2k links.
+	 *
+	 * Reads the file from this host's filesystem, so a caller holding a
+	 * remote core's path must resolve it first (FileLaunch::ResolvePath).
 	 *
 	 * Accepts a plain path or a file:// URL; file managers pass either
 	 * depending on the platform and the .desktop Exec field used.
 	 * Each link is validated through CheckPassedLink(), so the caller
 	 * gets the same canonicalisation and category suffix as a link typed
-	 * on the command line.
+	 * on the command line. Missing, malformed and empty collections are
+	 * reported by this function; the caller only has to stop.
 	 */
 	CollectionExpansion ExpandPassedCollection(const wxString &in, wxArrayString &out, int cat);
 
-public:
 	/**
 	 * Queues every collection among @a fileNames into the ED2KLinks file.
 	 *


### PR DESCRIPTION
Fixes #1055.

In Shared Files, *Add files in collection to transfer list* discarded its own failure. `OnAddCollection` built the path by hand and ignored what `CMuleCollection::Open()` returned:

```cpp
wxString CollectionFile = file->GetFilePath().JoinPaths(file->GetFileName()).GetRaw();
CMuleCollection my_collection;
if (my_collection.Open(CollectionFile)) {
    ...
}
```

There is no `else`. When that read failed the entry did **nothing at all** — no downloads queued, no dialog, no log line, in either binary. In monolithic that happens when the collection has been moved or deleted since it was hashed; in amulegui it is the normal case, because the shared list carries the *daemon's* directory while the collection is parsed on the GUI side.

To be clear about the scope, since it would be easy to read this as a regression: **adding a collection has never worked in amulegui unless the file is reachable from the GUI host.** The links are parsed here, so the bytes have to be readable here. Nothing took that away — the remote→local mapping simply made "reachable" a configurable state, and this call site never asked for it.

## Changes

**Resolve the path instead of joining it.** `FileLaunch::ResolvePath()` leaves the monolithic build's already-local path unchanged and, in amulegui, applies the configured mapping — the same resolution *Open the file* and *Show in file manager* already use. Where a collection was reachable before, nothing changes.

**Reuse the expansion instead of repeating it.** The parse loop here duplicated `CamuleAppCommon::ExpandPassedCollection()`, which already backs the command line and the macOS open-document path. Handing it the resolved path gets three things this menu never had:

- missing, malformed and empty collections are reported, each with its own message
- every entry goes through `CheckPassedLink()`, so magnet links convert and invalid ones are named rather than silently forwarded
- **no new strings** — the messages it logs already exist in the catalogs

It was `private`; this makes it and its result enum public, and rewords the doc comment to say it reads from *this host's* filesystem, so a caller holding a remote core's path has to resolve first.

**Guard part files before resolving, not after.** `CSharedFileList` shares `PS_READY` part files and the entry is offered on the filename extension alone, so a half-downloaded `foo.emulecollection` reaches it too. `ResolvePath()` deliberately resolves a part file to its `.part` in the temp directory — which *does* exist. So resolving without this guard would have upgraded a harmless no-op into silently queueing whichever links happened to be on disk already.

**Grey the entry out under the same conditions**, next to the existing `MP_VIEW` / `MP_SHOWINFOLDER` gates, so the state is visible before the click instead of only in the log afterwards.

## Effect per binary

| | monolithic | amulegui |
|---|---|---|
| Resolved path | unchanged | applies the configured mapping |
| Silent failure → log line | yes | yes |
| Entry greyed when unreachable | yes | yes |
| Links validated / magnets converted | yes | yes |
| Part file guarded | yes — was incidental, now deliberate | yes, and **required** here |

Nothing that works today becomes unavailable: the gate is `ResolvePath() && FileExists()`, and a file that does not exist was already failing into the silent path.

## Not in scope

Making this work in amulegui with no mapping and no shared filesystem. The right fix there is to let the **core** read the collection — it already has the file locally, being the one sharing it — which needs a new EC operation rather than a wider mapping. Worth its own issue.

## Testing

Built monolithic and amulegui on macOS; amulegui is the one that matters, since the mapping branch in `ResolvePath()` only compiles under `CLIENT_GUI`. `update-po.sh` produces no catalog change beyond the header timestamp, confirming no new strings.

clang-format and both clang-tidy tiers clean.

Not exercised end-to-end against a remote daemon with a mapping configured — the part-file and unreachable paths are reasoned from the code, not observed.
