### PR TITLE
fix(gui): stop the search tabs echoing column widths back at each other

### DIFF
--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -192,10 +192,19 @@ void CMuleDataViewCtrl::InitColumnState()
 #endif
 
 	m_columnHidden.resize(RealColumnCount(), false);
+	ResetKnownWidths();
+}
+
+void CMuleDataViewCtrl::ResetKnownWidths()
+{
 	m_lastKnownWidths.clear();
 	for (unsigned i = 0; i < RealColumnCount(); ++i) {
 		m_lastKnownWidths.push_back(GetColumn(i)->GetWidth());
 	}
+	// A programmatic change is not a drag in progress, so nothing is pending
+	// either -- otherwise the next quiet idle would report a resize that the
+	// user never made.
+	m_widthsSettling = false;
 }
 
 bool CMuleDataViewCtrl::IsColumnHidden(int col) const

--- a/src/MuleDataViewCtrl.h
+++ b/src/MuleDataViewCtrl.h
@@ -370,6 +370,25 @@ protected:
 	//! OnKeyDown).
 	void RaiseItemContextMenu();
 
+	/**
+	 * Re-baselines the widths the idle poll compares against.
+	 *
+	 * Call after changing a column width programmatically, so the poll reads
+	 * the result as the status quo rather than as a user drag. Takes the
+	 * widths the control actually ended up with, which is not always what was
+	 * asked for -- GTK clamps a column to a minimum derived from its header
+	 * and contents, so a narrow request comes back wider.
+	 *
+	 * Without it a programmatic width change is indistinguishable from a
+	 * drag, and any list that rebroadcasts on OnColumnWidthsChanged() feeds
+	 * its own echo: CSearchListCtrl mirrors widths to the other search tabs,
+	 * each of which then saw "its" widths change and mirrored them back. Two
+	 * tabs whose clamped minimums differ never agree on a value, so the pair
+	 * oscillated indefinitely, repainting on every hop, long after the mouse
+	 * was released (issue #1022).
+	 */
+	void ResetKnownWidths();
+
 private:
 	//! Per-column hidden state, indexed like the control's columns.
 	std::vector<bool> m_columnHidden;

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -554,6 +554,20 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 	}
 	dst->UpdateExpanderColumn();
 
+	// Re-baseline what dst's idle poll compares against, so the widths just
+	// written read as the status quo rather than as a drag the user made
+	// there. Without this the mirror echoes: dst notices "its" widths moved,
+	// runs its own OnColumnWidthsChanged(), and mirrors them straight back.
+	//
+	// That echo does not die out on its own. GTK clamps a column to a minimum
+	// taken from its header and contents, so a width that fits one tab comes
+	// back wider in another holding different results -- the two tabs never
+	// converge on a value and hand it back and forth indefinitely, repainting
+	// each time, long after the mouse was released. It showed up on the
+	// columns that were empty in one of the tabs, since those are the ones
+	// whose clamped minimum differs (issue #1022).
+	dst->ResetKnownWidths();
+
 	if (dst->m_sort_orders.empty() || src->m_sort_orders.empty() ||
 		dst->m_sort_orders.front() != src->m_sort_orders.front()) {
 		dst->m_sort_orders = src->m_sort_orders;


### PR DESCRIPTION
Fixes #1022.

Resizing a search-results column flickered and spiked the CPU, on and off, with the flicker continuing after the mouse was released.

## Cause

`CSearchListCtrl` mirrors column widths to the other open search tabs whenever its own change. Nothing marked a width as having *arrived* from that mirror, so the destination's idle poll read it as a resize made there, ran its own `OnColumnWidthsChanged()`, and mirrored it straight back.

`SyncLists` only writes a width when it differs, so the echo would die out if the value stuck. It does not always stick: GTK clamps a column to a minimum taken from its header and contents, and two tabs holding different results clamp the same column differently. Tab A pushes 40, tab B comes back 62, A pushes 62, B comes back 40 - the pair never agrees, and hands the value back and forth for as long as both tabs are open.

Every symptom the reporter described follows from that:

| observation | explained by |
|---|---|
| closing one of two tabs stops it | the loop needs a peer; one tab has none |
| keeps flickering in whichever tab is switched to | self-sustaining, not driven by the mouse |
| the horizontal scrollbar changes size rather than appearing | total content width oscillating between two values |
| widening the window does not help | nothing to do with the viewport edge |
| only some columns - the ones empty for that search | only a clamped column fails to round-trip, and an empty column is where the minimums differ |
| survived #1025 | that debounce slowed each hop without breaking the cycle |
| a second tester with ten tabs never reproduced it | similar searches clamp alike, so the values agree |

## Fix

Re-baseline the destination after the mirror writes it. `ResetKnownWidths()` takes the widths the control actually ended up with rather than the ones asked for, so the poll sees the status quo and does not rebroadcast.

It lives in the base class beside the poll it feeds, since any list that rebroadcasts on `OnColumnWidthsChanged()` would have the same problem, and it clears the settling flag as well - a programmatic change is not a drag, so nothing should be left pending after it.

## Testing

Builds clean, `clang-format` clean, unit suite 36/36.

Confirmed by the reporter on the environment that showed it (Ubuntu GNOME, Wayland, wxGTK3, `amulegui`): *"Oh, much better now. I cannot trigger the flickering with your branch!"*

That confirmation matters here because I was wrong twice before it. #1025 removed a real per-pixel inefficiency that turned out not to be the cause, and a scrollbar-toggle theory was ruled out by the reporter's own observations. The prediction this fix makes is specific and held: closing a tab is no longer what stops the flicker, because there is nothing left to stop.
