### PR TITLE
fix(core): report a browse's real lifecycle, and join a browse already in flight

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1196,6 +1196,8 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 { "ok": true, "search_id": 17 }
 ```
 
+**Idempotent while a browse is running.** Asking again for a peer that is already being browsed returns **the same `search_id`** rather than starting a second browse — amuled will not re-ask a peer that is still answering, so a second id would name a browse that never happens. Two clicks therefore leave one browse, one id and one entry on [`GET /api/v0/search`](#get-apiv0search). Once that browse has settled, a fresh request starts a new one with a new id.
+
 Status `202 Accepted` — the browse was started, not completed. Then poll:
 
 ```sh
@@ -1821,7 +1823,7 @@ Only one friend can hold the slot at a time, so granting it clears it on whoever
 
 Browse a friend's shared files. The friend-addressed twin of [`POST /api/v0/clients/{ecid}/shared_files`](#post-apiv0clientsecidshared_files), and more capable: a friend record carries a stored address, so the daemon can browse a friend who is **not currently connected**, which the clients route cannot do.
 
-**Response:** `202 Accepted` → `{ "ok": true, "search_id": 17 }`. Poll [`GET /api/v0/search/{id}/results`](#get-apiv0searchidresults) with that id.
+**Response:** `202 Accepted` → `{ "ok": true, "search_id": 17 }`. Poll [`GET /api/v0/search/{id}/results`](#get-apiv0searchidresults) with that id. Idempotent while a browse of that peer is running, exactly as on the clients route.
 
 **Errors:** `403 forbidden`, `404 not_found`, `502 amuled_rejected`, `503 ec_unavailable`.
 
@@ -2415,6 +2417,10 @@ Lists every search amuled currently holds — including ones started by a **diff
 ```
 
 `search_id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
+
+For a `"browse"` entry, `state` and the results endpoint's `progress.percent` come from the browse's own lifecycle rather than from a query's: the request being sent is `"running"`, and the peer having answered, denied the request, or disconnected mid-list is `"finished"` — a browse is never reported as `"idle"`. `percent` is the share of the peer's directory list received so far, so it climbs while the listing streams in rather than jumping straight from `0` to `100`.
+
+Browsing a peer that is **already being browsed** returns the id already in flight rather than starting a second one, so this list holds one entry per browsed peer, not one per request.
 
 `query` is the daemon's name for the search. For a `"browse"` that is **the peer's nickname**, not a query string — a browse has no query. `client_ecid` is the browsed peer's ecid and is present **only** on browse entries, so a consumer can tell whose share is being listed and cross-reference [`GET /clients`](#get-apiv0clients); it is omitted entirely on an ordinary search.
 

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2532,7 +2532,9 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		// GUI's optimistic EC_TAG_SEARCH_REF) so amuleGUI rekeys its browse tab.
 		// Legacy clients keep the old fire-and-forget EC_OP_NOOP (they can't
 		// display a browse anyway).
-		const uint32 browseId = multiSearch ? AllocateBrowseSearchId() : 0;
+		//
+		// The ID is allocated per branch, once the target peer is known and
+		// only if it has no browse running -- see browseInFlightId below.
 		const CECTag *reftag = tag->GetTagByName(EC_TAG_SEARCH_REF);
 		// A browse failure needs the correlation token for the same reason a
 		// failed search start does: amuleGUI created its optimistic browse tab
@@ -2550,32 +2552,74 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 			}
 			return fail;
 		};
+		// A browse of a peer that is already being browsed joins that browse
+		// instead of minting a second identity for it. CUpDownClient::
+		// RequestSharedFileList() declines to re-ask a peer that is still
+		// answering, so a freshly allocated ID would never be stamped with a
+		// lifecycle -- while SetBrowseSearchId has already repointed every
+		// later status write away from the first ID, leaving that one
+		// BROWSE_IN_PROGRESS with nothing able to terminalize it. There is
+		// exactly one m_browseStatus / m_iFileListRequested per client, so
+		// there can only be one ID to report on. Returns 0 when the peer has
+		// no browse running, i.e. when the caller should allocate as usual.
+		auto browseInFlightId = [](const CUpDownClient *peer) -> uint32 {
+			return (peer != nullptr && peer->GetFileListRequested() > 0)
+				       ? peer->GetBrowseSearchId()
+				       : 0;
+		};
+		// Same reply as a fresh browse, pointing at the browse that is really
+		// running: no allocation (the second ID would be stranded), no
+		// RegisterBrowseSearch (it would restamp m_searchStartTimes), no
+		// repoint, no re-request. A legacy client still gets its historical
+		// EC_OP_NOOP -- and, unlike before, no longer clears the pinned ID of
+		// a multi-search client's in-flight browse on its way past.
+		auto joinBrowse = [&](uint32 inFlightId) {
+			return BuildBrowseReply(multiSearch ? inFlightId : 0, reftag);
+		};
 		const CECTag *subtag = tag->GetTagByName(EC_TAG_FRIEND);
 		if (subtag) {
 			CFriend *Friend = theApp->friendlist->FindFriend(subtag->GetInt());
 			if (Friend) {
-				// Describe the browse before the results start arriving, so
-				// the search list can report it as one (kind + peer name)
-				// rather than as a nameless search of the scalar kind.
-				if (browseId) {
-					theApp->searchlist->RegisterBrowseSearch(
-						browseId, Friend->GetName(), subtag->GetInt());
+				// The linked client need not exist yet -- CFriendList::
+				// RequestSharedFileList creates it -- and without one there
+				// is by definition no browse to join.
+				const CClientRef &linked = Friend->GetLinkedClient();
+				const uint32 inFlight =
+					browseInFlightId(linked.IsLinked() ? linked.GetClient() : nullptr);
+				if (inFlight) {
+					response = joinBrowse(inFlight);
+				} else {
+					const uint32 browseId = multiSearch ? AllocateBrowseSearchId() : 0;
+					// Describe the browse before the results start arriving,
+					// so the search list can report it as one (kind + peer
+					// name) rather than as a nameless search of the scalar
+					// kind.
+					if (browseId) {
+						theApp->searchlist->RegisterBrowseSearch(
+							browseId, Friend->GetName(), subtag->GetInt());
+					}
+					theApp->friendlist->RequestSharedFileList(Friend, browseId);
+					response = BuildBrowseReply(browseId, reftag);
 				}
-				theApp->friendlist->RequestSharedFileList(Friend, browseId);
-				response = BuildBrowseReply(browseId, reftag);
 			} else {
 				response = browseFailure(wxTRANSLATE("Friend not found."));
 			}
 		} else if ((subtag = tag->GetTagByName(EC_TAG_CLIENT))) {
 			CUpDownClient *client = theApp->clientlist->FindClientByECID(subtag->GetInt());
 			if (client) {
-				if (browseId) {
-					theApp->searchlist->RegisterBrowseSearch(
-						browseId, client->GetUserName(), client->ECID());
+				const uint32 inFlight = browseInFlightId(client);
+				if (inFlight) {
+					response = joinBrowse(inFlight);
+				} else {
+					const uint32 browseId = multiSearch ? AllocateBrowseSearchId() : 0;
+					if (browseId) {
+						theApp->searchlist->RegisterBrowseSearch(
+							browseId, client->GetUserName(), client->ECID());
+					}
+					client->SetBrowseSearchId(browseId);
+					client->RequestSharedFileList();
+					response = BuildBrowseReply(browseId, reftag);
 				}
-				client->SetBrowseSearchId(browseId);
-				client->RequestSharedFileList();
-				response = BuildBrowseReply(browseId, reftag);
 			} else {
 				response = browseFailure(wxTRANSLATE("Client not found."));
 			}
@@ -2875,26 +2919,25 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 	return response;
 }
 
-// Enumerates every *search* the core currently holds
-// (CSearchList::GetKnownSearchIds() -- deliberately narrow, unlike the union
-// poll above, which also reads GetBrowseSearchIds()) so a client that never
-// started any of them locally -- a freshly (re)connected amulegui, a
-// stateless amuleapi request, or a search typed directly into the monolithic
-// GUI -- can discover what to ask about and build tabs for it. One entry per
-// known search: EC_TAG_SEARCH_ID as the entry's own value, with name/kind/
-// state as children. Only reached for m_multiSearchActive clients (see the
-// EC_OP_SEARCH_LIST case below): a legacy client has no concept of more than
-// the single 0xffffffff sentinel search, so there is nothing meaningful to
-// enumerate for it.
+// Enumerates every search the core currently holds
+// (CSearchList::GetKnownSearchIds()) so a client that never started any of
+// them locally -- a freshly (re)connected amulegui, a stateless amuleapi
+// request, or a search typed directly into the monolithic GUI -- can discover
+// what to ask about and build tabs for it. One entry per known search:
+// EC_TAG_SEARCH_ID as the entry's own value, with name/kind/state as children.
+// Only reached for m_multiSearchActive clients (see the EC_OP_SEARCH_LIST case
+// below): a legacy client has no concept of more than the single 0xffffffff
+// sentinel search, so there is nothing meaningful to enumerate for it.
 //
-// Must NOT also enumerate browse ids: a "View Files" tab already gets its own
-// tab via BuildBrowseReply's STRINGS reply (which rekeys through the same
-// RemapSearch path a search START does) the moment the user opens it, so
-// there is nothing here for a browse to be *discovered* by another client
-// for -- browsing is inherently per-request, not a standing search another
-// client could ever come to know about. Folding it in here anyway would
-// surface every open browse as a bogus search tab, with a made-up name, on
-// every connected client (got3nks, PR #680 review).
+// Browses are enumerated here too. This reverses PR #680, which kept them out
+// on the grounds that a browse is inherently per-request and could only
+// surface as a bogus, nameless search tab: PR #914 gave a browse a name, a
+// recorded kind and its peer's ECID (RegisterBrowseSearch), which is exactly
+// what lets a remote GUI rebuild it as a browse tab instead
+// (CSearchListRem::HandlePacket in amule-remote-gui.cpp branches on
+// BrowseSearch + EC_TAG_CLIENT), and made a local browse discoverable at all.
+// RegisterBrowseSearch writing m_searchStrings is what puts them in reach of
+// GetKnownSearchIds(); it is deliberate, not incidental.
 // amuleapi's SearchKindToString/SearchLifecycleStateToString (Api.cpp) decode
 // the two wire values written below from raw numeric literals, since amuleapi
 // cannot include SearchList.h. This file can see both CSearchList's enums and

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -1308,6 +1308,19 @@ void CSearchList::SetKadSearchFinished(uint32_t searchID)
 CSearchList::SearchLifecycleState CSearchList::GetSearchLifecycleStateById(wxUIntPtr searchID) const
 {
 	uint32_t sid = static_cast<uint32_t>(searchID);
+	// A browse ("View Files") is not a CSearchList search: its lifecycle lives
+	// in m_browseStatus, keyed by the same id this function is asked about.
+	// Without this the generic tail below decides it from retained results,
+	// which is wrong in both directions -- a browse still streaming reports
+	// finished as soon as its first directory lands, and one the peer denied
+	// reports idle forever, since a failed browse has no results to flip the
+	// ternary. Same mapping the EC progress reply applies (ExternalConn.cpp's
+	// AppendSearchProgress), here instead of only there so the SEARCH_LIST
+	// listing cannot disagree with the per-id progress reply about the same id.
+	if (HasBrowseStatus(searchID)) {
+		return GetBrowseStatusById(searchID) == BROWSE_IN_PROGRESS ? SEARCH_LIFECYCLE_RUNNING
+									   : SEARCH_LIFECYCLE_FINISHED;
+	}
 	// Kad searches are tracked per-ID: still registered in the manager =>
 	// running; recorded as finished (its CSearch was destroyed on the result
 	// cap or the 45s lifetime) => finished. Independent of any other search, so
@@ -1342,6 +1355,21 @@ uint8 CSearchList::GetSearchLifecyclePercentById(wxUIntPtr searchID) const
 	// An in-flight ed2k global uses its real server-queue percent — that state
 	// is single-slot, so it only applies to the current search.
 	const uint32_t sid = static_cast<uint32_t>(searchID);
+	// A browse reports the share of the peer's directory list received so far,
+	// rather than the 0/100 the state switch above would derive.
+	//
+	// Read m_browseBar directly, NOT through GetSearchBarStatusById: that
+	// function falls through to this one for anything it does not consider
+	// finished, so routing this branch through it would recurse between the two
+	// for an id with a browse status but no bar entry. The two maps are written
+	// and pruned together, so that should not arise -- which is exactly why it
+	// must not be load-bearing.
+	if (HasBrowseStatus(searchID)) {
+		std::map<wxUIntPtr, uint16>::const_iterator bar = m_browseBar.find(searchID);
+		const uint16 pct = (bar != m_browseBar.end()) ? bar->second : 0;
+		// 0xffff is the bar's terminal sentinel, not a percent.
+		return (pct == 0xffff) ? 100 : static_cast<uint8>(pct);
+	}
 	if (IsOrWasKadSearch(sid)) {
 		std::map<uint32_t, time_t>::const_iterator it = m_searchStartTimes.find(sid);
 		time_t start = (it != m_searchStartTimes.end()) ? it->second : m_searchStart;

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -192,27 +192,34 @@ public:
 	bool IsKnownSearchId(uint32_t searchID) const;
 
 	/**
-	 * Every search ID this core currently knows the query string for --
-	 * populated in StartNewSearch and pruned in RemoveResults, so this
-	 * covers a search regardless of how it was started (monolithic GUI or
-	 * an EC client) and is not bounded by any EC-connection-specific
-	 * registry. Used by EC_OP_SEARCH_LIST, which must stay narrow: a browse
-	 * tab is not a search and must not surface as one (got3nks, PR #680
-	 * review). Returned by reference -- called once per explicit
-	 * EC_OP_SEARCH_LIST request, but a copy is still needless. Neither
-	 * caller needs ownership.
+	 * Every search ID this core currently knows a name for -- populated in
+	 * StartNewSearch and RegisterBrowseSearch, pruned in RemoveResults, so
+	 * this covers a search regardless of how it was started (monolithic GUI
+	 * or an EC client) and is not bounded by any EC-connection-specific
+	 * registry.
+	 *
+	 * Browses are in here: PR #914 registers one under its peer's name so a
+	 * remote GUI listing the core's searches can rebuild it as a browse tab
+	 * rather than a nameless search one. PR #680's narrower rule -- that a
+	 * browse must never surface on EC_OP_SEARCH_LIST -- was superseded by
+	 * that, so this map is no longer searches-only.
+	 *
+	 * Returned by reference -- called once per explicit EC_OP_SEARCH_LIST
+	 * request, but a copy is still needless. Neither caller needs ownership.
 	 */
 	const std::map<uint32_t, wxString> &GetKnownSearchIds() const { return m_searchStrings; }
 
 	/**
-	 * Every ID this core currently routes results for: CSearchList searches
-	 * plus "View Files" browse tabs (see IsKnownSearchId). Used by the
-	 * multi-search results union poll, which -- unlike EC_OP_SEARCH_LIST --
-	 * must go wide, or a browse's results never reach the tab BuildBrowseReply
-	 * (ExternalConn.cpp) already told the client to expect them in (got3nks,
-	 * PR #680 review). Returned by reference; runs every poll tick for every
-	 * connected multi-search client, so a per-call copy here is the one that
-	 * would actually show up in the arithmetic.
+	 * Every ID this core currently holds a browse progress bar for, used as
+	 * the multi-search results union poll's second source. Not redundant with
+	 * GetKnownSearchIds() even though a browse is registered there too: the
+	 * bar is keyed by CUpDownClient::GetBrowseRoutingId(), which is the
+	 * client pointer until a browse has an ID of its own, so a monolithic
+	 * local browse has a pointer-keyed entry here between the request going
+	 * out and its first directory arriving (that is when ProcessSharedFileList
+	 * allocates the ID and registers it). Returned by reference; runs every
+	 * poll tick for every connected multi-search client, so a per-call copy
+	 * here is the one that would actually show up in the arithmetic.
 	 */
 	const std::map<wxUIntPtr, uint16> &GetBrowseSearchIds() const { return m_browseBar; }
 

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -1060,6 +1060,93 @@ if [ -n "$PEER_ECID" ]; then
 		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].result_count | type" \
 			number 'GET /search carries a numeric result_count on the browse'
 
+		# A browse must never report `idle` on the listing
+		# (amule-org/amule#1060). Before the fix the listing derived a
+		# browse's state from retained results, so a peer that denied the
+		# request or never answered -- which leaves none -- read `idle`
+		# forever, while the progress reply said `finished`.
+		#
+		# `running` or `finished` are both legitimate here and which one
+		# lands depends on the peer: BROWSE_IN_PROGRESS is stamped when the
+		# request is sent, but a peer that denies instantly can terminalize
+		# the browse before this round trip completes. `idle` is the failure.
+		LIST_STATE=$(printf '%s' "$CURL_BODY" | \
+			jq -r "[.searches[] | select(.search_id == $BROWSE_SID)][0].state")
+		case "$LIST_STATE" in
+		running | finished)
+			_pass "GET /search reports the browse as $LIST_STATE, never idle"
+			;;
+		*)
+			_fail "browse listing state" \
+				"expected running or finished, got $LIST_STATE"
+			;;
+		esac
+
+		# While the browse is still running the listing and the per-id
+		# progress reply must agree -- the invariant REFERENCE.md promises,
+		# and the two are served by different EC replies so nothing else
+		# enforces it. Only checked in the `running` case: the results
+		# endpoint serves amuleapi's cached slot, which the refresher
+		# refreshes on its own tick, so right after a state change the two
+		# can legitimately differ by one tick.
+		if [ "$LIST_STATE" = "running" ]; then
+			_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+				"$HOST/api/v0/search/$BROWSE_SID/results?limit=1"
+			PROG_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
+			if [ "$PROG_STATE" = "running" ]; then
+				_pass "listing and progress.state agree on the running browse"
+			else
+				_fail "listing vs progress state disagree" \
+					"GET /search said running, results said $PROG_STATE"
+			fi
+		fi
+
+		# A second browse of the same peer while the first is in flight joins
+		# it rather than minting a second id (amule-org/amule#1059): a second
+		# id would never receive a lifecycle, and the first would be stranded
+		# reporting `running` forever with nothing able to terminalize it.
+		#
+		# Only meaningful while the first browse is actually in flight. Every
+		# terminal path clears the in-flight counter, so once a browse settles
+		# a fresh id is the CORRECT answer -- re-read the state and skip
+		# rather than fail in that case, like the other peer-dependent
+		# assertions here.
+		#
+		# Counted as a delta, not an absolute: browses that have already
+		# settled stay on the listing until they are DELETEd or the daemon's
+		# LRU evicts them, so any daemon that has browsed this peer before
+		# legitimately shows more than one entry for it.
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		BROWSE_COUNT_BEFORE=$(printf '%s' "$CURL_BODY" | \
+			jq "[.searches[] | select(.kind == \"browse\")] | length")
+		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/clients/$PEER_ECID/shared_files"
+		_assert_status 202 "POST /clients/{ecid}/shared_files (duplicate) → 202"
+		DUP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		FIRST_STATE=$(printf '%s' "$CURL_BODY" | \
+			jq -r "[.searches[] | select(.search_id == $BROWSE_SID)][0].state")
+		BROWSE_COUNT_AFTER=$(printf '%s' "$CURL_BODY" | \
+			jq "[.searches[] | select(.kind == \"browse\")] | length")
+		if [ "$DUP_SID" = "$BROWSE_SID" ]; then
+			_pass "a duplicate browse returns the id already in flight ($BROWSE_SID)"
+			# ...so it added no entry to the listing.
+			if [ "$BROWSE_COUNT_AFTER" = "$BROWSE_COUNT_BEFORE" ]; then
+				_pass "a duplicate browse adds no listing entry (still $BROWSE_COUNT_AFTER)"
+			else
+				_fail "duplicate browse added a listing entry" \
+					"before=$BROWSE_COUNT_BEFORE after=$BROWSE_COUNT_AFTER"
+			fi
+		elif [ "$FIRST_STATE" = "finished" ]; then
+			echo "    info: first browse already settled before the duplicate was"
+			echo "          sent — a new id is correct; skipping the join check"
+			curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+				"$HOST/api/v0/search/$DUP_SID" >/dev/null 2>&1
+		else
+			_fail "duplicate browse minted a second id" \
+				"first=$BROWSE_SID (state $FIRST_STATE) second=$DUP_SID"
+		fi
+
 		# Give the peer a moment to answer, then check the browse-only
 		# folder field. An unreachable/denying peer returns nothing, which
 		# is not a failure of this contract.
@@ -1078,6 +1165,20 @@ if [ -n "$PEER_ECID" ]; then
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
 			"$HOST/api/v0/search/$BROWSE_SID/results?sort=directory"
 		_assert_status 200 "GET /search/{browse id}/results?sort=directory → 200"
+
+		# Same check after the browse has had time to settle: a peer that
+		# denied or never answered leaves no results at all, which is exactly
+		# the case the pre-#1060 listing reported as `idle` in perpetuity.
+		# `running` is still legitimate for a peer genuinely still streaming.
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		LIST_STATE=$(printf '%s' "$CURL_BODY" | \
+			jq -r "[.searches[] | select(.search_id == $BROWSE_SID)][0].state")
+		if [ "$LIST_STATE" = "finished" ] || [ "$LIST_STATE" = "running" ]; then
+			_pass "browse listing state is $LIST_STATE after settling (never idle)"
+		else
+			_fail "browse listing state after settling" \
+				"expected finished (or still running), got $LIST_STATE"
+		fi
 		curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 			"$HOST/api/v0/search/$BROWSE_SID" >/dev/null 2>&1
 	else


### PR DESCRIPTION
Fixes #1060 and #1059. Both are the same gap — the daemon knowing more about a browse than it reports — and they're together because **#1060 alone would have made #1059 worse**, see below.

## #1060 — the listing invented a browse's state

`EC_OP_SEARCH_LIST` derived a browse's state from whether results were retained (`SearchList.cpp:1326`), wrong in both directions: a browse still streaming read `finished` as soon as its first directory landed, and one the peer denied or never answered read `idle` **forever**, since a failed browse has no results to flip the ternary.

Taught `GetSearchLifecycleStateById` / `GetSearchLifecyclePercentById` about browses, rather than copying the mapping `AppendSearchProgress` already applies — so the listing and the per-id progress reply cannot disagree. The percent reads `m_browseBar` directly: `GetSearchBarStatusById` falls through to the percent accessor, so routing through it would recurse. `AppendSearchProgress` returns before the changed lines, so the progress reply is provably untouched.

## #1059 — a duplicate browse stranded the first id

Browsing a peer already being browsed allocated a fresh id and pinned it before firing a request `RequestSharedFileList()` then declined. The new id got no lifecycle; the old one kept `BROWSE_IN_PROGRESS` forever, because `SetBrowseSearchId` had repointed every later status write away from it.

**This is why one PR.** Landing #1060 first would have upgraded that phantom from harmless to costly: it would start reading `running` on the listing → `DiscoverSearchIfHeldByCore` seeds `active = state_val == 1` → the refresher polls it once a second forever. That is #1059's own acceptance criterion 4, created by the fix for #1060.

So a duplicate browse now joins the one in flight — same reply shape, no allocation, no re-registration (it would restamp `m_searchStartTimes`), no re-request. **It cannot wedge a peer:** all three paths that mark a browse terminal clear `m_iFileListRequested` first (`BaseClient.cpp:1398`, `ClientTCPSocket.cpp:996`, `:1017`), so the next request starts a fresh browse.

A legacy client keeps its fire-and-forget `EC_OP_NOOP` — and no longer clears the pinned id of a multi-search client's in-flight browse on its way past.

## Stale comments removed

Two comments cited PR #680 for the rule that a browse must never appear on `EC_OP_SEARCH_LIST`. **PR #914 deliberately reversed that** — `RegisterBrowseSearch` writes `m_searchStrings` (the map the listing walks) so a remote GUI can rebuild a browse tab (`CSearchListRem::HandlePacket` in `amule-remote-gui.cpp` branches on exactly that), and #914 added a `reveal` flag to stop the tab stealing focus *because* browses had started appearing. Left alone, those comments would tell the next reader this fix rests on a false premise.

## Verified live

macOS, `amuled` + `amuleapi`, against a real connected peer and a peer held mid-browse by a listener that accepts but never answers:

- **#1059** — 6 browse requests for one peer (3 via `/friends/{ecid}/shared_files`, 3 via `/clients/{ecid}/shared_files`) → **one id, one listing entry**. Both branches resolve to the same `CUpDownClient`, so the routes join each other.
- **#1060** — an in-flight browse with **zero results** reports `running` (impossible before: no results → `idle`); a failed browse with zero results reports `finished` (before: `idle` in perpetuity). Listing and progress agreed at every sample.
- Sequential browses after one settles still allocate a new id, as intended.

`19-search.sh` run against that daemon: all new assertions pass (`duplicate browse returns the id already in flight`, `adds no listing entry`, `running, never idle`, `listing and progress.state agree`).

## Known, pre-existing

`client_ecid` on a friend-started browse is the **friend's** ECID, not the client's — the two are different spaces, and this is unchanged from master. The join makes it reachable from the clients route: a clients browse that joins a friend browse of the same peer returns an id labelled with the friend's ECID. Worth a separate issue; fixing it means reworking friend-browse registration, which has no linked client at registration time.

---

Gates on the final tree: clang-format 18.1.8 clean, Tier-1 and Tier-2 clang-tidy clean (0 compiler errors, 8 TUs), full build across monolithic/daemon/remotegui/amuleapi, 36/36 unit tests. No new strings, so no po regen.
