### PR TITLE
fix(core): clear the complete-sources range too when the last uploader leaves

### DIFF
--- a/src/CompleteSourcesThrottle.h
+++ b/src/CompleteSourcesThrottle.h
@@ -1,0 +1,62 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef COMPLETESOURCESTHROTTLE_H
+#define COMPLETESOURCESTHROTTLE_H
+
+#include <cstdint>
+
+/**
+ * Whether an otherwise-throttled complete-sources recompute must run anyway.
+ *
+ * CKnownFile::UpdatePartsInfo() only recomputes every 60 s. One transition
+ * cannot wait that out: the upload list going empty. Every caller is driven by
+ * a peer event and there is no periodic sweep, so if the last requesting peer
+ * leaves inside the window, the throttled call is the last one that file will
+ * ever get and the counts keep their values for the life of the process.
+ *
+ * Non-zero is asked of all three exported fields, not just the scalar. They do
+ * not move together: Hi is a percentile of the peers' self-reported counts and
+ * is only ever floored at the scalar, never tied to it, so a mixed population
+ * -- the norm, since a peer without extended requests v2 contributes 0 --
+ * settles at scalar 0 with Hi non-zero. Guarding on the scalar alone let that
+ * Hi through, and the desktop column and Web UI detail panel both render
+ * "< Hi" whenever Lo is 0, so the file kept claiming sources it no longer had
+ * (issue #1065). Lo cannot diverge from the scalar, but it is included so the
+ * guard stays honest if the estimation is ever changed.
+ *
+ * Still false once all three have settled at 0, which is what stops an idle
+ * shared file re-entering the recompute on every later call.
+ *
+ * Free function in a header of its own so it can be unit-tested: CKnownFile
+ * itself reaches theApp and cannot be linked into a test.
+ */
+inline bool CompleteSourcesNeedRecompute(
+	bool uploadListEmpty, std::uint16_t count, std::uint16_t countLo, std::uint16_t countHi)
+{
+	return uploadListEmpty && (count != 0 || countLo != 0 || countHi != 0);
+}
+
+#endif // COMPLETESOURCESTHROTTLE_H
+// File_checked_for_headers

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -27,6 +27,8 @@
 
 #include "KnownFile.h" // Do_not_auto_remove
 
+#include "CompleteSourcesThrottle.h" // CompleteSourcesNeedRecompute
+
 #include <protocol/kad/Constants.h>
 #include <protocol/ed2k/Client2Client/TCP.h>
 #include <protocol/ed2k/ClientSoftware.h>
@@ -1658,9 +1660,17 @@ void CKnownFile::UpdatePartsInfo()
 	// certain and free -- no peers, no complete sources -- is not worth
 	// deferring.
 	//
-	// Guarded on the value actually being non-zero, so a file that has already
-	// settled at 0 does not re-enter the recompute on every later call.
-	if (!flag && m_ClientUploadList.empty() && m_nCompleteSourcesCount != 0) {
+	// Guarded on the values actually being non-zero, so a file that has already
+	// settled at 0 does not re-enter the recompute on every later call. All
+	// three exported fields are asked, not just the scalar: Hi is a percentile
+	// of the peers' self-reported counts, floored at the scalar but never tied
+	// to it, so it can still be non-zero once the scalar has reached 0 -- and
+	// Hi is what the desktop column and the Web UI detail panel render
+	// (issue #1065). See CompleteSourcesNeedRecompute().
+	if (!flag && CompleteSourcesNeedRecompute(m_ClientUploadList.empty(),
+			     m_nCompleteSourcesCount,
+			     m_nCompleteSourcesCountLo,
+			     m_nCompleteSourcesCountHi)) {
 		flag = true;
 	}
 

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -718,6 +718,27 @@ target_link_libraries (RefresherTest
 # the id it looks the column up by -- a registry that renumbered stored ids
 # would hand a saved width back to the wrong column, with nothing to see. Needs
 # no GUI: the registry half of the class is plain wxString bookkeeping.
+add_executable (CompleteSourcesThrottleTest
+	CompleteSourcesThrottleTest.cpp
+)
+
+add_test (NAME CompleteSourcesThrottleTest
+	COMMAND CompleteSourcesThrottleTest
+)
+
+target_include_directories (CompleteSourcesThrottleTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+# mulecommon even though the header is inline-only: macOS links without it,
+# GNU ld and mingw do not.
+target_link_libraries (CompleteSourcesThrottleTest
+	muleunit
+	mulecommon
+)
+
 add_executable (ListColumnStoreTest
 	ListColumnStoreTest.cpp
 	${CMAKE_SOURCE_DIR}/src/ListColumnStore.cpp

--- a/unittests/tests/CompleteSourcesThrottleTest.cpp
+++ b/unittests/tests/CompleteSourcesThrottleTest.cpp
@@ -1,0 +1,90 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// CKnownFile::UpdatePartsInfo() recomputes the complete-sources estimate at
+// most once every 60 s, with one exception: the upload list going empty. That
+// transition cannot be deferred, because every caller is peer-driven and there
+// is no periodic sweep -- a throttled call there is the last one the file ever
+// gets, and the counts keep their values until aMule restarts (issue #1050).
+//
+// The bypass is guarded so a file already settled at 0 does not re-enter the
+// recompute forever. #1052 guarded it on the scalar alone, which was too
+// narrow: Hi is a percentile of the peers' self-reported counts and is only
+// floored at the scalar, never tied to it, so scalar 0 with Hi non-zero is a
+// reachable and in fact ordinary state -- any peer without extended requests
+// v2 contributes 0. Since the desktop column and the Web UI detail panel both
+// render "< Hi" whenever Lo is 0, that stale Hi is exactly what the user sees
+// (issue #1065).
+//
+// The predicate lives in its own header precisely so this can be tested:
+// CKnownFile reaches theApp and cannot be linked into a unit test.
+
+#include <muleunit/test.h>
+
+#include <CompleteSourcesThrottle.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(CompleteSourcesThrottle)
+
+// The bypass only ever applies when there is nobody left to ask.
+TEST(CompleteSourcesThrottle, PeersStillPresentNeverBypasses)
+{
+	ASSERT_FALSE(CompleteSourcesNeedRecompute(false, 0, 0, 0));
+	ASSERT_FALSE(CompleteSourcesNeedRecompute(false, 5, 5, 5));
+	ASSERT_FALSE(CompleteSourcesNeedRecompute(false, 0, 0, 5));
+}
+
+// Criterion 4: a file settled at zero must short-circuit, or every later call
+// on every idle shared file re-runs the full recompute.
+TEST(CompleteSourcesThrottle, AllZeroStaysSettled)
+{
+	ASSERT_FALSE(CompleteSourcesNeedRecompute(true, 0, 0, 0));
+}
+
+// The case #1052 already handled: a non-zero scalar must still recompute.
+TEST(CompleteSourcesThrottle, NonZeroScalarBypasses)
+{
+	ASSERT_TRUE(CompleteSourcesNeedRecompute(true, 5, 5, 5));
+	ASSERT_TRUE(CompleteSourcesNeedRecompute(true, 1, 0, 0));
+}
+
+// The regression #1065 is about, and the reason the scalar-only guard was
+// wrong. These are the states the estimation actually produces for a mixed
+// peer population, taken from the issue's sweep: two peers, one of them
+// reporting a non-zero count, lands on scalar 0 / Lo 0 / Hi N.
+TEST(CompleteSourcesThrottle, StaleHighAloneStillBypasses)
+{
+	ASSERT_TRUE(CompleteSourcesNeedRecompute(true, 0, 0, 1));
+	ASSERT_TRUE(CompleteSourcesNeedRecompute(true, 0, 0, 5));
+}
+
+// Lo cannot diverge from the scalar in either estimation branch -- n < 20
+// assigns the scalar from Lo, n >= 20 floors the scalar at Lo -- so this state
+// is not reachable today. Pinned anyway: the guard is written to survive the
+// heuristic changing, and this is the assertion that would notice if it did.
+TEST(CompleteSourcesThrottle, StaleLowAloneStillBypasses)
+{
+	ASSERT_TRUE(CompleteSourcesNeedRecompute(true, 0, 3, 0));
+}


### PR DESCRIPTION
Fixes #1065. Follow-up to #1050 / #1052 - and a bug I introduced there.

#1052 gave `UpdatePartsInfo()` a throttle bypass so the upload list going empty is never deferred by the 60 s window, but guarded it on the scalar `m_nCompleteSourcesCount` alone. That is too narrow, and the field the user actually *sees* kept going stale.

The three exported fields do not move together. `Hi` is a percentile of the peers' self-reported counts, floored at the scalar but never tied to it, so a mixed peer population settles at scalar `0` with `Hi` non-zero - and mixed is the normal case, since a peer without extended requests v2 always contributes `0`. Two peers, one reporting a count, is enough. With the scalar already `0` the bypass declined; every caller is peer-driven with no periodic sweep, so the call the last departure triggered was the last that file would ever get, and `Hi` kept its value until restart.

That is what gets rendered: the desktop Complete Sources column and the Web UI detail panel both print `< Hi` whenever `Lo` is `0`, so the file went on claiming sources it no longer had, while the Web UI list column said `0` and the availability bar was all red. Three readings disagreeing about one file.

I verified each step of the analysis in the issue against the code - the guard, both estimation branches, the renderer, and that `Lo` genuinely cannot diverge from the scalar. The diagnosis was accurate throughout.

### Fix

Ask all three fields. `Lo` is strictly redundant but included so the guard stays honest if the estimation changes. A file settled at `0` on all three still short-circuits, which is what the guard was for. Criterion 3 comes free: `MarkECChanged()` already sits inside the recompute block.

### Test

The predicate moves into a header of its own **so that it can be tested** - `CKnownFile` reaches `theApp` and cannot be linked into a unit test, which is why #1050 and #1052 both shipped without coverage of the decision that has now been wrong twice.

`CompleteSourcesThrottleTest` pins the reachable states from the issue's sweep, and I ran it against the old guard as a control: it fails on `(true, 0, 0, 1)` - the exact `Hi`-alone case. Suite is 37/37 with the fix.
