### PR TITLE
fix(amuleapi): serve a shared partfile's real directory, with an explicit flag

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1344,7 +1344,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 |---|---|---|
 | `file_type` | string | Category token derived from the extension, lowercased: `"audio"`, `"videos"`, `"archives"`, `"cd-images"`, `"pictures"`, `"texts"`, `"programs"`, or `"any"` for unknown. |
 | `share_ratio` | number | `xfer.total / size`; `0` when `size == 0`. |
-| `path` | string | Directory path of the on-disk file, or `"[PartFile]"` when the shared file is still an incomplete partfile. |
+| `path` | string | Directory path of the on-disk file — the temp directory while the file is still an incomplete partfile, the destination directory once it has completed. Identical to `path` on `/downloads/{hash}` for the same file. |
+| `incomplete` | bool | `true` while the file is still an incomplete partfile, `false` once complete. Always present. A download that has finished but has not been cleared yet reports `false`, since its data already sits in the destination directory. |
 | `complete_sources_range` | object | `{ "low": int, "high": int }` — the estimated full-copy source range behind the scalar `complete_sources`. |
 | `aich_hash` | string | AICH master hash (hex); `""` if not yet computed. |
 | `part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2914,12 +2914,18 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.ValueDouble(
 		f.size > 0 ? static_cast<double>(f.shared.xfer_total) / static_cast<double>(f.size) : 0.0);
 	w.Key("path");
-	// "[PartFile]" only while genuinely an incomplete partfile; once the
-	// download completes (even if still listed under downloads, not yet
-	// cleared) the real destination directory is available (#417).
-	const bool incomplete_partfile = f.is_downloading && f.download.status != "completed";
-	w.ValueString(incomplete_partfile ? wxString::FromAscii("[PartFile]")
-					  : wxString::FromUTF8(f.on_disk_dir.c_str()));
+	// The on-disk directory (Temp while downloading, destination once
+	// completed) -- the same value /downloads/{hash} reports for this file.
+	// This was once masked with a placeholder while the file was incomplete,
+	// which hid nothing -- the sibling endpoint served the real value for the
+	// same file on the same tick -- and cost clients a usable field.
+	// `incomplete` below carries that state explicitly instead.
+	w.ValueString(wxString::FromUTF8(f.on_disk_dir.c_str()));
+	w.Key("incomplete");
+	// Always present, so clients can test it rather than probe for absence.
+	// Detail-only, like `path`: the list object and the shared_updated diff
+	// deliberately carry neither, so the SSE event rate is unaffected.
+	w.ValueBool(f.IsIncompletePartfile());
 	w.Key("complete_sources_range");
 	w.BeginObject();
 	w.Key("low");
@@ -8797,11 +8803,10 @@ CHttpServer::Response CApiDispatcher::HandleSharedVerify(
 	// Partfiles have no verify implementation: the hashing task bails out on
 	// IsPartFile(), and amuled's EC handler answers NOOP either way, so a
 	// caller would be told the re-hash was accepted and then never see a
-	// report. Reject up front instead. Same "genuinely incomplete" test the
-	// `path` field uses (#417): a download that has completed but is still
-	// listed keeps is_downloading set, yet is a knownfile by then and so is
-	// a legitimate verify target.
-	if (s.is_downloading && s.download.status != "completed") {
+	// report. Reject up front instead -- a download that has completed but is
+	// still listed is a knownfile by then, and so a legitimate verify target,
+	// which is exactly what IsIncompletePartfile() excludes.
+	if (s.IsIncompletePartfile()) {
 		return ErrorResponse(
 			409, "partfile_unsupported", "verify local data is not supported on a partfile");
 	}

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -273,6 +273,17 @@ struct FileSnapshot
 		std::uint32_t last_upload = 0;
 		std::uint32_t shared_since = 0;
 	} shared;
+
+	// True while the file is genuinely an incomplete partfile: still in the
+	// download queue, and not the "finished but not yet cleared" state.
+	//
+	// The distinction matters because a completed download keeps
+	// `is_downloading` set until the user clears it, while already being a
+	// knownfile whose data sits in its destination directory -- so
+	// `is_downloading` alone would misreport it. "completing" is incomplete
+	// on purpose: the data is still in the temp directory until the move
+	// finishes.
+	bool IsIncompletePartfile() const { return is_downloading && download.status != "completed"; }
 };
 
 // One per peer (CUpDownClient) in the daemon's active client list.

--- a/src/webapi/static/js/components.js
+++ b/src/webapi/static/js/components.js
@@ -105,8 +105,8 @@ function fullPath(file) {
   return dir + (dir.includes("\\") ? "\\" : "/") + (file.name || "");
 }
 
-// Rejects "" and the "[PartFile]" sentinel /shared returns for an incomplete
-// share (REFERENCE.md); accepts a POSIX path or a Windows drive letter.
+// Rejects "" (a path the daemon has not reported yet); accepts a POSIX path
+// or a Windows drive letter.
 const hasRealPath = (file) => /^([/\\]|[A-Za-z]:)/.test(file.path || "");
 
 // The identity group shared by both detail panels: the hash plus extra fields

--- a/unittests/curl-tests/amuleapi/30-shared-verify.sh
+++ b/unittests/curl-tests/amuleapi/30-shared-verify.sh
@@ -117,15 +117,14 @@ fi
 
 # Pick a completed entry — a shared partfile is rejected by design, so it
 # can't stand in for the happy path. The list object carries no partfile
-# flag; the detail object's `path` reads "[PartFile]" exactly while a file
-# is genuinely incomplete (#417), so classify through that. The same sweep
+# flag, so classify on the detail object's `incomplete`. The same sweep
 # picks up a partfile for the 409 guard below, when the library has one.
 TEST_HASH=""
 PART_HASH=""
 for h in $(printf '%s' "$CURL_BODY" | jq -r '.shared[].hash' | head -20); do
-	P=$(curl -s --max-time 10 -H "Authorization: Bearer $ADMIN_TOKEN" \
-		"$HOST/api/v0/shared/$h" | jq -r '.path')
-	if [ "$P" = "[PartFile]" ]; then
+	INCOMPLETE=$(curl -s --max-time 10 -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/shared/$h" | jq -r '.incomplete')
+	if [ "$INCOMPLETE" = "true" ]; then
 		[ -z "$PART_HASH" ] && PART_HASH=$h
 	else
 		[ -z "$TEST_HASH" ] && TEST_HASH=$h

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -900,7 +900,7 @@ TEST(Refresher, SharedDetailTagsDecodeIntoSnapshot)
 	ASSERT_EQUALS(static_cast<std::uint32_t>(9), s.queued_count);
 	ASSERT_EQUALS(std::string("FEDCBA9876"), s.aich_hash);
 	// Completed known file → the directory path arrives on its own tag
-	// (the write layer maps an incomplete shared partfile to "[PartFile]").
+	// (the write layer reports it verbatim, with `incomplete` alongside).
 	ASSERT_EQUALS(std::string("/home/me/Incoming"), s.on_disk_dir);
 	// Upload activity (issue #466) decodes into the shared sub-block.
 	ASSERT_EQUALS(static_cast<std::uint32_t>(51200), s.shared.upload_speed_bps);

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -218,6 +218,92 @@ TEST(State, MutateDownloadsDecodedRleFieldsRoundtrip)
 	ASSERT_EQUALS(static_cast<std::uint16_t>(7), via_find.download.decoded_part_sources[2]);
 }
 
+// FileSnapshot::IsIncompletePartfile() decides two things: whether
+// /shared/{hash} reports `incomplete`, and whether "verify local data" is
+// rejected as unsupported. Both want "genuinely still a partfile", which is
+// not the same question as "is in the download queue".
+TEST(State, IncompletePartfileIsFalseForAPureShare)
+{
+	FileSnapshot f;
+	f.is_shared = true;
+	f.is_downloading = false;
+	// A file that was never downloaded here has no download side at all, so
+	// the status string is empty rather than "completed".
+	ASSERT_TRUE(f.download.status.empty());
+	ASSERT_FALSE(f.IsIncompletePartfile());
+}
+
+TEST(State, IncompletePartfileIsTrueWhileDownloading)
+{
+	FileSnapshot f;
+	f.is_downloading = true;
+	f.download.status = "downloading";
+	ASSERT_TRUE(f.IsIncompletePartfile());
+}
+
+// The case the flag exists for: a finished download stays in the queue, with
+// is_downloading still set, until the user clears it -- but by then it is a
+// knownfile whose data is in the destination directory. Reporting it as an
+// incomplete partfile would be wrong, and would also reject a legitimate
+// verify target.
+TEST(State, IncompletePartfileIsFalseForCompletedButNotCleared)
+{
+	FileSnapshot f;
+	f.is_downloading = true;
+	f.download.status = "completed";
+	ASSERT_FALSE(f.IsIncompletePartfile());
+}
+
+// A paused or stopped partfile is still an incomplete partfile: pausing
+// changes whether it transfers, not whether its data is whole. Same for every
+// other non-completed state the wire exposes, including "completing" -- the
+// data lives in the temp directory until that move finishes.
+TEST(State, IncompletePartfileIsTrueForEveryNonCompletedStatus)
+{
+	static const char *const kIncompleteStates[] = { "downloading",
+		"paused",
+		"stopped",
+		"completing",
+		"hashing",
+		"waiting",
+		"allocating",
+		"erroneous",
+		"insufficient_disk",
+		"unknown" };
+	for (const char *status : kIncompleteStates) {
+		FileSnapshot f;
+		f.is_downloading = true;
+		f.download.status = status;
+		ASSERT_TRUE(f.IsIncompletePartfile());
+	}
+}
+
+// Only the exact wire string counts. The check is against "completed", not a
+// prefix or a substring, so the neighbouring "completing" state must not be
+// swept in with it.
+TEST(State, IncompletePartfileDistinguishesCompletingFromCompleted)
+{
+	FileSnapshot completing;
+	completing.is_downloading = true;
+	completing.download.status = "completing";
+	FileSnapshot completed;
+	completed.is_downloading = true;
+	completed.download.status = "completed";
+	ASSERT_TRUE(completing.IsIncompletePartfile());
+	ASSERT_FALSE(completed.IsIncompletePartfile());
+}
+
+// is_downloading is the gate: a shared knownfile never in the queue is
+// complete whatever the download side happens to hold.
+TEST(State, IncompletePartfileRequiresBeingInTheDownloadQueue)
+{
+	FileSnapshot f;
+	f.is_shared = true;
+	f.is_downloading = false;
+	f.download.status = "downloading";
+	ASSERT_FALSE(f.IsIncompletePartfile());
+}
+
 TEST(State, MutateClientsAndSharedRoundtrip)
 {
 	CState s;


### PR DESCRIPTION
Fixes #1063.

`GET /shared/{hash}` reported `path` as the literal `"[PartFile]"` while the file was still incomplete. That masked nothing — `GET /downloads/{hash}` served the real directory for the same file on the same tick — while costing clients a usable field.

It also contradicted the tree's own documentation in two places: `State.h` says `on_disk_dir` feeds "an unambiguous `path` on both /downloads/{hash} and /shared/{hash}", and the downloads writer's comment claims it "mirrors the `path` field on /shared/{hash}". It did not.

## The sentinel was load-bearing

`/shared/{hash}` emits no `status` and no `is_downloading` — I checked the full key set — so the sentinel was the endpoint's **only** incompleteness signal, and `30-shared-verify.sh` classified partfiles by string-matching it. Removing it alone would have broken that classifier, and with it the `409 partfile_unsupported` guard downstream that consumes the hash it picks.

So this is two changes: emit the real path, **and** add the boolean the sentinel stood in for.

`incomplete` is always present, and detail-only — the list object and the `shared_updated` diff carry neither field, so `EqualShared` is untouched and the SSE event rate is unchanged.

## Deduplicated rather than added

The predicate was already written out twice: once for the path masking, once for the verify endpoint's 409 guard. It is now stated once, as `FileSnapshot::IsIncompletePartfile()`.

It is deliberately not `is_downloading`: a finished download keeps that flag until the user clears it, while already being a knownfile whose data sits in its destination. That is exactly why the verify guard has to agree with the path field — and now it does so by construction rather than by two copies staying in sync.

## Tests

Six unit tests in `StateTest.cpp` cover the matrix, aimed at the states most likely to be got wrong:

- paused and stopped are **incomplete** — pausing changes whether a file transfers, not whether its data is whole
- `"completing"` is **incomplete** (data is still in temp) and must not be swept in with `"completed"` by a prefix match
- completed-but-not-cleared is **complete**
- a share that was never in the queue is complete whatever its download side holds

Verified by mutation, not just by passing: dropping the completed exception, prefix-matching `"complet"`, and dropping the queue gate each fail the suite; the real predicate passes.

## Verified against a live daemon

Ran an isolated `amuled` + `amuleapi` stack on macOS:

- complete share → real destination directory and `"incomplete": false`
- `/shared` list object carries neither `path` nor `incomplete` (criterion 5)
- `30-shared-verify.sh` passes **9/9** with the new `.incomplete` classifier
- a partfile with no complete parts reports its temp directory on `/downloads/{hash}`

**What I could not verify live, and why:** `"incomplete": true` on `/shared/{hash}` needs a partfile with at least one *complete* part, since `CSharedFileList` only shares `PS_READY` partfiles — I confirmed the zero-part case 404s on `/shared`, which is also why the suite's 409 guard reports "no shared partfile present" and skips. That branch is covered by the unit-test matrix and by both endpoints reading the same `f.on_disk_dir`, not by observation.

## Out of scope

`amulecmd`'s translated placeholder stays — it is a display string in a terminal client, not a typed API field. The Web UI needs no change: `hasRealPath()` starts matching on its own, so the shared detail panel gains the copy-path button and a real directory. Its comment naming the old sentinel is updated, since that string no longer exists.

clang-format and both clang-tidy tiers clean. The acceptance grep over `src/webapi/` and `docs/api/` comes back empty.
