### PR TITLE
fix(web-ui): keep the browse tab when a second browse joins it

### DIFF
--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -313,13 +313,24 @@ export const searches = {
 
   // "View files": a browse is an ordinary search of kind "browse", so it gets
   // an ordinary tab. Generic, so any future entry point reuses it.
+  //
+  // Find-or-create, unlike start(): browsing a peer that is already being
+  // browsed returns the id already in flight (amule-org/amule#1059), so a
+  // second click lands on the tab that is already open. Overwriting it would
+  // throw away its results, its badge and its per-tab ui state (selection,
+  // filter, per-row category) for a browse that never restarted.
   async browse(ecid, name) {
     const r = await api.post("clients/" + ecid + "/shared_files");
     const id = r.search_id;
-    tabs.set(id, newTab({
-      id, query: name || "", label: name || "", kind: "browse",
-      state: "running", startedAt: nowSec(),
-    }));
+    const open = tabs.get(id);
+    if (open) {
+      if (name) { open.query = name; open.label = name; }
+    } else {
+      tabs.set(id, newTab({
+        id, query: name || "", label: name || "", kind: "browse",
+        state: "running", startedAt: nowSec(),
+      }));
+    }
     setActive(id);
     toast(t("search_toast_browse_started"), "info");
     if (location.hash !== "#/search") location.hash = "#/search";


### PR DESCRIPTION
Since amule-org/amule#1059, browsing a peer that is already being browsed returns the search id already in flight rather than allocating a new one, so a second "View files" click on the same peer now resolves to the tab that is already open.

searches.browse() still built a fresh tab unconditionally, which under the new behaviour overwrites the live one: it dropped that tab's results map, its badge count, its moreExhausted flag and its per-tab ui state (selection, filter, per-row category and ecid), and restamped startedAt. The results came back on the setActive() -> refresh() round trip, but the user's selection and filter did not.

Make it find-or-create, like the desktop's CSearchDlg::EnsureBrowseTab: reuse the open tab, refreshing only its name, and create one just for an id that is new. start() is unchanged -- a POST /search always yields a new id, so it cannot collide with an open tab.