### PR TITLE
fix(core): end a browse the daemon never starts, instead of leaving it running

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1196,6 +1196,8 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 { "ok": true, "search_id": 17 }
 ```
 
+A browse the daemon cannot even start — a LowID peer it has no way to call back, for instance — is reported as `finished` immediately rather than left pending: no connection is attempted, so there is nothing to wait for. It carries no results, the same as a browse the peer denied.
+
 **Idempotent while a browse is running.** Asking again for a peer that is already being browsed returns **the same `search_id`** rather than starting a second browse — amuled will not re-ask a peer that is still answering, so a second id would name a browse that never happens. Two clicks therefore leave one browse, one id and one entry on [`GET /api/v0/search`](#get-apiv0search). Once that browse has settled, a fresh request starts a new one with a new id.
 
 Status `202 Accepted` — the browse was started, not completed. Then poll:

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -983,11 +983,6 @@ msgid "Unknown"
 msgstr ""
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1007,6 +1002,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1006,11 +1006,6 @@ msgid "Unknown"
 msgstr "غير معرف"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "بانتظار اﻻتصال ..."
@@ -1031,6 +1026,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1022,11 +1022,6 @@ msgid "Unknown"
 msgstr "Desconocíu"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Guetando a un collaciu con conexón idbaxa"
 
@@ -1047,6 +1042,11 @@ msgstr "xMule (Falsu eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basáu en eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1001,11 +1001,6 @@ msgid "Unknown"
 msgstr "Неизвестен"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "изчакване за свързване..."
@@ -1026,6 +1021,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -982,11 +982,6 @@ msgid "Unknown"
 msgstr ""
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1006,6 +1001,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1021,11 +1021,6 @@ msgid "Unknown"
 msgstr "Desconegut"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Buscant amic per connexió amb ID Baixa"
 
@@ -1046,6 +1041,11 @@ msgstr "xMule (eMule fals)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basat en l'eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1023,11 +1023,6 @@ msgid "Unknown"
 msgstr "Neznámý"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Hledám kamaráda pro LowID připojení"
 
@@ -1048,6 +1043,11 @@ msgstr "xMule (falešná eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (založeno na eMule v.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1009,11 +1009,6 @@ msgid "Unknown"
 msgstr "Ukendt"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
-
-#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "venter pÃ¥ forbindelse..."
@@ -1035,6 +1030,11 @@ msgstr "xMule (Falsk eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseret på eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1030,11 +1030,6 @@ msgid "Unknown"
 msgstr "Unbekannt"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Suche Kumpel für Verbindung mit niedriger ID"
 
@@ -1055,6 +1050,11 @@ msgstr "xMule (Fake eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basiert auf eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1031,11 +1031,6 @@ msgid "Unknown"
 msgstr "Άγνωστο"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1056,6 +1051,11 @@ msgstr "xMule (Πλασματικό eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (βασισμένο στο eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -983,11 +983,6 @@ msgid "Unknown"
 msgstr ""
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1007,6 +1002,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1029,11 +1029,6 @@ msgid "Unknown"
 msgstr "Desconocido"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Buscando un amigo para conexión con Id Baja"
 
@@ -1054,6 +1049,11 @@ msgstr "xMule (falso eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basado en eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1021,11 +1021,6 @@ msgid "Unknown"
 msgstr "Teadmata"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Otsin lowid ühenduse jaoks semu"
 
@@ -1046,6 +1041,11 @@ msgstr "xMule (Valetatud eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseerub eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1022,11 +1022,6 @@ msgid "Unknown"
 msgstr "Ezezaguna"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Laguna bilatzen id-baxu konexiorako"
 
@@ -1047,6 +1042,11 @@ msgstr "xMule (Gezurrezko eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (eMule v0.%u-tan oinarriturik)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1022,11 +1022,6 @@ msgid "Unknown"
 msgstr "Tuntematon"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Etsitään kaveria lowid-yhteydelle"
 
@@ -1047,6 +1042,11 @@ msgstr "xMule (Vale-eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (pohjautuu eMule-versioon v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1028,11 +1028,6 @@ msgid "Unknown"
 msgstr "Inconnu"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Recherche d'un pote pour une connexion lowid"
 
@@ -1053,6 +1048,11 @@ msgstr "xMule (Faux eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basé sur eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1043,11 +1043,6 @@ msgid "Unknown"
 msgstr "Descoñecido"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Buscando colega para unha conexión IDBaixa"
 
@@ -1068,6 +1063,11 @@ msgstr "xMule (eMule falso)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado en eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1012,11 +1012,6 @@ msgid "Unknown"
 msgstr "לא ידוע"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1037,6 +1032,11 @@ msgstr "אקס-מיול (חיקוי אימיול)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.איקס (מבוסס על אימיול בגרסת 0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1010,11 +1010,6 @@ msgid "Unknown"
 msgstr "Nepoznat"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 #, fuzzy
 msgid "Searching buddy for lowid connection"
 msgstr "ceka na spajanje..."
@@ -1035,6 +1030,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1024,11 +1024,6 @@ msgid "Unknown"
 msgstr "Ismeretlen"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Pajtás keresése lowid kapcsolatra"
 
@@ -1049,6 +1044,11 @@ msgstr "xMule (Hamis eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x  (az eMule v0.%u alapján)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1035,11 +1035,6 @@ msgid "Unknown"
 msgstr "Sconosciuto"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Ricerca amico per connessione con ID basso"
 
@@ -1060,6 +1055,11 @@ msgstr "xMule (falso eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (basato su eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1026,11 +1026,6 @@ msgid "Unknown"
 msgstr "不明"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1051,6 +1046,11 @@ msgstr "xMule（偽のeMule）"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x（eMule v0.%u に基づいています）"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1029,11 +1029,6 @@ msgid "Unknown"
 msgstr "알수없는"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1054,6 +1049,11 @@ msgstr "엑스뮬(가짜 이뮬)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (이뮬 v0.%u 기반)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1031,11 +1031,6 @@ msgid "Unknown"
 msgstr "Nežinoma"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1056,6 +1051,11 @@ msgstr "xMule (neteisinga eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (paremta eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -995,11 +995,6 @@ msgid "Unknown"
 msgstr "Nezināms"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Neizdevās iegūt dalībnieka '%s' kopīgoto datņu sarakstu"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1020,6 +1015,11 @@ msgstr ""
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Neizdevās iegūt dalībnieka '%s' kopīgoto datņu sarakstu"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1024,11 +1024,6 @@ msgid "Unknown"
 msgstr "Onbekend"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Op zoek naar buddy voor laag-ID-verbinding"
 
@@ -1049,6 +1044,11 @@ msgstr "xMule (Nep eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (gebaseerd op eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1029,11 +1029,6 @@ msgid "Unknown"
 msgstr "Ukjend"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1054,6 +1049,11 @@ msgstr "xMule (Falsk eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x·(basert på eMule·v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1024,11 +1024,6 @@ msgid "Unknown"
 msgstr "Nieznany"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Szukam kolegi dla połączenia lowid"
 
@@ -1049,6 +1044,11 @@ msgstr "xMule (Fałszywy eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (oparty na eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1029,11 +1029,6 @@ msgid "Unknown"
 msgstr "Desconhecido"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Falha ao receber lista de compartilhamentos do usuário '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Procurando amigo para conexão lowid"
 
@@ -1054,6 +1049,11 @@ msgstr "xMule (eMule Falso)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado no eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Falha ao receber lista de compartilhamentos do usuário '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1028,11 +1028,6 @@ msgid "Unknown"
 msgstr "Desconhecido"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "A procurar parceiro para ligação com lowid"
 
@@ -1053,6 +1048,11 @@ msgstr "xMule (eMule falso)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baseado no eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1021,11 +1021,6 @@ msgid "Unknown"
 msgstr "Necunoscut"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Se caută parteneri pentru conexiunea lowid"
 
@@ -1046,6 +1041,11 @@ msgstr "xMule (eMule fals)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (bazat pe eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1033,11 +1033,6 @@ msgid "Unknown"
 msgstr "Неизвестно"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Не удалось получить список доступных файлов от '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Ищем друга для соединения с Низким ИД"
 
@@ -1058,6 +1053,11 @@ msgstr "xMule (имитация eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (на основе eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Не удалось получить список доступных файлов от '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1027,11 +1027,6 @@ msgid "Unknown"
 msgstr "Neznano"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Iskanje kolega za povezavo z nizkim ID-jem"
 
@@ -1052,6 +1047,11 @@ msgstr "xMule (lažni eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (temelji na eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1026,11 +1026,6 @@ msgid "Unknown"
 msgstr "E panjohur"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1051,6 +1046,11 @@ msgstr "xMule (eMule e falsifikuar)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (e bazuar ne eMule v0 %u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1020,11 +1020,6 @@ msgid "Unknown"
 msgstr "Okänd"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Misslyckades med att hämta filer från användaren '%s'"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Letar efter en kompis för lowid-anslutning"
 
@@ -1045,6 +1040,11 @@ msgstr "xMule (Falsk eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (baserad på eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Misslyckades med att hämta filer från användaren '%s'"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -982,11 +982,6 @@ msgid "Unknown"
 msgstr ""
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1006,6 +1001,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1021,11 +1021,6 @@ msgid "Unknown"
 msgstr "Bilinmiyor"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "DüşükID bağlantı için bir eş aranıyor"
 
@@ -1046,6 +1041,11 @@ msgstr "xMule (Sahte eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (eMule s.0.%u üzerine kurulu)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1022,11 +1022,6 @@ msgid "Unknown"
 msgstr "Невідомо"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Неможливо отримати спільні файли користувача %s"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "Шукається друг для lowid-з'єднання"
 
@@ -1047,6 +1042,11 @@ msgstr "xMule (підробний eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (оснований на eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Неможливо отримати спільні файли користувача %s"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -981,11 +981,6 @@ msgid "Unknown"
 msgstr ""
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
@@ -1005,6 +1000,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
+msgstr ""
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/BaseClient.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1025,11 +1025,6 @@ msgid "Unknown"
 msgstr "未知"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "无法获取用户 %s 的共享文件"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "正在搜索好友进行 Low ID 连接"
 
@@ -1050,6 +1045,11 @@ msgstr "xMule (假冒 eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (基于 eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "无法获取用户 %s 的共享文件"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-22 15:15+0200\n"
+"POT-Creation-Date: 2026-08-22 19:49+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1025,11 +1025,6 @@ msgid "Unknown"
 msgstr "不明"
 
 #: src/BaseClient.cpp
-#, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "無法從使用者 %s 取得分享檔案清單"
-
-#: src/BaseClient.cpp
 msgid "Searching buddy for lowid connection"
 msgstr "搜尋 LowID 連線好友"
 
@@ -1050,6 +1045,11 @@ msgstr "xMule (假 eMule)"
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr "1.x (源自 eMule v0.%u)"
+
+#: src/BaseClient.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "無法從使用者 %s 取得分享檔案清單"
 
 #: src/BaseClient.cpp
 #, c-format

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -1395,11 +1395,7 @@ bool CUpDownClient::Disconnected(const wxString &DEBUG_ONLY(strReason), bool bFr
 
 	SetSocket(NULL);
 
-	if (m_iFileListRequested) {
-		AddLogLineC(CFormat(_("Failed to retrieve shared files from user '%s'")) % GetUserName());
-		m_iFileListRequested = 0;
-		MarkBrowse(BROWSE_FAILED);
-	}
+	FailPendingBrowse();
 
 	if (bDelete) {
 		if (m_Friend) {
@@ -2091,6 +2087,46 @@ void CUpDownClient::MarkBrowse(EBrowseStatus s)
 	Notify_Browse_Status((uint64)GetBrowseRoutingId(), s);
 }
 
+void CUpDownClient::FailPendingBrowse()
+{
+	if (m_iFileListRequested) {
+		AddLogLineC(CFormat(_("Failed to retrieve shared files from user '%s'")) % GetUserName());
+		m_iFileListRequested = 0;
+		MarkBrowse(BROWSE_FAILED);
+	}
+}
+
+bool CUpDownClient::IsPeerContactPending() const
+{
+	// A live connection carries the browse directly; ConnectionEstablished
+	// sends the request off the back of it.
+	//
+	// A socket that merely exists counts too: CUpDownClient::Connect starts an
+	// asynchronous connect, so the HighID path returns with the socket created
+	// but not yet connected, and OnConnect/Disconnected settle it either way.
+	// The silent exits this predicate exists to catch all return before the
+	// socket is created, so they cannot be confused with one in progress.
+	if (IsConnected() || GetSocket() != nullptr) {
+		return true;
+	}
+	// A direct UDP callback brings its own 45s deadline, after which
+	// CClientList::ProcessDirectCallbackList disconnects us and the browse
+	// fails through that path.
+	if (m_dwDirectCallbackTimeout != 0) {
+		return true;
+	}
+	// A server or Kad callback we have asked for: the peer may still connect
+	// back, and the browse rides that connection when it does.
+	switch (GetDownloadState()) {
+	case DS_CONNECTING:
+	case DS_WAITCALLBACK:
+	case DS_WAITCALLBACKKAD:
+		return true;
+	default:
+		return false;
+	}
+}
+
 void CUpDownClient::RequestSharedFileList()
 {
 	if (m_iFileListRequested == 0) {
@@ -2104,7 +2140,29 @@ void CUpDownClient::RequestSharedFileList()
 		m_browseStatus = BROWSE_IN_PROGRESS;
 		UpdateBrowseBar();
 		Notify_Browse_Started(ECID(), GetUserName(), (uint64)GetBrowseRoutingId());
-		TryToConnect(true);
+		if (!TryToConnect(true)) {
+			// false means the client was deleted (see TryToConnect), and it
+			// only gets there through Disconnected(), which has already
+			// failed the browse. Nothing left that may be touched.
+			return;
+		}
+		// TryToConnect returns true both when it started contacting the peer
+		// and when it decided not to, and several of its exits do the latter
+		// silently: a LowID peer we cannot call back, a Kad firewalled source
+		// with too many lookups in flight, a queued LowID source it merely
+		// arranges to reask later. None of those send a packet, so no terminal
+		// path downstream ever runs and the browse would sit BROWSE_IN_PROGRESS
+		// with nothing able to end it -- until the client-list cleanup reaps
+		// the peer 34 minutes later, or never, when the peer is also a download
+		// source (that same branch sets DS_LOWTOLOWIP, and the cleanup skips
+		// anything that is not DS_NONE).
+		//
+		// Tested here on the outcome rather than at each of those exits:
+		// there are four of them today, they are not marked as a family, and
+		// the next one added would silently rejoin this bug.
+		if (!IsPeerContactPending()) {
+			FailPendingBrowse();
+		}
 	} else {
 		AddDebugLogLineN(logClient,
 			CFormat("Requesting shared files from user %s (%u) is already in progress") %

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -506,6 +506,22 @@ public:
 	// Push the current bar value into CSearchList's browse-bar cache (keyed by
 	// GetBrowseRoutingId), so both the monolithic bar and the EC reply see it.
 	void UpdateBrowseBar();
+	/**
+	 * End a browse this client can no longer carry; no-op when none is pending.
+	 *
+	 * Clears the in-flight flag BEFORE the terminal mark, the order every
+	 * other terminal path takes, so a later request for this peer starts a
+	 * fresh browse instead of joining a dead one -- the invariant the EC
+	 * browse handler's join relies on (ExternalConn.cpp).
+	 */
+	void FailPendingBrowse();
+	/**
+	 * Whether anything is still on its way to or from this peer: a live
+	 * connection, a direct UDP callback, or a server/Kad callback we asked
+	 * for. False means nothing will arrive on its own, so a browse waiting on
+	 * this client can be failed at once instead of hanging.
+	 */
+	bool IsPeerContactPending() const;
 
 	void ResetFileStatusInfo();
 

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -1188,6 +1188,70 @@ else
 	echo "    info: no connected peer — skipping the browse happy path"
 fi
 
+# --- Browse of a peer the daemon declines to contact. --------------
+# A LowID peer amuled cannot call back is never contacted at all: TryToConnect
+# returns having sent nothing. Such a browse used to sit `running` forever --
+# bounded only by the 34-minute client-list cleanup, and not even by that when
+# the peer is also a download source, since the branch that declines the
+# contact sets DS_LOWTOLOWIP and the cleanup skips anything not DS_NONE
+# (amule-org/amule#1071). It must now reach a terminal state at once.
+#
+# Needs a peer in exactly that state, which no CI environment can guarantee,
+# so probe for one and skip -- not fail -- when there is none, like the other
+# peer-dependent assertions in this suite.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/clients"
+UNREACHABLE_ECID=$(printf '%s' "$CURL_BODY" \
+	| jq -r '[.clients[] | select(.download_state == "lowtolowip")][0].ecid // empty')
+if [ -n "$UNREACHABLE_ECID" ]; then
+	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/clients/$UNREACHABLE_ECID/shared_files"
+	if [ "$CURL_STATUS" = "202" ]; then
+		DEAD_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		# No peer round trip is involved -- the daemon decides not to contact
+		# it and fails the browse in the same call -- so a short settle is
+		# enough. Poll rather than sleep blindly, to keep it quick when it
+		# behaves and still generous when the machine is loaded.
+		DEAD_STATE=""
+		for _ in 1 2 3 4 5 6 7 8 9 10; do
+			_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+			DEAD_STATE=$(printf '%s' "$CURL_BODY" | \
+				jq -r "[.searches[] | select(.search_id == $DEAD_SID)][0].state")
+			[ "$DEAD_STATE" = "finished" ] && break
+			sleep 1
+		done
+		if [ "$DEAD_STATE" = "finished" ]; then
+			_pass "browse of an uncontactable peer reaches finished, not stuck running"
+		else
+			_fail "browse of an uncontactable peer" \
+				"expected finished within 10s, got $DEAD_STATE"
+		fi
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/search/$DEAD_SID/results?limit=1"
+		_assert_json_eq '.progress.state' finished \
+			'the results endpoint agrees the dead browse is finished'
+
+		# The in-flight flag was cleared with the terminal mark, so the peer
+		# is still browsable rather than joined to a dead browse for good.
+		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/clients/$UNREACHABLE_ECID/shared_files"
+		RETRY_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		if [ "$RETRY_SID" != "$DEAD_SID" ]; then
+			_pass "a later browse of that peer starts fresh ($RETRY_SID), not the dead id"
+		else
+			_fail "browse of an uncontactable peer is not retryable" \
+				"retry joined the failed browse $DEAD_SID"
+		fi
+		for SID_TO_FREE in $DEAD_SID $RETRY_SID; do
+			curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+				"$HOST/api/v0/search/$SID_TO_FREE" >/dev/null 2>&1
+		done
+	else
+		echo "    info: browse of $UNREACHABLE_ECID returned $CURL_STATUS — skipping"
+	fi
+else
+	echo "    info: no uncontactable (lowtolowip) peer — skipping the dead-browse check"
+fi
+
 # --- Related-files search (docs contract). -------------------------
 # There is no endpoint: the desktop composes a magic keyword and starts an
 # ordinary LOCAL search, so a REST client does the same. Assert the shape


### PR DESCRIPTION
Fixes #1071.

## The fix, and why it isn't where the issue proposed

The issue asks for `FailPendingBrowse()` at the two silent exits in `TryToConnect()`. I enumerated every exit in that function and there are **four** that contact nobody, not two:

| Exit | Reachable how |
|---|---|
| LowID peer we cannot call back | the reported case |
| `DS_TOOMANYCONNSKAD` | reported |
| **queued LowID source** — the `else` at the end of the LowID block, which only sets `m_bReaskPending` / `DS_ONQUEUE` | ordinary state for a download source we're queued on |
| **`CSearchManager::StartSearch` fails** — `wxFAIL`, then falls through | "should never happen", silent in Release |

The third is plainly reachable, so the point fix would have left the bug alive. Rather than patch four sites and hope the fifth never appears, this checks the **outcome** once, in `RequestSharedFileList()` — the single place a browse starts:

```cpp
if (!TryToConnect(true)) { return; }   // false means deleted; Disconnected already failed it
if (!IsPeerContactPending()) { FailPendingBrowse(); }
```

`TryToConnect` returns `true` both when it started contacting the peer and when it declined, so the return value cannot distinguish them — but the client state can. `IsPeerContactPending()` is true for a live connection, a socket mid-connect (`Connect()` is asynchronous, so the HighID path returns before it completes), a direct UDP callback in flight (which brings its own 45 s deadline), or a server/Kad callback we asked for. Nothing else can deliver a browse.

This also satisfies acceptance criterion 5 by construction rather than by a guard: the check lives on the `m_iFileListRequested == 0` branch, so the re-entrant `TryToConnect()` calls other callers make for the same client never reach it, and a streaming browse cannot be caught by it. No `!IsConnected()` guard needed.

`FailPendingBrowse()` is the factoring you described, and `Disconnected()` now calls it instead of repeating the three lines.

## On the 34-minute bound

Worth recording: the worst case is self-inflicted. `CleanUpClientList` skips any client whose download state is not `DS_NONE` — and the branch that declines the contact sets `DS_LOWTOLOWIP`. So the very code that strands the browse also disqualifies the peer from the cleanup that would have healed it.

## Verified live

macOS, `amuled` + `amuleapi`. This node had no `lowtolowip` peer, so I forced the silent exit with a temporary fault injection (reverted before commit, and re-verified after):

- **Wedge path** — browse reports `finished` on the *first* sample, `progress.state` agrees, the existing `Failed to retrieve shared files` log line fires exactly once, and `lsof` confirms **no connection was attempted** — so it really was the silent exit, not an ordinary connect-then-fail.
- **Retryable** — two subsequent browses of that peer got fresh ids (4, 5), each terminal. Pre-fix the first would have wedged and every retry joined it.
- **No regression** — a reachable peer's browse stays `running` across samples, with two `ESTABLISHED` connections confirming the connect really happened. Verified both before and after reverting the injection.

## Tests + docs

`19-search.sh` gains a block that probes for a `lowtolowip` peer and **skips, not fails**, when there is none, as the issue asks: the browse must reach `finished`, the results endpoint must agree, and a retry must get a new id. `REFERENCE.md` notes that a browse the daemon cannot start is reported `finished` immediately.

Gates: clang-format 18.1.8 clean, Tier-1 and Tier-2 clang-tidy clean, 37/37 unit tests, full build across all four binaries. No new strings — the log line already exists — so no po regen.

One gate note: the first Tier-2 run reported a compiler error (`common/Macros.h` not found) because clang-tidy-diff compiles a changed header standalone. Re-run with the project include paths, giving 0 compiler errors over 3 TUs; the earlier "clean" was checking nothing.
