### PR TITLE
fix(core): cover the LowID browse exits past the socket, and bound the rest by time

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -173,6 +173,7 @@ void CUpDownClient::Init()
 	bytesReceivedCycle = 0;
 	m_nServerPort = 0;
 	m_iFileListRequested = 0;
+	m_browseDeadline = 0;
 	m_browseSearchId = 0;
 	m_browseTotalDirs = 0;
 	m_browseStatus = BROWSE_NONE;
@@ -1796,6 +1797,9 @@ void CUpDownClient::ConnectionEstablished()
 			m_fSharedDirectories ? OP_ASKSHAREDDIRS : OP_ASKSHAREDFILES, 0, OP_EDONKEYPROT);
 		theStats::AddUpOverheadOther(packet->GetPacketSize());
 		SendPacket(packet, true, true);
+		// The ask is on the wire now; the peer's clock starts here, not at the
+		// click, which may have been a connect ago.
+		RefreshBrowseDeadline();
 #ifdef __DEBUG__
 		if (m_fSharedDirectories) {
 			AddDebugLogLineN(logLocalClient, "Local Client: OP_ASKSHAREDDIRS to " + GetFullIP());
@@ -2077,8 +2081,22 @@ void CUpDownClient::UpdateBrowseBar()
 	theApp->searchlist->SetBrowseStatusById(GetBrowseRoutingId(), static_cast<uint8>(m_browseStatus));
 }
 
+void CUpDownClient::RefreshBrowseDeadline()
+{
+	// Only while a browse is actually pending: called from the packet paths,
+	// which also run for clients that are not being browsed.
+	if (m_iFileListRequested) {
+		m_browseDeadline = ::GetTickCount64() + BROWSE_SILENCE_TIMEOUT;
+		theApp->clientlist->AddPendingBrowse(this);
+	}
+}
+
 void CUpDownClient::MarkBrowse(EBrowseStatus s)
 {
+	// Every terminal transition comes through here, so this is the one place
+	// the deadline has to be dropped.
+	m_browseDeadline = 0;
+	theApp->clientlist->RemovePendingBrowse(this);
 	m_browseStatus = s;
 	UpdateBrowseBar();
 	// Route by the tab's result-routing key (the EC-allocated browse ID on the
@@ -2101,12 +2119,21 @@ bool CUpDownClient::IsPeerContactPending() const
 	// A live connection carries the browse directly; ConnectionEstablished
 	// sends the request off the back of it.
 	//
-	// A socket that merely exists counts too: CUpDownClient::Connect starts an
-	// asynchronous connect, so the HighID path returns with the socket created
-	// but not yet connected, and OnConnect/Disconnected settle it either way.
-	// The silent exits this predicate exists to catch all return before the
-	// socket is created, so they cannot be confused with one in progress.
-	if (IsConnected() || GetSocket() != nullptr) {
+	// A socket that merely exists counts too, but ONLY on the HighID path:
+	// CUpDownClient::Connect starts an asynchronous connect, so that path
+	// returns with the socket created but not yet connected, and
+	// OnConnect/Disconnected settle it either way.
+	//
+	// It must not count on the LowID paths. TryToConnect mints the socket
+	// before its second LowID block and only the HighID branch ever calls
+	// Connect() on it, so a LowID exit past that point leaves a socket that
+	// nothing is connecting and nothing will connect later -- reading it as
+	// "contact pending" is what let those exits keep a browse running
+	// (amule-org/amule#1071). The three ways a LowID peer really does get
+	// contacted are covered by the other clauses below: a direct UDP
+	// callback, a server callback (DS_WAITCALLBACK), a Kad buddy callback
+	// (DS_WAITCALLBACKKAD) -- and an incoming connection by IsConnected().
+	if (IsConnected() || (!HasLowID() && GetSocket() != nullptr)) {
 		return true;
 	}
 	// A direct UDP callback brings its own 45s deadline, after which
@@ -2138,6 +2165,7 @@ void CUpDownClient::RequestSharedFileList()
 		// than nothing. The daemon uses the EC-allocated browse ID as the
 		// routing key; a monolithic local browse uses this client's pointer.
 		m_browseStatus = BROWSE_IN_PROGRESS;
+		RefreshBrowseDeadline();
 		UpdateBrowseBar();
 		Notify_Browse_Started(ECID(), GetUserName(), (uint64)GetBrowseRoutingId());
 		if (!TryToConnect(true)) {
@@ -2175,7 +2203,9 @@ void CUpDownClient::ProcessSharedFileList(const uint8_t *pachPacket, uint32 nSiz
 	if (m_iFileListRequested > 0) {
 		m_iFileListRequested--;
 		theApp->searchlist->ProcessSharedFileList(pachPacket, nSize, this, NULL, pszDirectory);
-		// One directory's worth of files arrived; advance the browse bar.
+		// One directory's worth of files arrived; advance the browse bar, and
+		// give a share that is still streaming the full timeout again.
+		RefreshBrowseDeadline();
 		UpdateBrowseBar();
 	}
 }

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -130,6 +130,7 @@ void CClientList::RemoveClient(CUpDownClient *client)
 {
 	RemoveFromKadList(client);
 	RemoveDirectCallback(client);
+	RemovePendingBrowse(client);
 
 	if (RemoveIDFromList(client)) {
 		// Also remove the ip and hash entries
@@ -725,6 +726,7 @@ void CClientList::Process()
 
 	CleanUpClientList();
 	ProcessDirectCallbackList();
+	ProcessPendingBrowseList();
 }
 
 void CClientList::AddBannedClient(uint32 dwIP)
@@ -1112,6 +1114,49 @@ void CClientList::AddDirectCallbackClient(CUpDownClient *toAdd)
 		}
 	}
 	m_currentDirectCallbacks.push_back(CCLIENTREF(toAdd, "CClientList::AddDirectCallbackClient"));
+}
+
+void CClientList::AddPendingBrowse(CUpDownClient *toAdd)
+{
+	if (toAdd->HasBeenDeleted()) {
+		return;
+	}
+	// Re-armed on every sign of progress, so the same client comes back here
+	// repeatedly during one browse -- keep a single entry, the deadline itself
+	// lives on the client.
+	for (CClientRefList::const_iterator it = m_pendingBrowses.begin(); it != m_pendingBrowses.end();
+		++it) {
+		if (it->GetClient() == toAdd) {
+			return;
+		}
+	}
+	m_pendingBrowses.emplace_back(toAdd CLIENT_DEBUGSTRING("CClientList::AddPendingBrowse"));
+}
+
+void CClientList::ProcessPendingBrowseList()
+{
+	// Give up on a browse that has gone quiet for BROWSE_SILENCE_TIMEOUT.
+	// FailPendingBrowse marks it failed and clears the in-flight flag, which
+	// removes the entry through MarkBrowse -- so this walk does not erase
+	// anything itself except the stale entries it can no longer act on.
+	const uint64_t cur_tick = ::GetTickCount64();
+	for (CClientRefList::iterator it = m_pendingBrowses.begin(); it != m_pendingBrowses.end();) {
+		CClientRefList::iterator it2 = it++;
+		CUpDownClient *curClient = it2->GetClient();
+		const uint64_t deadline = curClient->GetBrowseDeadline();
+		if (deadline == 0) {
+			// The browse ended without coming through MarkBrowse; nothing to
+			// expire, and holding the reference would keep the client alive.
+			m_pendingBrowses.erase(it2);
+			continue;
+		}
+		if (deadline < cur_tick) {
+			AddDebugLogLineN(logClient,
+				CFormat("Browse of %s timed out with nothing received") %
+					curClient->GetUserName());
+			curClient->FailPendingBrowse();
+		}
+	}
 }
 
 void CClientList::ProcessDirectCallbackList()

--- a/src/ClientList.h
+++ b/src/ClientList.h
@@ -326,6 +326,13 @@ public:
 	{
 		m_currentDirectCallbacks.remove(CCLIENTREF(toRemove, ""));
 	}
+	// Pending browses. A browse that never hears anything back has no other
+	// way to end: see CUpDownClient::RefreshBrowseDeadline.
+	void AddPendingBrowse(CUpDownClient *toAdd);
+	void RemovePendingBrowse(CUpDownClient *toRemove)
+	{
+		m_pendingBrowses.remove(CCLIENTREF(toRemove, ""));
+	}
 	void AddTrackCallbackRequests(uint32_t ip);
 	bool AllowCallbackRequest(uint32_t ip) const;
 
@@ -336,6 +343,8 @@ protected:
 	void CleanUpClientList();
 
 	void ProcessDirectCallbackList();
+
+	void ProcessPendingBrowseList();
 
 private:
 	/**
@@ -417,6 +426,10 @@ private:
 
 	typedef CClientRefList DirectCallbackList;
 	DirectCallbackList m_currentDirectCallbacks;
+	//! Clients with a browse in flight, walked every tick to expire the silent
+	//! ones. Same shape as m_currentDirectCallbacks, and kept small the same
+	//! way: entries leave on the browse's terminal mark, not on a sweep.
+	CClientRefList m_pendingBrowses;
 	IpAndTicksList m_directCallbackRequests;
 };
 

--- a/src/include/protocol/ed2k/Constants.h
+++ b/src/include/protocol/ed2k/Constants.h
@@ -84,6 +84,18 @@
 #define TRACKED_CLEANUP_TIME HR2MS(1)
 #define KEEPTRACK_TIME HR2MS(2) // how long to keep track of clients which were once in the uploadqueue
 #define CLIENTLIST_CLEANUP_TIME MIN2MS(34) // 34 min
+// How long a browse ("View Files") may sit with nothing arriving before it is
+// given up on. Refreshed whenever the browse makes progress -- the request
+// going out, each directory landing -- so this bounds silence, not the total
+// time a large share takes to stream in.
+//
+// A backstop, not the mechanism: a browse normally ends when the peer answers,
+// denies, or the socket dies, and CUpDownClient::IsPeerContactPending catches
+// the case where the daemon never contacts the peer at all. This exists
+// because TryToConnect has several exits that contact nobody, they are not
+// marked as a family, and two attempts at enumerating them both missed some
+// (amule-org/amule#1071).
+#define BROWSE_SILENCE_TIMEOUT SEC2MS(120)
 
 // (4294967295/PARTSIZE)*PARTSIZE = ~4GB
 #define OLD_MAX_FILE_SIZE 4290048000ull

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -522,6 +522,14 @@ public:
 	 * this client can be failed at once instead of hanging.
 	 */
 	bool IsPeerContactPending() const;
+	/**
+	 * Deadline for a browse to show any sign of life, or 0 when none is
+	 * pending. Armed when the browse is asked for and pushed forward on every
+	 * sign of progress, so it bounds silence rather than total duration -- a
+	 * large share may stream for minutes and must not be cut off.
+	 */
+	uint64_t GetBrowseDeadline() const { return m_browseDeadline; }
+	void RefreshBrowseDeadline();
 
 	void ResetFileStatusInfo();
 
@@ -811,6 +819,8 @@ private:
 	uint64 m_dwLastSourceAnswer;
 	uint64 m_dwLastAskedForSources;
 	int m_iFileListRequested;
+	//! See GetBrowseDeadline. 0 = no browse pending.
+	uint64_t m_browseDeadline;
 	uint32 m_browseSearchId;
 	int m_browseTotalDirs;
 	EBrowseStatus m_browseStatus;


### PR DESCRIPTION
Follow-up to #1072, which did not do what it claimed. Thanks @ngosang for catching it.

## The miss

`TryToConnect` mints the socket at `:1534`, **between** its two LowID blocks. `IsPeerContactPending` read any socket as "contact pending", so it only ever saw the two exits *before* it — the two originally reported in #1071. The two exits #1072 was argued around were never covered, and nor was the one you flagged as most worrying: a LowID Kad peer that isn't a download source falls through the `DS_WAITCALLBACK` guard (whose body needs `m_reqfile`) and returns having sent nothing.

## Part 1 — the narrowing (yours)

```cpp
if (IsConnected() || (!HasLowID() && GetSocket() != nullptr)) {
```

Only the HighID branch calls `Connect()`, so a socket means a connect is under way only for a HighID peer. A LowID peer is contacted by a direct UDP callback, a server callback or a Kad buddy callback — each already has its own clause — and an incoming connection is covered by `IsConnected()`.

## Part 2 — the backstop

That's still an enumeration, and it's the second one to come up short, so it now has one that doesn't depend on getting the list right. A browse carries a deadline, armed at request and pushed forward on every sign of life (the request going out, each directory landing); `CClientList` expires the silent ones on the core tick, in the `ProcessDirectCallbackList` pattern. It bounds **silence, not duration**, so a large share may stream as long as it needs.

At 120 s it sits above the 40 s ed2k socket timeout, so it never preempts the ordinary paths and only acts where nothing else can.

## One correction on severity

The exits past the socket were **not** unbounded. `CClientTCPSocket`'s constructor registers with `CListenSocket`, whose `Process()` calls `CheckTimeOut()` on every socket with `timeout_timer` set at construction — so a never-connected socket is reaped at `CONNECTION_TIMEOUT` (40 s), and that `Disconnect("Timeout")` terminalizes the browse through `Disconnected()`. I measured exactly that: every injected exit past the socket ended at 40–50 s. So `:1621` was a 40-second delay, not a permanent wedge, and `CleanUpClientList` never got the chance to matter. The genuinely unbounded exits are the two before the socket — the ones #1072 does fix. Doesn't change the fix, but the record should be right.

## Verified live

Injected past the socket this time, the shape that defeated #1072:

- **Narrowing** — LowID + silent exit past the socket → `finished` on the first sample. This is the case #1072 missed.
- **Backstop** — same exit but HighID, so the narrowing deliberately doesn't catch it. With the deadline temporarily at 20 s it fired at 19–22 s, tracking the constant rather than the 40 s socket timeout — isolating my sweep as the cause.
- Injections reverted, rebuilt, retested; a browse over a live connection is unaffected.

Gates: clang-format clean, both clang-tidy tiers clean (0 compiler errors, 6 TUs), 37/37 unit tests, full build. No po change — the catalogs use `--add-location=file`, and this adds no translatable string.
