### PR TITLE
fix(webapi): count JSON nesting depth, not every opener in the body

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3206,20 +3206,48 @@ namespace
 // JSON body parser. Returns true on success; false + `err` on
 // failure. Non-object roots are rejected.
 //
-// Pre-parse depth cap. picojson uses unbounded recursive descent for
-// `_parse_array` / `_parse_object` — a `{"a":{"a":...}}` body deep
-// enough blows the worker thread stack. 32 openers is past anything
-// legitimate (bodies are flat lists of scalars). Mirrors CJwt::Verify.
+// Pre-parse depth cap. picojson's `_parse_array` / `_parse_object`
+// recurse without a depth limit of their own, so a `{"a":{"a":...}}`
+// body nested deep enough exhausts the stack of the handler-pool
+// thread the parse runs on. The deepest legitimate body on this
+// surface is 3 (`{"remote_controls":{"webserver":{...}}}`), so 32
+// leaves ample headroom. CJwt::Verify caps its own parses for the
+// same reason.
+//
+// Nesting depth, not a count of openers: a flat body is legal at any
+// length. An earlier version incremented on every `{` and `[` in the
+// buffer without ever decrementing, which turned the cap into a
+// budget of 32 containers-plus-brackets-in-strings for the whole
+// request — a PATCH /preferences whose `shared` array held directory
+// names like "Some.Release-BRD [2023]" tripped it on the 33rd, three
+// levels deep. String literals are skipped for that same reason, and
+// backslash escapes are honoured so a `\"` inside one does not end it
+// early.
+//
+// Unbalanced closers are ignored rather than rejected: this is a
+// stack guard, not a validator, and picojson below still has the
+// final say on syntax.
 bool ParseJsonObjectBody(const std::string &body, picojson::value &out, std::string &err)
 {
-	constexpr std::size_t kMaxJsonOpeners = 32;
-	std::size_t openers = 0;
-	for (char c : body) {
-		if (c == '{' || c == '[') {
-			if (++openers > kMaxJsonOpeners) {
+	constexpr std::size_t kMaxJsonDepth = 32;
+	std::size_t depth = 0;
+	bool in_string = false;
+	for (std::size_t i = 0; i < body.size(); ++i) {
+		const char c = body[i];
+		if (in_string) {
+			if (c == '\\')
+				++i; // escaped char, never closes the string
+			else if (c == '"')
+				in_string = false;
+		} else if (c == '"') {
+			in_string = true;
+		} else if (c == '{' || c == '[') {
+			if (++depth > kMaxJsonDepth) {
 				err = "JSON nesting too deep";
 				return false;
 			}
+		} else if ((c == '}' || c == ']') && depth > 0) {
+			--depth;
 		}
 	}
 	const std::string parse_err = picojson::parse(out, body);


### PR DESCRIPTION
The pre-parse stack guard in ParseJsonObjectBody incremented on every '{' and '[' it saw and never decremented, so the cap acted as a budget of 32 containers for the whole request instead of a nesting limit. A flat body is legal at any length: a PATCH /preferences whose 'shared' array listed directory names such as "Some.Release-BRD [2023]" was rejected on the 33rd bracket while only three levels deep.

- Track real nesting depth: decrement on '}' and ']' so only genuine nesting counts against the limit.
- Skip string literals, honouring backslash escapes, so brackets and quotes inside directory names or other values never affect the depth.
- Ignore unbalanced closers rather than rejecting them; this is a stack guard against unbounded recursion in picojson, not a syntax validator, and picojson still has the final say.
- Expand the comment with the deepest legitimate body on this surface (3 levels) to justify the 32 headroom.