### PR TITLE
refactor(core): give the browse an owner, and its rules a test

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -10,6 +10,8 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		kademlia/routing/RoutingZone.cpp
 		amule.cpp
 		BaseClient.cpp
+		BrowseLifecycle.cpp
+		BrowseManager.cpp
 		ChatSessionStore.cpp
 		ClientCreditsList.cpp
 		ClientList.cpp

--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -12,6 +12,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		BaseClient.cpp
 		BrowseLifecycle.cpp
 		BrowseManager.cpp
+		BrowseStore.cpp
 		ChatSessionStore.cpp
 		ClientCreditsList.cpp
 		ClientList.cpp

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,6 +8,7 @@ src/amuleDlg.cpp
 src/amule-gui.cpp
 src/amule-remote-gui.cpp
 src/BaseClient.cpp
+src/BrowseManager.cpp
 src/CanceledFileList.cpp
 src/CaptchaDialog.cpp
 src/CatDialog.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1006,11 +1006,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1050,6 +1045,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1030,11 +1030,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1074,6 +1069,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1045,11 +1045,6 @@ msgstr "1.x (basáu en eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nomatu:  %s ID: %u"
 
@@ -1090,6 +1085,11 @@ msgstr "Nuevu mensax de '%s' (IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Usuariu %s (%u) solicitó la to llista de ficheros compartíos del direutoriu %s-> Refugada"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Fallu al obtener la llista de compartíos del usuariu '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1025,11 +1025,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1069,6 +1064,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1005,11 +1005,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1049,6 +1044,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1044,11 +1044,6 @@ msgstr "1.x (basat en l'eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Sobrenom: %s ID: %u"
 
@@ -1089,6 +1084,11 @@ msgstr "Nou missatge de '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'usuari %s (%u) ha demanat la llista de fitxers compartits del directori inexistent '%s' -> Ignorat"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "No s'han pogut obtenir els compartits de l'usuari '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1046,11 +1046,6 @@ msgstr "1.x (založeno na eMule v.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Přezdívka: %s ID: %u"
 
@@ -1093,6 +1088,11 @@ msgstr "Nová zpráva od '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Uživatel %s (%u) požádal o seznam sdílených souborů v neexistujícím adresáři '%s' -> ignorováno"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Nelze získat seznam sdílených souborů od uživatele '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1033,11 +1033,6 @@ msgstr "1.x (baseret på eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1078,6 +1073,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Bruger %s (%u) anmodede om din deleliste -> %s"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Hentelse af delte fier fra bruger '%s' fejlede"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1053,11 +1053,6 @@ msgstr "1.x (basiert auf eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Spitzname: %s ID: %u"
 
@@ -1098,6 +1093,11 @@ msgstr "Neue Nachricht von '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Benutzer %s (%u) hat die Liste freigegebener Dateien für das nicht vorhandene Verzeichnis '%s' angefordert -> Ignoriert"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1054,11 +1054,6 @@ msgstr "1.x (βασισμένο στο eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Παρατσούκλι: %s Ταυτότητα: %u"
 
@@ -1099,6 +1094,11 @@ msgstr "Καινούριο μήνυμα από τον '%s' (IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Ο χρήστης %s (%u) ζήτησε λίστα κοινόχρηστων αρχείων του κατάλογου %s -> Απορρίφθηκε"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Αποτυχία λήψης των κοινόχρηστων αρχείων του χρήστη '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1006,11 +1006,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1050,6 +1045,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1052,11 +1052,6 @@ msgstr "1.x (basado en eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alias: %s ID: %u"
 
@@ -1097,6 +1092,11 @@ msgstr "Nuevo mensaje de '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "El usuario %s (%u) ha pedido la lista de archivos compartidos de un directorio que no existe, '%s' -> Se ignora"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1044,11 +1044,6 @@ msgstr "1.x (baseerub eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Kasutajanimi: %s ID: %u"
 
@@ -1089,6 +1084,11 @@ msgstr "'%s' (IP:%s) saatis uue teate"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Kasutaja %s (%u) küsis sinu jagatudfailde loetelu kataloogile %s -> keeldusid"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Ei suuda tõmmata kasutaja '%s' jagatud faili"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1045,11 +1045,6 @@ msgstr "1.x (eMule v0.%u-tan oinarriturik)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Ezizena: %s ID-a: %u"
 
@@ -1090,6 +1085,11 @@ msgstr "'%s'-ren mezu berria (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "%s (%u) erabiltzaileak ez dagoen %s direktorioaren partekatutako fitxategi zerrenda eskatu du -> Ukatua"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Huts '%s' erabiltzailearen partekatutako fitxategiak jasotzerakoan"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1045,11 +1045,6 @@ msgstr "1.x (pohjautuu eMule-versioon v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nimimerkki: %s Tunnus: %u"
 
@@ -1090,6 +1085,11 @@ msgstr "Viesti käyttäjältä '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Käyttäjä %s (%u) kysyi listaa jaetuista tiedostoista olemattomassa kansiossa '%s' -> Jätettiin huomioimatta"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Jaettujen tiedostojen listaus käyttäjältä '%s' ei onnistunut"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1051,11 +1051,6 @@ msgstr "1.x (basé sur eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Pseudo : %s ID : %u"
 
@@ -1096,6 +1091,11 @@ msgstr "Nouveau message de '%s' (IP : %s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'utilisateur %s (%u) a demandé votre liste de fichier partagés pour le répertoire inexistant '%s' -> ignoré"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1066,11 +1066,6 @@ msgstr "1.x (baseado en eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alcume: %s ID: %u"
 
@@ -1111,6 +1106,11 @@ msgstr "Nova mensaxe de «%s» (IP: %s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "O usuario %s (%u) pediu a súa lista de ficheiros compartidos do directorio inexistente «%s» -> Ignorouse"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Non se puideron recuperar os ficheiros compartidos do usuario «%s»"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1035,11 +1035,6 @@ msgstr "1.איקס (מבוסס על אימיול בגרסת 0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "כינוי:%s מ\"ז: %u"
 
@@ -1080,6 +1075,11 @@ msgstr "הודעה חדשה מ '%s'·(IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "המשתמש %s (%u) ביקש את רשימת הקבצים המשותפים שלך בתקייה %s -> נדחה"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "הניסיון לקבל את רשימת הקבצים המשותפים מהמשתמש '%s' כשלה."
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1034,11 +1034,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1081,6 +1076,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Korisnik %s (%u) ja zahtio tvoju listu dijeljenih fajlova za direktorij %s -> %s"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1047,11 +1047,6 @@ msgstr "1.x  (az eMule v0.%u alapján)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Becenév: %s ID: %u"
 
@@ -1090,6 +1085,11 @@ msgstr "Új üzenet '%s'-től (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "A(z) %s (%u) felhasználó lekérdezte a nem létező '%s' könyvtárban megosztott fájljaid listájá -> Mellőzve"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Megosztott fájlok lehozatala sikertelen a(z) '%s' felhasználótól"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1058,11 +1058,6 @@ msgstr "1.x (basato su eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nickname: %s ID: %u"
 
@@ -1103,6 +1098,11 @@ msgstr "Nuovo messaggio da '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "L'utente %s (%u) ha richiesto la lista dei file condivisi in una cartella inesistente '%s' -> richiesta ignorata"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1049,11 +1049,6 @@ msgstr "1.x（eMule v0.%u に基づいています）"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "NickName: %s ID: %u"
 
@@ -1092,6 +1087,11 @@ msgstr "%s（IP：%s）から新しいメッセージが届きました"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "ユーザ %s（%u）はあなたのディレクトリ %s の共有ファイル・リストを要求しました -> 拒否しました"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "ユーザ '%s' から共有ファイルを取得することができませんでした"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1052,11 +1052,6 @@ msgstr "1.x (이뮬 v0.%u 기반)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "별명: %s 아이디: %u"
 
@@ -1097,6 +1092,11 @@ msgstr "'%s'로부터 새로운 메시지 (IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "사용자 %s(%u)가 폴더 %s의 공유파일 목록을 요청합니다. -> 거부됨"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "사용자 %s로부터 공유파일을 찾지 못했습니다."
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1054,11 +1054,6 @@ msgstr "1.x (paremta eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Slapyvardis: %s ID: %u"
 
@@ -1101,6 +1096,11 @@ msgstr "Naują žinutę atsiuntė %s (IP %s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Naudotojas %s (%u) paprašė dalinamų failų iš aplanko %s sąrašo –> atmesta"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Nepavyko gauti dalinamų failų iš vartotojo „%s“"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1018,11 +1018,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Neizdevās iegūt dalībnieka '%s' kopīgoto datņu sarakstu"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Iesauka: %s ID: %u"
 
@@ -1063,6 +1058,11 @@ msgstr "Jauns ziņojums no '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Neizdevās iegūt dalībnieka '%s' kopīgoto datņu sarakstu"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1047,11 +1047,6 @@ msgstr "1.x (gebaseerd op eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Bijnaam: %s ID: %u"
 
@@ -1092,6 +1087,11 @@ msgstr "Nieuw bericht van '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Gebruiker %s (%u) vroeg uw gedeelde-bestandenlijst van niet-bestaande map '%s' op -> Genegeerd"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Kon gedeelde bestanden niet ontvangen van gebruiker '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1052,11 +1052,6 @@ msgstr "1.x·(basert på eMule·v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Brukarnamn: %s·ID:·%u"
 
@@ -1097,6 +1092,11 @@ msgstr "Ny melding frå '%s'·(IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Brukar·%s (%u)·etterspurte·lista·over·delte·filer·for·katalogen·%s ->·nekta"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Greidde ikkje å hente delte filer frå brukar '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1047,11 +1047,6 @@ msgstr "1.x (oparty na eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Użytkownik: %s ID: %u"
 
@@ -1094,6 +1089,11 @@ msgstr "Nowa wiadomość od '%s' (IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Użytkownik %s (%u) zażądał twojej listy plików udostępnionych w katalogu %s -> Odmówiono"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Nieudane pobieranie udostępnionych plików od użytkownika '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1052,11 +1052,6 @@ msgstr "1.x (baseado no eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Falha ao receber lista de compartilhamentos do usuário '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nickname: %s ID: %u"
 
@@ -1097,6 +1092,11 @@ msgstr "Nova mensagem de '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Usuário %s (%u) solicitou sua lista de compartilhados para pasta não existente '%s' -> Negado"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Falha ao receber lista de compartilhamentos do usuário '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1051,11 +1051,6 @@ msgstr "1.x (baseado no eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Alcunha: %s ID: %u"
 
@@ -1096,6 +1091,11 @@ msgstr "Nova mensagem de '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "O utilizador %s (%u) pediu a sua lista de ficheiros partilhados para a pasta '%s' -> Ignorado"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Erro ao receber ficheiros partilhados do utilizador '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1044,11 +1044,6 @@ msgstr "1.x (bazat pe eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Nume Nick: %s ID: %u"
 
@@ -1091,6 +1086,11 @@ msgstr "Mesaj nou de la '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Utilizatorul %s (%u) a solicitat lista fișierelor partajate pentru un director inexistent '%s' -> se ignoră"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "A eșuat preluarea fișierelor partajate de la utilizatorul '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1056,11 +1056,6 @@ msgstr "1.x (на основе eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Не удалось получить список доступных файлов от '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Псевдоним: %s ID: %u"
 
@@ -1103,6 +1098,11 @@ msgstr "Новое сообщение от '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Пользователь %s (%u) запросил список публикуемых файлов из несуществующего каталога «%s» -> Проигнорировано"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Не удалось получить список доступных файлов от '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1050,11 +1050,6 @@ msgstr "1.x (temelji na eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Vzdevek: %s ID: %u"
 
@@ -1099,6 +1094,11 @@ msgstr "Novo sporočilo od »%s« (IP: %s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Uporabnik %s (%u) je zahteval seznam deljenih datotek za mapo »%s« → prezrto"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Ni bilo mogoče dobiti deljenih datotek od uporabnika »%s«"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1049,11 +1049,6 @@ msgstr "1.x (e bazuar ne eMule v0 %u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Emri: %s ID: %u"
 
@@ -1094,6 +1089,11 @@ msgstr "Mesazh i ri nga '%s' (IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Perdoruesi %s (%u) kerkoi listen e faileve tuaja te ndara per kartelen %s -> nuk u lejua"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Deshtoi te rimarri failet e ndara nga perdoruesi '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1043,11 +1043,6 @@ msgstr "1.x (baserad på eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Misslyckades med att hämta filer från användaren '%s'"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Smeknamn: %s ID: %u"
 
@@ -1088,6 +1083,11 @@ msgstr "Nytt meddelande från '%s' (IP:%s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Användare %s (%u) begärde sharedfiles-list för icke exiterade mapp '%s' -> Ignorerad"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Misslyckades med att hämta filer från användaren '%s'"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1005,11 +1005,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1049,6 +1044,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1044,11 +1044,6 @@ msgstr "1.x (eMule s.0.%u üzerine kurulu)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Rumuz: %s ID: %u"
 
@@ -1089,6 +1084,11 @@ msgstr "'%s' kullanıcısından yeni ileti geldi (IP: %s)"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Kullanıcı %s (%u), var olmayan '%s' dizini için paylaşılmış dosya listenizi istedi. -> Görmezden gelindi."
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "'%s' kullanıcısının paylaşılmış dosyalarını alma başarısız"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1045,11 +1045,6 @@ msgstr "1.x (оснований на eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "Неможливо отримати спільні файли користувача %s"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "Прізвисько: %s ID: %u"
 
@@ -1092,6 +1087,11 @@ msgstr "Нове повідомлення від '%s' (IP:%s)"
 #, fuzzy, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "Користувач %s (%u) запитав ваш перелік спільних файлів для теки %s -> відмовлено"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "Неможливо отримати спільні файли користувача %s"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1004,11 +1004,6 @@ msgstr ""
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr ""
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
@@ -1048,6 +1043,11 @@ msgstr ""
 #: src/BaseClient.cpp
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
+msgstr ""
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1048,11 +1048,6 @@ msgstr "1.x (基于 eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "无法获取用户 %s 的共享文件"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "昵称：%s ID：%u"
 
@@ -1093,6 +1088,11 @@ msgstr "新消息来自于 %s（IP：%s）"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "用户 %s（%u）请求目录 %s 的共享文件列表 -> 已忽略"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "无法获取用户 %s 的共享文件"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 20:18+0200\n"
+"POT-Creation-Date: 2026-08-23 22:15+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1048,11 +1048,6 @@ msgstr "1.x (源自 eMule v0.%u)"
 
 #: src/BaseClient.cpp
 #, c-format
-msgid "Failed to retrieve shared files from user '%s'"
-msgstr "無法從使用者 %s 取得分享檔案清單"
-
-#: src/BaseClient.cpp
-#, c-format
 msgid "NickName: %s ID: %u"
 msgstr "暱稱：%s ID：%u"
 
@@ -1091,6 +1086,11 @@ msgstr "來自 %s (IP:%s) 的新訊息"
 #, c-format
 msgid "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> Ignored"
 msgstr "使用者 %s (%u) 要求不存在的目錄 %s 的分享檔案清單 -> 已忽略"
+
+#: src/BrowseManager.cpp
+#, c-format
+msgid "Failed to retrieve shared files from user '%s'"
+msgstr "無法從使用者 %s 取得分享檔案清單"
 
 #: src/CanceledFileList.cpp src/KnownFileList.cpp src/SearchList.cpp
 #, c-format

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2086,10 +2086,18 @@ void CUpDownClient::RequestSharedFileList()
 	if (m_browseSearchId == 0) {
 		m_browseSearchId = theApp->searchlist->AllocateEd2kId();
 	}
+	// Take the browse first: it is the thing that can refuse, and refusing
+	// after announcing a tab would leave one open against a browse nobody is
+	// running.
+	if (!theApp->browsemanager->Start(this, m_browseSearchId, ECID(), ::GetTickCount64())) {
+		AddDebugLogLineN(logClient,
+			CFormat("Browse of user %s (%u) was not started") % GetUserName() %
+				GetUserIDHybrid());
+		return;
+	}
 	// Describe it before any result arrives, so it is listable as a browse of
 	// this peer rather than as a nameless search.
 	theApp->searchlist->RegisterBrowseSearch(m_browseSearchId, GetUserName(), ECID());
-	theApp->browsemanager->Start(this, m_browseSearchId, ECID(), ::GetTickCount64());
 
 	// Open the "View Files" tab up front (monolithic) so a peer that denies or
 	// never answers still shows a tab that can flip to "failed".

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -1428,14 +1428,22 @@ bool CUpDownClient::Disconnected(const wxString &DEBUG_ONLY(strReason), bool bFr
 // true means the client was not deleted!
 bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 {
+	const EContactResult result = TryToContact(bIgnoreMaxCon);
+	// Exactly what this returned before the outcomes were named: false where
+	// the caller must stop touching the client, true otherwise.
+	return result != EContactResult::ClientDeleted && result != EContactResult::ConnectNotStarted;
+}
+
+EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
+{
 	// Kad reviewed
 	if (theApp->listensocket->TooManySockets() && !bIgnoreMaxCon) {
 		if (!(m_socket && m_socket->IsConnected())) {
 			if (Disconnected("Too many connections")) {
 				Safe_Delete();
-				return false;
+				return EContactResult::ClientDeleted;
 			}
-			return true;
+			return EContactResult::Declined;
 		}
 	}
 
@@ -1445,9 +1453,9 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 		(thePrefs::IsClientCryptLayerRequired() && !SupportsCryptLayer())) {
 		if (Disconnected("CryptLayer-Settings (Obfuscation) incompatible")) {
 			Safe_Delete();
-			return false;
+			return EContactResult::ClientDeleted;
 		} else {
-			return true;
+			return EContactResult::Declined;
 		}
 	}
 
@@ -1467,9 +1475,9 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 					Uint32toStringIP(uClientIP));
 			if (Disconnected("IPFilter")) {
 				Safe_Delete();
-				return false;
+				return EContactResult::ClientDeleted;
 			}
-			return true;
+			return EContactResult::Declined;
 		}
 
 		// for safety: check again whether that IP is banned
@@ -1478,9 +1486,9 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 				"Refused to connect to banned client " + Uint32toStringIP(uClientIP));
 			if (Disconnected("Banned IP")) {
 				Safe_Delete();
-				return false;
+				return EContactResult::ClientDeleted;
 			}
-			return true;
+			return EContactResult::Declined;
 		}
 	}
 
@@ -1502,10 +1510,12 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 			if (GetUploadState() == US_CONNECTING) {
 				if (Disconnected("LowID->LowID and US_CONNECTING")) {
 					Safe_Delete();
-					return false;
+					return EContactResult::ClientDeleted;
 				}
 			}
-			return true;
+			// Nothing was sent and nothing will arrive: this peer cannot be
+			// reached while we cannot call back.
+			return EContactResult::Declined;
 		}
 
 		// We already know we are not firewalled here as the above condition already detected
@@ -1525,7 +1535,7 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 					// There are too many source lookups already or we are already
 					// searching this key.
 					SetDownloadState(DS_TOOMANYCONNSKAD);
-					return true;
+					return EContactResult::Declined;
 				}
 			}
 		}
@@ -1538,7 +1548,7 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 		m_socket = new CClientTCPSocket(this, thePrefs::GetProxyData());
 	} else {
 		ConnectionEstablished();
-		return true;
+		return EContactResult::Contacting;
 	}
 
 	if (HasLowID() && SupportsDirectUDPCallback() && thePrefs::GetEffectiveUDPPort() != 0 &&
@@ -1548,7 +1558,8 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 				"ERROR: Trying Direct UDP Callback while already trying to connect to client "
 				"on ip " +
 					Uint32toStringIP(GetConnectIP()));
-			return true; // We're already trying a direct connection to this client
+			// Already on its way, with its own 45s deadline.
+			return EContactResult::Contacting;
 		}
 		// a direct callback is possible - since no other parties are involved and only one additional
 		// packet overhead is used we basically handle it like a normal connection try, no
@@ -1584,9 +1595,9 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 		if (GetUploadState() == US_CONNECTING) {
 			if (Disconnected("LowID and US_CONNECTING")) {
 				Safe_Delete();
-				return false;
+				return EContactResult::ClientDeleted;
 			}
-			return true;
+			return EContactResult::Declined;
 		}
 
 		if (theApp->serverconnect->IsLocalServer(m_dwServerIP, m_nServerPort)) {
@@ -1607,9 +1618,9 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 					theApp->downloadqueue->RemoveSource(this);
 					if (Disconnected("LowID and US_NONE and QR=0")) {
 						Safe_Delete();
-						return false;
+						return EContactResult::ClientDeleted;
 					}
-					return true;
+					return EContactResult::Declined;
 				}
 
 				if (!Kademlia::CKademlia::IsConnected()) {
@@ -1617,9 +1628,9 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 					theApp->downloadqueue->RemoveSource(this);
 					if (Disconnected("Kad Firewalled source but not connected to Kad.")) {
 						Safe_Delete();
-						return false;
+						return EContactResult::ClientDeleted;
 					}
-					return true;
+					return EContactResult::Declined;
 				}
 
 				if (GetDownloadState() == DS_WAITCALLBACK) {
@@ -1673,10 +1684,12 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 		}
 	} else { // HIGHID
 		if (!Connect()) {
-			return false;
+			return EContactResult::ConnectNotStarted;
 		}
 	}
-	return true;
+	// Everything that reaches here sent something: a server or Kad callback
+	// request, a direct UDP callback, or a connect.
+	return EContactResult::Contacting;
 }
 
 bool CUpDownClient::Connect()
@@ -2055,41 +2068,6 @@ void CUpDownClient::ReGetClientSoft()
 	UpdateStats();
 }
 
-bool CUpDownClient::IsPeerContactPending() const
-{
-	// A live connection carries the browse directly; ConnectionEstablished
-	// sends the request off the back of it.
-	//
-	// A socket that merely exists counts too, but ONLY on the HighID path:
-	// CUpDownClient::Connect starts an asynchronous connect, so that path
-	// returns with the socket created but not yet connected. It must not count
-	// on the LowID paths -- TryToConnect mints the socket before its second
-	// LowID block and only the HighID branch ever calls Connect() on it, so a
-	// LowID exit past that point leaves a socket nothing is connecting.
-	// The three ways a LowID peer really does get contacted are the clauses
-	// below: a direct UDP callback, a server callback (DS_WAITCALLBACK), a Kad
-	// buddy callback (DS_WAITCALLBACKKAD) -- and an incoming connection by
-	// IsConnected().
-	if (IsConnected() || (!HasLowID() && GetSocket() != nullptr)) {
-		return true;
-	}
-	// A direct UDP callback brings its own 45s deadline, after which
-	// CClientList::ProcessDirectCallbackList disconnects us.
-	if (m_dwDirectCallbackTimeout != 0) {
-		return true;
-	}
-	// A server or Kad callback we have asked for: the peer may still connect
-	// back, and the browse rides that connection when it does.
-	switch (GetDownloadState()) {
-	case DS_CONNECTING:
-	case DS_WAITCALLBACK:
-	case DS_WAITCALLBACKKAD:
-		return true;
-	default:
-		return false;
-	}
-}
-
 void CUpDownClient::RequestSharedFileList()
 {
 	if (theApp->browsemanager->SearchIdFor(this) != 0) {
@@ -2117,21 +2095,22 @@ void CUpDownClient::RequestSharedFileList()
 	// never answers still shows a tab that can flip to "failed".
 	Notify_Browse_Started(ECID(), GetUserName(), (uint64)m_browseSearchId);
 
-	if (!TryToConnect(true)) {
-		// false means the client was deleted (see TryToConnect), and it only
-		// gets there through Disconnected(), which has already ended the
-		// browse. Nothing left that may be touched.
+	switch (TryToContact(true)) {
+	case EContactResult::ClientDeleted:
+		// Destroyed on the way out, through Disconnected(), which has already
+		// ended the browse. Nothing left that may be touched.
 		return;
-	}
-	// TryToConnect returns true both when it started contacting the peer and
-	// when it decided not to, and several of its exits do the latter silently.
-	// None of those send a packet, so nothing downstream would ever end the
-	// browse; the deadline would, eventually, but saying so now is both
-	// correct and cheaper. Tested on the outcome rather than at each exit,
-	// because the exits are not a closed set -- two attempts at enumerating
-	// them both came up short.
-	if (!IsPeerContactPending()) {
+	case EContactResult::Declined:
+	case EContactResult::ConnectNotStarted:
+		// Nothing was sent, so no terminal path downstream will ever run.
+		// The deadline would catch it eventually; saying so now is both
+		// correct and cheaper. This used to be inferred from the client's
+		// side effects, because the bool could not distinguish "I tried" from
+		// "I decided not to" -- and the inference was wrong twice.
 		theApp->browsemanager->Fail(this);
+		return;
+	case EContactResult::Contacting:
+		break;
 	}
 }
 

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -175,6 +175,7 @@ void CUpDownClient::Init()
 	m_nServerPort = 0;
 	m_browseSearchId = 0;
 	m_browseEcInitiated = false;
+	m_browsePinned = false;
 	m_dwLastUpRequest = 0;
 	m_bEmuleProtocol = false;
 	m_bCompleteSource = false;
@@ -1820,7 +1821,11 @@ void CUpDownClient::ConnectionEstablished()
 				logLocalClient, "Local Client: OP_ACCEPTUPLOADREQ to " + GetFullIP());
 		}
 	}
-	if (theApp->browsemanager->SearchIdFor(this) != 0) {
+	// Only while the browse is still waiting to hear back. ConnectionEstablished
+	// runs on every reconnect, and a browsed peer that is also a download
+	// source reconnects often -- re-asking each time put unrequested packets
+	// on the wire and an error line in the peer's log.
+	if (theApp->browsemanager->AwaitingDirectoryList(this)) {
 		CPacket *packet = new CPacket(
 			m_fSharedDirectories ? OP_ASKSHAREDDIRS : OP_ASKSHAREDFILES, 0, OP_EDONKEYPROT);
 		theStats::AddUpOverheadOther(packet->GetPacketSize());
@@ -2095,21 +2100,22 @@ void CUpDownClient::RequestSharedFileList()
 	// until then the browse was keyed on this client's pointer -- which left
 	// state behind that nothing pruned, and collided when an address was
 	// reused. The EC handler pins the ID it allocated before calling here.
-	// A pinned ID belongs to this browse only if the manager has not seen it
-	// yet -- the EC handler pins one immediately before calling. An ID left
-	// over from a previous browse of this peer is still tracked, and reusing
-	// it would be refused, silently: Store::Start turns away an ID it already
-	// holds, to protect the record still answering for it.
-	if (m_browseSearchId == 0 || theApp->browsemanager->Has(m_browseSearchId)) {
+	// Use the ID the EC handler pinned for this browse, once; otherwise take a
+	// fresh one. Anything left over from a previous browse of this peer is
+	// unusable -- Store::Start refuses an ID it still holds, and an ID whose
+	// record has been disposed of may since have been handed to another
+	// search.
+	if (!m_browsePinned) {
 		m_browseSearchId = theApp->searchlist->AllocateEd2kId();
 		// Locally allocated, so this browse is ours -- otherwise the flag
 		// would still describe whoever asked for the previous one.
 		m_browseEcInitiated = false;
 	}
+	m_browsePinned = false;
 	// Take the browse first: it is the thing that can refuse, and refusing
 	// after announcing a tab would leave one open against a browse nobody is
 	// running.
-	if (!theApp->browsemanager->Start(this, m_browseSearchId, ECID(), ::GetTickCount64())) {
+	if (!theApp->browsemanager->Start(this, m_browseSearchId, ::GetTickCount64())) {
 		AddDebugLogLineN(logClient,
 			CFormat("Browse of user %s (%u) was not started") % GetUserName() %
 				GetUserIDHybrid());

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -1589,6 +1589,12 @@ EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
 			false,
 			0);
 	} else if (HasLowID()) { // LOWID
+		// Set where a packet actually goes out. Several of the paths below reach
+		// the end having sent nothing -- a source we are merely queued at, a
+		// peer that is not a download source, a Kad lookup that fails to start --
+		// and reporting those as Contacting is what let a browse of them wait out
+		// the whole silence timeout instead of failing at once.
+		bool contacted = false;
 		if (GetDownloadState() == DS_CONNECTING) {
 			SetDownloadState(DS_WAITCALLBACK);
 		}
@@ -1611,6 +1617,7 @@ EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
 				logLocalClient, "Local Client: OP_CALLBACKREQUEST to " + GetFullIP());
 			theApp->serverconnect->SendPacket(packet);
 			SetDownloadState(DS_WAITCALLBACK);
+			contacted = true;
 		} else {
 			if (GetUploadState() == US_NONE && (!GetRemoteQueueRank() || m_bReaskPending)) {
 
@@ -1658,6 +1665,7 @@ EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
 									GetBuddyIP(), GetBuddyPort()));
 						theStats::AddUpOverheadKad(packet->GetRealPacketSize());
 						SetDownloadState(DS_WAITCALLBACKKAD);
+						contacted = true;
 					} else {
 						AddLogLineN(_("Searching buddy for lowid connection"));
 						// Create search to find buddy.
@@ -1669,6 +1677,7 @@ EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
 						if (Kademlia::CSearchManager::StartSearch(findSource)) {
 							// Started lookup..
 							SetDownloadState(DS_WAITCALLBACKKAD);
+							contacted = true;
 						} else {
 							// This should never happen..
 							wxFAIL;
@@ -1682,13 +1691,16 @@ EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
 				}
 			}
 		}
+		if (!contacted) {
+			return EContactResult::Declined;
+		}
 	} else { // HIGHID
 		if (!Connect()) {
 			return EContactResult::ConnectNotStarted;
 		}
 	}
-	// Everything that reaches here sent something: a server or Kad callback
-	// request, a direct UDP callback, or a connect.
+	// A direct UDP callback, a LowID path that reported sending, or a HighID
+	// connect: something is on its way.
 	return EContactResult::Contacting;
 }
 
@@ -2083,8 +2095,16 @@ void CUpDownClient::RequestSharedFileList()
 	// until then the browse was keyed on this client's pointer -- which left
 	// state behind that nothing pruned, and collided when an address was
 	// reused. The EC handler pins the ID it allocated before calling here.
-	if (m_browseSearchId == 0) {
+	// A pinned ID belongs to this browse only if the manager has not seen it
+	// yet -- the EC handler pins one immediately before calling. An ID left
+	// over from a previous browse of this peer is still tracked, and reusing
+	// it would be refused, silently: Store::Start turns away an ID it already
+	// holds, to protect the record still answering for it.
+	if (m_browseSearchId == 0 || theApp->browsemanager->Has(m_browseSearchId)) {
 		m_browseSearchId = theApp->searchlist->AllocateEd2kId();
+		// Locally allocated, so this browse is ours -- otherwise the flag
+		// would still describe whoever asked for the previous one.
+		m_browseEcInitiated = false;
 	}
 	// Take the browse first: it is the thing that can refuse, and refusing
 	// after announcing a tab would leave one open against a browse nobody is

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2100,18 +2100,31 @@ void CUpDownClient::RequestSharedFileList()
 	// until then the browse was keyed on this client's pointer -- which left
 	// state behind that nothing pruned, and collided when an address was
 	// reused. The EC handler pins the ID it allocated before calling here.
-	// Use the ID the EC handler pinned for this browse, once; otherwise take a
-	// fresh one. Anything left over from a previous browse of this peer is
-	// unusable -- Store::Start refuses an ID it still holds, and an ID whose
-	// record has been disposed of may since have been handed to another
-	// search.
-	if (!m_browsePinned) {
-		m_browseSearchId = theApp->searchlist->AllocateEd2kId();
-		// Locally allocated, so this browse is ours -- otherwise the flag
-		// would still describe whoever asked for the previous one.
+	// Use the ID the EC handler pinned for this browse, once. Otherwise this
+	// peer keeps the ID it was browsed under before: AllocateEd2kId is a
+	// monotonic counter that never reissues, so an ID we were given stays
+	// ours, and reusing it keeps one tab and one result bucket per peer
+	// however many times the user asks. Allocating afresh each time -- which
+	// is what replacing the old reuse condition did -- left the previous
+	// registration, results and browse record behind with nothing to free
+	// them, since only the newest ID ever reaches RemoveResults when the tab
+	// is closed.
+	//
+	// The previous record has to go before the new one can take its place:
+	// Store::Start refuses an ID it still holds, to protect whatever that
+	// record is still answering for.
+	if (m_browsePinned) {
+		m_browsePinned = false;
+	} else {
+		if (m_browseSearchId == 0) {
+			m_browseSearchId = theApp->searchlist->AllocateEd2kId();
+		} else {
+			theApp->browsemanager->Remove(m_browseSearchId);
+		}
+		// Chosen here, so this browse is ours -- otherwise the flag would
+		// still describe whoever asked for the previous one.
 		m_browseEcInitiated = false;
 	}
-	m_browsePinned = false;
 	// Take the browse first: it is the thing that can refuse, and refusing
 	// after announcing a tab would leave one open against a browse nobody is
 	// running.
@@ -2122,8 +2135,15 @@ void CUpDownClient::RequestSharedFileList()
 		return;
 	}
 	// Describe it before any result arrives, so it is listable as a browse of
-	// this peer rather than as a nameless search.
-	theApp->searchlist->RegisterBrowseSearch(m_browseSearchId, GetUserName(), ECID());
+	// this peer rather than as a nameless search -- but only when the ID is
+	// ours to describe. A caller that pinned one has already registered it,
+	// under the identity IT considers authoritative: the friend path keys on
+	// the friend's ECID, and re-registering here would overwrite that with
+	// this client's, which is a different number from the same counter. An
+	// adopting GUI would then open a second tab under a different name.
+	if (!m_browseEcInitiated) {
+		theApp->searchlist->RegisterBrowseSearch(m_browseSearchId, GetUserName(), ECID());
+	}
 
 	// Open the "View Files" tab up front (monolithic) so a peer that denies or
 	// never answers still shows a tab that can flip to "failed".

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -66,6 +66,7 @@
 #include "CaptchaGenerator.h"
 #include "ChatWnd.h" // Needed for CChatWnd
 #endif
+#include "BrowseManager.h"
 #include "amule.h"           // Needed for theApp
 #include "PartFile.h"        // Needed for CPartFile
 #include "ClientTCPSocket.h" // Needed for CClientTCPSocket
@@ -172,11 +173,8 @@ void CUpDownClient::Init()
 	kBpsDown = 0.0;
 	bytesReceivedCycle = 0;
 	m_nServerPort = 0;
-	m_iFileListRequested = 0;
-	m_browseDeadline = 0;
 	m_browseSearchId = 0;
-	m_browseTotalDirs = 0;
-	m_browseStatus = BROWSE_NONE;
+	m_browseEcInitiated = false;
 	m_dwLastUpRequest = 0;
 	m_bEmuleProtocol = false;
 	m_bCompleteSource = false;
@@ -1401,7 +1399,7 @@ bool CUpDownClient::Disconnected(const wxString &DEBUG_ONLY(strReason), bool bFr
 
 	SetSocket(NULL);
 
-	FailPendingBrowse();
+	theApp->browsemanager->Fail(this);
 
 	if (bDelete) {
 		if (m_Friend) {
@@ -1797,14 +1795,14 @@ void CUpDownClient::ConnectionEstablished()
 				logLocalClient, "Local Client: OP_ACCEPTUPLOADREQ to " + GetFullIP());
 		}
 	}
-	if (m_iFileListRequested == 1) {
+	if (theApp->browsemanager->SearchIdFor(this) != 0) {
 		CPacket *packet = new CPacket(
 			m_fSharedDirectories ? OP_ASKSHAREDDIRS : OP_ASKSHAREDFILES, 0, OP_EDONKEYPROT);
 		theStats::AddUpOverheadOther(packet->GetPacketSize());
 		SendPacket(packet, true, true);
-		// The ask is on the wire now; the peer's clock starts here, not at the
-		// click, which may have been a connect ago.
-		RefreshBrowseDeadline();
+		// The ask is on the wire now; the peer's clock starts here, not at
+		// the click, which may have been a connect ago.
+		theApp->browsemanager->OnRequestSent(this, ::GetTickCount64());
 #ifdef __DEBUG__
 		if (m_fSharedDirectories) {
 			AddDebugLogLineN(logLocalClient, "Local Client: OP_ASKSHAREDDIRS to " + GetFullIP());
@@ -2057,68 +2055,6 @@ void CUpDownClient::ReGetClientSoft()
 	UpdateStats();
 }
 
-uint16 CUpDownClient::GetBrowseBarValue() const
-{
-	if (m_browseStatus == BROWSE_FINISHED || m_browseStatus == BROWSE_FAILED) {
-		// Clear the bar (search "finished" sentinel; browse is not Kad).
-		return 0xffff;
-	}
-	if (m_browseTotalDirs > 0) {
-		int done = m_browseTotalDirs - m_iFileListRequested;
-		if (done < 0) {
-			done = 0;
-		} else if (done > m_browseTotalDirs) {
-			done = m_browseTotalDirs;
-		}
-		return static_cast<uint16>(done * 100 / m_browseTotalDirs);
-	}
-	// Connecting, or a flat share with no directory list: no meaningful percent.
-	return 0;
-}
-
-void CUpDownClient::UpdateBrowseBar()
-{
-	// Mirror both the bar value and the lifecycle status into the search list,
-	// keyed by the routing ID. The status is what lets the EC PROGRESS reply
-	// report a terminal "failed" (vs "finished") after this client — which is
-	// transient, especially a browse that fails on disconnect — has been reaped.
-	theApp->searchlist->SetBrowseBar(GetBrowseRoutingId(), GetBrowseBarValue());
-	theApp->searchlist->SetBrowseStatusById(GetBrowseRoutingId(), static_cast<uint8>(m_browseStatus));
-}
-
-void CUpDownClient::RefreshBrowseDeadline()
-{
-	// Only while a browse is actually pending: called from the packet paths,
-	// which also run for clients that are not being browsed.
-	if (m_iFileListRequested) {
-		m_browseDeadline = ::GetTickCount64() + BROWSE_SILENCE_TIMEOUT;
-		theApp->clientlist->AddPendingBrowse(this);
-	}
-}
-
-void CUpDownClient::MarkBrowse(EBrowseStatus s)
-{
-	// Every terminal transition comes through here, so this is the one place
-	// the deadline has to be dropped.
-	m_browseDeadline = 0;
-	theApp->clientlist->RemovePendingBrowse(this);
-	m_browseStatus = s;
-	UpdateBrowseBar();
-	// Route by the tab's result-routing key (the EC-allocated browse ID on the
-	// daemon, or this client's pointer for a monolithic local browse). The
-	// notify is a no-op on the daemon; amuleGUI learns the status over EC.
-	Notify_Browse_Status((uint64)GetBrowseRoutingId(), s);
-}
-
-void CUpDownClient::FailPendingBrowse()
-{
-	if (m_iFileListRequested) {
-		AddLogLineC(CFormat(_("Failed to retrieve shared files from user '%s'")) % GetUserName());
-		m_iFileListRequested = 0;
-		MarkBrowse(BROWSE_FAILED);
-	}
-}
-
 bool CUpDownClient::IsPeerContactPending() const
 {
 	// A live connection carries the browse directly; ConnectionEstablished
@@ -2126,24 +2062,19 @@ bool CUpDownClient::IsPeerContactPending() const
 	//
 	// A socket that merely exists counts too, but ONLY on the HighID path:
 	// CUpDownClient::Connect starts an asynchronous connect, so that path
-	// returns with the socket created but not yet connected, and
-	// OnConnect/Disconnected settle it either way.
-	//
-	// It must not count on the LowID paths. TryToConnect mints the socket
-	// before its second LowID block and only the HighID branch ever calls
-	// Connect() on it, so a LowID exit past that point leaves a socket that
-	// nothing is connecting and nothing will connect later -- reading it as
-	// "contact pending" is what let those exits keep a browse running
-	// (amule-org/amule#1071). The three ways a LowID peer really does get
-	// contacted are covered by the other clauses below: a direct UDP
-	// callback, a server callback (DS_WAITCALLBACK), a Kad buddy callback
-	// (DS_WAITCALLBACKKAD) -- and an incoming connection by IsConnected().
+	// returns with the socket created but not yet connected. It must not count
+	// on the LowID paths -- TryToConnect mints the socket before its second
+	// LowID block and only the HighID branch ever calls Connect() on it, so a
+	// LowID exit past that point leaves a socket nothing is connecting.
+	// The three ways a LowID peer really does get contacted are the clauses
+	// below: a direct UDP callback, a server callback (DS_WAITCALLBACK), a Kad
+	// buddy callback (DS_WAITCALLBACKKAD) -- and an incoming connection by
+	// IsConnected().
 	if (IsConnected() || (!HasLowID() && GetSocket() != nullptr)) {
 		return true;
 	}
 	// A direct UDP callback brings its own 45s deadline, after which
-	// CClientList::ProcessDirectCallbackList disconnects us and the browse
-	// fails through that path.
+	// CClientList::ProcessDirectCallbackList disconnects us.
 	if (m_dwDirectCallbackTimeout != 0) {
 		return true;
 	}
@@ -2161,58 +2092,59 @@ bool CUpDownClient::IsPeerContactPending() const
 
 void CUpDownClient::RequestSharedFileList()
 {
-	if (m_iFileListRequested == 0) {
-		AddDebugLogLineN(logClient, wxString("Requesting shared files from ") + GetUserName());
-		m_iFileListRequested = 1;
-		m_browseTotalDirs = 0;
-		// Open the "View Files" tab up front (monolithic) so a peer that denies
-		// or never answers still shows a tab that can flip to "failed", rather
-		// than nothing. The daemon uses the EC-allocated browse ID as the
-		// routing key; a monolithic local browse uses this client's pointer.
-		m_browseStatus = BROWSE_IN_PROGRESS;
-		RefreshBrowseDeadline();
-		UpdateBrowseBar();
-		Notify_Browse_Started(ECID(), GetUserName(), (uint64)GetBrowseRoutingId());
-		if (!TryToConnect(true)) {
-			// false means the client was deleted (see TryToConnect), and it
-			// only gets there through Disconnected(), which has already
-			// failed the browse. Nothing left that may be touched.
-			return;
-		}
-		// TryToConnect returns true both when it started contacting the peer
-		// and when it decided not to, and several of its exits do the latter
-		// silently: a LowID peer we cannot call back, a Kad firewalled source
-		// with too many lookups in flight, a queued LowID source it merely
-		// arranges to reask later. None of those send a packet, so no terminal
-		// path downstream ever runs and the browse would sit BROWSE_IN_PROGRESS
-		// with nothing able to end it -- until the client-list cleanup reaps
-		// the peer 34 minutes later, or never, when the peer is also a download
-		// source (that same branch sets DS_LOWTOLOWIP, and the cleanup skips
-		// anything that is not DS_NONE).
-		//
-		// Tested here on the outcome rather than at each of those exits:
-		// there are four of them today, they are not marked as a family, and
-		// the next one added would silently rejoin this bug.
-		if (!IsPeerContactPending()) {
-			FailPendingBrowse();
-		}
-	} else {
+	if (theApp->browsemanager->SearchIdFor(this) != 0) {
 		AddDebugLogLineN(logClient,
 			CFormat("Requesting shared files from user %s (%u) is already in progress") %
 				GetUserName() % GetUserIDHybrid());
+		return;
+	}
+	AddDebugLogLineN(logClient, wxString("Requesting shared files from ") + GetUserName());
+
+	// Allocate the ID before the request goes out, for a local browse as much
+	// as an EC one. It used to be assigned when the first result arrived, so
+	// until then the browse was keyed on this client's pointer -- which left
+	// state behind that nothing pruned, and collided when an address was
+	// reused. The EC handler pins the ID it allocated before calling here.
+	if (m_browseSearchId == 0) {
+		m_browseSearchId = theApp->searchlist->AllocateEd2kId();
+	}
+	// Describe it before any result arrives, so it is listable as a browse of
+	// this peer rather than as a nameless search.
+	theApp->searchlist->RegisterBrowseSearch(m_browseSearchId, GetUserName(), ECID());
+	theApp->browsemanager->Start(this, m_browseSearchId, ECID(), ::GetTickCount64());
+
+	// Open the "View Files" tab up front (monolithic) so a peer that denies or
+	// never answers still shows a tab that can flip to "failed".
+	Notify_Browse_Started(ECID(), GetUserName(), (uint64)m_browseSearchId);
+
+	if (!TryToConnect(true)) {
+		// false means the client was deleted (see TryToConnect), and it only
+		// gets there through Disconnected(), which has already ended the
+		// browse. Nothing left that may be touched.
+		return;
+	}
+	// TryToConnect returns true both when it started contacting the peer and
+	// when it decided not to, and several of its exits do the latter silently.
+	// None of those send a packet, so nothing downstream would ever end the
+	// browse; the deadline would, eventually, but saying so now is both
+	// correct and cheaper. Tested on the outcome rather than at each exit,
+	// because the exits are not a closed set -- two attempts at enumerating
+	// them both came up short.
+	if (!IsPeerContactPending()) {
+		theApp->browsemanager->Fail(this);
 	}
 }
 
 void CUpDownClient::ProcessSharedFileList(const uint8_t *pachPacket, uint32 nSize, wxString &pszDirectory)
 {
-	if (m_iFileListRequested > 0) {
-		m_iFileListRequested--;
-		theApp->searchlist->ProcessSharedFileList(pachPacket, nSize, this, NULL, pszDirectory);
-		// One directory's worth of files arrived; advance the browse bar, and
-		// give a share that is still streaming the full timeout again.
-		RefreshBrowseDeadline();
-		UpdateBrowseBar();
+	if (theApp->browsemanager->SearchIdFor(this) == 0) {
+		return;
 	}
+	theApp->searchlist->ProcessSharedFileList(pachPacket, nSize, this, nullptr, pszDirectory);
+	// A listing arrived, so the browse is alive and one step further along.
+	// Both protocol forms report here, and completion is decided in one place
+	// from the count -- the flat form used to have nothing mark it at all.
+	theApp->browsemanager->OnListingReceived(this, ::GetTickCount64());
 }
 
 void CUpDownClient::ResetFileStatusInfo()

--- a/src/BrowseLifecycle.cpp
+++ b/src/BrowseLifecycle.cpp
@@ -1,0 +1,112 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "BrowseLifecycle.h"
+
+namespace browse
+{
+
+Action Tick(const Record &rec, std::uint64_t now)
+{
+	if (rec.state != State::InProgress) {
+		// Terminal already: whoever is tracking it should stop.
+		return Action::Drop;
+	}
+	// Completion wins over expiry. A browse whose last listing landed in the
+	// same tick its deadline passed succeeded; reporting that as a timeout
+	// would throw away results we are holding.
+	if (rec.outstanding == 0) {
+		return Action::Complete;
+	}
+	if (rec.deadline != 0 && rec.deadline < now) {
+		return Action::Expire;
+	}
+	return Action::None;
+}
+
+std::uint16_t BarValue(const Record &rec)
+{
+	if (rec.state != State::InProgress) {
+		return 0xffff;
+	}
+	if (rec.totalDirs > 0) {
+		int done = rec.totalDirs - (rec.outstanding > 0 ? rec.outstanding : 0);
+		if (done < 0) {
+			done = 0;
+		} else if (done > rec.totalDirs) {
+			done = rec.totalDirs;
+		}
+		return static_cast<std::uint16_t>(done * 100 / rec.totalDirs);
+	}
+	return 0;
+}
+
+Record ApplyAction(Record rec, Action action)
+{
+	if (rec.state != State::InProgress) {
+		return rec;
+	}
+	switch (action) {
+	case Action::Complete:
+		rec.state = State::Finished;
+		break;
+	case Action::Expire:
+		rec.state = State::Failed;
+		break;
+	case Action::None:
+	case Action::Drop:
+		break;
+	}
+	return rec;
+}
+
+Record OnDirectoryList(Record rec, int dirCount, std::uint64_t deadline)
+{
+	if (rec.state != State::InProgress) {
+		// A late or duplicate answer for a browse that already ended changes
+		// nothing; taking it would resurrect a terminal record.
+		return rec;
+	}
+	rec.outstanding = dirCount > 0 ? dirCount : 0;
+	rec.totalDirs = dirCount > 0 ? dirCount : 0;
+	rec.deadline = deadline;
+	return rec;
+}
+
+Record OnListingReceived(Record rec, std::uint64_t deadline)
+{
+	if (rec.state != State::InProgress) {
+		return rec;
+	}
+	if (rec.outstanding == kFlatBrowse) {
+		// The single answer a flat browse was waiting for.
+		rec.outstanding = 0;
+	} else if (rec.outstanding > 0) {
+		--rec.outstanding;
+	}
+	rec.deadline = deadline;
+	return rec;
+}
+
+} // namespace browse

--- a/src/BrowseLifecycle.h
+++ b/src/BrowseLifecycle.h
@@ -71,6 +71,21 @@ enum class Action
  */
 constexpr int kFlatBrowse = -1;
 
+/**
+ * How long a browse may sit with nothing arriving before it is given up on.
+ *
+ * Refreshed on every sign of progress -- the request going out, each directory
+ * landing -- so it bounds silence, not the total time a large share takes to
+ * stream in.
+ *
+ * A backstop, not the mechanism: a browse normally ends when the peer answers,
+ * denies, or the socket dies. This exists because TryToContact has several
+ * exits that contact nobody, and two attempts at enumerating them both came up
+ * short (amule-org/amule#1071). At 120s it sits above the 40s ed2k socket
+ * timeout, so it never preempts the ordinary paths.
+ */
+constexpr std::uint64_t kSilenceTimeoutMs = 120000;
+
 //! One browse, start to finish.
 struct Record
 {

--- a/src/BrowseLifecycle.h
+++ b/src/BrowseLifecycle.h
@@ -1,0 +1,142 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef BROWSELIFECYCLE_H
+#define BROWSELIFECYCLE_H
+
+#include <cstdint>
+
+/**
+ * The state machine behind a "View Files" browse, with no dependency on
+ * theApp, the client, or the clock.
+ *
+ * It lives apart from CBrowseManager so it can be driven directly by a test.
+ * That is not incidental: every defect in this area so far has been this
+ * machine going wrong in a place that only a live peer of the right kind could
+ * reach -- a browse that completes without being marked finished, a peer we
+ * decline to contact, a terminal browse still sitting on the pending list --
+ * and none of those were reachable from a unit test while the logic was spread
+ * across CUpDownClient, CSearchList and the packet handlers.
+ */
+namespace browse
+{
+
+//! Where a browse is in its life. Mirrors EBrowseStatus on the wire side.
+enum class State
+{
+	InProgress, //!< asked for; nothing terminal has happened yet
+	Finished,   //!< the peer sent its whole list
+	Failed      //!< denied, unreachable, disconnected, or given up on
+};
+
+//! What the periodic tick should do with a record.
+enum class Action
+{
+	None,     //!< still legitimately in flight
+	Complete, //!< everything asked for has arrived: mark it finished
+	Expire,   //!< nothing has arrived for too long: give up on it
+	Drop      //!< already terminal: stop tracking it
+};
+
+/**
+ * `outstanding` for a browse answered in a single packet (OP_ASKSHAREDFILES),
+ * as opposed to the directory-by-directory form (OP_ASKSHAREDDIRS).
+ *
+ * The distinction is the reason a successful flat browse used to hang: the
+ * directory form counts down to 0 and the packet handler marked it finished
+ * there, while the flat form had no counter to reach 0 and nothing marked it
+ * at all. Modelling "one answer expected" explicitly means both forms complete
+ * through the same rule.
+ */
+constexpr int kFlatBrowse = -1;
+
+//! One browse, start to finish.
+struct Record
+{
+	//! Search ID this browse's results are filed under. Allocated when the
+	//! browse is asked for, so it is never 0 for a live record.
+	std::uint32_t searchId = 0;
+	//! ECID of the peer being browsed, for the listing and the GUI tab.
+	std::uint32_t peerEcid = 0;
+	State state = State::InProgress;
+	//! Directory listings still expected, or kFlatBrowse.
+	int outstanding = kFlatBrowse;
+	//! Directories the peer said it has; 0 until it answers, and always 0 for
+	//! a flat browse. Only used for the progress percent.
+	int totalDirs = 0;
+	//! Tick count after which silence means the browse is dead. Never 0 for a
+	//! record still in progress.
+	std::uint64_t deadline = 0;
+};
+
+/**
+ * What to do with `rec` at time `now`.
+ *
+ * Completion is checked before expiry: a browse whose last directory arrived
+ * in the same tick that its deadline passed has succeeded, not timed out.
+ */
+Action Tick(const Record &rec, std::uint64_t now);
+
+/**
+ * Progress bar value: 0..100 while running, or 0xffff once terminal, which is
+ * the sentinel the search list's bar already uses to mean "clear it".
+ *
+ * A browse with no directory count -- still connecting, or flat -- has no
+ * meaningful percent and reports 0 rather than guessing.
+ */
+std::uint16_t BarValue(const Record &rec);
+
+/**
+ * Apply `action` to `rec`, returning the record it leaves behind.
+ *
+ * A browse that has already ended stays ended. That is the whole rule, and it
+ * has to live here rather than at the call sites: the peer disconnecting
+ * immediately after sending its last directory is the ordinary case, not an
+ * edge one, and the disconnect path asks for a failure without knowing the
+ * browse just succeeded. Deciding it at each caller is how the invariant got
+ * broken five times before it had an owner.
+ *
+ * Action::Drop is not a state change and is handled by the caller, which knows
+ * what tracking means.
+ */
+Record ApplyAction(Record rec, Action action);
+
+/**
+ * The peer answered OP_ASKSHAREDDIRS with `dirCount` directories.
+ *
+ * `dirCount == 0` is a real answer, not a malformed one: the peer is telling
+ * us it has nothing to send, which completes the browse rather than leaving it
+ * waiting for listings that will never come.
+ */
+Record OnDirectoryList(Record rec, int dirCount, std::uint64_t deadline);
+
+/**
+ * One directory's worth of files arrived (either form), so the browse is alive
+ * and one step further along.
+ */
+Record OnListingReceived(Record rec, std::uint64_t deadline);
+
+} // namespace browse
+
+#endif // BROWSELIFECYCLE_H

--- a/src/BrowseLifecycle.h
+++ b/src/BrowseLifecycle.h
@@ -92,8 +92,6 @@ struct Record
 	//! Search ID this browse's results are filed under. Allocated when the
 	//! browse is asked for, so it is never 0 for a live record.
 	std::uint32_t searchId = 0;
-	//! ECID of the peer being browsed, for the listing and the GUI tab.
-	std::uint32_t peerEcid = 0;
 	State state = State::InProgress;
 	//! Directory listings still expected, or kFlatBrowse.
 	int outstanding = kFlatBrowse;

--- a/src/BrowseManager.cpp
+++ b/src/BrowseManager.cpp
@@ -35,7 +35,11 @@
 bool CBrowseManager::Start(
 	CUpDownClient *client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
 {
-	if (!m_store.Start(client, searchId, peerEcid, now)) {
+	const browse::Store::StartResult result = m_store.Start(client, searchId, peerEcid, now);
+	// Release whatever this peer was attached to before linking it afresh, so
+	// the reference map never holds two entries for one peer.
+	Perform(result.displaced);
+	if (!result.started) {
 		return false;
 	}
 	m_clients[searchId].Link(client CLIENT_DEBUGSTRING("CBrowseManager::Start"));
@@ -49,41 +53,30 @@ void CBrowseManager::OnRequestSent(CUpDownClient *client, std::uint64_t now)
 
 void CBrowseManager::OnDirectoryList(CUpDownClient *client, int dirCount, std::uint64_t now)
 {
-	// Read the ID first, in its own statement: the argument order of a call is
-	// unspecified, and a peer answering "no directories" completes the browse
-	// here -- after which SearchIdFor no longer answers and the announcement
-	// would be dropped on whichever compiler evaluated right-to-left.
-	const std::uint32_t searchId = m_store.SearchIdFor(client);
-	Perform(searchId, m_store.OnDirectoryList(client, dirCount, now));
+	Perform(m_store.OnDirectoryList(client, dirCount, now));
 }
 
 void CBrowseManager::OnListingReceived(CUpDownClient *client, std::uint64_t now)
 {
-	// The ID has to be read before the call: completing the browse is exactly
-	// what stops SearchIdFor from answering.
-	const std::uint32_t searchId = m_store.SearchIdFor(client);
-	Perform(searchId, m_store.OnListingReceived(client, now));
+	Perform(m_store.OnListingReceived(client, now));
 }
 
 void CBrowseManager::Fail(CUpDownClient *client)
 {
-	const std::uint32_t searchId = m_store.SearchIdFor(client);
-	Perform(searchId, m_store.Fail(client));
+	Perform(m_store.Fail(client));
 }
 
 void CBrowseManager::Finish(CUpDownClient *client)
 {
-	const std::uint32_t searchId = m_store.SearchIdFor(client);
-	Perform(searchId, m_store.Finish(client));
+	Perform(m_store.Finish(client));
 }
 
 void CBrowseManager::Forget(CUpDownClient *client)
 {
-	const std::uint32_t searchId = m_store.SearchIdFor(client);
 	// Ordered: the failure is reported while the reference that names the peer
 	// is still held, and only then released.
-	for (const browse::Effect effect : m_store.Forget(client)) {
-		Perform(searchId, effect);
+	for (const browse::Outcome &outcome : m_store.Forget(client)) {
+		Perform(outcome);
 	}
 }
 
@@ -95,35 +88,35 @@ void CBrowseManager::Remove(std::uint32_t searchId)
 
 void CBrowseManager::Process(std::uint64_t now)
 {
-	for (const auto &todo : m_store.Tick(now)) {
-		Perform(todo.first, todo.second);
+	for (const browse::Outcome &outcome : m_store.Tick(now)) {
+		Perform(outcome);
 	}
 }
 
-void CBrowseManager::Perform(std::uint32_t searchId, browse::Effect effect)
+void CBrowseManager::Perform(const browse::Outcome &outcome)
 {
-	if (searchId == 0 || effect == browse::Effect::Nothing) {
-		return;
-	}
-	switch (effect) {
+	// The ID travels with the effect, so there is no way for the two to
+	// disagree -- which is how a release went missing when the manager looked
+	// the ID up separately and the lookup excluded terminal browses.
+	switch (outcome.effect) {
 	case browse::Effect::Nothing:
 		break;
 	case browse::Effect::ReleaseClient:
 		// Terminal and announced; the peer is free to be reaped. The record
 		// stays until its search is freed.
-		m_clients.erase(searchId);
+		m_clients.erase(outcome.searchId);
 		break;
 	case browse::Effect::AnnounceFailure: {
-		const auto it = m_clients.find(searchId);
+		const auto it = m_clients.find(outcome.searchId);
 		AddLogLineC(CFormat(_("Failed to retrieve shared files from user '%s'")) %
 			    (it != m_clients.end() && it->second.IsLinked()
 					    ? it->second.GetClient()->GetUserName()
 					    : wxString()));
-		Announce(searchId);
+		Announce(outcome.searchId);
 		break;
 	}
 	case browse::Effect::Announce:
-		Announce(searchId);
+		Announce(outcome.searchId);
 		break;
 	}
 }
@@ -155,9 +148,4 @@ browse::State CBrowseManager::StateOf(std::uint32_t searchId) const
 std::uint16_t CBrowseManager::BarValue(std::uint32_t searchId) const
 {
 	return m_store.BarValue(searchId);
-}
-
-std::vector<std::uint32_t> CBrowseManager::Ids() const
-{
-	return m_store.Ids();
 }

--- a/src/BrowseManager.cpp
+++ b/src/BrowseManager.cpp
@@ -35,14 +35,17 @@
 bool CBrowseManager::Start(CUpDownClient *client, std::uint32_t searchId, std::uint64_t now)
 {
 	const browse::Store::StartResult result = m_store.Start(client, searchId, now);
-	// Release whatever this peer was attached to before linking it afresh, so
-	// the reference map never holds two entries for one peer.
-	Perform(result.displaced);
-	if (!result.started) {
-		return false;
+	if (result.started) {
+		m_clients[searchId].Link(client CLIENT_DEBUGSTRING("CBrowseManager::Start"));
 	}
-	m_clients[searchId].Link(client CLIENT_DEBUGSTRING("CBrowseManager::Start"));
-	return true;
+	// Only now release whatever this peer was attached to before, so the
+	// reference map never holds two entries for one peer. Deliberately after
+	// the link: CClientRef::Unlink deletes at a refcount of zero, so releasing
+	// first would free `client` here if this map ever held the last reference.
+	// It does not today -- clientlist keeps one for any browsable peer -- but
+	// that is another class's invariant, and this order does not need it.
+	Perform(result.displaced);
+	return result.started;
 }
 
 void CBrowseManager::OnRequestSent(CUpDownClient *client, std::uint64_t now)

--- a/src/BrowseManager.cpp
+++ b/src/BrowseManager.cpp
@@ -135,6 +135,11 @@ std::uint32_t CBrowseManager::SearchIdFor(const CUpDownClient *client) const
 	return m_store.SearchIdFor(client);
 }
 
+bool CBrowseManager::AwaitingDirectoryList(const CUpDownClient *client) const
+{
+	return m_store.AwaitingDirectoryList(client);
+}
+
 bool CBrowseManager::Has(std::uint32_t searchId) const
 {
 	return m_store.Has(searchId);

--- a/src/BrowseManager.cpp
+++ b/src/BrowseManager.cpp
@@ -31,219 +31,133 @@
 #include <common/Format.h>
 
 #include <wx/intl.h> // _()
-#include <protocol/ed2k/Constants.h>
-
-#include <vector>
 
 bool CBrowseManager::Start(
 	CUpDownClient *client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
 {
-	if (client == nullptr || searchId == 0) {
+	if (!m_store.Start(client, searchId, peerEcid, now)) {
 		return false;
 	}
-	if (FindFor(client) != m_browses.end()) {
-		// One browse per peer: there is a single exchange with that client to
-		// report on, so a second record could only ever describe the same one.
-		return false;
-	}
-	Entry entry;
-	entry.rec.searchId = searchId;
-	entry.rec.peerEcid = peerEcid;
-	entry.rec.state = browse::State::InProgress;
-	entry.rec.outstanding = browse::kFlatBrowse;
-	entry.rec.deadline = now + BROWSE_SILENCE_TIMEOUT;
-	entry.client.Link(client CLIENT_DEBUGSTRING("CBrowseManager::Start"));
-	m_browses[searchId] = entry;
+	m_clients[searchId].Link(client CLIENT_DEBUGSTRING("CBrowseManager::Start"));
 	return true;
 }
 
 void CBrowseManager::OnRequestSent(CUpDownClient *client, std::uint64_t now)
 {
-	const auto it = FindFor(client);
-	if (it != m_browses.end() && it->second.rec.state == browse::State::InProgress) {
-		it->second.rec.deadline = now + BROWSE_SILENCE_TIMEOUT;
-	}
+	m_store.Touch(client, now);
 }
 
 void CBrowseManager::OnDirectoryList(CUpDownClient *client, int dirCount, std::uint64_t now)
 {
-	const auto it = FindFor(client);
-	if (it == m_browses.end()) {
-		return;
-	}
-	it->second.rec = browse::OnDirectoryList(it->second.rec, dirCount, now + BROWSE_SILENCE_TIMEOUT);
-	// A peer answering "0 directories" has told us everything it intends to,
-	// so this may already complete the browse.
-	Apply(it, browse::Tick(it->second.rec, now));
+	// Read the ID first, in its own statement: the argument order of a call is
+	// unspecified, and a peer answering "no directories" completes the browse
+	// here -- after which SearchIdFor no longer answers and the announcement
+	// would be dropped on whichever compiler evaluated right-to-left.
+	const std::uint32_t searchId = m_store.SearchIdFor(client);
+	Perform(searchId, m_store.OnDirectoryList(client, dirCount, now));
 }
 
 void CBrowseManager::OnListingReceived(CUpDownClient *client, std::uint64_t now)
 {
-	const auto it = FindFor(client);
-	if (it == m_browses.end()) {
-		return;
-	}
-	it->second.rec = browse::OnListingReceived(it->second.rec, now + BROWSE_SILENCE_TIMEOUT);
-	// Both protocol forms complete here -- the directory form when its count
-	// reaches zero, the flat form on its single answer. Marking completion in
-	// one place is what the packet handlers could not do, since only one of
-	// them knew it was the last.
-	Apply(it, browse::Tick(it->second.rec, now));
+	// The ID has to be read before the call: completing the browse is exactly
+	// what stops SearchIdFor from answering.
+	const std::uint32_t searchId = m_store.SearchIdFor(client);
+	Perform(searchId, m_store.OnListingReceived(client, now));
 }
 
 void CBrowseManager::Fail(CUpDownClient *client)
 {
-	const auto it = FindFor(client);
-	if (it != m_browses.end()) {
-		Apply(it, browse::Action::Expire);
-	}
+	const std::uint32_t searchId = m_store.SearchIdFor(client);
+	Perform(searchId, m_store.Fail(client));
 }
 
 void CBrowseManager::Finish(CUpDownClient *client)
 {
-	const auto it = FindFor(client);
-	if (it != m_browses.end()) {
-		Apply(it, browse::Action::Complete);
+	const std::uint32_t searchId = m_store.SearchIdFor(client);
+	Perform(searchId, m_store.Finish(client));
+}
+
+void CBrowseManager::Forget(CUpDownClient *client)
+{
+	const std::uint32_t searchId = m_store.SearchIdFor(client);
+	// Ordered: the failure is reported while the reference that names the peer
+	// is still held, and only then released.
+	for (const browse::Effect effect : m_store.Forget(client)) {
+		Perform(searchId, effect);
 	}
 }
 
 void CBrowseManager::Remove(std::uint32_t searchId)
 {
-	m_browses.erase(searchId);
-}
-
-void CBrowseManager::Forget(CUpDownClient *client)
-{
-	const auto it = FindFor(client);
-	if (it == m_browses.end()) {
-		return;
-	}
-	if (it->second.rec.state == browse::State::InProgress) {
-		// The peer is going away mid-browse: that is a failure, and it has to
-		// be reported like any other rather than vanishing.
-		Apply(it, browse::Action::Expire);
-	}
-	// Let go of the client; the record outlives it, until the search is freed.
-	if (it->second.client.IsLinked()) {
-		it->second.client.Unlink();
-	}
+	m_store.Remove(searchId);
+	m_clients.erase(searchId);
 }
 
 void CBrowseManager::Process(std::uint64_t now)
 {
-	for (auto it = m_browses.begin(); it != m_browses.end();) {
-		const auto current = it++;
-		// Apply may erase `current`; `it` already points past it.
-		Apply(current, browse::Tick(current->second.rec, now));
+	for (const auto &todo : m_store.Tick(now)) {
+		Perform(todo.first, todo.second);
 	}
 }
 
-bool CBrowseManager::Apply(std::map<std::uint32_t, Entry>::iterator it, browse::Action action)
+void CBrowseManager::Perform(std::uint32_t searchId, browse::Effect effect)
 {
-	if (action == browse::Action::None) {
-		return false;
+	if (searchId == 0 || effect == browse::Effect::Nothing) {
+		return;
 	}
-	if (action != browse::Action::Drop) {
-		const browse::State before = it->second.rec.state;
-		it->second.rec = browse::ApplyAction(it->second.rec, action);
-		if (it->second.rec.state == before) {
-			// Already terminal; the transition was refused. Nothing to
-			// report, and nothing to log -- the disconnect that follows a
-			// completed browse must not be announced as a failure.
-			return false;
-		}
-	}
-	switch (action) {
-	case browse::Action::None:
-	case browse::Action::Complete:
-	case browse::Action::Expire:
+	switch (effect) {
+	case browse::Effect::Nothing:
 		break;
-	case browse::Action::Drop:
-		// Terminal and already reported. The RECORD stays: the search ID is
-		// still listed, and every consumer asks this manager what state it is
-		// in -- drop it here and a failed browse would fall back to "results
-		// retained?" and report idle again, which is the bug this ownership
-		// was meant to end. It is released with the search itself, in
-		// Remove(). What can go now is the client reference, so a peer that
-		// is finished with is free to be reaped.
-		if (it->second.client.IsLinked()) {
-			it->second.client.Unlink();
-		}
-		return false;
-	}
-	NotifyTransition(it->second);
-	if (action == browse::Action::Expire) {
+	case browse::Effect::ReleaseClient:
+		// Terminal and announced; the peer is free to be reaped. The record
+		// stays until its search is freed.
+		m_clients.erase(searchId);
+		break;
+	case browse::Effect::AnnounceFailure: {
+		const auto it = m_clients.find(searchId);
 		AddLogLineC(CFormat(_("Failed to retrieve shared files from user '%s'")) %
-			    (it->second.client.IsLinked() ? it->second.client.GetClient()->GetUserName()
-							  : wxString()));
+			    (it != m_clients.end() && it->second.IsLinked()
+					    ? it->second.GetClient()->GetUserName()
+					    : wxString()));
+		Announce(searchId);
+		break;
 	}
-	// Terminal now: hold it one more tick so readers that poll between the
-	// transition and the next tick still see the final state, then Drop.
-	return false;
+	case browse::Effect::Announce:
+		Announce(searchId);
+		break;
+	}
 }
 
-void CBrowseManager::NotifyTransition(const Entry &entry)
+void CBrowseManager::Announce(std::uint32_t searchId)
 {
 	// The GUI's tab marker, and nothing else: every other consumer -- the EC
 	// progress reply, the EC search listing, the monolithic bar -- reads this
 	// manager rather than holding a copy to be kept in step.
-	Notify_Browse_Status(static_cast<std::uint64_t>(entry.rec.searchId),
-		entry.rec.state == browse::State::Finished ? BROWSE_FINISHED : BROWSE_FAILED);
-}
-
-std::map<std::uint32_t, CBrowseManager::Entry>::iterator CBrowseManager::FindFor(const CUpDownClient *client)
-{
-	if (client == nullptr) {
-		return m_browses.end();
-	}
-	for (auto it = m_browses.begin(); it != m_browses.end(); ++it) {
-		if (it->second.client.GetClient() == client) {
-			return it;
-		}
-	}
-	return m_browses.end();
+	Notify_Browse_Status(static_cast<std::uint64_t>(searchId),
+		m_store.StateOf(searchId) == browse::State::Finished ? BROWSE_FINISHED : BROWSE_FAILED);
 }
 
 std::uint32_t CBrowseManager::SearchIdFor(const CUpDownClient *client) const
 {
-	for (const auto &kv : m_browses) {
-		if (kv.second.client.GetClient() == client &&
-			kv.second.rec.state == browse::State::InProgress) {
-			return kv.first;
-		}
-	}
-	return 0;
+	return m_store.SearchIdFor(client);
 }
 
 bool CBrowseManager::Has(std::uint32_t searchId) const
 {
-	return m_browses.find(searchId) != m_browses.end();
+	return m_store.Has(searchId);
 }
 
 browse::State CBrowseManager::StateOf(std::uint32_t searchId) const
 {
-	const auto it = m_browses.find(searchId);
-	return it != m_browses.end() ? it->second.rec.state : browse::State::Failed;
+	return m_store.StateOf(searchId);
 }
 
 std::uint16_t CBrowseManager::BarValue(std::uint32_t searchId) const
 {
-	const auto it = m_browses.find(searchId);
-	return it != m_browses.end() ? browse::BarValue(it->second.rec) : 0xffff;
-}
-
-int CBrowseManager::Outstanding(std::uint32_t searchId) const
-{
-	const auto it = m_browses.find(searchId);
-	return it != m_browses.end() ? it->second.rec.outstanding : 0;
+	return m_store.BarValue(searchId);
 }
 
 std::vector<std::uint32_t> CBrowseManager::Ids() const
 {
-	std::vector<std::uint32_t> out;
-	out.reserve(m_browses.size());
-	for (const auto &kv : m_browses) {
-		out.push_back(kv.first);
-	}
-	return out;
+	return m_store.Ids();
 }

--- a/src/BrowseManager.cpp
+++ b/src/BrowseManager.cpp
@@ -1,0 +1,249 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "BrowseManager.h"
+
+#include "GuiEvents.h"
+#include "Logger.h"
+#include "updownclient.h"
+
+#include <common/Format.h>
+
+#include <wx/intl.h> // _()
+#include <protocol/ed2k/Constants.h>
+
+#include <vector>
+
+bool CBrowseManager::Start(
+	CUpDownClient *client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
+{
+	if (client == nullptr || searchId == 0) {
+		return false;
+	}
+	if (FindFor(client) != m_browses.end()) {
+		// One browse per peer: there is a single exchange with that client to
+		// report on, so a second record could only ever describe the same one.
+		return false;
+	}
+	Entry entry;
+	entry.rec.searchId = searchId;
+	entry.rec.peerEcid = peerEcid;
+	entry.rec.state = browse::State::InProgress;
+	entry.rec.outstanding = browse::kFlatBrowse;
+	entry.rec.deadline = now + BROWSE_SILENCE_TIMEOUT;
+	entry.client.Link(client CLIENT_DEBUGSTRING("CBrowseManager::Start"));
+	m_browses[searchId] = entry;
+	return true;
+}
+
+void CBrowseManager::OnRequestSent(CUpDownClient *client, std::uint64_t now)
+{
+	const auto it = FindFor(client);
+	if (it != m_browses.end() && it->second.rec.state == browse::State::InProgress) {
+		it->second.rec.deadline = now + BROWSE_SILENCE_TIMEOUT;
+	}
+}
+
+void CBrowseManager::OnDirectoryList(CUpDownClient *client, int dirCount, std::uint64_t now)
+{
+	const auto it = FindFor(client);
+	if (it == m_browses.end()) {
+		return;
+	}
+	it->second.rec = browse::OnDirectoryList(it->second.rec, dirCount, now + BROWSE_SILENCE_TIMEOUT);
+	// A peer answering "0 directories" has told us everything it intends to,
+	// so this may already complete the browse.
+	Apply(it, browse::Tick(it->second.rec, now));
+}
+
+void CBrowseManager::OnListingReceived(CUpDownClient *client, std::uint64_t now)
+{
+	const auto it = FindFor(client);
+	if (it == m_browses.end()) {
+		return;
+	}
+	it->second.rec = browse::OnListingReceived(it->second.rec, now + BROWSE_SILENCE_TIMEOUT);
+	// Both protocol forms complete here -- the directory form when its count
+	// reaches zero, the flat form on its single answer. Marking completion in
+	// one place is what the packet handlers could not do, since only one of
+	// them knew it was the last.
+	Apply(it, browse::Tick(it->second.rec, now));
+}
+
+void CBrowseManager::Fail(CUpDownClient *client)
+{
+	const auto it = FindFor(client);
+	if (it != m_browses.end()) {
+		Apply(it, browse::Action::Expire);
+	}
+}
+
+void CBrowseManager::Finish(CUpDownClient *client)
+{
+	const auto it = FindFor(client);
+	if (it != m_browses.end()) {
+		Apply(it, browse::Action::Complete);
+	}
+}
+
+void CBrowseManager::Remove(std::uint32_t searchId)
+{
+	m_browses.erase(searchId);
+}
+
+void CBrowseManager::Forget(CUpDownClient *client)
+{
+	const auto it = FindFor(client);
+	if (it == m_browses.end()) {
+		return;
+	}
+	if (it->second.rec.state == browse::State::InProgress) {
+		// The peer is going away mid-browse: that is a failure, and it has to
+		// be reported like any other rather than vanishing.
+		Apply(it, browse::Action::Expire);
+	}
+	// Let go of the client; the record outlives it, until the search is freed.
+	if (it->second.client.IsLinked()) {
+		it->second.client.Unlink();
+	}
+}
+
+void CBrowseManager::Process(std::uint64_t now)
+{
+	for (auto it = m_browses.begin(); it != m_browses.end();) {
+		const auto current = it++;
+		// Apply may erase `current`; `it` already points past it.
+		Apply(current, browse::Tick(current->second.rec, now));
+	}
+}
+
+bool CBrowseManager::Apply(std::map<std::uint32_t, Entry>::iterator it, browse::Action action)
+{
+	if (action == browse::Action::None) {
+		return false;
+	}
+	if (action != browse::Action::Drop) {
+		const browse::State before = it->second.rec.state;
+		it->second.rec = browse::ApplyAction(it->second.rec, action);
+		if (it->second.rec.state == before) {
+			// Already terminal; the transition was refused. Nothing to
+			// report, and nothing to log -- the disconnect that follows a
+			// completed browse must not be announced as a failure.
+			return false;
+		}
+	}
+	switch (action) {
+	case browse::Action::None:
+	case browse::Action::Complete:
+	case browse::Action::Expire:
+		break;
+	case browse::Action::Drop:
+		// Terminal and already reported. The RECORD stays: the search ID is
+		// still listed, and every consumer asks this manager what state it is
+		// in -- drop it here and a failed browse would fall back to "results
+		// retained?" and report idle again, which is the bug this ownership
+		// was meant to end. It is released with the search itself, in
+		// Remove(). What can go now is the client reference, so a peer that
+		// is finished with is free to be reaped.
+		if (it->second.client.IsLinked()) {
+			it->second.client.Unlink();
+		}
+		return false;
+	}
+	NotifyTransition(it->second);
+	if (action == browse::Action::Expire) {
+		AddLogLineC(CFormat(_("Failed to retrieve shared files from user '%s'")) %
+			    (it->second.client.IsLinked() ? it->second.client.GetClient()->GetUserName()
+							  : wxString()));
+	}
+	// Terminal now: hold it one more tick so readers that poll between the
+	// transition and the next tick still see the final state, then Drop.
+	return false;
+}
+
+void CBrowseManager::NotifyTransition(const Entry &entry)
+{
+	// The GUI's tab marker, and nothing else: every other consumer -- the EC
+	// progress reply, the EC search listing, the monolithic bar -- reads this
+	// manager rather than holding a copy to be kept in step.
+	Notify_Browse_Status(static_cast<std::uint64_t>(entry.rec.searchId),
+		entry.rec.state == browse::State::Finished ? BROWSE_FINISHED : BROWSE_FAILED);
+}
+
+std::map<std::uint32_t, CBrowseManager::Entry>::iterator CBrowseManager::FindFor(const CUpDownClient *client)
+{
+	if (client == nullptr) {
+		return m_browses.end();
+	}
+	for (auto it = m_browses.begin(); it != m_browses.end(); ++it) {
+		if (it->second.client.GetClient() == client) {
+			return it;
+		}
+	}
+	return m_browses.end();
+}
+
+std::uint32_t CBrowseManager::SearchIdFor(const CUpDownClient *client) const
+{
+	for (const auto &kv : m_browses) {
+		if (kv.second.client.GetClient() == client &&
+			kv.second.rec.state == browse::State::InProgress) {
+			return kv.first;
+		}
+	}
+	return 0;
+}
+
+bool CBrowseManager::Has(std::uint32_t searchId) const
+{
+	return m_browses.find(searchId) != m_browses.end();
+}
+
+browse::State CBrowseManager::StateOf(std::uint32_t searchId) const
+{
+	const auto it = m_browses.find(searchId);
+	return it != m_browses.end() ? it->second.rec.state : browse::State::Failed;
+}
+
+std::uint16_t CBrowseManager::BarValue(std::uint32_t searchId) const
+{
+	const auto it = m_browses.find(searchId);
+	return it != m_browses.end() ? browse::BarValue(it->second.rec) : 0xffff;
+}
+
+int CBrowseManager::Outstanding(std::uint32_t searchId) const
+{
+	const auto it = m_browses.find(searchId);
+	return it != m_browses.end() ? it->second.rec.outstanding : 0;
+}
+
+std::vector<std::uint32_t> CBrowseManager::Ids() const
+{
+	std::vector<std::uint32_t> out;
+	out.reserve(m_browses.size());
+	for (const auto &kv : m_browses) {
+		out.push_back(kv.first);
+	}
+	return out;
+}

--- a/src/BrowseManager.cpp
+++ b/src/BrowseManager.cpp
@@ -32,10 +32,9 @@
 
 #include <wx/intl.h> // _()
 
-bool CBrowseManager::Start(
-	CUpDownClient *client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
+bool CBrowseManager::Start(CUpDownClient *client, std::uint32_t searchId, std::uint64_t now)
 {
-	const browse::Store::StartResult result = m_store.Start(client, searchId, peerEcid, now);
+	const browse::Store::StartResult result = m_store.Start(client, searchId, now);
 	// Release whatever this peer was attached to before linking it afresh, so
 	// the reference map never holds two entries for one peer.
 	Perform(result.displaced);

--- a/src/BrowseManager.h
+++ b/src/BrowseManager.h
@@ -68,7 +68,7 @@ public:
 	 * Refuses to start a second browse of a client that already has one, so
 	 * the caller's own "already in flight" check and this cannot disagree.
 	 */
-	bool Start(CUpDownClient *client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
+	bool Start(CUpDownClient *client, std::uint32_t searchId, std::uint64_t now);
 
 	/**
 	 * The ask is on the wire. Restarts the silence budget, because the click

--- a/src/BrowseManager.h
+++ b/src/BrowseManager.h
@@ -125,12 +125,9 @@ public:
 	//! list's bar and the EC progress reply already use.
 	std::uint16_t BarValue(std::uint32_t searchId) const;
 
-	//! Every browse ID currently tracked, for the EC results union poll.
-	std::vector<std::uint32_t> Ids() const;
-
 private:
 	//! Perform what the store asked for, on the browse named by `searchId`.
-	void Perform(std::uint32_t searchId, browse::Effect effect);
+	void Perform(const browse::Outcome &outcome);
 	//! Tell the GUI a browse reached its terminal state.
 	void Announce(std::uint32_t searchId);
 

--- a/src/BrowseManager.h
+++ b/src/BrowseManager.h
@@ -117,6 +117,8 @@ public:
 	//! this peer" test the EC handler joins on.
 	std::uint32_t SearchIdFor(const CUpDownClient *client) const;
 
+	//! See browse::Store::AwaitingDirectoryList.
+	bool AwaitingDirectoryList(const CUpDownClient *client) const;
 	bool Has(std::uint32_t searchId) const;
 	//! browse::State of `searchId`; InProgress for an unknown ID is never
 	//! reported -- callers gate on Has() first.

--- a/src/BrowseManager.h
+++ b/src/BrowseManager.h
@@ -1,0 +1,152 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef BROWSEMANAGER_H
+#define BROWSEMANAGER_H
+
+#include "BrowseLifecycle.h"
+#include "ClientRef.h"
+
+#include <cstdint>
+#include <map>
+
+class CUpDownClient;
+
+/**
+ * Owns every "View Files" browse the core is running.
+ *
+ * Before this existed a browse was four fields borrowed on CUpDownClient plus
+ * two maps on CSearchList plus a list on CClientList, and the same fact was
+ * written independently in seven files. Five separate defects were that one
+ * invariant broken somewhere different -- a successful browse never marked
+ * finished, a peer we declined to contact, a terminal browse re-examined on
+ * every tick forever. One owner is the point: the lifecycle is decided by
+ * browse::Tick and stored here, and every other subsystem reads it rather than
+ * keeping a copy that has to be made to agree.
+ *
+ * Core-only. Everything that touches browse state -- CUpDownClient,
+ * CClientTCPSocket, CSearchList, the EC handlers, and the monolithic search
+ * dialog's #ifndef CLIENT_GUI paths -- is core; amulegui learns a browse's
+ * state over EC instead.
+ */
+class CBrowseManager
+{
+public:
+	/**
+	 * Begin tracking a browse of `client` under `searchId`.
+	 *
+	 * The ID is allocated by the caller before the request goes out, for both
+	 * the EC and the local path, so a browse is addressable from the moment it
+	 * exists. That is what lets this map be keyed by ID: the old code had no
+	 * ID for a local browse until its first result arrived and keyed the
+	 * interim state on the client pointer instead, which left entries behind
+	 * that nothing could prune and made two browses of different peers
+	 * collide when an address was reused.
+	 *
+	 * Refuses to start a second browse of a client that already has one, so
+	 * the caller's own "already in flight" check and this cannot disagree.
+	 */
+	bool Start(CUpDownClient *client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
+
+	/**
+	 * The ask is on the wire. Restarts the silence budget, because the click
+	 * may have been a connect ago and the peer's clock starts here.
+	 */
+	void OnRequestSent(CUpDownClient *client, std::uint64_t now);
+
+	//! The peer answered OP_ASKSHAREDDIRS with its directory count.
+	void OnDirectoryList(CUpDownClient *client, int dirCount, std::uint64_t now);
+
+	/**
+	 * One listing arrived, of either protocol form. Completes the browse when
+	 * nothing more is expected -- which is where the flat (single-answer) form
+	 * used to be left hanging, because only the directory form's packet
+	 * handler marked anything.
+	 */
+	void OnListingReceived(CUpDownClient *client, std::uint64_t now);
+
+	//! Terminalize the browse of `client`, if it has one. Safe to call for a
+	//! client that never had one, which is most of them.
+	void Fail(CUpDownClient *client);
+	void Finish(CUpDownClient *client);
+
+	/**
+	 * The client is being destroyed: fail its browse if one is still running,
+	 * then let go of the reference. The record itself outlives the peer --
+	 * the search ID is still listed and still has to answer for its state.
+	 */
+	void Forget(CUpDownClient *client);
+
+	/**
+	 * Release a browse for good, when its search is freed.
+	 *
+	 * Records are deliberately kept after they terminate: every consumer asks
+	 * here what a browse's state is, so a record dropped at completion would
+	 * send the listing back to guessing from whether results were retained --
+	 * which reports a failed browse as idle, forever.
+	 */
+	void Remove(std::uint32_t searchId);
+
+	//! Expire the silent, complete the finished, drop the terminal. Driven by
+	//! the core timer; `now` is injected so the policy stays testable.
+	void Process(std::uint64_t now);
+
+	//! Search ID of `client`'s browse, or 0. This is the "already browsing
+	//! this peer" test the EC handler joins on.
+	std::uint32_t SearchIdFor(const CUpDownClient *client) const;
+
+	bool Has(std::uint32_t searchId) const;
+	//! browse::State of `searchId`; InProgress for an unknown ID is never
+	//! reported -- callers gate on Has() first.
+	browse::State StateOf(std::uint32_t searchId) const;
+	//! 0..100 while running, 0xffff once terminal: the value space the search
+	//! list's bar and the EC progress reply already use.
+	std::uint16_t BarValue(std::uint32_t searchId) const;
+	//! Directory listings still expected; kFlatBrowse before the peer answers.
+	int Outstanding(std::uint32_t searchId) const;
+
+	//! Every browse ID currently tracked, for the EC results union poll.
+	std::vector<std::uint32_t> Ids() const;
+
+private:
+	struct Entry
+	{
+		browse::Record rec;
+		CClientRef client;
+	};
+
+	//! Applies `action` to the entry `it` names. Returns true when the entry
+	//! was erased, so callers iterating know their iterator is spent.
+	bool Apply(std::map<std::uint32_t, Entry>::iterator it, browse::Action action);
+
+	//! Mirrors the record's bar + status into the client's GUI notification.
+	//! The only place a browse transition reaches the rest of the program.
+	void NotifyTransition(const Entry &entry);
+
+	std::map<std::uint32_t, Entry>::iterator FindFor(const CUpDownClient *client);
+
+	std::map<std::uint32_t, Entry> m_browses;
+};
+
+#endif // BROWSEMANAGER_H

--- a/src/BrowseManager.h
+++ b/src/BrowseManager.h
@@ -26,6 +26,7 @@
 #define BROWSEMANAGER_H
 
 #include "BrowseLifecycle.h"
+#include "BrowseStore.h"
 #include "ClientRef.h"
 
 #include <cstdint>
@@ -123,30 +124,28 @@ public:
 	//! 0..100 while running, 0xffff once terminal: the value space the search
 	//! list's bar and the EC progress reply already use.
 	std::uint16_t BarValue(std::uint32_t searchId) const;
-	//! Directory listings still expected; kFlatBrowse before the peer answers.
-	int Outstanding(std::uint32_t searchId) const;
 
 	//! Every browse ID currently tracked, for the EC results union poll.
 	std::vector<std::uint32_t> Ids() const;
 
 private:
-	struct Entry
-	{
-		browse::Record rec;
-		CClientRef client;
-	};
+	//! Perform what the store asked for, on the browse named by `searchId`.
+	void Perform(std::uint32_t searchId, browse::Effect effect);
+	//! Tell the GUI a browse reached its terminal state.
+	void Announce(std::uint32_t searchId);
 
-	//! Applies `action` to the entry `it` names. Returns true when the entry
-	//! was erased, so callers iterating know their iterator is spent.
-	bool Apply(std::map<std::uint32_t, Entry>::iterator it, browse::Action action);
+	//! Every rule about browses. Kept separate so it can be driven by a test:
+	//! it identifies peers by an opaque key and never reaches theApp.
+	browse::Store m_store;
 
-	//! Mirrors the record's bar + status into the client's GUI notification.
-	//! The only place a browse transition reaches the rest of the program.
-	void NotifyTransition(const Entry &entry);
-
-	std::map<std::uint32_t, Entry>::iterator FindFor(const CUpDownClient *client);
-
-	std::map<std::uint32_t, Entry> m_browses;
+	/**
+	 * The references that keep browsed peers alive, keyed the same way.
+	 *
+	 * Not a second copy of the browse -- the store owns that. This holds only
+	 * lifetime, and entries leave it as soon as the store says the peer is no
+	 * longer needed, which is well before the record itself is disposed of.
+	 */
+	std::map<std::uint32_t, CClientRef> m_clients;
 };
 
 #endif // BROWSEMANAGER_H

--- a/src/BrowseStore.cpp
+++ b/src/BrowseStore.cpp
@@ -1,0 +1,208 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "BrowseStore.h"
+
+namespace browse
+{
+
+bool Store::Start(ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
+{
+	if (client == nullptr || searchId == 0 || FindFor(client) != m_records.end()) {
+		return false;
+	}
+	Held held;
+	held.rec.searchId = searchId;
+	held.rec.peerEcid = peerEcid;
+	held.rec.state = State::InProgress;
+	held.rec.outstanding = kFlatBrowse;
+	held.rec.deadline = now + kSilenceTimeoutMs;
+	held.client = client;
+	m_records[searchId] = held;
+	return true;
+}
+
+void Store::Touch(ClientKey client, std::uint64_t now)
+{
+	const auto it = FindFor(client);
+	if (it != m_records.end() && it->second.rec.state == State::InProgress) {
+		it->second.rec.deadline = now + kSilenceTimeoutMs;
+	}
+}
+
+Effect Store::OnDirectoryList(ClientKey client, int dirCount, std::uint64_t now)
+{
+	const auto it = FindFor(client);
+	if (it == m_records.end()) {
+		return Effect::Nothing;
+	}
+	it->second.rec = browse::OnDirectoryList(it->second.rec, dirCount, now + kSilenceTimeoutMs);
+	// A peer answering "no directories" has said everything it means to, so
+	// this may complete the browse outright.
+	return ApplyTo(it->second, ::browse::Tick(it->second.rec, now));
+}
+
+Effect Store::OnListingReceived(ClientKey client, std::uint64_t now)
+{
+	const auto it = FindFor(client);
+	if (it == m_records.end()) {
+		return Effect::Nothing;
+	}
+	it->second.rec = browse::OnListingReceived(it->second.rec, now + kSilenceTimeoutMs);
+	// Both protocol forms complete here, from the outstanding count -- the
+	// only thing that knows whether anything is still expected.
+	return ApplyTo(it->second, ::browse::Tick(it->second.rec, now));
+}
+
+Effect Store::Fail(ClientKey client)
+{
+	const auto it = FindFor(client);
+	return it == m_records.end() ? Effect::Nothing : ApplyTo(it->second, Action::Expire);
+}
+
+Effect Store::Finish(ClientKey client)
+{
+	const auto it = FindFor(client);
+	return it == m_records.end() ? Effect::Nothing : ApplyTo(it->second, Action::Complete);
+}
+
+std::vector<Effect> Store::Forget(ClientKey client)
+{
+	std::vector<Effect> out;
+	const auto it = FindFor(client);
+	if (it == m_records.end()) {
+		return out;
+	}
+	if (it->second.rec.state == State::InProgress) {
+		// Going away mid-browse is a failure, and has to be reported like any
+		// other rather than quietly vanishing.
+		out.push_back(ApplyTo(it->second, Action::Expire));
+	}
+	it->second.client = nullptr;
+	out.push_back(Effect::ReleaseClient);
+	return out;
+}
+
+void Store::Remove(std::uint32_t searchId)
+{
+	m_records.erase(searchId);
+}
+
+std::vector<std::pair<std::uint32_t, Effect>> Store::Tick(std::uint64_t now)
+{
+	std::vector<std::pair<std::uint32_t, Effect>> out;
+	for (auto &kv : m_records) {
+		const Effect effect = ApplyTo(kv.second, ::browse::Tick(kv.second.rec, now));
+		if (effect != Effect::Nothing) {
+			out.emplace_back(kv.first, effect);
+		}
+	}
+	return out;
+}
+
+Effect Store::ApplyTo(Held &held, Action action)
+{
+	if (action == Action::Drop) {
+		// Terminal and already announced. Releasing the peer is all that is
+		// left; the record itself outlives it, because the search ID is still
+		// listed and every consumer asks here what state it is in. Dropping it
+		// now would send them back to guessing from whether results were
+		// retained, which reports a failed browse as idle, forever.
+		if (held.client == nullptr) {
+			return Effect::Nothing;
+		}
+		held.client = nullptr;
+		return Effect::ReleaseClient;
+	}
+	const State before = held.rec.state;
+	held.rec = ApplyAction(held.rec, action);
+	if (held.rec.state == before) {
+		// Refused, because it had already ended. Nothing to announce -- and
+		// nothing to log, which is what keeps the disconnect that follows a
+		// completed browse from being reported as a failure.
+		return Effect::Nothing;
+	}
+	return held.rec.state == State::Failed ? Effect::AnnounceFailure : Effect::Announce;
+}
+
+std::map<std::uint32_t, Store::Held>::iterator Store::FindFor(ClientKey client)
+{
+	if (client == nullptr) {
+		return m_records.end();
+	}
+	for (auto it = m_records.begin(); it != m_records.end(); ++it) {
+		if (it->second.client == client) {
+			return it;
+		}
+	}
+	return m_records.end();
+}
+
+std::map<std::uint32_t, Store::Held>::const_iterator Store::FindFor(ClientKey client) const
+{
+	if (client == nullptr) {
+		return m_records.end();
+	}
+	for (auto it = m_records.begin(); it != m_records.end(); ++it) {
+		if (it->second.client == client) {
+			return it;
+		}
+	}
+	return m_records.end();
+}
+
+std::uint32_t Store::SearchIdFor(ClientKey client) const
+{
+	const auto it = FindFor(client);
+	return (it != m_records.end() && it->second.rec.state == State::InProgress) ? it->first : 0;
+}
+
+bool Store::Has(std::uint32_t searchId) const
+{
+	return m_records.find(searchId) != m_records.end();
+}
+
+State Store::StateOf(std::uint32_t searchId) const
+{
+	const auto it = m_records.find(searchId);
+	return it != m_records.end() ? it->second.rec.state : State::Failed;
+}
+
+std::uint16_t Store::BarValue(std::uint32_t searchId) const
+{
+	const auto it = m_records.find(searchId);
+	return it != m_records.end() ? browse::BarValue(it->second.rec) : 0xffff;
+}
+
+std::vector<std::uint32_t> Store::Ids() const
+{
+	std::vector<std::uint32_t> out;
+	out.reserve(m_records.size());
+	for (const auto &kv : m_records) {
+		out.push_back(kv.first);
+	}
+	return out;
+}
+
+} // namespace browse

--- a/src/BrowseStore.cpp
+++ b/src/BrowseStore.cpp
@@ -197,6 +197,15 @@ std::uint32_t Store::SearchIdFor(ClientKey client) const
 	return (it != m_records.end() && it->second.rec.state == State::InProgress) ? it->first : 0;
 }
 
+bool Store::AwaitingDirectoryList(ClientKey client) const
+{
+	const auto it = FindFor(client);
+	// kFlatBrowse is the "nothing announced yet" state; the answer replaces it
+	// with a count, so a second answer finds it already gone.
+	return it != m_records.end() && it->second.rec.state == State::InProgress &&
+	       it->second.rec.outstanding == kFlatBrowse;
+}
+
 bool Store::Has(std::uint32_t searchId) const
 {
 	return m_records.find(searchId) != m_records.end();

--- a/src/BrowseStore.cpp
+++ b/src/BrowseStore.cpp
@@ -214,14 +214,4 @@ std::uint16_t Store::BarValue(std::uint32_t searchId) const
 	return it != m_records.end() ? browse::BarValue(it->second.rec) : 0xffff;
 }
 
-std::vector<std::uint32_t> Store::Ids() const
-{
-	std::vector<std::uint32_t> out;
-	out.reserve(m_records.size());
-	for (const auto &kv : m_records) {
-		out.push_back(kv.first);
-	}
-	return out;
-}
-
 } // namespace browse

--- a/src/BrowseStore.cpp
+++ b/src/BrowseStore.cpp
@@ -27,10 +27,24 @@
 namespace browse
 {
 
-bool Store::Start(ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
+Store::StartResult Store::Start(
+	ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
 {
-	if (client == nullptr || searchId == 0 || FindFor(client) != m_records.end()) {
-		return false;
+	StartResult result;
+	if (client == nullptr || searchId == 0 || m_records.count(searchId) != 0) {
+		return result;
+	}
+	const auto existing = FindFor(client);
+	if (existing != m_records.end()) {
+		if (existing->second.rec.state == State::InProgress) {
+			// One live browse per peer -- the rule the EC handler's join
+			// depends on.
+			return result;
+		}
+		// Ended, but not yet released. Let go now, so exactly one record ever
+		// names a given peer.
+		existing->second.client = nullptr;
+		result.displaced = { existing->first, Effect::ReleaseClient };
 	}
 	Held held;
 	held.rec.searchId = searchId;
@@ -40,7 +54,8 @@ bool Store::Start(ClientKey client, std::uint32_t searchId, std::uint32_t peerEc
 	held.rec.deadline = now + kSilenceTimeoutMs;
 	held.client = client;
 	m_records[searchId] = held;
-	return true;
+	result.started = true;
+	return result;
 }
 
 void Store::Touch(ClientKey client, std::uint64_t now)
@@ -51,45 +66,46 @@ void Store::Touch(ClientKey client, std::uint64_t now)
 	}
 }
 
-Effect Store::OnDirectoryList(ClientKey client, int dirCount, std::uint64_t now)
+Outcome Store::OnDirectoryList(ClientKey client, int dirCount, std::uint64_t now)
 {
 	const auto it = FindFor(client);
 	if (it == m_records.end()) {
-		return Effect::Nothing;
+		return Outcome();
 	}
 	it->second.rec = browse::OnDirectoryList(it->second.rec, dirCount, now + kSilenceTimeoutMs);
 	// A peer answering "no directories" has said everything it means to, so
 	// this may complete the browse outright.
-	return ApplyTo(it->second, ::browse::Tick(it->second.rec, now));
+	return { it->first, ApplyTo(it->second, ::browse::Tick(it->second.rec, now)) };
 }
 
-Effect Store::OnListingReceived(ClientKey client, std::uint64_t now)
+Outcome Store::OnListingReceived(ClientKey client, std::uint64_t now)
 {
 	const auto it = FindFor(client);
 	if (it == m_records.end()) {
-		return Effect::Nothing;
+		return Outcome();
 	}
 	it->second.rec = browse::OnListingReceived(it->second.rec, now + kSilenceTimeoutMs);
 	// Both protocol forms complete here, from the outstanding count -- the
 	// only thing that knows whether anything is still expected.
-	return ApplyTo(it->second, ::browse::Tick(it->second.rec, now));
+	return { it->first, ApplyTo(it->second, ::browse::Tick(it->second.rec, now)) };
 }
 
-Effect Store::Fail(ClientKey client)
+Outcome Store::Fail(ClientKey client)
 {
 	const auto it = FindFor(client);
-	return it == m_records.end() ? Effect::Nothing : ApplyTo(it->second, Action::Expire);
+	return it == m_records.end() ? Outcome() : Outcome{ it->first, ApplyTo(it->second, Action::Expire) };
 }
 
-Effect Store::Finish(ClientKey client)
+Outcome Store::Finish(ClientKey client)
 {
 	const auto it = FindFor(client);
-	return it == m_records.end() ? Effect::Nothing : ApplyTo(it->second, Action::Complete);
+	return it == m_records.end() ? Outcome()
+				     : Outcome{ it->first, ApplyTo(it->second, Action::Complete) };
 }
 
-std::vector<Effect> Store::Forget(ClientKey client)
+std::vector<Outcome> Store::Forget(ClientKey client)
 {
-	std::vector<Effect> out;
+	std::vector<Outcome> out;
 	const auto it = FindFor(client);
 	if (it == m_records.end()) {
 		return out;
@@ -97,10 +113,13 @@ std::vector<Effect> Store::Forget(ClientKey client)
 	if (it->second.rec.state == State::InProgress) {
 		// Going away mid-browse is a failure, and has to be reported like any
 		// other rather than quietly vanishing.
-		out.push_back(ApplyTo(it->second, Action::Expire));
+		out.push_back({ it->first, ApplyTo(it->second, Action::Expire) });
 	}
 	it->second.client = nullptr;
-	out.push_back(Effect::ReleaseClient);
+	// Carries the ID whatever state the browse is in. Deriving it from the
+	// peer instead lost this for a browse that had already ended, which is
+	// most of them by the time their peer goes away.
+	out.push_back({ it->first, Effect::ReleaseClient });
 	return out;
 }
 
@@ -109,13 +128,13 @@ void Store::Remove(std::uint32_t searchId)
 	m_records.erase(searchId);
 }
 
-std::vector<std::pair<std::uint32_t, Effect>> Store::Tick(std::uint64_t now)
+std::vector<Outcome> Store::Tick(std::uint64_t now)
 {
-	std::vector<std::pair<std::uint32_t, Effect>> out;
+	std::vector<Outcome> out;
 	for (auto &kv : m_records) {
 		const Effect effect = ApplyTo(kv.second, ::browse::Tick(kv.second.rec, now));
 		if (effect != Effect::Nothing) {
-			out.emplace_back(kv.first, effect);
+			out.push_back({ kv.first, effect });
 		}
 	}
 	return out;

--- a/src/BrowseStore.cpp
+++ b/src/BrowseStore.cpp
@@ -27,8 +27,7 @@
 namespace browse
 {
 
-Store::StartResult Store::Start(
-	ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now)
+Store::StartResult Store::Start(ClientKey client, std::uint32_t searchId, std::uint64_t now)
 {
 	StartResult result;
 	if (client == nullptr || searchId == 0 || m_records.count(searchId) != 0) {
@@ -48,7 +47,6 @@ Store::StartResult Store::Start(
 	}
 	Held held;
 	held.rec.searchId = searchId;
-	held.rec.peerEcid = peerEcid;
 	held.rec.state = State::InProgress;
 	held.rec.outstanding = kFlatBrowse;
 	held.rec.deadline = now + kSilenceTimeoutMs;

--- a/src/BrowseStore.cpp
+++ b/src/BrowseStore.cpp
@@ -178,15 +178,10 @@ std::map<std::uint32_t, Store::Held>::iterator Store::FindFor(ClientKey client)
 
 std::map<std::uint32_t, Store::Held>::const_iterator Store::FindFor(ClientKey client) const
 {
-	if (client == nullptr) {
-		return m_records.end();
-	}
-	for (auto it = m_records.begin(); it != m_records.end(); ++it) {
-		if (it->second.client == client) {
-			return it;
-		}
-	}
-	return m_records.end();
+	// One implementation, so a change to how a peer is matched cannot land on
+	// only half the callers and leave const and non-const disagreeing about
+	// which record owns a peer.
+	return const_cast<Store *>(this)->FindFor(client);
 }
 
 std::uint32_t Store::SearchIdFor(ClientKey client) const

--- a/src/BrowseStore.h
+++ b/src/BrowseStore.h
@@ -143,6 +143,18 @@ public:
 	std::vector<Outcome> Tick(std::uint64_t now);
 
 	std::uint32_t SearchIdFor(ClientKey client) const;
+
+	/**
+	 * Whether `client`'s browse is still waiting for its directory list.
+	 *
+	 * True exactly once per browse, between the request going out and the
+	 * peer's OP_ASKSHAREDDIRSANS. The handler needs that: its old guard was
+	 * single-shot by accident (it compared an outstanding count to 1), and
+	 * widening it to "this peer has a browse" let a peer resend the answer as
+	 * often as it liked, each time re-asking for every directory and pushing
+	 * the silence deadline back.
+	 */
+	bool AwaitingDirectoryList(ClientKey client) const;
 	bool Has(std::uint32_t searchId) const;
 	State StateOf(std::uint32_t searchId) const;
 	std::uint16_t BarValue(std::uint32_t searchId) const;

--- a/src/BrowseStore.h
+++ b/src/BrowseStore.h
@@ -84,19 +84,6 @@ public:
 	using ClientKey = const void *;
 
 	/**
-	 * Track a browse of `client` under `searchId`.
-	 *
-	 * Refuses when that client already has one STILL RUNNING: there is a
-	 * single exchange with a peer to report on, so a second record could only
-	 * ever describe the same browse. This is the rule the EC handler's "join
-	 * the browse already in flight" depends on being true.
-	 *
-	 * A browse that has ended is no obstacle, even before its peer has been
-	 * released -- matching SearchIdFor, which also answers only for a running
-	 * one. Disagreeing about that left a peer un-rebrowsable for the second
-	 * or so between its browse ending and the next tick.
-	 */
-	/**
 	 * The answer to Start: whether it took, and any peer it displaced.
 	 *
 	 * A peer whose last browse has ended may be browsed again straight away,
@@ -111,6 +98,24 @@ public:
 		Outcome displaced;
 	};
 
+	/**
+	 * Track a browse of `client` under `searchId`.
+	 *
+	 * Refuses when that client already has one STILL RUNNING: there is a
+	 * single exchange with a peer to report on, so a second record could only
+	 * ever describe the same browse. This is the rule the EC handler's "join
+	 * the browse already in flight" depends on being true.
+	 *
+	 * A browse that has ended is no obstacle, even before its peer has been
+	 * released -- matching SearchIdFor, which also answers only for a running
+	 * one. Disagreeing about that left a peer un-rebrowsable for the second
+	 * or so between its browse ending and the next tick.
+	 *
+	 * Refuses an ID already tracked, whatever its state: a second record on
+	 * one key would replace the first and everything it still has to answer
+	 * for. No caller reuses an ID -- both routes pass a freshly allocated one
+	 * -- so this guards an invariant rather than a case.
+	 */
 	StartResult Start(
 		ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
 
@@ -141,7 +146,6 @@ public:
 	bool Has(std::uint32_t searchId) const;
 	State StateOf(std::uint32_t searchId) const;
 	std::uint16_t BarValue(std::uint32_t searchId) const;
-	std::vector<std::uint32_t> Ids() const;
 	std::size_t Size() const { return m_records.size(); }
 
 private:

--- a/src/BrowseStore.h
+++ b/src/BrowseStore.h
@@ -58,6 +58,19 @@ enum class Effect
 };
 
 /**
+ * A change, and the browse it happened to.
+ *
+ * The two travel together because deriving the ID separately is how the effect
+ * got lost: the manager asked which browse a peer had, and the answer excluded
+ * the terminal ones -- exactly the records whose peer most needs releasing.
+ */
+struct Outcome
+{
+	std::uint32_t searchId = 0;
+	Effect effect = Effect::Nothing;
+};
+
+/**
  * Every browse the core is tracking, and the rules about them.
  *
  * Clients are identified by an opaque key rather than held: lifetime is the
@@ -73,35 +86,56 @@ public:
 	/**
 	 * Track a browse of `client` under `searchId`.
 	 *
-	 * Refuses when that client already has one: there is a single exchange
-	 * with a peer to report on, so a second record could only ever describe
-	 * the same browse. This is the rule the EC handler's "join the browse
-	 * already in flight" depends on being true.
+	 * Refuses when that client already has one STILL RUNNING: there is a
+	 * single exchange with a peer to report on, so a second record could only
+	 * ever describe the same browse. This is the rule the EC handler's "join
+	 * the browse already in flight" depends on being true.
+	 *
+	 * A browse that has ended is no obstacle, even before its peer has been
+	 * released -- matching SearchIdFor, which also answers only for a running
+	 * one. Disagreeing about that left a peer un-rebrowsable for the second
+	 * or so between its browse ending and the next tick.
 	 */
-	bool Start(ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
+	/**
+	 * The answer to Start: whether it took, and any peer it displaced.
+	 *
+	 * A peer whose last browse has ended may be browsed again straight away,
+	 * before the tick that would have released it. Two records would then name
+	 * the same peer, and a lookup by peer could answer with either -- so the
+	 * old one lets go here, and says so, since its owner is holding a
+	 * reference on the strength of it.
+	 */
+	struct StartResult
+	{
+		bool started = false;
+		Outcome displaced;
+	};
+
+	StartResult Start(
+		ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
 
 	//! Push the silence deadline back; the peer has shown a sign of life.
 	void Touch(ClientKey client, std::uint64_t now);
 
-	Effect OnDirectoryList(ClientKey client, int dirCount, std::uint64_t now);
-	Effect OnListingReceived(ClientKey client, std::uint64_t now);
+	Outcome OnDirectoryList(ClientKey client, int dirCount, std::uint64_t now);
+	Outcome OnListingReceived(ClientKey client, std::uint64_t now);
 
 	//! Terminalize `client`'s browse. Refused, silently, if it already ended.
-	Effect Fail(ClientKey client);
-	Effect Finish(ClientKey client);
+	Outcome Fail(ClientKey client);
+	Outcome Finish(ClientKey client);
 
 	/**
 	 * The peer is going away: fail a browse still running, then release it.
 	 * Returns both effects in order, so the caller reports the failure before
 	 * dropping the reference it needs to name the peer.
 	 */
-	std::vector<Effect> Forget(ClientKey client);
+	std::vector<Outcome> Forget(ClientKey client);
 
 	//! Dispose of a record for good, with its search.
 	void Remove(std::uint32_t searchId);
 
-	//! Advance every record; returns what to do, per search ID.
-	std::vector<std::pair<std::uint32_t, Effect>> Tick(std::uint64_t now);
+	//! Advance every record; returns what to do about each.
+	std::vector<Outcome> Tick(std::uint64_t now);
 
 	std::uint32_t SearchIdFor(ClientKey client) const;
 	bool Has(std::uint32_t searchId) const;

--- a/src/BrowseStore.h
+++ b/src/BrowseStore.h
@@ -116,8 +116,7 @@ public:
 	 * for. No caller reuses an ID -- both routes pass a freshly allocated one
 	 * -- so this guards an invariant rather than a case.
 	 */
-	StartResult Start(
-		ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
+	StartResult Start(ClientKey client, std::uint32_t searchId, std::uint64_t now);
 
 	//! Push the silence deadline back; the peer has shown a sign of life.
 	void Touch(ClientKey client, std::uint64_t now);

--- a/src/BrowseStore.h
+++ b/src/BrowseStore.h
@@ -144,14 +144,23 @@ public:
 	std::uint32_t SearchIdFor(ClientKey client) const;
 
 	/**
-	 * Whether `client`'s browse is still waiting for its directory list.
+	 * Whether `client`'s browse is still waiting to hear back.
 	 *
-	 * True exactly once per browse, between the request going out and the
-	 * peer's OP_ASKSHAREDDIRSANS. The handler needs that: its old guard was
-	 * single-shot by accident (it compared an outstanding count to 1), and
-	 * widening it to "this peer has a browse" let a peer resend the answer as
-	 * often as it liked, each time re-asking for every directory and pushing
-	 * the silence deadline back.
+	 * True from the request going out until the peer answers -- with its
+	 * directory list, or, on the flat protocol form, with the listing itself.
+	 *
+	 * For a directory browse that makes the answer single-shot, which is what
+	 * the OP_ASKSHAREDDIRSANS handler needs: its old guard was single-shot by
+	 * accident (it compared an outstanding count to 1), and widening it to
+	 * "this peer has a browse" let a peer resend the answer as often as it
+	 * liked, each time re-asking for every directory and pushing the silence
+	 * deadline back.
+	 *
+	 * A FLAT browse has no directory round, so this stays true for its whole
+	 * life and the outbound ask can be repeated on a reconnect. That matches
+	 * what the counter-based guard did before, and is deliberate -- the first
+	 * ask may never have arrived -- but it is not the "once per browse"
+	 * property the directory form gets, and should not be read as one.
 	 */
 	bool AwaitingDirectoryList(ClientKey client) const;
 	bool Has(std::uint32_t searchId) const;

--- a/src/BrowseStore.h
+++ b/src/BrowseStore.h
@@ -1,0 +1,129 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef BROWSESTORE_H
+#define BROWSESTORE_H
+
+#include "BrowseLifecycle.h"
+
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace browse
+{
+
+/**
+ * What the owner must do about a change the store has just made.
+ *
+ * The store decides; the caller performs. That split is the point: the rules
+ * are then reachable from a test, which the manager holding them was not --
+ * and both bugs found after the lifecycle was extracted were rules, not state
+ * machine (a terminal record erased instead of retained, a disconnect after
+ * success reported as a failure).
+ */
+enum class Effect
+{
+	Nothing,
+	//! The browse reached a terminal state; tell whoever is watching.
+	Announce,
+	//! ...and it failed, which is also worth a line in the log.
+	AnnounceFailure,
+	//! Terminal and announced already: let go of the peer. The RECORD stays,
+	//! because the search ID is still listed and still has to answer for its
+	//! state; only Remove() disposes of it.
+	ReleaseClient
+};
+
+/**
+ * Every browse the core is tracking, and the rules about them.
+ *
+ * Clients are identified by an opaque key rather than held: lifetime is the
+ * owner's problem, and keeping it out here is what lets the rules be driven
+ * from a test with no client, no theApp and no clock.
+ */
+class Store
+{
+public:
+	//! Opaque stand-in for the peer. The owner maps it back to a real client.
+	using ClientKey = const void *;
+
+	/**
+	 * Track a browse of `client` under `searchId`.
+	 *
+	 * Refuses when that client already has one: there is a single exchange
+	 * with a peer to report on, so a second record could only ever describe
+	 * the same browse. This is the rule the EC handler's "join the browse
+	 * already in flight" depends on being true.
+	 */
+	bool Start(ClientKey client, std::uint32_t searchId, std::uint32_t peerEcid, std::uint64_t now);
+
+	//! Push the silence deadline back; the peer has shown a sign of life.
+	void Touch(ClientKey client, std::uint64_t now);
+
+	Effect OnDirectoryList(ClientKey client, int dirCount, std::uint64_t now);
+	Effect OnListingReceived(ClientKey client, std::uint64_t now);
+
+	//! Terminalize `client`'s browse. Refused, silently, if it already ended.
+	Effect Fail(ClientKey client);
+	Effect Finish(ClientKey client);
+
+	/**
+	 * The peer is going away: fail a browse still running, then release it.
+	 * Returns both effects in order, so the caller reports the failure before
+	 * dropping the reference it needs to name the peer.
+	 */
+	std::vector<Effect> Forget(ClientKey client);
+
+	//! Dispose of a record for good, with its search.
+	void Remove(std::uint32_t searchId);
+
+	//! Advance every record; returns what to do, per search ID.
+	std::vector<std::pair<std::uint32_t, Effect>> Tick(std::uint64_t now);
+
+	std::uint32_t SearchIdFor(ClientKey client) const;
+	bool Has(std::uint32_t searchId) const;
+	State StateOf(std::uint32_t searchId) const;
+	std::uint16_t BarValue(std::uint32_t searchId) const;
+	std::vector<std::uint32_t> Ids() const;
+	std::size_t Size() const { return m_records.size(); }
+
+private:
+	struct Held
+	{
+		Record rec;
+		ClientKey client = nullptr;
+	};
+
+	Effect ApplyTo(Held &held, Action action);
+	std::map<std::uint32_t, Held>::iterator FindFor(ClientKey client);
+	std::map<std::uint32_t, Held>::const_iterator FindFor(ClientKey client) const;
+
+	std::map<std::uint32_t, Held> m_records;
+};
+
+} // namespace browse
+
+#endif // BROWSESTORE_H

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -23,9 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "ClientList.h"
+#include "ClientList.h" // Interface declarations.
 
-#include "BrowseManager.h" // Interface declarations.
+#include "BrowseManager.h"
 
 #include <protocol/Protocols.h>
 #include <protocol/ed2k/Constants.h>

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -23,7 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "ClientList.h" // Interface declarations.
+#include "ClientList.h"
+
+#include "BrowseManager.h" // Interface declarations.
 
 #include <protocol/Protocols.h>
 #include <protocol/ed2k/Constants.h>
@@ -130,7 +132,9 @@ void CClientList::RemoveClient(CUpDownClient *client)
 {
 	RemoveFromKadList(client);
 	RemoveDirectCallback(client);
-	RemovePendingBrowse(client);
+	// Drop any browse of this client: the manager holds a reference, and the
+	// client is going away, so there is nothing left to report a result to.
+	theApp->browsemanager->Forget(client);
 
 	if (RemoveIDFromList(client)) {
 		// Also remove the ip and hash entries
@@ -726,7 +730,7 @@ void CClientList::Process()
 
 	CleanUpClientList();
 	ProcessDirectCallbackList();
-	ProcessPendingBrowseList();
+	theApp->browsemanager->Process(cur_tick);
 }
 
 void CClientList::AddBannedClient(uint32 dwIP)
@@ -1114,49 +1118,6 @@ void CClientList::AddDirectCallbackClient(CUpDownClient *toAdd)
 		}
 	}
 	m_currentDirectCallbacks.push_back(CCLIENTREF(toAdd, "CClientList::AddDirectCallbackClient"));
-}
-
-void CClientList::AddPendingBrowse(CUpDownClient *toAdd)
-{
-	if (toAdd->HasBeenDeleted()) {
-		return;
-	}
-	// Re-armed on every sign of progress, so the same client comes back here
-	// repeatedly during one browse -- keep a single entry, the deadline itself
-	// lives on the client.
-	for (CClientRefList::const_iterator it = m_pendingBrowses.begin(); it != m_pendingBrowses.end();
-		++it) {
-		if (it->GetClient() == toAdd) {
-			return;
-		}
-	}
-	m_pendingBrowses.emplace_back(toAdd CLIENT_DEBUGSTRING("CClientList::AddPendingBrowse"));
-}
-
-void CClientList::ProcessPendingBrowseList()
-{
-	// Give up on a browse that has gone quiet for BROWSE_SILENCE_TIMEOUT.
-	// FailPendingBrowse marks it failed and clears the in-flight flag, which
-	// removes the entry through MarkBrowse -- so this walk does not erase
-	// anything itself except the stale entries it can no longer act on.
-	const uint64_t cur_tick = ::GetTickCount64();
-	for (CClientRefList::iterator it = m_pendingBrowses.begin(); it != m_pendingBrowses.end();) {
-		CClientRefList::iterator it2 = it++;
-		CUpDownClient *curClient = it2->GetClient();
-		const uint64_t deadline = curClient->GetBrowseDeadline();
-		if (deadline == 0) {
-			// The browse ended without coming through MarkBrowse; nothing to
-			// expire, and holding the reference would keep the client alive.
-			m_pendingBrowses.erase(it2);
-			continue;
-		}
-		if (deadline < cur_tick) {
-			AddDebugLogLineN(logClient,
-				CFormat("Browse of %s timed out with nothing received") %
-					curClient->GetUserName());
-			curClient->FailPendingBrowse();
-		}
-	}
 }
 
 void CClientList::ProcessDirectCallbackList()

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -134,7 +134,11 @@ void CClientList::RemoveClient(CUpDownClient *client)
 	RemoveDirectCallback(client);
 	// Drop any browse of this client: the manager holds a reference, and the
 	// client is going away, so there is nothing left to report a result to.
-	theApp->browsemanager->Forget(client);
+	// Guarded like the clientlist call in CUpDownClient::Safe_Delete: clients
+	// are still being reaped while the app tears itself down.
+	if (theApp->browsemanager) {
+		theApp->browsemanager->Forget(client);
+	}
 
 	if (RemoveIDFromList(client)) {
 		// Also remove the ip and hash entries

--- a/src/ClientList.h
+++ b/src/ClientList.h
@@ -326,13 +326,6 @@ public:
 	{
 		m_currentDirectCallbacks.remove(CCLIENTREF(toRemove, ""));
 	}
-	// Pending browses. A browse that never hears anything back has no other
-	// way to end: see CUpDownClient::RefreshBrowseDeadline.
-	void AddPendingBrowse(CUpDownClient *toAdd);
-	void RemovePendingBrowse(CUpDownClient *toRemove)
-	{
-		m_pendingBrowses.remove(CCLIENTREF(toRemove, ""));
-	}
 	void AddTrackCallbackRequests(uint32_t ip);
 	bool AllowCallbackRequest(uint32_t ip) const;
 
@@ -343,8 +336,6 @@ protected:
 	void CleanUpClientList();
 
 	void ProcessDirectCallbackList();
-
-	void ProcessPendingBrowseList();
 
 private:
 	/**
@@ -426,10 +417,6 @@ private:
 
 	typedef CClientRefList DirectCallbackList;
 	DirectCallbackList m_currentDirectCallbacks;
-	//! Clients with a browse in flight, walked every tick to expire the silent
-	//! ones. Same shape as m_currentDirectCallbacks, and kept small the same
-	//! way: entries leave on the browse's terminal mark, not on a sweep.
-	CClientRefList m_pendingBrowses;
 	IpAndTicksList m_directCallbackRequests;
 };
 

--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -22,7 +22,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "ClientTCPSocket.h" // Interface declarations
+#include "ClientTCPSocket.h"
+
+#include "BrowseManager.h" // Interface declarations
 
 #include <protocol/Protocols.h>
 #include <protocol/ed2k/Client2Client/TCP.h>
@@ -858,6 +860,9 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 
 		theStats::AddDownOverheadOther(size);
 		wxString EmptyStr;
+		// The whole share in one packet. ProcessSharedFileList completes the
+		// browse from the outstanding count, so this form no longer needs --
+		// and no longer lacks -- a terminal mark of its own.
 		m_client->ProcessSharedFileList(buffer, size, EmptyStr);
 		break;
 	}
@@ -941,7 +946,7 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			logRemoteClient, "Remote Client: OP_ASKSHAREDDIRSANS from " + m_client->GetFullIP());
 
 		theStats::AddDownOverheadOther(size);
-		if (m_client->GetFileListRequested() == 1) {
+		if (theApp->browsemanager->SearchIdFor(m_client) != 0) {
 			CMemFile data(buffer, size);
 			uint32 uDirs = data.ReadUInt32();
 			for (uint32 i = 0; i < uDirs; i++) {
@@ -968,9 +973,11 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 						(unsigned)(data.GetLength() - data.GetPosition()) %
 						m_client->GetFullIP());
 			}
-			m_client->SetFileListRequested(uDirs);
-			// Total directory count drives the browse progress bar percent.
-			m_client->SetBrowseTotalDirs(static_cast<int>(uDirs));
+			// Drives the progress percent, and completes the browse outright
+			// when the peer says it has none -- which used to set the counter
+			// to 0 with nothing marking it, leaving the browse at 0% forever.
+			theApp->browsemanager->OnDirectoryList(
+				m_client, static_cast<int>(uDirs), ::GetTickCount64());
 		} else {
 			AddLogLineC(CFormat(_("User %s (%u) sent unrequested shared dirs.")) %
 				    m_client->GetUserName() % m_client->GetUserIDHybrid());
@@ -986,16 +993,15 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 		CMemFile data(buffer, size);
 		wxString strDir = data.ReadString((m_client->GetUnicodeSupport() != utf8strNone));
 
-		if (m_client->GetFileListRequested() > 0) {
+		if (theApp->browsemanager->SearchIdFor(m_client) != 0) {
 			AddLogLineC(CFormat(_("User %s (%u) sent sharedfiles-list for directory '%s'")) %
 				    m_client->GetUserName() % m_client->GetUserIDHybrid() % strDir);
 
 			m_client->ProcessSharedFileList(
 				buffer + data.GetPosition(), size - data.GetPosition(), strDir);
-			if (m_client->GetFileListRequested() == 0) {
+			if (theApp->browsemanager->SearchIdFor(m_client) == 0) {
 				AddLogLineC(CFormat(_("User %s (%u) finished sending sharedfiles-list")) %
 					    m_client->GetUserName() % m_client->GetUserIDHybrid());
-				m_client->MarkBrowse(BROWSE_FINISHED);
 			}
 		} else {
 			AddLogLineC(CFormat(_("User %s (%u) sent unwanted sharedfiles-list")) %
@@ -1013,8 +1019,7 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 		AddLogLineC(CFormat(_("User %s (%u) denied access to shared directories/files list")) %
 			    m_client->GetUserName() % m_client->GetUserIDHybrid());
 
-		m_client->SetFileListRequested(0);
-		m_client->MarkBrowse(BROWSE_FAILED);
+		theApp->browsemanager->Fail(m_client);
 		break;
 
 	default:

--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -22,9 +22,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "ClientTCPSocket.h"
+#include "ClientTCPSocket.h" // Interface declarations.
 
-#include "BrowseManager.h" // Interface declarations
+#include "BrowseManager.h"
 
 #include <protocol/Protocols.h>
 #include <protocol/ed2k/Client2Client/TCP.h>

--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -946,7 +946,9 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			logRemoteClient, "Remote Client: OP_ASKSHAREDDIRSANS from " + m_client->GetFullIP());
 
 		theStats::AddDownOverheadOther(size);
-		if (theApp->browsemanager->SearchIdFor(m_client) != 0) {
+		// Once per browse: a peer replaying its directory list would otherwise
+		// re-ask for every directory and keep the browse alive indefinitely.
+		if (theApp->browsemanager->AwaitingDirectoryList(m_client)) {
 			CMemFile data(buffer, size);
 			uint32 uDirs = data.ReadUInt32();
 			for (uint32 i = 0; i < uDirs; i++) {

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2821,9 +2821,9 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // which demuxes by search ID), and its container's bulk-delete-on-poll works
 // correctly across the union. Only reached for m_multiSearchActive clients.
 //
-// Enumerates CSearchList::GetKnownSearchIds() + CBrowseManager::Ids() -- every
-// search AND "View Files" browse tab the core holds, started by the
-// monolithic GUI or by any EC client -- rather than s_ecSearches.ActiveIds(),
+// Enumerates CSearchList::GetKnownSearchIds() -- every search AND "View Files"
+// browse tab the core holds, started by the monolithic GUI or by any EC client
+// -- rather than s_ecSearches.ActiveIds(),
 // which only ever holds EC-initiated searches (Register() is called from
 // exactly one place, the EC_OP_SEARCH_START handler). A monolithic-started
 // search's results would otherwise never reach amulegui even once
@@ -2889,9 +2889,9 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 		}
 	};
 	// GetKnownSearchIds() covers browses too: RequestSharedFileList registers
-	// every one of them, by either route, before the request goes out. The
-	// second source this loop used to have -- CSearchList's browse-bar map,
-	// and briefly CBrowseManager::Ids() -- emitted each browse a second time.
+	// every one of them, by either route, before the request goes out, and
+	// RemoveResults drops the registration and the browse together. The second
+	// source this loop used to have emitted each browse a second time.
 	for (const auto &entry : theApp->searchlist->GetKnownSearchIds()) {
 		emitResultsFor(entry.first);
 	}

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2888,11 +2888,12 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 			}
 		}
 	};
+	// GetKnownSearchIds() covers browses too: RequestSharedFileList registers
+	// every one of them, by either route, before the request goes out. The
+	// second source this loop used to have -- CSearchList's browse-bar map,
+	// and briefly CBrowseManager::Ids() -- emitted each browse a second time.
 	for (const auto &entry : theApp->searchlist->GetKnownSearchIds()) {
 		emitResultsFor(entry.first);
-	}
-	for (const uint32 browseId : theApp->browsemanager->Ids()) {
-		emitResultsFor(browseId);
 	}
 
 	if (partial_update_active) {
@@ -3134,11 +3135,9 @@ static CECPacket *Get_EC_Response_Search_Progress_Union(const CECPacket *request
 
 	// No ids named: report everything the daemon holds. Used by a stateless
 	// caller that has no tracked set to enumerate.
+	// Browses included; see the union poll above.
 	for (const auto &known : theApp->searchlist->GetKnownSearchIds()) {
 		emitOne(known.first);
-	}
-	for (const uint32 browseId : theApp->browsemanager->Ids()) {
-		emitOne(browseId);
 	}
 
 	return response;

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2557,7 +2557,7 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		// instead of minting a second identity for it. CUpDownClient::
 		// RequestSharedFileList() declines to re-ask a peer that is still
 		// answering, so a freshly allocated ID would never be stamped with a
-		// lifecycle -- while SetBrowseSearchId has already repointed every
+		// lifecycle -- while PinBrowseSearchId has already repointed every
 		// later status write away from the first ID, leaving that one
 		// BROWSE_IN_PROGRESS with nothing able to terminalize it. There is
 		// exactly one browse per client, so there can only be one ID to
@@ -2615,7 +2615,7 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 						theApp->searchlist->RegisterBrowseSearch(
 							browseId, client->GetUserName(), client->ECID());
 					}
-					client->SetBrowseSearchId(browseId);
+					client->PinBrowseSearchId(browseId);
 					client->RequestSharedFileList();
 					response = BuildBrowseReply(browseId, reftag);
 				}

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2829,12 +2829,12 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // search's results would otherwise never reach amulegui even once
 // Get_EC_Response_Search_List (below) learned to enumerate it: the two have
 // to agree on the same set, or a discovered tab appears and never fills.
-// Browses need their own second source here (but NOT in
-// Get_EC_Response_Search_List -- see that function) since a browse tab is
-// not a CSearchList search and so is absent from m_searchStrings; without
-// it, a browse's own STRINGS reply (BuildBrowseReply) tells the client to
-// expect results on this id, but this union never sends any (got3nks, PR
-// #680 review). s_ecSearches keeps governing EC-client lifecycle and
+// Browses need no second source here any more: every one of them reaches
+// RegisterBrowseSearch before its request goes out, so m_searchStrings holds
+// them alongside real searches and GetKnownSearchIds() covers both. It used
+// to be absent from that map, and the second source was what stopped a
+// browse's own STRINGS reply (BuildBrowseReply) promising results this union
+// would then never send (got3nks, PR #680 review). s_ecSearches keeps governing EC-client lifecycle and
 // eviction only -- folding monolithic searches into that 20-entry LRU would
 // let unrelated EC traffic evict, and so stop, a local user's own
 // still-running Kad search.

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -48,6 +48,7 @@
 #include "ServerConnect.h"       // Needed for CServerConnect
 #include "UploadQueue.h"         // Needed for CUploadQueue
 #include "AmuleApiCredentials.h"
+#include "BrowseManager.h"
 #include "amule.h"      // Needed for theApp
 #include "SearchList.h" // Needed for GetSearchResults
 #include "ClientList.h"
@@ -2559,13 +2560,11 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		// lifecycle -- while SetBrowseSearchId has already repointed every
 		// later status write away from the first ID, leaving that one
 		// BROWSE_IN_PROGRESS with nothing able to terminalize it. There is
-		// exactly one m_browseStatus / m_iFileListRequested per client, so
-		// there can only be one ID to report on. Returns 0 when the peer has
-		// no browse running, i.e. when the caller should allocate as usual.
+		// exactly one browse per client, so there can only be one ID to
+		// report on. Returns 0 when the peer has no browse running, i.e. when
+		// the caller should allocate as usual.
 		auto browseInFlightId = [](const CUpDownClient *peer) -> uint32 {
-			return (peer != nullptr && peer->GetFileListRequested() > 0)
-				       ? peer->GetBrowseSearchId()
-				       : 0;
+			return peer != nullptr ? theApp->browsemanager->SearchIdFor(peer) : 0;
 		};
 		// Same reply as a fresh browse, pointing at the browse that is really
 		// running: no allocation (the second ID would be stranded), no
@@ -2822,7 +2821,7 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 // which demuxes by search ID), and its container's bulk-delete-on-poll works
 // correctly across the union. Only reached for m_multiSearchActive clients.
 //
-// Enumerates CSearchList::GetKnownSearchIds() + GetBrowseSearchIds() -- every
+// Enumerates CSearchList::GetKnownSearchIds() + CBrowseManager::Ids() -- every
 // search AND "View Files" browse tab the core holds, started by the
 // monolithic GUI or by any EC client -- rather than s_ecSearches.ActiveIds(),
 // which only ever holds EC-initiated searches (Register() is called from
@@ -2892,8 +2891,8 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 	for (const auto &entry : theApp->searchlist->GetKnownSearchIds()) {
 		emitResultsFor(entry.first);
 	}
-	for (const auto &entry : theApp->searchlist->GetBrowseSearchIds()) {
-		emitResultsFor(static_cast<uint32>(entry.first));
+	for (const uint32 browseId : theApp->browsemanager->Ids()) {
+		emitResultsFor(browseId);
 	}
 
 	if (partial_update_active) {
@@ -3020,8 +3019,12 @@ static CECPacket *Get_EC_Response_Search_List()
 // reply's (or the entry's) first tag via GetFirstTagSafe.
 static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
 {
-	if (theApp->searchlist->HasBrowseStatus(sid)) {
-		const uint8 browseStatus = theApp->searchlist->GetBrowseStatusById(sid);
+	if (theApp->browsemanager->Has(static_cast<uint32>(sid))) {
+		const browse::State bstate = theApp->browsemanager->StateOf(static_cast<uint32>(sid));
+		const uint8 browseStatus =
+			static_cast<uint8>(bstate == browse::State::InProgress ? BROWSE_IN_PROGRESS
+					   : bstate == browse::State::Finished ? BROWSE_FINISHED
+									       : BROWSE_FAILED);
 		// Bar value (0..100 running, 0xffff done/failed) so amuleGUI drives
 		// the browse tab's gauge via the same UpdateSearchProgress path as
 		// a search.
@@ -3134,8 +3137,8 @@ static CECPacket *Get_EC_Response_Search_Progress_Union(const CECPacket *request
 	for (const auto &known : theApp->searchlist->GetKnownSearchIds()) {
 		emitOne(known.first);
 	}
-	for (const auto &browse : theApp->searchlist->GetBrowseSearchIds()) {
-		emitOne(browse.first);
+	for (const uint32 browseId : theApp->browsemanager->Ids()) {
+		emitOne(browseId);
 	}
 
 	return response;

--- a/src/FriendList.cpp
+++ b/src/FriendList.cpp
@@ -226,7 +226,7 @@ void CFriendList::RequestSharedFileList(CFriend *cur_friend, uint32 browseSearch
 		// browse's ID overwritten: with 0 for a local "View Files", which is
 		// what the rest of its listing would then be filed under.
 		if (theApp->browsemanager->SearchIdFor(client) == 0) {
-			client->SetBrowseSearchId(browseSearchId);
+			client->PinBrowseSearchId(browseSearchId);
 		}
 		client->RequestSharedFileList();
 	}

--- a/src/FriendList.cpp
+++ b/src/FriendList.cpp
@@ -23,7 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "FriendList.h" // Interface
+#include "FriendList.h"
+
+#include "BrowseManager.h" // Interface
 
 #include <common/DataFileVersion.h>
 
@@ -217,9 +219,15 @@ void CFriendList::RequestSharedFileList(CFriend *cur_friend, uint32 browseSearch
 			theApp->clientlist->AddClient(client);
 			cur_friend->LinkClient(CCLIENTREF(client, "CFriendList::RequestSharedFileList"));
 		}
-		// Pin the EC-allocated browse ID (0 for a monolithic local browse) before
-		// firing the request so ProcessSharedFileList files the listing under it.
-		client->SetBrowseSearchId(browseSearchId);
+		// Pin the EC-allocated browse ID before firing the request, so
+		// ProcessSharedFileList files the listing under it -- but only when
+		// this peer has no browse running. RequestSharedFileList returns
+		// early for one that has, and pinning first would have left the live
+		// browse's ID overwritten: with 0 for a local "View Files", which is
+		// what the rest of its listing would then be filed under.
+		if (theApp->browsemanager->SearchIdFor(client) == 0) {
+			client->SetBrowseSearchId(browseSearchId);
+		}
 		client->RequestSharedFileList();
 	}
 }

--- a/src/FriendList.cpp
+++ b/src/FriendList.cpp
@@ -23,9 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "FriendList.h"
+#include "FriendList.h" // Interface declarations.
 
-#include "BrowseManager.h" // Interface
+#include "BrowseManager.h"
 
 #include <common/DataFileVersion.h>
 

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -262,12 +262,20 @@ void CFriendListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 		CFriend *cur_friend = reinterpret_cast<CFriend *>(data);
 		// If this friend's listing is already open in the Search panel, switch
 		// to that tab instead of re-requesting -- a second request would
-		// duplicate the results in the existing tab. The browse tab is keyed by
-		// the linked client's ECID (0 when the friend isn't currently linked).
+		// duplicate the results in the existing tab.
+		//
+		// Which ECID keys that tab depends on who opened it, so both are
+		// tried. The monolithic opens it from Notify_Browse_Started, which
+		// carries the browsed CLIENT's ECID; amulegui opens it from
+		// SendBrowseRequest, which has only the FRIEND's -- a friend need not
+		// be linked to a client at the moment the browse is asked for. They
+		// are different numbers from one counter, so matching on the client
+		// alone never found amulegui's tab, and every click re-asked the peer.
+		CSearchDlg *const searchwnd = theApp->amuledlg ? theApp->amuledlg->m_searchwnd : nullptr;
 		const CClientRef &linked = cur_friend->GetLinkedClient();
-		const uint32 ecid = linked.IsLinked() ? linked.ECID() : 0;
-		if (!(theApp->amuledlg && theApp->amuledlg->m_searchwnd &&
-			    theApp->amuledlg->m_searchwnd->ActivateBrowseTabIfOpen(ecid))) {
+		const uint32 clientEcid = linked.IsLinked() ? linked.ECID() : 0;
+		if (!(searchwnd && (searchwnd->ActivateBrowseTabIfOpen(clientEcid) ||
+					   searchwnd->ActivateBrowseTabIfOpen(cur_friend->ECID())))) {
 			theApp->friendlist->RequestSharedFileList(cur_friend);
 		}
 	}

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -329,6 +329,7 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 	m_searchStartTimes.erase(static_cast<uint32_t>(searchID));
 	m_searchKinds.erase(static_cast<uint32_t>(searchID));
 	m_searchStrings.erase(static_cast<uint32_t>(searchID));
+	m_browsePeers.erase(static_cast<uint32_t>(searchID));
 	// The browse record outlives its client but not its search.
 	theApp->browsemanager->Remove(static_cast<uint32_t>(searchID));
 

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -23,9 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "SearchList.h"
+#include "SearchList.h" // Interface declarations.
 
-#include "BrowseManager.h" // Interface declarations.
+#include "BrowseManager.h"
 
 #include <algorithm> // Needed for std::sort (StoreSearches)
 #include <utility>   // Needed for std::move (LoadSearches)

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -23,7 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "SearchList.h" // Interface declarations.
+#include "SearchList.h"
+
+#include "BrowseManager.h" // Interface declarations.
 
 #include <algorithm> // Needed for std::sort (StoreSearches)
 #include <utility>   // Needed for std::move (LoadSearches)
@@ -327,8 +329,8 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 	m_searchStartTimes.erase(static_cast<uint32_t>(searchID));
 	m_searchKinds.erase(static_cast<uint32_t>(searchID));
 	m_searchStrings.erase(static_cast<uint32_t>(searchID));
-	m_browseBar.erase(searchID);
-	m_browseStatus.erase(searchID);
+	// The browse record outlives its client but not its search.
+	theApp->browsemanager->Remove(static_cast<uint32_t>(searchID));
 
 	// This list owns its results, so free them before dropping the index
 	// (which, being shared with the remote search list, never deletes).
@@ -962,11 +964,6 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	const bool ecInitiated = sender->IsBrowseEcInitiated();
 #endif
 
-	if (!sender->GetBrowseSearchId()) {
-		const uint32 localBrowseId = AllocateEd2kId();
-		sender->SetBrowseSearchId(localBrowseId);
-		RegisterBrowseSearch(localBrowseId, sender->GetUserName(), sender->ECID());
-	}
 	wxUIntPtr searchID = static_cast<wxUIntPtr>(sender->GetBrowseSearchId());
 
 #ifndef AMULE_DAEMON
@@ -1214,7 +1211,7 @@ wxString CSearchList::GetSearchStringById(uint32_t searchID) const
 
 bool CSearchList::IsKnownSearchId(uint32_t searchID) const
 {
-	return m_searchStrings.count(searchID) != 0 || m_browseBar.count(searchID) != 0;
+	return m_searchStrings.count(searchID) != 0 || theApp->browsemanager->Has(searchID);
 }
 
 uint32 CSearchList::GetBrowsePeerEcid(uint32 searchID) const
@@ -1308,8 +1305,8 @@ void CSearchList::SetKadSearchFinished(uint32_t searchID)
 CSearchList::SearchLifecycleState CSearchList::GetSearchLifecycleStateById(wxUIntPtr searchID) const
 {
 	uint32_t sid = static_cast<uint32_t>(searchID);
-	// A browse ("View Files") is not a CSearchList search: its lifecycle lives
-	// in m_browseStatus, keyed by the same id this function is asked about.
+	// A browse ("View Files") is not a CSearchList search: CBrowseManager owns
+	// its lifecycle, keyed by the same id this function is asked about.
 	// Without this the generic tail below decides it from retained results,
 	// which is wrong in both directions -- a browse still streaming reports
 	// finished as soon as its first directory lands, and one the peer denied
@@ -1317,9 +1314,10 @@ CSearchList::SearchLifecycleState CSearchList::GetSearchLifecycleStateById(wxUIn
 	// ternary. Same mapping the EC progress reply applies (ExternalConn.cpp's
 	// AppendSearchProgress), here instead of only there so the SEARCH_LIST
 	// listing cannot disagree with the per-id progress reply about the same id.
-	if (HasBrowseStatus(searchID)) {
-		return GetBrowseStatusById(searchID) == BROWSE_IN_PROGRESS ? SEARCH_LIFECYCLE_RUNNING
-									   : SEARCH_LIFECYCLE_FINISHED;
+	if (theApp->browsemanager->Has(sid)) {
+		return theApp->browsemanager->StateOf(sid) == browse::State::InProgress
+			       ? SEARCH_LIFECYCLE_RUNNING
+			       : SEARCH_LIFECYCLE_FINISHED;
 	}
 	// Kad searches are tracked per-ID: still registered in the manager =>
 	// running; recorded as finished (its CSearch was destroyed on the result
@@ -1358,15 +1356,12 @@ uint8 CSearchList::GetSearchLifecyclePercentById(wxUIntPtr searchID) const
 	// A browse reports the share of the peer's directory list received so far,
 	// rather than the 0/100 the state switch above would derive.
 	//
-	// Read m_browseBar directly, NOT through GetSearchBarStatusById: that
+	// Straight from the manager, NOT through GetSearchBarStatusById: that
 	// function falls through to this one for anything it does not consider
-	// finished, so routing this branch through it would recurse between the two
-	// for an id with a browse status but no bar entry. The two maps are written
-	// and pruned together, so that should not arise -- which is exactly why it
-	// must not be load-bearing.
-	if (HasBrowseStatus(searchID)) {
-		std::map<wxUIntPtr, uint16>::const_iterator bar = m_browseBar.find(searchID);
-		const uint16 pct = (bar != m_browseBar.end()) ? bar->second : 0;
+	// finished, so routing this branch through it would recurse between the
+	// two.
+	if (theApp->browsemanager->Has(sid)) {
+		const uint16 pct = theApp->browsemanager->BarValue(sid);
 		// 0xffff is the bar's terminal sentinel, not a percent.
 		return (pct == 0xffff) ? 100 : static_cast<uint8>(pct);
 	}
@@ -1389,13 +1384,11 @@ uint8 CSearchList::GetSearchLifecyclePercentById(wxUIntPtr searchID) const
 
 uint32 CSearchList::GetSearchBarStatusById(wxUIntPtr searchID) const
 {
-	// A "View Files" browse tab isn't a CSearchList search: its bar value is
-	// pushed by the browsing client. Return it directly when present.
-	if (!m_browseBar.empty()) {
-		std::map<wxUIntPtr, uint16>::const_iterator it = m_browseBar.find(searchID);
-		if (it != m_browseBar.end()) {
-			return it->second;
-		}
+	// A "View Files" browse tab isn't a CSearchList search: CBrowseManager
+	// owns its lifecycle, so ask there rather than keeping a second copy here
+	// that would have to be kept in step by hand.
+	if (theApp->browsemanager->Has(static_cast<uint32_t>(searchID))) {
+		return theApp->browsemanager->BarValue(static_cast<uint32_t>(searchID));
 	}
 	if (GetSearchLifecycleStateById(searchID) == SEARCH_LIFECYCLE_FINISHED) {
 		return IsOrWasKadSearch(static_cast<uint32_t>(searchID)) ? 0xfffe : 0xffff;

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -936,11 +936,10 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 {
 	wxCHECK_RET(sender, "No sender in search-results from client.");
 
-	// Route the browsed listing to a result bucket. For an EC-initiated browse
-	// (remote GUI) the daemon has pinned a real, wire-safe search ID on the
-	// client; use it so the union/per-ID poll and the LRU ring can address these
-	// results. A monolithic local browse leaves it 0 and keeps the historical
-	// per-client-pointer key.
+	// Route the browsed listing to a result bucket. Every browse has a real,
+	// wire-safe search ID by now -- pinned by the EC handler for a remote one,
+	// allocated by RequestSharedFileList for a local one -- so the union and
+	// per-ID polls and the LRU ring can all address these results.
 	// A local browse used to key its results on the client pointer, which no
 	// remote client can address -- it is this process's memory, so the browse
 	// was invisible to amulegui, amuleweb and amuleapi while an EC-initiated

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -181,7 +181,7 @@ public:
 	 * True if this core currently routes results/progress for searchID --
 	 * either a CSearchList search (m_searchStrings, populated in
 	 * StartNewSearch, pruned in RemoveResults) or a "View Files" browse tab
-	 * (m_browseBar; browses are not CSearchList searches but share the same
+	 * (CBrowseManager; browses are not CSearchList searches but share the same
 	 * per-ID result-routing and EC lifecycle -- got3nks, PR #680 review).
 	 * Use this to gate per-ID EC replies (SEARCH_PROGRESS, single-ID
 	 * SEARCH_RESULTS, Stop, Request_More) instead of the EC-only
@@ -246,7 +246,7 @@ public:
 	// "View Files" browse tabs are not CSearchList searches: CBrowseManager
 	// owns their bar, and GetSearchBarStatusById consults it first, so the
 	// monolithic bar and the EC PROGRESS reply render the same value.
-	// The browse lifecycle (EBrowseStatus: browsing / finished / failed) recorded
+
 	// Echoes m_searchType for the current/last search; meaningful only
 	// when state is RUNNING or FINISHED. Returns LocalSearch by default.
 	SearchType GetSearchLifecycleKind() const { return m_searchType; }
@@ -526,13 +526,6 @@ private:
 	//! client that didn't start it locally and so has no tab-title string
 	//! of its own to fall back on.
 	std::map<uint32_t, wxString> m_searchStrings;
-
-	//! Bar value for "View Files" browse tabs, keyed by routing ID and set by
-	//! the browsing client (0..100 percent, or 0xffff finished/failed). Read by
-	//! GetSearchBarStatusById. Pruned in RemoveResults.
-	//! Browse lifecycle (EBrowseStatus) by search ID, kept in lockstep with
-	//! m_browseBar so a browse's terminal state survives the client's teardown.
-	//! Pruned in RemoveResults.
 
 	//! ED2K-side counterpart of m_KadSearchFinished, covering both local
 	//! and global searches. Cleared to false in StartNewSearch when an

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -210,20 +210,6 @@ public:
 	const std::map<uint32_t, wxString> &GetKnownSearchIds() const { return m_searchStrings; }
 
 	/**
-	 * Every ID this core currently holds a browse progress bar for, used as
-	 * the multi-search results union poll's second source. Not redundant with
-	 * GetKnownSearchIds() even though a browse is registered there too: the
-	 * bar is keyed by CUpDownClient::GetBrowseRoutingId(), which is the
-	 * client pointer until a browse has an ID of its own, so a monolithic
-	 * local browse has a pointer-keyed entry here between the request going
-	 * out and its first directory arriving (that is when ProcessSharedFileList
-	 * allocates the ID and registers it). Returned by reference; runs every
-	 * poll tick for every connected multi-search client, so a per-call copy
-	 * here is the one that would actually show up in the arithmetic.
-	 */
-	const std::map<wxUIntPtr, uint16> &GetBrowseSearchIds() const { return m_browseBar; }
-
-	/**
 	 * Ask the Kad search identified by searchID to widen its frontier
 	 * via KADEMLIA_FIND_VALUE_MORE.  Wired to the search dialog "More"
 	 * button.  Returns true if a reask was dispatched, false otherwise.
@@ -257,28 +243,10 @@ public:
 	// percent. Single source of truth for the bottom bar, shared by the EC
 	// PROGRESS reply (remote GUI / amuleapi) and the monolithic search dialog.
 	uint32 GetSearchBarStatusById(wxUIntPtr searchID) const;
-	// "View Files" browse tabs are not CSearchList searches, so their bar value
-	// is supplied by the browsing client (CUpDownClient::UpdateBrowseBar): 0..100
-	// running percent while the listing streams in, 0xffff when done/failed.
-	// GetSearchBarStatusById consults this first, so both the monolithic bar and
-	// the EC PROGRESS reply render the browse percent through the same path.
-	void SetBrowseBar(wxUIntPtr searchID, uint16 value) { m_browseBar[searchID] = value; }
+	// "View Files" browse tabs are not CSearchList searches: CBrowseManager
+	// owns their bar, and GetSearchBarStatusById consults it first, so the
+	// monolithic bar and the EC PROGRESS reply render the same value.
 	// The browse lifecycle (EBrowseStatus: browsing / finished / failed) recorded
-	// by search ID alongside the bar, so the EC PROGRESS reply can report a
-	// browse's terminal state even after the browsing client has been reaped
-	// (0xffff in m_browseBar can't tell "finished" from "failed"). Set from
-	// CUpDownClient::UpdateBrowseBar; pruned in RemoveResults, so it's bounded by
-	// the same LRU ring that caps m_browseBar and every ed2k/Kad search bucket.
-	void SetBrowseStatusById(wxUIntPtr searchID, uint8 status) { m_browseStatus[searchID] = status; }
-	bool HasBrowseStatus(wxUIntPtr searchID) const
-	{
-		return m_browseStatus.find(searchID) != m_browseStatus.end();
-	}
-	uint8 GetBrowseStatusById(wxUIntPtr searchID) const
-	{
-		std::map<wxUIntPtr, uint8>::const_iterator it = m_browseStatus.find(searchID);
-		return it != m_browseStatus.end() ? it->second : 0 /* BROWSE_NONE */;
-	}
 	// Echoes m_searchType for the current/last search; meaningful only
 	// when state is RUNNING or FINISHED. Returns LocalSearch by default.
 	SearchType GetSearchLifecycleKind() const { return m_searchType; }
@@ -562,11 +530,9 @@ private:
 	//! Bar value for "View Files" browse tabs, keyed by routing ID and set by
 	//! the browsing client (0..100 percent, or 0xffff finished/failed). Read by
 	//! GetSearchBarStatusById. Pruned in RemoveResults.
-	std::map<wxUIntPtr, uint16> m_browseBar;
 	//! Browse lifecycle (EBrowseStatus) by search ID, kept in lockstep with
 	//! m_browseBar so a browse's terminal state survives the client's teardown.
 	//! Pruned in RemoveResults.
-	std::map<wxUIntPtr, uint8> m_browseStatus;
 
 	//! ED2K-side counterpart of m_KadSearchFinished, covering both local
 	//! and global searches. Cleared to false in StartNewSearch when an

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -399,11 +399,6 @@ int CamuleApp::OnExit()
 	delete searchlist;
 	searchlist = NULL;
 
-	// After searchlist, before clientlist: a browse holds a client reference,
-	// so it has to let go before the clients themselves are destroyed.
-	delete browsemanager;
-	browsemanager = nullptr;
-
 	delete clientcredits;
 	clientcredits = NULL;
 
@@ -432,6 +427,15 @@ int CamuleApp::OnExit()
 
 	delete canceledfiles;
 	canceledfiles = NULL;
+
+	// Immediately before clientlist, and after everything that destroys
+	// clients on its way out -- serverconnect, listensocket, clientudp. Each
+	// of those reaps peers through CClientList::RemoveClient, which asks the
+	// manager to let go of any browse of them; deleting it earlier left that
+	// call reaching through a dangling pointer whenever a peer socket was
+	// still open at exit, which is the ordinary case.
+	delete browsemanager;
+	browsemanager = nullptr;
 
 	delete clientlist;
 	clientlist = NULL;

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -228,6 +228,7 @@ CamuleApp::CamuleApp()
 	clientlist = NULL;
 	chatsessions = nullptr;
 	searchlist = NULL;
+	browsemanager = nullptr;
 	knownfiles = NULL;
 	canceledfiles = NULL;
 	serverlist = NULL;

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -23,9 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "amule.h"
+#include "amule.h" // Interface declarations.
 
-#include "BrowseManager.h" // Interface declarations.
+#include "BrowseManager.h"
 
 #include <csignal>
 #include <cstring>

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -23,7 +23,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "amule.h" // Interface declarations.
+#include "amule.h"
+
+#include "BrowseManager.h" // Interface declarations.
 
 #include <csignal>
 #include <cstring>
@@ -396,6 +398,11 @@ int CamuleApp::OnExit()
 	}
 	delete searchlist;
 	searchlist = NULL;
+
+	// After searchlist, before clientlist: a browse holds a client reference,
+	// so it has to let go before the clients themselves are destroyed.
+	delete browsemanager;
+	browsemanager = nullptr;
 
 	delete clientcredits;
 	clientcredits = NULL;
@@ -870,6 +877,7 @@ bool CamuleApp::OnInit()
 	friendlist = new CFriendList();
 	chatsessions = new CChatSessionStore();
 	searchlist = new CSearchList();
+	browsemanager = new CBrowseManager();
 	knownfiles = new CKnownFileList();
 	canceledfiles = new CCanceledFileList;
 	serverlist = new CServerList();

--- a/src/amule.h
+++ b/src/amule.h
@@ -76,6 +76,7 @@ class CClientList;
 class CKnownFileList;
 class CCanceledFileList;
 class CSearchList;
+class CBrowseManager;
 class CClientCreditsList;
 class CFriendList;
 class CChatSessionStore;
@@ -464,6 +465,9 @@ public:
 	CKnownFileList *knownfiles;
 	CCanceledFileList *canceledfiles;
 	CSearchList *searchlist;
+	//! Every "View Files" browse in flight. Owns their whole lifecycle; see
+	//! CBrowseManager.
+	CBrowseManager *browsemanager;
 	CClientCreditsList *clientcredits;
 	CFriendList *friendlist;
 	// The core's chat transcript, shared by the local GUI and every EC

--- a/src/include/protocol/ed2k/Constants.h
+++ b/src/include/protocol/ed2k/Constants.h
@@ -84,18 +84,6 @@
 #define TRACKED_CLEANUP_TIME HR2MS(1)
 #define KEEPTRACK_TIME HR2MS(2) // how long to keep track of clients which were once in the uploadqueue
 #define CLIENTLIST_CLEANUP_TIME MIN2MS(34) // 34 min
-// How long a browse ("View Files") may sit with nothing arriving before it is
-// given up on. Refreshed whenever the browse makes progress -- the request
-// going out, each directory landing -- so this bounds silence, not the total
-// time a large share takes to stream in.
-//
-// A backstop, not the mechanism: a browse normally ends when the peer answers,
-// denies, or the socket dies, and CUpDownClient::IsPeerContactPending catches
-// the case where the daemon never contacts the peer at all. This exists
-// because TryToConnect has several exits that contact nobody, they are not
-// marked as a family, and two attempts at enumerating them both missed some
-// (amule-org/amule#1071).
-#define BROWSE_SILENCE_TIMEOUT SEC2MS(120)
 
 // (4294967295/PARTSIZE)*PARTSIZE = ~4GB
 #define OLD_MAX_FILE_SIZE 4290048000ull

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -116,6 +116,32 @@ enum ClientState
 // This is fixed on ed2k v1, but can be any number on ED2Kv2
 #define STANDARD_BLOCKS_REQUEST 3
 
+/**
+ * What TryToConnect did about the peer it was asked to reach.
+ *
+ * It used to answer with a bool that meant three different things -- and the
+ * one the browse code needed, "did you actually try?", was not among them, so
+ * that code inferred it from side effects instead. The inference was wrong
+ * twice, in both cases because an exit was added or moved without anything
+ * forcing a decision about what it meant (amule-org/amule#1071). Naming the
+ * outcomes is what turns that from a silent default into a choice the compiler
+ * makes somebody make.
+ */
+enum class EContactResult
+{
+	//! A connection attempt or a callback request is under way.
+	Contacting,
+	//! Nothing was sent: this peer cannot be reached the way things stand.
+	//! The client is still valid.
+	Declined,
+	//! Connect() declined to start, because the socket was already live. Kept
+	//! distinct only to preserve the historical bool -- callers have always
+	//! been told "false" here, and changing that is not this change's job.
+	ConnectNotStarted,
+	//! The client was destroyed on the way out. Touching it is undefined.
+	ClientDeleted
+};
+
 class CUpDownClient : public CECID
 {
 	friend class CClientList;
@@ -190,6 +216,19 @@ public:
 	ClientState GetClientState() { return m_clientState; }
 
 	bool Disconnected(const wxString &strReason, bool bFromSocket = false);
+	/**
+	 * Try to reach this peer, and say which of the three things happened.
+	 *
+	 * Prefer this over the bool overload when the answer matters: "I decided
+	 * not to" and "I am on my way" are different facts, and only this
+	 * spelling carries them.
+	 */
+	EContactResult TryToContact(bool bIgnoreMaxCon = false);
+	/**
+	 * As TryToContact, reduced to the historical answer: false means the
+	 * client was deleted (or Connect() declined to start) and must not be
+	 * touched again. Kept for the callers that only need that much.
+	 */
 	bool TryToConnect(bool bIgnoreMaxCon = false);
 	bool Connect();
 	void ConnectionEstablished();
@@ -493,13 +532,6 @@ public:
 		m_browseSearchId = id;
 		m_browseEcInitiated = id != 0;
 	}
-	/**
-	 * Whether anything is still on its way to or from this peer: a live
-	 * connection, a direct UDP callback, or a server/Kad callback we asked
-	 * for. False means nothing will arrive on its own, so a browse waiting on
-	 * this client can be failed at once instead of hanging.
-	 */
-	bool IsPeerContactPending() const;
 
 	void ResetFileStatusInfo();
 

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -461,14 +461,12 @@ public:
 		uint32 *lenUnzipped,
 		int iRecursion = 0);
 	void UpdateDisplayedInfo(bool force = false);
-	int GetFileListRequested() const { return m_iFileListRequested; }
-	void SetFileListRequested(int iFileListRequested) { m_iFileListRequested = iFileListRequested; }
 
-	// "View Files" (browse) over EC: the daemon allocates a search ID for a
-	// browse initiated by a remote GUI and pins it here so ProcessSharedFileList
-	// files the results under it (instead of the raw client pointer) and the
-	// terminal paths can stamp m_browseStatus. 0 = not an EC-initiated browse
-	// (monolithic local browse keeps the pointer-keyed path).
+	// "View Files" (browse): the search ID this peer's listing is filed under.
+	// Allocated before the request goes out -- by the EC handler for a remote
+	// browse, by RequestSharedFileList itself for a local one -- so it is the
+	// single key for the browse everywhere, and CBrowseManager owns the
+	// lifecycle behind it. 0 = this client has never been browsed.
 	uint32 GetBrowseSearchId() const { return m_browseSearchId; }
 	/**
 	 * Whether this browse was asked for by a remote client rather than here.
@@ -480,41 +478,21 @@ public:
 	 * call: a browse someone else asked for must not pull this user's panel or
 	 * tab selection.
 	 */
-	bool IsBrowseEcInitiated() const { return m_browseSearchId != 0; }
-	void SetBrowseSearchId(uint32 id) { m_browseSearchId = id; }
-	EBrowseStatus GetBrowseStatus() const { return m_browseStatus; }
-	void SetBrowseStatus(EBrowseStatus s) { m_browseStatus = s; }
-	// Total shared directories the peer advertised (captured at
-	// OP_ASKSHAREDDIRSANS); drives the browse progress percent as m_iFileListRequested
-	// counts down. 0 = not yet known / flat share with no directory list.
-	void SetBrowseTotalDirs(int n) { m_browseTotalDirs = n; }
-	// The tab's result-routing key: the EC-allocated browse ID (remote GUI) or
-	// this client's pointer (monolithic local browse). Shared by the bar cache.
-	wxUIntPtr GetBrowseRoutingId() const
-	{
-		return m_browseSearchId ? static_cast<wxUIntPtr>(m_browseSearchId)
-					: reinterpret_cast<wxUIntPtr>(this);
-	}
-	// Progress-bar sentinel for this browse: 0..100 running percent while the
-	// listing streams in, or 0xffff (finished/failed) to clear the bar — the
-	// same value space GetSearchBarStatusById returns for a search.
-	uint16 GetBrowseBarValue() const;
-	// Record a browse lifecycle transition: update the shared bar cache and
-	// notify the GUI (monolithic renders the tab marker; on the daemon the
-	// notify is a no-op and amuleGUI reads the status over EC via SEARCH_PROGRESS).
-	void MarkBrowse(EBrowseStatus s);
-	// Push the current bar value into CSearchList's browse-bar cache (keyed by
-	// GetBrowseRoutingId), so both the monolithic bar and the EC reply see it.
-	void UpdateBrowseBar();
+	bool IsBrowseEcInitiated() const { return m_browseEcInitiated; }
 	/**
-	 * End a browse this client can no longer carry; no-op when none is pending.
+	 * Pin the ID a remote client's browse will be filed under.
 	 *
-	 * Clears the in-flight flag BEFORE the terminal mark, the order every
-	 * other terminal path takes, so a later request for this peer starts a
-	 * fresh browse instead of joining a dead one -- the invariant the EC
-	 * browse handler's join relies on (ExternalConn.cpp).
+	 * Only the EC handler calls this: a local browse allocates its own ID
+	 * inside RequestSharedFileList. Setting it here is therefore also what
+	 * marks the browse as somebody else's, which used to be inferred from the
+	 * ID being set at all -- an inference that stopped working once local
+	 * browses got their ID up front as well.
 	 */
-	void FailPendingBrowse();
+	void SetBrowseSearchId(uint32 id)
+	{
+		m_browseSearchId = id;
+		m_browseEcInitiated = id != 0;
+	}
 	/**
 	 * Whether anything is still on its way to or from this peer: a live
 	 * connection, a direct UDP callback, or a server/Kad callback we asked
@@ -522,14 +500,6 @@ public:
 	 * this client can be failed at once instead of hanging.
 	 */
 	bool IsPeerContactPending() const;
-	/**
-	 * Deadline for a browse to show any sign of life, or 0 when none is
-	 * pending. Armed when the browse is asked for and pushed forward on every
-	 * sign of progress, so it bounds silence rather than total duration -- a
-	 * large share may stream for minutes and must not be cut off.
-	 */
-	uint64_t GetBrowseDeadline() const { return m_browseDeadline; }
-	void RefreshBrowseDeadline();
 
 	void ResetFileStatusInfo();
 
@@ -818,12 +788,9 @@ private:
 	uint64 m_dwLastSourceRequest;
 	uint64 m_dwLastSourceAnswer;
 	uint64 m_dwLastAskedForSources;
-	int m_iFileListRequested;
-	//! See GetBrowseDeadline. 0 = no browse pending.
-	uint64_t m_browseDeadline;
 	uint32 m_browseSearchId;
-	int m_browseTotalDirs;
-	EBrowseStatus m_browseStatus;
+	//! See IsBrowseEcInitiated.
+	bool m_browseEcInitiated;
 	bool m_bFriendSlot;
 	bool m_bCommentDirty;
 	bool m_bIsHybrid;

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -531,6 +531,13 @@ public:
 	{
 		m_browseSearchId = id;
 		m_browseEcInitiated = id != 0;
+		// Consumed by the next RequestSharedFileList, which otherwise
+		// allocates its own. Inferring this from whether the manager already
+		// knew the ID did not work: an ID whose record had been disposed of
+		// looked identical to one just pinned, so a local re-browse of a peer
+		// previously browsed over EC kept both the stale ID and the stale
+		// notion that somebody else had asked for it.
+		m_browsePinned = id != 0;
 	}
 
 	void ResetFileStatusInfo();
@@ -823,6 +830,8 @@ private:
 	uint32 m_browseSearchId;
 	//! See IsBrowseEcInitiated.
 	bool m_browseEcInitiated;
+	//! See SetBrowseSearchId: an ID pinned for the next browse, not yet used.
+	bool m_browsePinned;
 	bool m_bFriendSlot;
 	bool m_bCommentDirty;
 	bool m_bIsHybrid;

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -510,25 +510,23 @@ public:
 	/**
 	 * Whether this browse was asked for by a remote client rather than here.
 	 *
-	 * The id is pinned by the EC handler before the request goes out, and a
-	 * browse started locally has none until its results arrive, so its presence
-	 * at request time is what tells the two apart. Named because both the
-	 * result path and the browse-started notification have to make the same
-	 * call: a browse someone else asked for must not pull this user's panel or
-	 * tab selection.
+	 * Recorded when the ID is pinned, NOT inferred from the ID being set: a
+	 * local browse allocates one of its own before the request goes out, so
+	 * "has an ID" stopped telling the two apart. Simplifying this back to
+	 * `m_browseSearchId != 0` compiles, passes, and silently stops every local
+	 * browse revealing its tab.
+	 *
+	 * Named because both the result path and the browse-started notification
+	 * have to make the same call: a browse someone else asked for must not
+	 * pull this user's panel or tab selection.
 	 */
 	bool IsBrowseEcInitiated() const { return m_browseEcInitiated; }
 	/**
-	 * Pin the ID a remote client's browse will be filed under.
-	 *
-	 * Only the EC handler calls this: a local browse allocates its own ID
-	 * inside RequestSharedFileList. Setting it here is therefore also what
-	 * marks the browse as somebody else's, which used to be inferred from the
-	 * ID being set at all -- an inference that stopped working once local
-	 * browses got their ID up front as well.
-	 */
-	/**
 	 * Hand the next browse of this peer an ID somebody else allocated.
+	 *
+	 * Only the EC and friend handlers call this; a local browse chooses its
+	 * own inside RequestSharedFileList. Pinning is therefore also what marks
+	 * the browse as somebody else's.
 	 *
 	 * 0 means "nothing to pin", not "forget the ID you have": both callers
 	 * pass the EC-allocated ID or 0, and 0 is what a monolithic browse and a

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -527,17 +527,29 @@ public:
 	 * ID being set at all -- an inference that stopped working once local
 	 * browses got their ID up front as well.
 	 */
-	void SetBrowseSearchId(uint32 id)
+	/**
+	 * Hand the next browse of this peer an ID somebody else allocated.
+	 *
+	 * 0 means "nothing to pin", not "forget the ID you have": both callers
+	 * pass the EC-allocated ID or 0, and 0 is what a monolithic browse and a
+	 * legacy EC client both supply. Wiping the remembered ID on those left
+	 * RequestSharedFileList unable to find the peer's previous record, so it
+	 * allocated afresh and orphaned the registration, results and browse
+	 * record behind it.
+	 *
+	 * The pin is consumed by the next RequestSharedFileList, which otherwise
+	 * chooses for itself. Whether one was pinned cannot be inferred later:
+	 * an ID whose record has been disposed of looks exactly like one just
+	 * handed over.
+	 */
+	void PinBrowseSearchId(uint32 id)
 	{
+		if (id == 0) {
+			return;
+		}
 		m_browseSearchId = id;
-		m_browseEcInitiated = id != 0;
-		// Consumed by the next RequestSharedFileList, which otherwise
-		// allocates its own. Inferring this from whether the manager already
-		// knew the ID did not work: an ID whose record had been disposed of
-		// looked identical to one just pinned, so a local re-browse of a peer
-		// previously browsed over EC kept both the stale ID and the stale
-		// notion that somebody else had asked for it.
-		m_browsePinned = id != 0;
+		m_browseEcInitiated = true;
+		m_browsePinned = true;
 	}
 
 	void ResetFileStatusInfo();
@@ -830,7 +842,7 @@ private:
 	uint32 m_browseSearchId;
 	//! See IsBrowseEcInitiated.
 	bool m_browseEcInitiated;
-	//! See SetBrowseSearchId: an ID pinned for the next browse, not yet used.
+	//! See PinBrowseSearchId: an ID pinned for the next browse, not yet used.
 	bool m_browsePinned;
 	bool m_bFriendSlot;
 	bool m_bCommentDirty;

--- a/unittests/tests/BrowseLifecycleTest.cpp
+++ b/unittests/tests/BrowseLifecycleTest.cpp
@@ -38,7 +38,6 @@ Record DirBrowse(std::uint64_t deadline = 1000)
 {
 	Record r;
 	r.searchId = 42;
-	r.peerEcid = 7;
 	r.state = State::InProgress;
 	r.outstanding = kFlatBrowse; // until the peer answers with a count
 	r.deadline = deadline;

--- a/unittests/tests/BrowseLifecycleTest.cpp
+++ b/unittests/tests/BrowseLifecycleTest.cpp
@@ -1,0 +1,240 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include <BrowseLifecycle.h>
+
+using namespace muleunit;
+using namespace browse;
+
+DECLARE_SIMPLE(BrowseLifecycle)
+
+namespace
+{
+//! A browse just asked for, over the directory-by-directory protocol form.
+Record DirBrowse(std::uint64_t deadline = 1000)
+{
+	Record r;
+	r.searchId = 42;
+	r.peerEcid = 7;
+	r.state = State::InProgress;
+	r.outstanding = kFlatBrowse; // until the peer answers with a count
+	r.deadline = deadline;
+	return r;
+}
+} // namespace
+
+// --- The five defects this machine exists to make unreachable. ---------
+// Each of these was a live bug that only the right kind of peer could reach:
+// amule-org/amule#1071 and its two follow-ups. They are the reason the
+// lifecycle was pulled out of CUpDownClient at all.
+
+TEST(BrowseLifecycle, FlatBrowseCompletesWhenItsSingleAnswerArrives)
+{
+	// A peer without directory support (MLdonkey, plain eDonkey, eMule < 0.28)
+	// answers OP_ASKSHAREDFILES in one packet. That used to leave the browse
+	// BROWSE_IN_PROGRESS forever -- a *successful* browse that never ended,
+	// with no timeout able to touch it.
+	Record r = DirBrowse();
+	ASSERT_TRUE(Tick(r, 1) == Action::None);
+
+	r = OnListingReceived(r, 2000);
+	ASSERT_EQUALS(0, r.outstanding);
+	ASSERT_TRUE(Tick(r, 1) == Action::Complete);
+}
+
+TEST(BrowseLifecycle, ZeroDirectoriesCompletesRatherThanWaiting)
+{
+	// A peer answering "I have 0 directories" is a real answer. It used to set
+	// the counter to 0 with nothing marking the browse finished, leaving it
+	// hanging at 0%.
+	Record r = DirBrowse();
+	r = OnDirectoryList(r, 0, 2000);
+	ASSERT_EQUALS(0, r.outstanding);
+	ASSERT_TRUE(Tick(r, 1) == Action::Complete);
+}
+
+TEST(BrowseLifecycle, TerminalRecordIsDroppedNotRetriedForever)
+{
+	// The pending list used to key its erase on the deadline rather than the
+	// state, so a browse that ended without clearing its deadline was
+	// re-examined on every core tick for the life of the client.
+	for (State s : { State::Finished, State::Failed }) {
+		Record r = DirBrowse();
+		r.state = s;
+		ASSERT_TRUE(Tick(r, 1) == Action::Drop);
+		ASSERT_TRUE(Tick(r, 999999) == Action::Drop);
+	}
+}
+
+TEST(BrowseLifecycle, SilenceExpiresOnlyAfterTheDeadline)
+{
+	Record r = DirBrowse(1000);
+	r = OnDirectoryList(r, 3, 1000);
+	ASSERT_TRUE(Tick(r, 999) == Action::None);
+	ASSERT_TRUE(Tick(r, 1000) == Action::None); // not yet: strictly after
+	ASSERT_TRUE(Tick(r, 1001) == Action::Expire);
+}
+
+TEST(BrowseLifecycle, ProgressPushesTheDeadlineBackSoALiveStreamSurvives)
+{
+	// The deadline bounds silence, not duration: a large share may stream for
+	// far longer than the timeout as long as something keeps arriving.
+	Record r = DirBrowse(1000);
+	r = OnDirectoryList(r, 3, 1000);
+	// Each directory lands just before the previous deadline would have run
+	// out, so total elapsed time (2700) far exceeds the 1000-tick timeout.
+	std::uint64_t t = 900;
+	for (int dir = 0; dir < 3; ++dir, t += 900) {
+		ASSERT_TRUE(Tick(r, t) == Action::None);
+		r = OnListingReceived(r, t + 1000);
+	}
+	// Three listings for three directories: complete, never expired.
+	ASSERT_EQUALS(0, r.outstanding);
+	ASSERT_TRUE(Tick(r, t) == Action::Complete);
+}
+
+TEST(BrowseLifecycle, CompletionWinsOverAnExpiryInTheSameTick)
+{
+	// The last listing landing exactly as the deadline passes is a success.
+	// Reporting it as a timeout would discard results already in hand.
+	Record r = DirBrowse();
+	r = OnDirectoryList(r, 1, 500);
+	r = OnListingReceived(r, 500);
+	ASSERT_EQUALS(0, r.outstanding);
+	ASSERT_TRUE(Tick(r, 100000) == Action::Complete);
+}
+
+// --- Progress reporting. ----------------------------------------------
+
+TEST(BrowseLifecycle, BarTracksDirectoriesReceived)
+{
+	Record r = DirBrowse();
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0), BarValue(r)); // no count yet
+	r = OnDirectoryList(r, 4, 2000);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0), BarValue(r));
+	r = OnListingReceived(r, 2000);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(25), BarValue(r));
+	r = OnListingReceived(r, 2000);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(50), BarValue(r));
+}
+
+TEST(BrowseLifecycle, BarClearsOnceTerminal)
+{
+	// 0xffff is the sentinel the search list's bar already reads as "clear".
+	Record r = DirBrowse();
+	r = OnDirectoryList(r, 2, 2000);
+	r.state = State::Finished;
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0xffff), BarValue(r));
+	r.state = State::Failed;
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0xffff), BarValue(r));
+}
+
+TEST(BrowseLifecycle, FlatBrowseReportsNoPercent)
+{
+	// Nothing to count against, so it reports 0 rather than inventing progress.
+	Record r = DirBrowse();
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0), BarValue(r));
+	ASSERT_EQUALS(kFlatBrowse, r.outstanding);
+}
+
+// --- Late and duplicate packets. --------------------------------------
+
+TEST(BrowseLifecycle, PacketsForATerminalBrowseChangeNothing)
+{
+	// A peer that answers after we gave up must not resurrect the record --
+	// the search id may already have been reused for a fresh browse of the
+	// same peer.
+	Record failed = DirBrowse();
+	failed.state = State::Failed;
+
+	Record after = OnDirectoryList(failed, 5, 9999);
+	ASSERT_TRUE(after.state == State::Failed);
+	ASSERT_EQUALS(kFlatBrowse, after.outstanding);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(1000), after.deadline);
+
+	after = OnListingReceived(failed, 9999);
+	ASSERT_TRUE(after.state == State::Failed);
+	ASSERT_EQUALS(kFlatBrowse, after.outstanding);
+}
+
+TEST(BrowseLifecycle, MoreListingsThanAnnouncedDoNotUnderflow)
+{
+	// A peer sending more directories than it announced must not drive the
+	// counter negative, which would make the browse un-completable.
+	Record r = DirBrowse();
+	r = OnDirectoryList(r, 1, 2000);
+	r = OnListingReceived(r, 2000);
+	ASSERT_EQUALS(0, r.outstanding);
+	r = OnListingReceived(r, 2000);
+	ASSERT_EQUALS(0, r.outstanding);
+	ASSERT_TRUE(Tick(r, 1) == Action::Complete);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(100), BarValue(r));
+}
+
+TEST(BrowseLifecycle, ADirectoryAnswerAfterListingsHaveStartedIsStillHonoured)
+{
+	// OP_ASKSHAREDDIRSANS is the clearest sign of life in the exchange, so it
+	// must push the deadline back like any other progress.
+	Record r = DirBrowse(1000);
+	r = OnDirectoryList(r, 2, 5000);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(5000), r.deadline);
+	ASSERT_TRUE(Tick(r, 1001) == Action::None);
+}
+
+// --- Terminal is terminal. ---------------------------------------------
+
+TEST(BrowseLifecycle, ADisconnectAfterCompletionDoesNotTurnSuccessIntoFailure)
+{
+	// The ordinary shape of a successful browse: the peer sends its last
+	// directory and then drops the connection. The disconnect path asks for a
+	// failure without knowing the browse just succeeded, so the rule has to be
+	// here rather than at that call site.
+	Record r = DirBrowse();
+	r = OnDirectoryList(r, 1, 2000);
+	r = OnListingReceived(r, 2000);
+	r = ApplyAction(r, Action::Complete);
+	ASSERT_TRUE(r.state == State::Finished);
+
+	r = ApplyAction(r, Action::Expire);
+	ASSERT_TRUE(r.state == State::Finished);
+}
+
+TEST(BrowseLifecycle, AFailedBrowseIsNotCompletedByALatePacket)
+{
+	Record r = DirBrowse();
+	r = ApplyAction(r, Action::Expire);
+	ASSERT_TRUE(r.state == State::Failed);
+
+	r = ApplyAction(r, Action::Complete);
+	ASSERT_TRUE(r.state == State::Failed);
+}
+
+TEST(BrowseLifecycle, DropAndNoneAreNotStateChanges)
+{
+	Record r = DirBrowse();
+	ASSERT_TRUE(ApplyAction(r, Action::None).state == State::InProgress);
+	ASSERT_TRUE(ApplyAction(r, Action::Drop).state == State::InProgress);
+}

--- a/unittests/tests/BrowseStoreTest.cpp
+++ b/unittests/tests/BrowseStoreTest.cpp
@@ -405,3 +405,28 @@ TEST(BrowseStore, ReusingAnIdIsRefusedEvenForTheSamePeer)
 	s.Remove(kSidA);
 	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 3000).started);
 }
+
+TEST(BrowseStore, TheDirectoryListIsAcceptedExactlyOnce)
+{
+	// A peer replaying OP_ASKSHAREDDIRSANS would otherwise have every
+	// directory re-requested and the silence deadline pushed back on each
+	// resend, keeping its browse alive for as long as it kept sending.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
+
+	s.OnDirectoryList(ALICE, 3, 1000);
+	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+	// ...and it stays shut while the listings arrive.
+	s.OnListingReceived(ALICE, 1000);
+	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+}
+
+TEST(BrowseStore, ATerminalOrAbsentBrowseIsNotAwaitingAnything)
+{
+	Store s;
+	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Fail(ALICE);
+	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+}

--- a/unittests/tests/BrowseStoreTest.cpp
+++ b/unittests/tests/BrowseStoreTest.cpp
@@ -49,7 +49,7 @@ constexpr std::uint32_t kSidB = 20;
 TEST(BrowseStore, StartTracksTheBrowseAndAnswersForThePeer)
 {
 	Store s;
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 1000).started);
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 	ASSERT_TRUE(s.Has(kSidA));
 	ASSERT_TRUE(s.StateOf(kSidA) == State::InProgress);
@@ -62,8 +62,8 @@ TEST(BrowseStore, ASecondBrowseOfTheSamePeerIsRefused)
 	// rests on: there is one exchange with a peer, so a second record could
 	// only ever describe the same one.
 	Store s;
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000).started);
-	ASSERT_FALSE(s.Start(ALICE, kSidB, 7, 1000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 1000).started);
+	ASSERT_FALSE(s.Start(ALICE, kSidB, 1000).started);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 }
@@ -71,8 +71,8 @@ TEST(BrowseStore, ASecondBrowseOfTheSamePeerIsRefused)
 TEST(BrowseStore, DifferentPeersAreTrackedIndependently)
 {
 	Store s;
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000).started);
-	ASSERT_TRUE(s.Start(BOB, kSidB, 8, 1000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 1000).started);
+	ASSERT_TRUE(s.Start(BOB, kSidB, 1000).started);
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 	ASSERT_EQUALS(kSidB, s.SearchIdFor(BOB));
 
@@ -84,8 +84,8 @@ TEST(BrowseStore, DifferentPeersAreTrackedIndependently)
 TEST(BrowseStore, StartRejectsNonsense)
 {
 	Store s;
-	ASSERT_FALSE(s.Start(nullptr, kSidA, 7, 1000).started);
-	ASSERT_FALSE(s.Start(ALICE, 0, 7, 1000).started);
+	ASSERT_FALSE(s.Start(nullptr, kSidA, 1000).started);
+	ASSERT_FALSE(s.Start(ALICE, 0, 1000).started);
 	ASSERT_EQUALS(static_cast<std::size_t>(0), s.Size());
 }
 
@@ -94,7 +94,7 @@ TEST(BrowseStore, AFinishedBrowseNoLongerAnswersAsThePeersLiveOne)
 	// SearchIdFor reports only a browse in progress, so a peer whose browse
 	// has ended can be browsed afresh rather than joined to a dead one.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Finish(ALICE);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
 	// ...but it is still on the books, and still answers for its state.
@@ -111,7 +111,7 @@ TEST(BrowseStore, ATerminalRecordOutlivesItsClient)
 	// sends the listing back to guessing from whether results were retained --
 	// which reports a failed browse as idle, forever.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.Fail(ALICE).effect == Effect::AnnounceFailure);
 
 	// The tick that follows releases the peer and nothing else.
@@ -134,7 +134,7 @@ TEST(BrowseStore, ADisconnectAfterSuccessIsNotReportedAsAFailure)
 	// directory and drops the connection, and the disconnect path asks for a
 	// failure without knowing the browse just succeeded.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.OnDirectoryList(ALICE, 1, 1000);
 	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
@@ -148,7 +148,7 @@ TEST(BrowseStore, ADisconnectAfterSuccessIsNotReportedAsAFailure)
 TEST(BrowseStore, AFlatBrowseCompletesOnItsSingleAnswer)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }
@@ -156,7 +156,7 @@ TEST(BrowseStore, AFlatBrowseCompletesOnItsSingleAnswer)
 TEST(BrowseStore, ADirectoryBrowseCompletesOnItsLastListing)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.OnDirectoryList(ALICE, 2, 1000).effect == Effect::Nothing);
 	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Nothing);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(50), s.BarValue(kSidA));
@@ -168,7 +168,7 @@ TEST(BrowseStore, ADirectoryBrowseCompletesOnItsLastListing)
 TEST(BrowseStore, APeerWithNoDirectoriesCompletesImmediately)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.OnDirectoryList(ALICE, 0, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }
@@ -178,7 +178,7 @@ TEST(BrowseStore, APeerWithNoDirectoriesCompletesImmediately)
 TEST(BrowseStore, SilenceExpiresTheBrowse)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.Tick(1000 + kSilenceTimeoutMs).empty());
 
 	const auto todo = s.Tick(1001 + kSilenceTimeoutMs);
@@ -190,7 +190,7 @@ TEST(BrowseStore, SilenceExpiresTheBrowse)
 TEST(BrowseStore, EverySignOfLifePushesTheDeadlineBack)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 0);
+	s.Start(ALICE, kSidA, 0);
 	// The request going out...
 	s.Touch(ALICE, 100000);
 	ASSERT_TRUE(s.Tick(100000 + kSilenceTimeoutMs).empty());
@@ -206,7 +206,7 @@ TEST(BrowseStore, EverySignOfLifePushesTheDeadlineBack)
 TEST(BrowseStore, TouchDoesNotReviveATerminalBrowse)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Fail(ALICE);
 	s.Touch(ALICE, 999999);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
@@ -219,7 +219,7 @@ TEST(BrowseStore, ForgetFailsARunningBrowseThenReleasesThePeer)
 	// Order matters: the failure is reported while the caller still holds the
 	// reference it needs to name the peer in the log line.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	const auto effects = s.Forget(ALICE);
 	ASSERT_EQUALS(static_cast<std::size_t>(2), effects.size());
 	ASSERT_TRUE(effects[0].effect == Effect::AnnounceFailure);
@@ -233,7 +233,7 @@ TEST(BrowseStore, ForgetFailsARunningBrowseThenReleasesThePeer)
 TEST(BrowseStore, ForgettingAFinishedBrowseAnnouncesNothing)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Finish(ALICE);
 	const auto effects = s.Forget(ALICE);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), effects.size());
@@ -252,7 +252,7 @@ TEST(BrowseStore, PacketsFromAForgottenPeerAreIgnored)
 	// The reference is gone, so the peer no longer resolves to its record --
 	// a late packet must not resurrect it or touch somebody else's.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Forget(ALICE);
 	ASSERT_TRUE(s.OnListingReceived(ALICE, 2000).effect == Effect::Nothing);
 	ASSERT_TRUE(s.OnDirectoryList(ALICE, 3, 2000).effect == Effect::Nothing);
@@ -264,13 +264,13 @@ TEST(BrowseStore, PacketsFromAForgottenPeerAreIgnored)
 TEST(BrowseStore, RemoveDisposesOfTheRecordWithItsSearch)
 {
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Finish(ALICE);
 	s.Remove(kSidA);
 	ASSERT_FALSE(s.Has(kSidA));
 	ASSERT_EQUALS(static_cast<std::size_t>(0), s.Size());
 	// ...and the peer is browsable again.
-	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 2000).started);
 }
 
 TEST(BrowseStore, UnknownSearchIdsAnswerSafely)
@@ -295,7 +295,7 @@ TEST(BrowseStore, ForgettingAnEndedBrowseStillNamesItForRelease)
 	// the user closed the tab. Most peers are in this state by the time they
 	// go away: the listing arrives, then the connection closes.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.OnListingReceived(ALICE, 1000); // flat browse: finished
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
@@ -312,7 +312,7 @@ TEST(BrowseStore, EveryOutcomeCarriesTheBrowseItHappenedTo)
 	// an owner acting on the pair cannot then act on the wrong one, or on
 	// none.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_EQUALS(kSidA, s.OnDirectoryList(ALICE, 1, 1000).searchId);
 	ASSERT_EQUALS(kSidA, s.OnListingReceived(ALICE, 1000).searchId);
 	const auto todo = s.Tick(2000);
@@ -320,7 +320,7 @@ TEST(BrowseStore, EveryOutcomeCarriesTheBrowseItHappenedTo)
 	ASSERT_EQUALS(kSidA, todo[0].searchId);
 
 	Store s2;
-	s2.Start(BOB, kSidB, 8, 1000);
+	s2.Start(BOB, kSidB, 1000);
 	ASSERT_EQUALS(kSidB, s2.Fail(BOB).searchId);
 }
 
@@ -331,13 +331,13 @@ TEST(BrowseStore, APeerIsBrowsableAgainAsSoonAsItsBrowseEnds)
 	// passed and the start it made was silently rejected. The two now agree:
 	// only a RUNNING browse blocks a new one.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Fail(ALICE);
 	// The peer has not been released yet -- that happens on the next tick.
 	ASSERT_TRUE(s.Has(kSidA));
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
 
-	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 2000).started);
 	ASSERT_EQUALS(kSidB, s.SearchIdFor(ALICE));
 	// ...and the old record is untouched, still answering for its own state.
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
@@ -350,10 +350,10 @@ TEST(BrowseStore, ARebrowseDisplacesThePeerFromItsOldRecord)
 	// one peer, and a lookup by peer answered with whichever the map ordered
 	// first -- the stale one, since ids ascend.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Fail(ALICE);
 
-	const auto result = s.Start(ALICE, kSidB, 7, 2000);
+	const auto result = s.Start(ALICE, kSidB, 2000);
 	ASSERT_TRUE(result.started);
 	// The old record let go, and said so: its owner is holding a reference.
 	ASSERT_TRUE(result.displaced.effect == Effect::ReleaseClient);
@@ -368,7 +368,7 @@ TEST(BrowseStore, ARebrowseDisplacesThePeerFromItsOldRecord)
 TEST(BrowseStore, AFirstBrowseDisplacesNothing)
 {
 	Store s;
-	const auto result = s.Start(ALICE, kSidA, 7, 1000);
+	const auto result = s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(result.started);
 	ASSERT_TRUE(result.displaced.effect == Effect::Nothing);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), result.displaced.searchId);
@@ -379,8 +379,8 @@ TEST(BrowseStore, AnIdAlreadyInUseIsRefused)
 	// Ids come from an allocator, but a record keyed by one already tracked
 	// would silently replace it along with whatever state it held.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
-	ASSERT_FALSE(s.Start(BOB, kSidA, 8, 1000).started);
+	s.Start(ALICE, kSidA, 1000);
+	ASSERT_FALSE(s.Start(BOB, kSidA, 1000).started);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(BOB));
@@ -395,15 +395,15 @@ TEST(BrowseStore, ReusingAnIdIsRefusedEvenForTheSamePeer)
 	// the callers, and a store this permissive-looking invites the assumption
 	// that it does not.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Fail(ALICE);
-	ASSERT_FALSE(s.Start(ALICE, kSidA, 7, 2000).started);
+	ASSERT_FALSE(s.Start(ALICE, kSidA, 2000).started);
 	// A different ID is the supported way, and works.
-	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 2000).started);
 	// ...as does reusing the ID once its record has been disposed of.
 	s.Remove(kSidB);
 	s.Remove(kSidA);
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 3000).started);
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 3000).started);
 }
 
 TEST(BrowseStore, TheDirectoryListIsAcceptedExactlyOnce)
@@ -412,7 +412,7 @@ TEST(BrowseStore, TheDirectoryListIsAcceptedExactlyOnce)
 	// directory re-requested and the silence deadline pushed back on each
 	// resend, keeping its browse alive for as long as it kept sending.
 	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
 
 	s.OnDirectoryList(ALICE, 3, 1000);
@@ -426,7 +426,36 @@ TEST(BrowseStore, ATerminalOrAbsentBrowseIsNotAwaitingAnything)
 {
 	Store s;
 	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
-	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(ALICE, kSidA, 1000);
 	s.Fail(ALICE);
+	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+}
+
+TEST(BrowseStore, TheOutboundAskIsOneShotPerBrowse)
+{
+	// ConnectionEstablished gates the OP_ASKSHAREDDIRS it sends on this, and
+	// it runs on every reconnect. A browsed peer that is also a download
+	// source reconnects often, so a predicate true for the whole browse put
+	// an unrequested ask on the wire each time.
+	Store s;
+	s.Start(ALICE, kSidA, 1000);
+	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
+	// Still true across a reconnect before the peer has answered -- the first
+	// ask may never have arrived, which is what the old counter-based guard
+	// allowed for too.
+	s.Touch(ALICE, 2000);
+	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
+	// ...and false from the moment it has.
+	s.OnDirectoryList(ALICE, 2, 3000);
+	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+}
+
+TEST(BrowseStore, AFlatAnswerAlsoClosesTheAskWindow)
+{
+	// The flat form never sends a directory count; its single answer both
+	// completes the browse and stops the ask being repeated.
+	Store s;
+	s.Start(ALICE, kSidA, 1000);
+	s.OnListingReceived(ALICE, 1000);
 	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
 }

--- a/unittests/tests/BrowseStoreTest.cpp
+++ b/unittests/tests/BrowseStoreTest.cpp
@@ -1,0 +1,296 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include <BrowseStore.h>
+
+using namespace muleunit;
+using namespace browse;
+
+DECLARE_SIMPLE(BrowseStore)
+
+namespace
+{
+// Stand-ins for peers. Only their addresses matter -- the store never
+// dereferences a client, which is what lets these be anything at all.
+int g_alice = 0;
+int g_bob = 0;
+Store::ClientKey ALICE = &g_alice;
+Store::ClientKey BOB = &g_bob;
+
+constexpr std::uint32_t kSidA = 10;
+constexpr std::uint32_t kSidB = 20;
+} // namespace
+
+// --- Starting, and the join the EC handler depends on. ----------------
+
+TEST(BrowseStore, StartTracksTheBrowseAndAnswersForThePeer)
+{
+	Store s;
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000));
+	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
+	ASSERT_TRUE(s.Has(kSidA));
+	ASSERT_TRUE(s.StateOf(kSidA) == State::InProgress);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
+}
+
+TEST(BrowseStore, ASecondBrowseOfTheSamePeerIsRefused)
+{
+	// This is the rule the EC handler's "join the browse already in flight"
+	// rests on: there is one exchange with a peer, so a second record could
+	// only ever describe the same one.
+	Store s;
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000));
+	ASSERT_FALSE(s.Start(ALICE, kSidB, 7, 1000));
+	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
+	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
+}
+
+TEST(BrowseStore, DifferentPeersAreTrackedIndependently)
+{
+	Store s;
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000));
+	ASSERT_TRUE(s.Start(BOB, kSidB, 8, 1000));
+	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
+	ASSERT_EQUALS(kSidB, s.SearchIdFor(BOB));
+
+	s.Fail(ALICE);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+	ASSERT_TRUE(s.StateOf(kSidB) == State::InProgress);
+}
+
+TEST(BrowseStore, StartRejectsNonsense)
+{
+	Store s;
+	ASSERT_FALSE(s.Start(nullptr, kSidA, 7, 1000));
+	ASSERT_FALSE(s.Start(ALICE, 0, 7, 1000));
+	ASSERT_EQUALS(static_cast<std::size_t>(0), s.Size());
+}
+
+TEST(BrowseStore, AFinishedBrowseNoLongerAnswersAsThePeersLiveOne)
+{
+	// SearchIdFor reports only a browse in progress, so a peer whose browse
+	// has ended can be browsed afresh rather than joined to a dead one.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Finish(ALICE);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
+	// ...but it is still on the books, and still answers for its state.
+	ASSERT_TRUE(s.Has(kSidA));
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+}
+
+// --- The two bugs that live verification caught, not the tests. --------
+
+TEST(BrowseStore, ATerminalRecordOutlivesItsClient)
+{
+	// Erasing the record when the browse ended was a real regression: every
+	// consumer asks the store what state a search is in, so a dropped record
+	// sends the listing back to guessing from whether results were retained --
+	// which reports a failed browse as idle, forever.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(s.Fail(ALICE) == Effect::AnnounceFailure);
+
+	// The tick that follows releases the peer and nothing else.
+	const auto todo = s.Tick(2000);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), todo.size());
+	ASSERT_EQUALS(kSidA, todo[0].first);
+	ASSERT_TRUE(todo[0].second == Effect::ReleaseClient);
+
+	ASSERT_TRUE(s.Has(kSidA));
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+
+	// And it settles: no further ticks keep reporting it.
+	ASSERT_TRUE(s.Tick(3000).empty());
+	ASSERT_TRUE(s.Tick(999999).empty());
+}
+
+TEST(BrowseStore, ADisconnectAfterSuccessIsNotReportedAsAFailure)
+{
+	// The ordinary end of a successful browse: the peer sends its last
+	// directory and drops the connection, and the disconnect path asks for a
+	// failure without knowing the browse just succeeded.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.OnDirectoryList(ALICE, 1, 1000);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+
+	ASSERT_TRUE(s.Fail(ALICE) == Effect::Nothing);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+}
+
+// --- Completion, both protocol forms. ---------------------------------
+
+TEST(BrowseStore, AFlatBrowseCompletesOnItsSingleAnswer)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+}
+
+TEST(BrowseStore, ADirectoryBrowseCompletesOnItsLastListing)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(s.OnDirectoryList(ALICE, 2, 1000) == Effect::Nothing);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Nothing);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(50), s.BarValue(kSidA));
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0xffff), s.BarValue(kSidA));
+}
+
+TEST(BrowseStore, APeerWithNoDirectoriesCompletesImmediately)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(s.OnDirectoryList(ALICE, 0, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+}
+
+// --- Silence, and what pushes it back. --------------------------------
+
+TEST(BrowseStore, SilenceExpiresTheBrowse)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(s.Tick(1000 + kSilenceTimeoutMs).empty());
+
+	const auto todo = s.Tick(1001 + kSilenceTimeoutMs);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), todo.size());
+	ASSERT_TRUE(todo[0].second == Effect::AnnounceFailure);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+}
+
+TEST(BrowseStore, EverySignOfLifePushesTheDeadlineBack)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 0);
+	// The request going out...
+	s.Touch(ALICE, 100000);
+	ASSERT_TRUE(s.Tick(100000 + kSilenceTimeoutMs).empty());
+	// ...the directory answer...
+	s.OnDirectoryList(ALICE, 2, 200000);
+	ASSERT_TRUE(s.Tick(200000 + kSilenceTimeoutMs).empty());
+	// ...and each listing.
+	s.OnListingReceived(ALICE, 300000);
+	ASSERT_TRUE(s.Tick(300000 + kSilenceTimeoutMs).empty());
+	ASSERT_TRUE(s.StateOf(kSidA) == State::InProgress);
+}
+
+TEST(BrowseStore, TouchDoesNotReviveATerminalBrowse)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Fail(ALICE);
+	s.Touch(ALICE, 999999);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+}
+
+// --- The peer going away. ---------------------------------------------
+
+TEST(BrowseStore, ForgetFailsARunningBrowseThenReleasesThePeer)
+{
+	// Order matters: the failure is reported while the caller still holds the
+	// reference it needs to name the peer in the log line.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	const auto effects = s.Forget(ALICE);
+	ASSERT_EQUALS(static_cast<std::size_t>(2), effects.size());
+	ASSERT_TRUE(effects[0] == Effect::AnnounceFailure);
+	ASSERT_TRUE(effects[1] == Effect::ReleaseClient);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
+	// The record survives its peer.
+	ASSERT_TRUE(s.Has(kSidA));
+}
+
+TEST(BrowseStore, ForgettingAFinishedBrowseAnnouncesNothing)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Finish(ALICE);
+	const auto effects = s.Forget(ALICE);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), effects.size());
+	ASSERT_TRUE(effects[0] == Effect::ReleaseClient);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+}
+
+TEST(BrowseStore, ForgettingAPeerWithNoBrowseDoesNothing)
+{
+	Store s;
+	ASSERT_TRUE(s.Forget(ALICE).empty());
+}
+
+TEST(BrowseStore, PacketsFromAForgottenPeerAreIgnored)
+{
+	// The reference is gone, so the peer no longer resolves to its record --
+	// a late packet must not resurrect it or touch somebody else's.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Forget(ALICE);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 2000) == Effect::Nothing);
+	ASSERT_TRUE(s.OnDirectoryList(ALICE, 3, 2000) == Effect::Nothing);
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+}
+
+// --- Disposal. ---------------------------------------------------------
+
+TEST(BrowseStore, RemoveDisposesOfTheRecordWithItsSearch)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Finish(ALICE);
+	s.Remove(kSidA);
+	ASSERT_FALSE(s.Has(kSidA));
+	ASSERT_EQUALS(static_cast<std::size_t>(0), s.Size());
+	// ...and the peer is browsable again.
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000));
+}
+
+TEST(BrowseStore, IdsEnumeratesEveryTrackedBrowse)
+{
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Start(BOB, kSidB, 8, 1000);
+	const auto ids = s.Ids();
+	ASSERT_EQUALS(static_cast<std::size_t>(2), ids.size());
+	ASSERT_EQUALS(kSidA, ids[0]);
+	ASSERT_EQUALS(kSidB, ids[1]);
+}
+
+TEST(BrowseStore, UnknownSearchIdsAnswerSafely)
+{
+	// The EC reply paths gate on Has(), but the accessors must not invent a
+	// running browse for an ID nobody is tracking.
+	Store s;
+	ASSERT_FALSE(s.Has(kSidA));
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(0xffff), s.BarValue(kSidA));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(nullptr));
+}

--- a/unittests/tests/BrowseStoreTest.cpp
+++ b/unittests/tests/BrowseStoreTest.cpp
@@ -273,17 +273,6 @@ TEST(BrowseStore, RemoveDisposesOfTheRecordWithItsSearch)
 	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
 }
 
-TEST(BrowseStore, IdsEnumeratesEveryTrackedBrowse)
-{
-	Store s;
-	s.Start(ALICE, kSidA, 7, 1000);
-	s.Start(BOB, kSidB, 8, 1000);
-	const auto ids = s.Ids();
-	ASSERT_EQUALS(static_cast<std::size_t>(2), ids.size());
-	ASSERT_EQUALS(kSidA, ids[0]);
-	ASSERT_EQUALS(kSidB, ids[1]);
-}
-
 TEST(BrowseStore, UnknownSearchIdsAnswerSafely)
 {
 	// The EC reply paths gate on Has(), but the accessors must not invent a
@@ -395,4 +384,24 @@ TEST(BrowseStore, AnIdAlreadyInUseIsRefused)
 	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(BOB));
+}
+
+TEST(BrowseStore, ReusingAnIdIsRefusedEvenForTheSamePeer)
+{
+	// The ID guard is unconditional, so a peer re-browsed under the ID its own
+	// last browse still holds is turned away -- it must Remove() that one
+	// first. No caller does this: both routes allocate a fresh ID, and closing
+	// a tab frees the old record. Pinned because that safety lives entirely in
+	// the callers, and a store this permissive-looking invites the assumption
+	// that it does not.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Fail(ALICE);
+	ASSERT_FALSE(s.Start(ALICE, kSidA, 7, 2000).started);
+	// A different ID is the supported way, and works.
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
+	// ...as does reusing the ID once its record has been disposed of.
+	s.Remove(kSidB);
+	s.Remove(kSidA);
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 3000).started);
 }

--- a/unittests/tests/BrowseStoreTest.cpp
+++ b/unittests/tests/BrowseStoreTest.cpp
@@ -49,7 +49,7 @@ constexpr std::uint32_t kSidB = 20;
 TEST(BrowseStore, StartTracksTheBrowseAndAnswersForThePeer)
 {
 	Store s;
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000));
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000).started);
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 	ASSERT_TRUE(s.Has(kSidA));
 	ASSERT_TRUE(s.StateOf(kSidA) == State::InProgress);
@@ -62,8 +62,8 @@ TEST(BrowseStore, ASecondBrowseOfTheSamePeerIsRefused)
 	// rests on: there is one exchange with a peer, so a second record could
 	// only ever describe the same one.
 	Store s;
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000));
-	ASSERT_FALSE(s.Start(ALICE, kSidB, 7, 1000));
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000).started);
+	ASSERT_FALSE(s.Start(ALICE, kSidB, 7, 1000).started);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 }
@@ -71,8 +71,8 @@ TEST(BrowseStore, ASecondBrowseOfTheSamePeerIsRefused)
 TEST(BrowseStore, DifferentPeersAreTrackedIndependently)
 {
 	Store s;
-	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000));
-	ASSERT_TRUE(s.Start(BOB, kSidB, 8, 1000));
+	ASSERT_TRUE(s.Start(ALICE, kSidA, 7, 1000).started);
+	ASSERT_TRUE(s.Start(BOB, kSidB, 8, 1000).started);
 	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
 	ASSERT_EQUALS(kSidB, s.SearchIdFor(BOB));
 
@@ -84,8 +84,8 @@ TEST(BrowseStore, DifferentPeersAreTrackedIndependently)
 TEST(BrowseStore, StartRejectsNonsense)
 {
 	Store s;
-	ASSERT_FALSE(s.Start(nullptr, kSidA, 7, 1000));
-	ASSERT_FALSE(s.Start(ALICE, 0, 7, 1000));
+	ASSERT_FALSE(s.Start(nullptr, kSidA, 7, 1000).started);
+	ASSERT_FALSE(s.Start(ALICE, 0, 7, 1000).started);
 	ASSERT_EQUALS(static_cast<std::size_t>(0), s.Size());
 }
 
@@ -112,13 +112,13 @@ TEST(BrowseStore, ATerminalRecordOutlivesItsClient)
 	// which reports a failed browse as idle, forever.
 	Store s;
 	s.Start(ALICE, kSidA, 7, 1000);
-	ASSERT_TRUE(s.Fail(ALICE) == Effect::AnnounceFailure);
+	ASSERT_TRUE(s.Fail(ALICE).effect == Effect::AnnounceFailure);
 
 	// The tick that follows releases the peer and nothing else.
 	const auto todo = s.Tick(2000);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), todo.size());
-	ASSERT_EQUALS(kSidA, todo[0].first);
-	ASSERT_TRUE(todo[0].second == Effect::ReleaseClient);
+	ASSERT_EQUALS(kSidA, todo[0].searchId);
+	ASSERT_TRUE(todo[0].effect == Effect::ReleaseClient);
 
 	ASSERT_TRUE(s.Has(kSidA));
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
@@ -136,10 +136,10 @@ TEST(BrowseStore, ADisconnectAfterSuccessIsNotReportedAsAFailure)
 	Store s;
 	s.Start(ALICE, kSidA, 7, 1000);
 	s.OnDirectoryList(ALICE, 1, 1000);
-	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 
-	ASSERT_TRUE(s.Fail(ALICE) == Effect::Nothing);
+	ASSERT_TRUE(s.Fail(ALICE).effect == Effect::Nothing);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }
 
@@ -149,7 +149,7 @@ TEST(BrowseStore, AFlatBrowseCompletesOnItsSingleAnswer)
 {
 	Store s;
 	s.Start(ALICE, kSidA, 7, 1000);
-	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }
 
@@ -157,10 +157,10 @@ TEST(BrowseStore, ADirectoryBrowseCompletesOnItsLastListing)
 {
 	Store s;
 	s.Start(ALICE, kSidA, 7, 1000);
-	ASSERT_TRUE(s.OnDirectoryList(ALICE, 2, 1000) == Effect::Nothing);
-	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Nothing);
+	ASSERT_TRUE(s.OnDirectoryList(ALICE, 2, 1000).effect == Effect::Nothing);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Nothing);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(50), s.BarValue(kSidA));
-	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(0xffff), s.BarValue(kSidA));
 }
@@ -169,7 +169,7 @@ TEST(BrowseStore, APeerWithNoDirectoriesCompletesImmediately)
 {
 	Store s;
 	s.Start(ALICE, kSidA, 7, 1000);
-	ASSERT_TRUE(s.OnDirectoryList(ALICE, 0, 1000) == Effect::Announce);
+	ASSERT_TRUE(s.OnDirectoryList(ALICE, 0, 1000).effect == Effect::Announce);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }
 
@@ -183,7 +183,7 @@ TEST(BrowseStore, SilenceExpiresTheBrowse)
 
 	const auto todo = s.Tick(1001 + kSilenceTimeoutMs);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), todo.size());
-	ASSERT_TRUE(todo[0].second == Effect::AnnounceFailure);
+	ASSERT_TRUE(todo[0].effect == Effect::AnnounceFailure);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
 }
 
@@ -222,8 +222,8 @@ TEST(BrowseStore, ForgetFailsARunningBrowseThenReleasesThePeer)
 	s.Start(ALICE, kSidA, 7, 1000);
 	const auto effects = s.Forget(ALICE);
 	ASSERT_EQUALS(static_cast<std::size_t>(2), effects.size());
-	ASSERT_TRUE(effects[0] == Effect::AnnounceFailure);
-	ASSERT_TRUE(effects[1] == Effect::ReleaseClient);
+	ASSERT_TRUE(effects[0].effect == Effect::AnnounceFailure);
+	ASSERT_TRUE(effects[1].effect == Effect::ReleaseClient);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
 	// The record survives its peer.
@@ -237,7 +237,7 @@ TEST(BrowseStore, ForgettingAFinishedBrowseAnnouncesNothing)
 	s.Finish(ALICE);
 	const auto effects = s.Forget(ALICE);
 	ASSERT_EQUALS(static_cast<std::size_t>(1), effects.size());
-	ASSERT_TRUE(effects[0] == Effect::ReleaseClient);
+	ASSERT_TRUE(effects[0].effect == Effect::ReleaseClient);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }
 
@@ -254,8 +254,8 @@ TEST(BrowseStore, PacketsFromAForgottenPeerAreIgnored)
 	Store s;
 	s.Start(ALICE, kSidA, 7, 1000);
 	s.Forget(ALICE);
-	ASSERT_TRUE(s.OnListingReceived(ALICE, 2000) == Effect::Nothing);
-	ASSERT_TRUE(s.OnDirectoryList(ALICE, 3, 2000) == Effect::Nothing);
+	ASSERT_TRUE(s.OnListingReceived(ALICE, 2000).effect == Effect::Nothing);
+	ASSERT_TRUE(s.OnDirectoryList(ALICE, 3, 2000).effect == Effect::Nothing);
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
 }
 
@@ -270,7 +270,7 @@ TEST(BrowseStore, RemoveDisposesOfTheRecordWithItsSearch)
 	ASSERT_FALSE(s.Has(kSidA));
 	ASSERT_EQUALS(static_cast<std::size_t>(0), s.Size());
 	// ...and the peer is browsable again.
-	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000));
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
 }
 
 TEST(BrowseStore, IdsEnumeratesEveryTrackedBrowse)
@@ -293,4 +293,106 @@ TEST(BrowseStore, UnknownSearchIdsAnswerSafely)
 	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(0xffff), s.BarValue(kSidA));
 	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(nullptr));
+}
+
+// --- Composed: the rules above are each right, and were wrong together. -
+
+TEST(BrowseStore, ForgettingAnEndedBrowseStillNamesItForRelease)
+{
+	// Both halves of this were already tested apart -- that Forget releases
+	// the peer, and that a finished browse no longer answers as the peer's
+	// live one. Composed, the release came back with no browse attached to it,
+	// so the owner had nothing to release and kept the peer allocated until
+	// the user closed the tab. Most peers are in this state by the time they
+	// go away: the listing arrives, then the connection closes.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.OnListingReceived(ALICE, 1000); // flat browse: finished
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
+
+	const auto effects = s.Forget(ALICE);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), effects.size());
+	ASSERT_TRUE(effects[0].effect == Effect::ReleaseClient);
+	ASSERT_EQUALS(kSidA, effects[0].searchId);
+}
+
+TEST(BrowseStore, EveryOutcomeCarriesTheBrowseItHappenedTo)
+{
+	// Nothing may report an effect without saying which browse it belongs to;
+	// an owner acting on the pair cannot then act on the wrong one, or on
+	// none.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_EQUALS(kSidA, s.OnDirectoryList(ALICE, 1, 1000).searchId);
+	ASSERT_EQUALS(kSidA, s.OnListingReceived(ALICE, 1000).searchId);
+	const auto todo = s.Tick(2000);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), todo.size());
+	ASSERT_EQUALS(kSidA, todo[0].searchId);
+
+	Store s2;
+	s2.Start(BOB, kSidB, 8, 1000);
+	ASSERT_EQUALS(kSidB, s2.Fail(BOB).searchId);
+}
+
+TEST(BrowseStore, APeerIsBrowsableAgainAsSoonAsItsBrowseEnds)
+{
+	// Start refused while a terminal record still held the peer, but
+	// SearchIdFor said the peer had no browse -- so the caller's own check
+	// passed and the start it made was silently rejected. The two now agree:
+	// only a RUNNING browse blocks a new one.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Fail(ALICE);
+	// The peer has not been released yet -- that happens on the next tick.
+	ASSERT_TRUE(s.Has(kSidA));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(ALICE));
+
+	ASSERT_TRUE(s.Start(ALICE, kSidB, 7, 2000).started);
+	ASSERT_EQUALS(kSidB, s.SearchIdFor(ALICE));
+	// ...and the old record is untouched, still answering for its own state.
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+	ASSERT_TRUE(s.StateOf(kSidB) == State::InProgress);
+}
+
+TEST(BrowseStore, ARebrowseDisplacesThePeerFromItsOldRecord)
+{
+	// Re-browsing before the old record was released left two records naming
+	// one peer, and a lookup by peer answered with whichever the map ordered
+	// first -- the stale one, since ids ascend.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	s.Fail(ALICE);
+
+	const auto result = s.Start(ALICE, kSidB, 7, 2000);
+	ASSERT_TRUE(result.started);
+	// The old record let go, and said so: its owner is holding a reference.
+	ASSERT_TRUE(result.displaced.effect == Effect::ReleaseClient);
+	ASSERT_EQUALS(kSidA, result.displaced.searchId);
+	// The peer now resolves to the new browse, and only that one.
+	ASSERT_EQUALS(kSidB, s.SearchIdFor(ALICE));
+	ASSERT_TRUE(s.Fail(ALICE).searchId == kSidB);
+	// The displaced record is untouched otherwise.
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Failed);
+}
+
+TEST(BrowseStore, AFirstBrowseDisplacesNothing)
+{
+	Store s;
+	const auto result = s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_TRUE(result.started);
+	ASSERT_TRUE(result.displaced.effect == Effect::Nothing);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), result.displaced.searchId);
+}
+
+TEST(BrowseStore, AnIdAlreadyInUseIsRefused)
+{
+	// Ids come from an allocator, but a record keyed by one already tracked
+	// would silently replace it along with whatever state it held.
+	Store s;
+	s.Start(ALICE, kSidA, 7, 1000);
+	ASSERT_FALSE(s.Start(BOB, kSidA, 8, 1000).started);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), s.Size());
+	ASSERT_EQUALS(kSidA, s.SearchIdFor(ALICE));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0), s.SearchIdFor(BOB));
 }

--- a/unittests/tests/BrowseStoreTest.cpp
+++ b/unittests/tests/BrowseStoreTest.cpp
@@ -431,12 +431,15 @@ TEST(BrowseStore, ATerminalOrAbsentBrowseIsNotAwaitingAnything)
 	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
 }
 
-TEST(BrowseStore, TheOutboundAskIsOneShotPerBrowse)
+TEST(BrowseStore, ADirectoryBrowseAsksOnlyUntilThePeerAnswers)
 {
 	// ConnectionEstablished gates the OP_ASKSHAREDDIRS it sends on this, and
 	// it runs on every reconnect. A browsed peer that is also a download
 	// source reconnects often, so a predicate true for the whole browse put
 	// an unrequested ask on the wire each time.
+	//
+	// This is the DIRECTORY form; the flat one has no such round and is
+	// covered separately below.
 	Store s;
 	s.Start(ALICE, kSidA, 1000);
 	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
@@ -450,12 +453,19 @@ TEST(BrowseStore, TheOutboundAskIsOneShotPerBrowse)
 	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
 }
 
-TEST(BrowseStore, AFlatAnswerAlsoClosesTheAskWindow)
+TEST(BrowseStore, AFlatBrowseStaysAskableUntilItsOneAnswerArrives)
 {
-	// The flat form never sends a directory count; its single answer both
-	// completes the browse and stops the ask being repeated.
+	// The flat form has no directory round, so the window stays open for the
+	// whole browse: a reconnect before the peer answers re-asks, which is what
+	// the counter-based guard did too and is wanted -- the first ask may never
+	// have arrived. It closes on the single answer, which also completes it.
 	Store s;
 	s.Start(ALICE, kSidA, 1000);
-	s.OnListingReceived(ALICE, 1000);
+	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
+	s.Touch(ALICE, 2000);
+	ASSERT_TRUE(s.AwaitingDirectoryList(ALICE));
+
+	s.OnListingReceived(ALICE, 3000);
 	ASSERT_FALSE(s.AwaitingDirectoryList(ALICE));
+	ASSERT_TRUE(s.StateOf(kSidA) == State::Finished);
 }

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -802,6 +802,33 @@ target_link_libraries (BrowseLifecycleTest
 	mulecommon
 )
 
+# The rules about browses -- one per peer, a terminal record outliving its
+# client, a disconnect after success not being a failure. They used to live on
+# CBrowseManager next to the notify and the log line, which put them out of a
+# test's reach; the two defects found after the lifecycle was extracted were
+# both here rather than in the state machine. The store identifies peers by an
+# opaque key and touches no theApp, so all of it is drivable.
+add_executable (BrowseStoreTest
+	BrowseStoreTest.cpp
+	${CMAKE_SOURCE_DIR}/src/BrowseStore.cpp
+	${CMAKE_SOURCE_DIR}/src/BrowseLifecycle.cpp
+)
+
+add_test (NAME BrowseStoreTest
+	COMMAND BrowseStoreTest
+)
+
+target_include_directories (BrowseStoreTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (BrowseStoreTest
+	muleunit
+	mulecommon
+)
+
 # CListColumnStore maps a column id to its persistence key and default width.
 # The key is the on-disk config format, so the id a caller registers has to be
 # the id it looks the column up by -- a registry that renumbered stored ids

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -776,6 +776,32 @@ target_link_libraries (CompleteSourcesThrottleTest
 	mulecommon
 )
 
+# The browse ("View Files") state machine. Five separate defects have been the
+# same machine going wrong in a place only a peer of the right kind could reach
+# -- a flat browse that completes without ever being marked finished, a peer we
+# decline to contact, a terminal browse still on the pending list (#1071 and
+# its follow-ups). None were reachable from a test while the logic sat on
+# CUpDownClient, so it lives in a pair of its own that touches no theApp.
+add_executable (BrowseLifecycleTest
+	BrowseLifecycleTest.cpp
+	${CMAKE_SOURCE_DIR}/src/BrowseLifecycle.cpp
+)
+
+add_test (NAME BrowseLifecycleTest
+	COMMAND BrowseLifecycleTest
+)
+
+target_include_directories (BrowseLifecycleTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (BrowseLifecycleTest
+	muleunit
+	mulecommon
+)
+
 # CListColumnStore maps a column id to its persistence key and default width.
 # The key is the on-disk config format, so the id a caller registers has to be
 # the id it looks the column up by -- a registry that renumbered stored ids


### PR DESCRIPTION
Fixes #1071.

Third attempt at that issue, and the first that stops treating it as a bug. Thanks @ngosang — the analysis in #1071 is what made the shape of this obvious, and both of the fixes it replaces were his catches.

## Why a refactor

Five defects in this area across three passes were one invariant broken in five different places. A browse was four fields borrowed on `CUpDownClient`, two maps on `CSearchList` keyed by a routing id that was sometimes a client *pointer*, and a list on `CClientList` — the same fact written independently across seven files, owned by nobody and reachable by no test. Both point fixes (#1072, #1074) went in wrong, and both looked green under hand-verification.

## What it does

`CBrowseManager` owns one record per browse, keyed by search id. `CSearchList::m_browseBar`/`m_browseStatus`, `CClientList::m_pendingBrowses` and four `CUpDownClient` fields are gone; the EC progress reply, the EC listing and the monolithic bar all read the manager. Ids are allocated at *request* time for local browses too, which removes the pointer keying entirely.

`TryToConnect` gained an honest return — `EContactResult { Contacting, Declined, ConnectNotStarted, ClientDeleted }`, all 21 exits classified — and `IsPeerContactPending` is deleted. That predicate was an oracle reconstructing the answer from side effects, and it was wrong twice. The `bool` wrapper maps exactly as before (the 8 `Safe_Delete` exits plus the 1 `Connect()` refusal → false, the other 12 → true), so the eleven external callers are untouched.

The rules live in `browse::Store` over an opaque client key, and the state machine in `browse::Tick`. Neither reaches `theApp`, a client, or the clock.

## What this fixes on master

Four things are broken today and fixed here:

- A **successful** flat (`OP_ASKSHAREDFILES`) browse never completing. Only the directory form's handler marked it, and every terminal path was a no-op because they guarded on the counter that had already reached 0 — so nothing could end it, including the #1074 deadline. Affects MLdonkey, plain eDonkey and eMule < 0.28.
- A peer answering with **zero directories**, same shape.
- Terminal records re-examined on **every core tick** for the life of the client, because the #1074 sweep keyed its erase on the deadline rather than the state.
- Both EC union polls emitting **every browse twice** — `RegisterBrowseSearch` writes `m_searchStrings`, so the second source was never disjoint from the first.

## What review found inside this PR

Eighteen more defects were introduced and resolved before merge, across six review rounds and a manual pass over both GUIs. None of them exist on master, so they are not fixes — but they are the argument for the refactor, and for reviewing it hard:

- a terminal record erased at completion, sending the listing back to reporting a failed browse as `idle`
- a disconnect after success reported as a failure
- `OnDirectoryList` reading the search id as an argument of the call that completed the browse — **unspecified evaluation order**, so `uDirs == 0` announced or not depending on the compiler
- a null dereference on shutdown, and the manager left **uninitialised** in the constructor, which made the guard added for that crash read indeterminate memory
- `Outcome`'s id lost for any browse that had already ended, leaking the client reference
- `Contacting` returned from LowID paths that send nothing — the exact case the deleted `IsPeerContactPending` used to catch
- a re-browse of the same peer reusing its old search id, which the store then refused in silence
- a peer able to replay its directory list indefinitely, each resend re-asking every directory and pushing the deadline back
- a second "View Files" on a friend overwriting the live browse's id, filing the rest of its listing under search id **0**
- "pinned for this browse" inferred from the manager not yet knowing the id, which is equally true of a disposed one — so a local re-browse of a peer previously browsed over EC never revealed its own tab
- the outbound `OP_ASKSHAREDDIRS` re-sent on **every reconnect**, putting unrequested packets on the wire and an error line in the peer's log
- a `Record::peerEcid` written and never read
- a friend browse re-registered under this client's ECID rather than the friend's, so an adopting GUI opened a second tab under the peer's nick
- a fresh search id allocated on every repeat local browse, leaking the previous registration, results and browse record — the cost of the round-three fix above, now paid by reusing the peer's id as this did before the refactor
- that same leak reachable again through the friend list menu, because pinning id `0` wiped the id the peer was meant to keep
- `m_browsePeers` never pruned in `RemoveResults` — pre-existing, but this PR made it grow for browses that return nothing at all
- **amulegui** re-asking the peer instead of switching to a friend's already-open browse tab. The tab is keyed by whichever ECID opened it, and the two builds differ — the monolithic has the browsed client's, amulegui only the friend's. Looking it up by the client alone never matched there; it had appeared to work only because the duplicate tab fixed above was being found instead. Caught by hand, not by any check here.

## Tests: 45

`BrowseLifecycleTest` (15) drives the state machine, `BrowseStoreTest` (30) the ownership rules — both over plain values, with no `theApp`, no client and no clock.

Honest accounting of what caught what: **review found most of them**, one was caught by a test failing as it was written (two records naming one peer after a re-browse), and two more surfaced while making the code testable. The point is not that the tests found everything — it is that the parts now under test are the parts that had been wrong five times, and they are pinned rather than argued about.

## Worth a close look

- The `EContactResult` classification of all 21 exits — a misclassification there is silent, and one already slipped through a round.
- Local browses now appear on `EC_OP_SEARCH_LIST` at request time rather than when their first result lands.
- `src/BrowseManager.cpp` added to `po/POTFILES.in`; without it the moved log string goes obsolete and all 41 translations drop.
- `BROWSE_SILENCE_TIMEOUT` moved out of the ed2k protocol constants to `browse::kSilenceTimeoutMs` — it was never a protocol constant.

## Verification

macOS, all four binaries, 41/41 test targets, clang-format and both clang-tidy tiers clean. Both GUIs driven by hand for the browse paths no automated check reaches — opening, re-opening and switching to a friend's browse tab in the monolithic and in amulegui. Reviewed twice on the fork at https://github.com/got3nks/amule/pull/1 and five times here. Live against a real daemon: the join returns one id, listing and progress agree, a reachable peer runs, an unroutable one fails at once, a terminal browse stays terminal, and a re-browse after one ends gets a fresh id.
