### PR TITLE
fix(core,gui): log a deferred client deletion as normal, not critical

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -454,8 +454,13 @@ void CUpDownClient::Safe_Delete()
 
 #ifdef DEBUG_ZOMBIE_CLIENTS
 	if (m_linked > 1) {
-		AddLogLineC(CFormat("Client %d still linked in %d places: %s") % ECID() % (m_linked - 1) %
-			    GetLinkedFrom());
+		// Normal level, same as the "last reference ... delete it" line this
+		// pairs with. Deferred deletion is the expected outcome of a source
+		// list being walked from a snapshot, not a fault; logging the first
+		// half as critical and the second as normal made every ordinary
+		// deferral read as an error (amule-org/amule#1086).
+		AddLogLineN(CFormat("Client %d: deletion deferred, still referenced in %d place(s): %s") %
+			    ECID() % (m_linked - 1) % GetLinkedFrom());
 		m_linkedDebug = true;
 	}
 #endif

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2732,8 +2732,9 @@ void CUpDownClientListRem::DeleteItem(CClientRef *clientref)
 
 #ifdef DEBUG_ZOMBIE_CLIENTS
 	if (client->m_linked > 1) {
-		AddLogLineC(CFormat("Client %d still linked in %d places: %s") % client->ECID() %
-			    (client->m_linked - 1) % client->GetLinkedFrom());
+		// Same level and wording as the core-side twin in BaseClient.cpp.
+		AddLogLineN(CFormat("Client %d: deletion deferred, still referenced in %d place(s): %s") %
+			    client->ECID() % (client->m_linked - 1) % client->GetLinkedFrom());
 		client->m_linkedDebug = true;
 	}
 #endif


### PR DESCRIPTION
Closes #1086.

The zombie-client tracing logs a pair of lines: one when a client is due for deletion but something still holds a reference, and one when the last reference goes and the delete happens.

```
BaseClient.cpp(455): Client 121118 still linked in 1 places: ... CPartFile::AddSource,
BaseClient.cpp(3221): Last reference to client 121118 ... unlinked, delete it.
```

The first was `AddLogLineC`, the second `AddLogLineN` - the alarming half shouted and the reassuring half did not, so an ordinary deferral read as a fault.

## Why it is not one

A file's source list is walked from a snapshot, so the list cannot change underneath the loop, and that snapshot holds a reference to each client for the duration of the pass. A client deleted during the pass is freed when the snapshot is discarded. That is why both lines land in the **same second** - which the reporter read as suspicious and is in fact exactly what this explanation predicts.

It was reported with nothing downloading, which fits: the `CPartFile::AddSource` label only appears for a client in a download's source list, and the reporter confirmed idle entries in the downloads list on the monolithic GUI.

## Change

Both halves log at normal level, and the first says what is actually happening:

```
Client 121118: deletion deferred, still referenced in 1 place(s): ...
```

The case still worth reporting is a *deletion deferred* line with **no** *last reference* line after it - a client that never gets freed.

`amule-remote-gui.cpp` carries the same pair for the remote GUI's client list and had drifted the same way, so it is fixed identically rather than left as the odd one out.

## Scope and verification

Debug builds only, before and after: `DEBUG_ZOMBIE_CLIENTS` follows `__DEBUG__`, so no release user sees either line.

That also means a Release build verifies nothing here, since the changed lines are preprocessed away. Verified with a **Debug** build instead - the new wording is present in both `amuled` and `amulegui`, and the old wording is gone from both:

```
amuled     NEW string present (code compiled in)   old wording: 0
aMuleGUI   NEW string present (code compiled in)   old wording: 0
```

clang-format and both clang-tidy tiers clean on the diff. No translatable strings touched, so no catalog regeneration.
