### PR TITLE
perf(amuleapi): accumulate JSON as UTF-8 instead of UTF-32

### DIFF
--- a/src/libwebcommon/JsonWriter.cpp
+++ b/src/libwebcommon/JsonWriter.cpp
@@ -34,7 +34,7 @@ CJsonWriter::CJsonWriter()
 {
 }
 
-CJsonWriter::CJsonWriter(wxString *external_buf)
+CJsonWriter::CJsonWriter(std::string *external_buf)
 : m_buf(external_buf)
 , m_needs_comma(false)
 {
@@ -43,33 +43,33 @@ CJsonWriter::CJsonWriter(wxString *external_buf)
 void CJsonWriter::MaybeComma()
 {
 	if (m_needs_comma) {
-		*m_buf += wxT(",");
+		*m_buf += ",";
 	}
 }
 
 void CJsonWriter::BeginObject()
 {
 	MaybeComma();
-	*m_buf += wxT("{");
+	*m_buf += "{";
 	m_needs_comma = false;
 }
 
 void CJsonWriter::EndObject()
 {
-	*m_buf += wxT("}");
+	*m_buf += "}";
 	m_needs_comma = true;
 }
 
 void CJsonWriter::BeginArray()
 {
 	MaybeComma();
-	*m_buf += wxT("[");
+	*m_buf += "[";
 	m_needs_comma = false;
 }
 
 void CJsonWriter::EndArray()
 {
-	*m_buf += wxT("]");
+	*m_buf += "]";
 	m_needs_comma = true;
 }
 
@@ -82,21 +82,21 @@ void CJsonWriter::Key(const wxString &name)
 {
 	MaybeComma();
 	WriteEscapedString(name);
-	*m_buf += wxT(":");
+	*m_buf += ":";
 	m_needs_comma = false;
 }
 
 void CJsonWriter::ValueNull()
 {
 	MaybeComma();
-	*m_buf += wxT("null");
+	*m_buf += "null";
 	m_needs_comma = true;
 }
 
 void CJsonWriter::ValueBool(bool v)
 {
 	MaybeComma();
-	*m_buf += v ? wxT("true") : wxT("false");
+	*m_buf += v ? "true" : "false";
 	m_needs_comma = true;
 }
 
@@ -105,7 +105,7 @@ void CJsonWriter::ValueInt(int64_t v)
 	MaybeComma();
 	char buf[32];
 	std::snprintf(buf, sizeof(buf), "%lld", static_cast<long long>(v));
-	*m_buf += wxString::FromAscii(buf);
+	*m_buf += buf;
 	m_needs_comma = true;
 }
 
@@ -114,7 +114,7 @@ void CJsonWriter::ValueUInt(uint64_t v)
 	MaybeComma();
 	char buf[32];
 	std::snprintf(buf, sizeof(buf), "%llu", static_cast<unsigned long long>(v));
-	*m_buf += wxString::FromAscii(buf);
+	*m_buf += buf;
 	m_needs_comma = true;
 }
 
@@ -146,7 +146,7 @@ std::string JsonDoubleToString(double v)
 void CJsonWriter::ValueDouble(double v)
 {
 	MaybeComma();
-	*m_buf += wxString::FromAscii(JsonDoubleToString(v).c_str());
+	*m_buf += JsonDoubleToString(v);
 	m_needs_comma = true;
 }
 
@@ -162,16 +162,30 @@ void CJsonWriter::ValueString(const char *s)
 	ValueString(s ? wxString::FromUTF8(s) : wxString());
 }
 
-void CJsonWriter::ValueRaw(const wxString &json_fragment)
+void CJsonWriter::ValueRaw(const std::string &json_fragment)
 {
 	MaybeComma();
 	*m_buf += json_fragment;
 	m_needs_comma = true;
 }
 
+void CJsonWriter::AppendUtf8(std::uint32_t cp)
+{
+	if (cp < 0x80) {
+		*m_buf += static_cast<char>(cp);
+	} else if (cp < 0x800) {
+		*m_buf += static_cast<char>(0xC0 | (cp >> 6));
+		*m_buf += static_cast<char>(0x80 | (cp & 0x3F));
+	} else {
+		*m_buf += static_cast<char>(0xE0 | (cp >> 12));
+		*m_buf += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+		*m_buf += static_cast<char>(0x80 | (cp & 0x3F));
+	}
+}
+
 void CJsonWriter::WriteEscapedString(const wxString &s)
 {
-	*m_buf += wxT("\"");
+	*m_buf += "\"";
 	for (wxString::const_iterator i = s.begin(); i != s.end(); ++i) {
 		wxUniChar uc = *i;
 		uint32_t cp = uc.GetValue();
@@ -194,8 +208,7 @@ void CJsonWriter::WriteEscapedString(const wxString &s)
 			}
 			if (!paired) {
 				// Unpaired high surrogate. Falling through would
-				// emit invalid UTF-8 (CESU-8) once the buffer is
-				// utf8_str()-flushed. Replace with U+FFFD so the
+				// emit invalid UTF-8 (CESU-8). Replace with U+FFFD so the
 				// JSON output stays valid Unicode. Same treatment
 				// for an unpaired low surrogate below.
 				cp = 0xFFFD;
@@ -205,25 +218,25 @@ void CJsonWriter::WriteEscapedString(const wxString &s)
 		}
 		switch (cp) {
 		case '"':
-			*m_buf += wxT("\\\"");
+			*m_buf += "\\\"";
 			continue;
 		case '\\':
-			*m_buf += wxT("\\\\");
+			*m_buf += "\\\\";
 			continue;
 		case '\b':
-			*m_buf += wxT("\\b");
+			*m_buf += "\\b";
 			continue;
 		case '\f':
-			*m_buf += wxT("\\f");
+			*m_buf += "\\f";
 			continue;
 		case '\n':
-			*m_buf += wxT("\\n");
+			*m_buf += "\\n";
 			continue;
 		case '\r':
-			*m_buf += wxT("\\r");
+			*m_buf += "\\r";
 			continue;
 		case '\t':
-			*m_buf += wxT("\\t");
+			*m_buf += "\\t";
 			continue;
 		default:
 			break;
@@ -232,12 +245,10 @@ void CJsonWriter::WriteEscapedString(const wxString &s)
 			// Control characters: \uXXXX form.
 			char buf[8];
 			std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned>(cp));
-			*m_buf += wxString::FromAscii(buf);
+			*m_buf += buf;
 		} else if (cp <= 0xFFFF) {
-			// BMP non-control: emit verbatim. Non-ASCII bytes ride
-			// through as the wxString native encoding and are
-			// converted to UTF-8 by the response serializer.
-			*m_buf += uc;
+			// BMP non-control: no escape needed, emit as UTF-8.
+			AppendUtf8(cp);
 		} else {
 			// Supplementary plane: emit as UTF-16 surrogate pair.
 			// This is the only escape form JSON allows above U+FFFF.
@@ -250,8 +261,8 @@ void CJsonWriter::WriteEscapedString(const wxString &s)
 				"\\u%04x\\u%04x",
 				static_cast<unsigned>(hi),
 				static_cast<unsigned>(lo));
-			*m_buf += wxString::FromAscii(buf);
+			*m_buf += buf;
 		}
 	}
-	*m_buf += wxT("\"");
+	*m_buf += "\"";
 }

--- a/src/libwebcommon/JsonWriter.h
+++ b/src/libwebcommon/JsonWriter.h
@@ -29,9 +29,11 @@
 #include <cstdint>
 #include <string>
 
-// Streaming JSON output. Appends to an internal or caller-owned wxString
-// buffer; the buffer holds JSON text suitable for UTF-8 emission via
-// wxString::utf8_str() at flush time.
+// Streaming JSON output. Appends UTF-8 bytes to an internal or caller-owned
+// std::string, ready to be a response body with no conversion. Inputs stay
+// wxString -- that is what callers hold -- and are encoded on append. Do not
+// put the buffer back to wxString: it is UTF-32 here (wxUSE_UNICODE_WCHAR),
+// which held an ASCII body at four bytes a character.
 //
 // Usage:
 //  CJsonWriter w;
@@ -39,7 +41,7 @@
 //    w.Key("name"); w.ValueString("aMule");
 //    w.Key("version"); w.ValueString("2.3.3");
 //  w.EndObject();
-//  const wxString &out = w.GetBuffer();
+//  const std::string &out = w.GetBuffer();
 //
 // Commas between siblings are inserted automatically. Calling Key()
 // outside an object, or omitting it inside one, is a programmer error
@@ -62,7 +64,7 @@ class CJsonWriter
 {
 public:
 	CJsonWriter();
-	explicit CJsonWriter(wxString *external_buf);
+	explicit CJsonWriter(std::string *external_buf);
 
 	void BeginObject();
 	void EndObject();
@@ -81,21 +83,30 @@ public:
 	void ValueString(const wxString &s);
 	void ValueString(const char *s);
 	// Pre-formatted JSON fragment, written verbatim. Caller responsible
-	// for valid syntax. Useful when the writer is composing a response
-	// from a sub-component that already produced JSON text.
-	void ValueRaw(const wxString &json_fragment);
+	// for valid syntax and for it being UTF-8. Useful when the writer is
+	// composing a response from a sub-component that already produced JSON
+	// text.
+	void ValueRaw(const std::string &json_fragment);
 
-	const wxString &GetBuffer() const { return *m_buf; }
+	const std::string &GetBuffer() const { return *m_buf; }
+
+	// Move the accumulated text out, leaving the writer empty. Saves copying a
+	// multi-megabyte body at the end of a response. Copies instead when the
+	// buffer belongs to the caller -- emptying someone else's is not ours to do.
+	std::string TakeBuffer() { return m_buf == &m_internal ? std::move(m_internal) : *m_buf; }
 
 private:
-	wxString m_internal;
-	wxString *m_buf;
+	std::string m_internal;
+	std::string *m_buf;
 	// True when the next value/key/closer must be preceded by a comma.
 	// Reset by BeginObject/BeginArray/Key.
 	bool m_needs_comma;
 
 	void MaybeComma();
 	void WriteEscapedString(const wxString &s);
+	// Append one code point as UTF-8. BMP scalars only -- control characters
+	// and supplementary planes take escape forms, surrogates become U+FFFD.
+	void AppendUtf8(std::uint32_t cp);
 };
 
 #endif // LIBWEBCOMMON_JSONWRITER_H

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -112,6 +112,19 @@ void SplitPathAndQuery(const std::string &target, std::string &path, std::string
 	}
 }
 
+// Serialise the writer's buffer into the response body. Every JSON response in
+// this file goes through here -- open-coding it is how nine handlers came to
+// hold a stale copy of the conversion.
+void FinalizeJsonBody(CJsonWriter &w, CHttpServer::Response &r)
+{
+	// The writer already holds UTF-8, so this is a move, not a convert+copy.
+	// Never route it through wxString: amuleapi calls neither setlocale nor
+	// wxLocale, so it runs in the "C" locale whatever LANG says, and
+	// wxString's std::string ctor decodes with the locale -- turning a body
+	// with any non-ASCII byte into an empty one.
+	r.body = w.TakeBuffer();
+}
+
 CHttpServer::Response ErrorResponse(unsigned status, const char *code, const char *message)
 {
 	CHttpServer::Response r;
@@ -127,9 +140,7 @@ CHttpServer::Response ErrorResponse(unsigned status, const char *code, const cha
 	w.ValueString(wxString::FromAscii(message));
 	w.EndObject();
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -1735,9 +1746,7 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 		w.EndObject();
 	}
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -1822,9 +1831,7 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 	w.BeginObject();
 	BeginSession(req, role, r, w);
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -1971,9 +1978,7 @@ CHttpServer::Response CApiDispatcher::HandleLogout(const CHttpServer::Request &r
 	w.Key("ok");
 	w.ValueBool(true);
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -2008,9 +2013,7 @@ CHttpServer::Response CApiDispatcher::HandleSession(const CHttpServer::Request &
 	w.Key("exp_unix");
 	w.ValueInt(static_cast<int64_t>(a.verified.exp));
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -2036,9 +2039,7 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswords(const CHttpServer::Req
 	w.Key("guest_enabled");
 	w.ValueBool(!m_config.GuestCredential().empty());
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -2186,9 +2187,7 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 	w.ValueBool(true);
 	BeginSession(req, Role::ADMIN, r, w);
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -2339,25 +2338,12 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	// Nickname is a /preferences field, not a /status one.
 	w.EndObject();
 
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
 namespace
 {
-
-// Compact helper — every read endpoint serialises its body the same
-// way (build a wxString via CJsonWriter, then utf8_str into the
-// response body). Hide the boilerplate behind a helper that takes a
-// ready CJsonWriter.
-void FinalizeJsonBody(CJsonWriter &w, CHttpServer::Response &r)
-{
-	const wxString &js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
-}
 
 // Write a single download object. Used both inline (in the list
 // endpoint, iterated) and as the body of the detail endpoint (bare,
@@ -4253,9 +4239,7 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	w.Key("status");
 	w.ValueString("started");
 	w.EndObject();
-	const wxString js = w.GetBuffer();
-	const wxScopedCharBuffer ub = js.utf8_str();
-	r.body.assign(ub.data(), ub.length());
+	FinalizeJsonBody(w, r);
 	return r;
 }
 
@@ -4984,9 +4968,9 @@ void WriteServerObject(CJsonWriter &w, const webapi::ServerSnapshot &s)
 	// tables so this object and the SSE payload in EventDiff.cpp -- two
 	// different writers, one documented shape -- cannot drift apart.
 	w.Key("tcp_flags");
-	w.ValueRaw(wxString::FromAscii(webapi::ServerTcpFlagsJson(s.tcp_flags).c_str()));
+	w.ValueRaw(webapi::ServerTcpFlagsJson(s.tcp_flags));
 	w.Key("udp_flags");
-	w.ValueRaw(wxString::FromAscii(webapi::ServerUdpFlagsJson(s.udp_flags).c_str()));
+	w.ValueRaw(webapi::ServerUdpFlagsJson(s.udp_flags));
 	w.EndObject();
 }
 

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -767,9 +767,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 					w.ValueInt(static_cast<int64_t>(sid));
 					WriteSearchResultFields(w, kv.second);
 					w.EndObject();
-					const wxScopedCharBuffer utf8 = w.GetBuffer().utf8_str();
-					bus.Publish("search_result_added",
-						std::string(utf8.data(), utf8.length()));
+					bus.Publish("search_result_added", w.TakeBuffer());
 				}
 			}
 			// search_progress: a percent change while running, the

--- a/unittests/tests/JsonWriterTest.cpp
+++ b/unittests/tests/JsonWriterTest.cpp
@@ -38,7 +38,7 @@ TEST(JsonWriter, EmptyObject)
 	CJsonWriter w;
 	w.BeginObject();
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, EmptyArray)
@@ -46,7 +46,7 @@ TEST(JsonWriter, EmptyArray)
 	CJsonWriter w;
 	w.BeginArray();
 	w.EndArray();
-	ASSERT_EQUALS(wxString("[]"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("[]"), w.GetBuffer());
 }
 
 TEST(JsonWriter, ObjectWithStringValue)
@@ -56,7 +56,7 @@ TEST(JsonWriter, ObjectWithStringValue)
 	w.Key("app");
 	w.ValueString("aMule");
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"app\":\"aMule\"}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{\"app\":\"aMule\"}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, ObjectWithMultipleKeys)
@@ -70,7 +70,8 @@ TEST(JsonWriter, ObjectWithMultipleKeys)
 	w.Key("api");
 	w.ValueString("v0.1");
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"app\":\"aMule\",\"version\":\"2.3.3\",\"api\":\"v0.1\"}"), w.GetBuffer());
+	ASSERT_EQUALS(
+		std::string("{\"app\":\"aMule\",\"version\":\"2.3.3\",\"api\":\"v0.1\"}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, Primitives)
@@ -88,7 +89,7 @@ TEST(JsonWriter, Primitives)
 	w.Key("u");
 	w.ValueUInt(uint64_t(42));
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"n\":null,\"t\":true,\"f\":false,\"i\":-42,\"u\":42}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{\"n\":null,\"t\":true,\"f\":false,\"i\":-42,\"u\":42}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, IntegerBoundaries)
@@ -99,8 +100,8 @@ TEST(JsonWriter, IntegerBoundaries)
 	w.ValueInt(std::numeric_limits<int64_t>::max());
 	w.ValueUInt(std::numeric_limits<uint64_t>::max());
 	w.EndArray();
-	ASSERT_EQUALS(
-		wxString("[-9223372036854775808,9223372036854775807,18446744073709551615]"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("[-9223372036854775808,9223372036854775807,18446744073709551615]"),
+		w.GetBuffer());
 }
 
 TEST(JsonWriter, DoubleSpecials)
@@ -112,7 +113,7 @@ TEST(JsonWriter, DoubleSpecials)
 	w.ValueDouble(std::numeric_limits<double>::infinity());
 	w.ValueDouble(-std::numeric_limits<double>::infinity());
 	w.EndArray();
-	ASSERT_EQUALS(wxString("[null,null,null]"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("[null,null,null]"), w.GetBuffer());
 }
 
 TEST(JsonWriter, NestedObject)
@@ -125,7 +126,7 @@ TEST(JsonWriter, NestedObject)
 	w.ValueString("v");
 	w.EndObject();
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"outer\":{\"inner\":\"v\"}}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{\"outer\":{\"inner\":\"v\"}}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, ArrayOfObjects)
@@ -144,21 +145,21 @@ TEST(JsonWriter, ArrayOfObjects)
 	w.EndObject();
 	w.EndArray();
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"items\":[{\"k\":1},{\"k\":2}]}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{\"items\":[{\"k\":1},{\"k\":2}]}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, EscapesQuoteAndBackslash)
 {
 	CJsonWriter w;
 	w.ValueString(wxString::FromUTF8("a\"b\\c"));
-	ASSERT_EQUALS(wxString("\"a\\\"b\\\\c\""), w.GetBuffer());
+	ASSERT_EQUALS(std::string("\"a\\\"b\\\\c\""), w.GetBuffer());
 }
 
 TEST(JsonWriter, EscapesShortControlChars)
 {
 	CJsonWriter w;
 	w.ValueString(wxString::FromUTF8("\b\f\n\r\t"));
-	ASSERT_EQUALS(wxString("\"\\b\\f\\n\\r\\t\""), w.GetBuffer());
+	ASSERT_EQUALS(std::string("\"\\b\\f\\n\\r\\t\""), w.GetBuffer());
 }
 
 TEST(JsonWriter, EscapesGenericControlChars)
@@ -172,7 +173,7 @@ TEST(JsonWriter, EscapesGenericControlChars)
 	w.ValueString(wxString(wxUniChar(uint32_t(0x1F))));
 	w.ValueString(wxString(wxUniChar(uint32_t(0x7F))));
 	w.EndArray();
-	ASSERT_EQUALS(wxString("[\"\\u0000\",\"\\u0001\",\"\\u001f\",\"\\u007f\"]"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("[\"\\u0000\",\"\\u0001\",\"\\u001f\",\"\\u007f\"]"), w.GetBuffer());
 }
 
 TEST(JsonWriter, SupplementaryPlaneAsSurrogatePair)
@@ -181,24 +182,20 @@ TEST(JsonWriter, SupplementaryPlaneAsSurrogatePair)
 	// emitted as the UTF-16 surrogate pair 😀.
 	CJsonWriter w;
 	w.ValueString(wxString(wxUniChar(uint32_t(0x1F600))));
-	ASSERT_EQUALS(wxString("\"\\ud83d\\ude00\""), w.GetBuffer());
+	ASSERT_EQUALS(std::string("\"\\ud83d\\ude00\""), w.GetBuffer());
 }
 
-TEST(JsonWriter, BmpNonAsciiEmittedVerbatim)
+TEST(JsonWriter, BmpNonAsciiEmittedAsUtf8)
 {
-	// Non-control codepoints in the BMP are passed through as wxString
-	// content. The serializer encodes the whole buffer as UTF-8 at
-	// flush time; here we just verify the round trip is invariant.
-	const wxString input =
-		wxString::FromUTF8("\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82"); // "привет"
+	// Non-control BMP codepoints need no JSON escape and are emitted as the
+	// UTF-8 the buffer holds -- byte for byte what went in, since the input
+	// was built from the same UTF-8.
+	const char cyrillic[] = "\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82"; // "привет"
 	CJsonWriter w;
-	w.ValueString(input);
-	// The wxString contains exactly: " <6 cyrillic chars> "
-	wxString expected;
-	expected += wxT("\"");
-	expected += input;
-	expected += wxT("\"");
-	ASSERT_EQUALS(expected, w.GetBuffer());
+	w.ValueString(wxString::FromUTF8(cyrillic));
+	ASSERT_EQUALS(std::string("\"") + cyrillic + "\"", w.GetBuffer());
+	// Two bytes per character here, not one wide unit: the buffer is UTF-8.
+	ASSERT_EQUALS(static_cast<size_t>(14), w.GetBuffer().size());
 }
 
 TEST(JsonWriter, KeyEscaping)
@@ -210,7 +207,7 @@ TEST(JsonWriter, KeyEscaping)
 	w.Key(wxString::FromUTF8("a\"b"));
 	w.ValueInt(1);
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"a\\\"b\":1}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{\"a\\\"b\":1}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, ValueRawFragment)
@@ -221,19 +218,19 @@ TEST(JsonWriter, ValueRawFragment)
 	CJsonWriter w;
 	w.BeginObject();
 	w.Key("pre");
-	w.ValueRaw(wxT("[1,2,3]"));
+	w.ValueRaw("[1,2,3]");
 	w.Key("post");
 	w.ValueInt(4);
 	w.EndObject();
-	ASSERT_EQUALS(wxString("{\"pre\":[1,2,3],\"post\":4}"), w.GetBuffer());
+	ASSERT_EQUALS(std::string("{\"pre\":[1,2,3],\"post\":4}"), w.GetBuffer());
 }
 
 TEST(JsonWriter, ExternalBuffer)
 {
 	// The writer can append into a caller-owned buffer instead of its
 	// own. Used when composing a response from multiple writers.
-	wxString shared;
-	shared += wxT("prefix:");
+	std::string shared;
+	shared += "prefix:";
 	{
 		CJsonWriter w(&shared);
 		w.BeginObject();
@@ -241,7 +238,7 @@ TEST(JsonWriter, ExternalBuffer)
 		w.ValueInt(1);
 		w.EndObject();
 	}
-	ASSERT_EQUALS(wxString("prefix:{\"x\":1}"), shared);
+	ASSERT_EQUALS(std::string("prefix:{\"x\":1}"), shared);
 }
 
 TEST(JsonWriter, LargeString)


### PR DESCRIPTION
CJsonWriter appended into a wxString, which on this platform is wxUSE_UNICODE_WCHAR with sizeof(wxChar) == 4. JSON is ASCII apart from the occasional filename character, so a response body was being held at four bytes per character, grown geometrically at that width, and then converted and copied twice more on the way out:

    const wxString &js = w.GetBuffer();
    const wxScopedCharBuffer ub = js.utf8_str();   // convert + allocate
    r.body.assign(ub.data(), ub.length());         // copy again

For GET /shared on an 11 906-file library that is a 6.4 MB body held as ~25.6 MB, plus the reallocation that got it there, plus 12.8 MB of copies. The whole request peaked at ~63 MB of transients to emit 6.4 MB of output, and 16 concurrent ones took the process to a 1.1 GB high-water mark. Measured after: 591 MB, and the median request went 2.1 s -> 1.5 s.

The buffer is a std::string of UTF-8 now. Inputs stay wxString -- that is what the callers hold -- and are encoded as they are appended: ASCII and the escape forms are already bytes, and BMP scalars go through AppendUtf8(). The escape logic is unchanged and still walks the input by code point, so surrogate pairing and the \uXXXX forms behave exactly as before.

FinalizeJsonBody becomes a move, and becomes the only place that touches the buffer on the way out. Nine handlers -- ErrorResponse, version, login, logout, session, auth/passwords (x2), status, version_check -- open-coded the same three lines rather than calling it, which is why they could not simply be left alone: with a std::string buffer, `wxString js = w.GetBuffer()` decodes rather than copies, and amuleapi calls neither setlocale nor wxLocale, so it runs in the "C" locale whatever LANG says. In "C", wxString's std::string ctor rejects non-ASCII input and yields an empty string -- not a mangled field, an empty response body with a 200 and a Content-Length of 0. /status emits the ed2k server name, which is arbitrary UTF-8. They call FinalizeJsonBody now, and its comment says why that route is closed.

The two ValueRaw call sites stop converting a std::string to a wxString for a parameter that is a std::string again, and the SSE search_result_added payload stops round-tripping through wxScopedCharBuffer.

TakeBuffer() copies rather than moves when the buffer belongs to the caller; emptying someone else's is not this class's to do.

JsonWriterTest passes (21 cases). Its non-ASCII case asserted that the buffer held the input verbatim, which was a statement about wxString internals; it now asserts the UTF-8 bytes and their count. The nine endpoints above were diffed against an unmodified daemon and are byte-identical.