### PR TITLE
perf(amuleapi): read the file map in place instead of copying it out

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3459,16 +3459,6 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 		}
 	}
 
-	std::vector<webapi::FileSnapshot> downloads = m_state.Downloads();
-	if (!include_completed) {
-		downloads.erase(std::remove_if(downloads.begin(),
-					downloads.end(),
-					[](const webapi::FileSnapshot &d) {
-						return d.download.status == "completed";
-					}),
-			downloads.end());
-	}
-
 	ListParams params;
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
@@ -3494,18 +3484,34 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 				return a.download.status < b.download.status;
 			} },
 	};
-	return ListResponse(
-		m_state,
-		"downloads",
-		downloads,
-		[](CJsonWriter &w, const webapi::FileSnapshot &d) {
-			// List mode — omit `progress.parts` (Q2 + the per-list
-			// shape: omitting parts keeps the list response compact,
-			// detail endpoint is where parts ship).
-			WriteDownloadObject(w, d, /*include_parts=*/false);
-		},
-		params,
-		kComps);
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+	// Pointers into the live map rather than copies; see HandleSharedList.
+	CHttpServer::Response resp;
+	m_state.WithFiles([&](const webapi::FileMap &files) {
+		std::vector<const webapi::FileSnapshot *> ptrs;
+		ptrs.reserve(files.size());
+		for (const auto &entry : files) {
+			const webapi::FileSnapshot &d = entry.second;
+			if (!d.is_downloading)
+				continue;
+			if (!include_completed && d.download.status == "completed")
+				continue;
+			ptrs.push_back(&d);
+		}
+		resp = ListResponseFromPtrsUnlocked(
+			"downloads",
+			ptrs,
+			[](CJsonWriter &w, const webapi::FileSnapshot &d) {
+				// List mode — omit `progress.parts` (Q2 + the per-list
+				// shape: omitting parts keeps the list response compact,
+				// detail endpoint is where parts ship).
+				WriteDownloadObject(w, d, /*include_parts=*/false);
+			},
+			params,
+			kComps);
+	});
+	return resp;
 }
 
 namespace
@@ -3760,7 +3766,24 @@ CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Reques
 				return a.size < b.size;
 			} },
 	};
-	return ListResponse(m_state, "shared", m_state.Shared(), WriteSharedObject, params, kComps);
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+	// Pointers into the live map rather than copies -- this was the single
+	// biggest allocation the daemon made per request. Serialising inside the
+	// read lock is safe because WriteSharedObject reads only the snapshot it is
+	// handed, so ListResponseFromPtrsUnlocked's "must not re-enter CState"
+	// contract holds.
+	CHttpServer::Response resp;
+	m_state.WithFiles([&](const webapi::FileMap &files) {
+		std::vector<const webapi::FileSnapshot *> ptrs;
+		ptrs.reserve(files.size());
+		for (const auto &entry : files) {
+			if (entry.second.is_shared)
+				ptrs.push_back(&entry.second);
+		}
+		resp = ListResponseFromPtrsUnlocked("shared", ptrs, WriteSharedObject, params, kComps);
+	});
+	return resp;
 }
 
 CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
@@ -4852,12 +4875,15 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 		ecids.push_back(d.ecid);
 		hashes_cleared.push_back(d.hash);
 	} else {
-		for (const auto &d : m_state.Downloads()) {
-			if (d.download.status == "completed") {
-				ecids.push_back(d.ecid);
-				hashes_cleared.push_back(d.hash);
+		m_state.WithFiles([&](const webapi::FileMap &files) {
+			for (const auto &entry : files) {
+				const webapi::FileSnapshot &d = entry.second;
+				if (d.is_downloading && d.download.status == "completed") {
+					ecids.push_back(d.ecid);
+					hashes_cleared.push_back(d.hash);
+				}
 			}
-		}
+		});
 	}
 
 	if (ecids.empty()) {

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -180,10 +180,13 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		// REQUEST_FILE into MD4 hashes at walker time (the wire
 		// contract is hash-only — ECIDs never leak out).
 		std::map<std::uint32_t, std::string> file_hash_by_ecid;
-		for (const auto &f : state.Files()) {
-			if (!f.hash.empty())
-				file_hash_by_ecid.emplace(f.ecid, f.hash);
-		}
+		state.WithFiles([&file_hash_by_ecid](const FileMap &files) {
+			for (const auto &entry : files) {
+				const FileSnapshot &f = entry.second;
+				if (!f.hash.empty())
+					file_hash_by_ecid.emplace(f.ecid, f.hash);
+			}
+		});
 		state.MutateClients([&](std::map<std::uint32_t, ClientSnapshot> &cache) {
 			ApplyGetUpdateToClients(resp, cache, file_hash_by_ecid);
 		});

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -488,30 +488,6 @@ void CState::MutateChats(const std::function<void(std::vector<ChatSessionSnapsho
 	fn(m_chats, m_chat_cursor);
 }
 
-std::vector<FileSnapshot> CState::Downloads() const
-{
-	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	std::vector<FileSnapshot> out;
-	out.reserve(m_files.size());
-	for (const auto &kv : m_files) {
-		if (kv.second.is_downloading)
-			out.push_back(kv.second);
-	}
-	return out;
-}
-
-std::vector<FileSnapshot> CState::Shared() const
-{
-	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	std::vector<FileSnapshot> out;
-	out.reserve(m_files.size());
-	for (const auto &kv : m_files) {
-		if (kv.second.is_shared)
-			out.push_back(kv.second);
-	}
-	return out;
-}
-
 std::vector<FileSnapshot> CState::Files() const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1460,11 +1460,18 @@ public:
 	// that want a specific order sort on their side (by name / date /
 	// progress / etc.).
 	//
-	// `Downloads()` filters `m_files` by `is_downloading`, `Shared()`
-	// filters by `is_shared`. Both views consult the same underlying
-	// unified map — see FileSnapshot above for the role-flag model.
-	std::vector<FileSnapshot> Downloads() const;
-	std::vector<FileSnapshot> Shared() const;
+	// The role-filtered views are gone: no reader wanted whole snapshots copied
+	// out. Filter `m_files` on the role flag inside WithFiles() instead.
+	//! Read the unified file map in place, under the shared lock. Same contract
+	//! as WithKnownClients: the callback must not call back into CState, nor
+	//! retain the reference. For readers wanting a few fields per file, or
+	//! pointers to sort and page -- a FileSnapshot is 848 bytes plus a heap
+	//! allocation per string, so copying the collection out is never cheap.
+	template <class F> void WithFiles(F &&fn) const
+	{
+		std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+		fn(static_cast<const FileMap &>(m_files));
+	}
 	// Unfiltered view used by EventDiff to compute role-flag
 	// transitions. Not surfaced on the REST API.
 	std::vector<FileSnapshot> Files() const;

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -37,6 +37,33 @@
 using namespace muleunit;
 using namespace webapi;
 
+namespace
+{
+// Stand-ins for the role-filtered accessors CState no longer exposes; the
+// assertions below just want a countable, indexable list.
+std::vector<FileSnapshot> RoleView(const CState &s, bool FileSnapshot::*role)
+{
+	std::vector<FileSnapshot> out;
+	s.WithFiles([&](const FileMap &files) {
+		for (const auto &entry : files) {
+			if (entry.second.*role)
+				out.push_back(entry.second);
+		}
+	});
+	return out;
+}
+
+std::vector<FileSnapshot> Downloads(const CState &s)
+{
+	return RoleView(s, &FileSnapshot::is_downloading);
+}
+
+std::vector<FileSnapshot> Shared(const CState &s)
+{
+	return RoleView(s, &FileSnapshot::is_shared);
+}
+} // namespace
+
 DECLARE_SIMPLE(State)
 
 TEST(State, FreshHasNoSnapshot)
@@ -149,7 +176,7 @@ TEST(State, MutateDownloadsRoundtripAndFind)
 	// Both entries should be present in the vector view. Order is
 	// unordered_map-bucket-defined (FileMap drops std::map's ECID
 	// ordering), so look entries up by ECID instead of position.
-	const auto out = s.Downloads();
+	const auto out = Downloads(s);
 	ASSERT_EQUALS(static_cast<size_t>(2), out.size());
 	std::string foo_name, bar_name;
 	for (const auto &f : out) {
@@ -197,7 +224,7 @@ TEST(State, MutateDownloadsDecodedRleFieldsRoundtrip)
 		cache.emplace(a.ecid, a);
 	});
 
-	const auto out = s.Downloads();
+	const auto out = Downloads(s);
 	ASSERT_EQUALS(static_cast<size_t>(1), out.size());
 	ASSERT_EQUALS(static_cast<size_t>(4), out[0].download.decoded_gaps.size());
 	ASSERT_EQUALS(static_cast<std::uint64_t>(100), out[0].download.decoded_gaps[0]);
@@ -332,8 +359,8 @@ TEST(State, MutateClientsAndSharedRoundtrip)
 		x.shared.priority = "normal";
 		cache.emplace(x.ecid, x);
 	});
-	ASSERT_EQUALS(static_cast<size_t>(1), s.Shared().size());
-	ASSERT_EQUALS(std::string("shared.iso"), s.Shared()[0].name);
+	ASSERT_EQUALS(static_cast<size_t>(1), Shared(s).size());
+	ASSERT_EQUALS(std::string("shared.iso"), Shared(s)[0].name);
 }
 
 TEST(State, WriteKadAndPreferencesRoundtrip)
@@ -869,14 +896,14 @@ TEST(State, ResetListsClearsAll)
 			it->second.is_shared = true;
 		}
 	});
-	ASSERT_EQUALS(static_cast<size_t>(1), s.Downloads().size());
+	ASSERT_EQUALS(static_cast<size_t>(1), Downloads(s).size());
 	ASSERT_EQUALS(static_cast<size_t>(1), s.Clients().size());
-	ASSERT_EQUALS(static_cast<size_t>(1), s.Shared().size());
+	ASSERT_EQUALS(static_cast<size_t>(1), Shared(s).size());
 
 	s.ResetLists();
-	ASSERT_EQUALS(static_cast<size_t>(0), s.Downloads().size());
+	ASSERT_EQUALS(static_cast<size_t>(0), Downloads(s).size());
 	ASSERT_EQUALS(static_cast<size_t>(0), s.Clients().size());
-	ASSERT_EQUALS(static_cast<size_t>(0), s.Shared().size());
+	ASSERT_EQUALS(static_cast<size_t>(0), Shared(s).size());
 }
 
 TEST(State, ConcurrentReadersDontTearSnapshot)


### PR DESCRIPTION
CState exposed its file collections by value: Downloads() and Shared() each built a std::vector<FileSnapshot> under the read lock and returned it. A FileSnapshot is 848 bytes plus a heap allocation for each of a dozen strings and vectors, so on an 11 906-file library every caller paid ~18 MB and tens of thousands of mallocs for a copy it did not need.

Two callers, both hot:

The refresher's clients walker needs an ecid->hash map so it can resolve EC_TAG_CLIENT_UPLOAD_FILE / REQUEST_FILE into the hashes the wire contract exposes. It built that by iterating Files() -- a full deep copy, every tick, on the thread that is already the bulk of the daemon's CPU, to read two fields per record.

GET /shared copied every shared snapshot before serialising anything. The copy bought nothing: BuildListWindow already sorts and pages `std::vector<const T *>`, ListResponseFromPtrsUnlocked already exists for callers that address their rows as pointers, and /known_clients already uses it for exactly this reason. /shared and /downloads now do the same, filtering the live map on the role flag into a pointer vector under the read lock and writing the response there. The clear-completed sweep in HandleDownloadsClear was copying the same list to read two fields per row; it filters in place too.

Measured on an 11 906-file library, GET /shared?limit=1 -- which pays the copy in full, since the accessor ran before `limit` was looked at:

  before   VmRSS 98.7 MB -> 116.3 MB   (+17.7 MB), VmHWM unmoved
  after    VmRSS 133.4 MB -> 133.4 MB  (+0.1 MB),  VmHWM unmoved

What this does not do is lower the peak of a full response, and the same runs say so: 195 MB VmHWM either way. The copy landed in pages the process had already mapped, so it never set the high-water mark -- it inflated steady-state RSS and burned allocator time. The peak of a full /shared is ~63 MB for a 6.4 MB body and lives in CJsonWriter's buffer, which is its own change.

Holding the read lock across serialisation rather than only across the copy is a longer critical section for the refresher's exclusive tick to wait on. No tick exceeded its 3 s budget under 16 concurrent full requests, and p50 of those requests improved (2.29 s -> 1.98 s). It is safe because the writers are pure: WriteSharedObject and WriteDownloadObject read only the snapshot handed to them, so the "must not re-enter CState" contract on ListResponseFromPtrsUnlocked holds.

Downloads() and Shared() go with their last callers. They were the footgun this fixes -- a convenient by-value view of a collection that is only small on a small node -- so they should not stay behind for the next reader to reach for. The tests that wanted an indexable list build one locally. Files() stays: EventDiff is its only caller and needs its own change.

/clients keeps its by-value accessor deliberately: it is bounded by MaxConnections, so a few hundred rows, and converting it needs the derived part_progress_percent (which re-enters CState) restructured first.