### PR TITLE
test(amuleapi): stop the curl smokes failing on setup rather than on the daemon

### DIFF
--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -45,7 +45,29 @@ GUEST_PASS=${GUEST_PASS:-guestpass}
 EC_HOST=${EC_HOST:-127.0.0.1}
 EC_PORT=${EC_PORT:-4712}
 EC_PASSWORD=${EC_PASSWORD:-amule}
-AMULEAPI_BIN=${AMULEAPI_BIN:-$(cd "$(dirname "$0")/../../.." && pwd)/build-macos/src/webapi/amuleapi}
+# Locate the amuleapi binary the sub-instances need. Deliberately NOT falling
+# back to PATH: an installed package would silently be tested in place of the
+# working tree, which is worse than not finding anything. Set AMULEAPI_BIN to
+# point somewhere else on purpose.
+_find_amuleapi_bin() {
+	local root=$1 c
+	for c in . build build-macos build-linux _build cmake-build-debug cmake-build-release; do
+		if [ -x "$root/$c/src/webapi/amuleapi" ]; then
+			echo "$root/$c/src/webapi/amuleapi"
+			return 0
+		fi
+	done
+	return 1
+}
+
+AMULEAPI_BIN=${AMULEAPI_BIN:-$(_find_amuleapi_bin "$(cd "$(dirname "$0")/../../.." && pwd)")}
+# Three sections below drive a SECOND amuleapi against the same amuled. Without
+# a binary to start one, skip them rather than fail on the daemon's behalf.
+if [ -x "${AMULEAPI_BIN:-/nonexistent}" ]; then
+	HAVE_SECOND_INSTANCE=1
+else
+	HAVE_SECOND_INSTANCE=0
+fi
 
 # A query likely to return results on any operator's daemon connected
 # to ed2k. "ubuntu" is a safe choice — well-seeded across the network.
@@ -244,6 +266,9 @@ if [ "$HAVE_GUEST" = "1" ]; then
 	_assert_status 200 "GET /search (guest) → 200 (GUEST-readable)"
 fi
 
+if [ "$HAVE_SECOND_INSTANCE" -eq 0 ]; then
+	echo "  SKIP  3.2 cross-session discovery (no amuleapi binary; set AMULEAPI_BIN)"
+else
 # --- 3.2 Cross-session discovery: a second amuleapi instance against the
 # same amuled sees $FIRST_SID even though it never called POST /search
 # itself (got3nks, PR #680 review point 6 — no amulecmd needed, two
@@ -312,6 +337,7 @@ fi
 kill "$SECOND_PID" >/dev/null 2>&1
 wait "$SECOND_PID" 2>/dev/null
 rm -rf "$SECOND_CONFIG_DIR" "$SECOND_LOG"
+fi # HAVE_SECOND_INSTANCE -- section 3.2
 
 # --- 3.5 Regression: progress shouldn't claim finished right after POST. -
 # amuled briefly reports raw=100 in the "queue-empty-at-start" window
@@ -322,7 +348,19 @@ rm -rf "$SECOND_CONFIG_DIR" "$SECOND_LOG"
 # this asserts the mask is in force.
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
 _assert_status 200 "GET /search/{id}/results immediately after POST → 200"
-_assert_json_eq '.progress.state' running 'progress.state is "running" after POST /search'
+# The window guarded here is `finished` with an EMPTY list, from the unmasked
+# raw=100. A search that genuinely completed first is also `finished`, so a flat
+# `running` comparison failed on a fast local hit or a warm server queue.
+EARLY_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state' 2>/dev/null)
+EARLY_RESULTS=$(printf '%s' "$CURL_BODY" | jq -r '.results | length' 2>/dev/null)
+if [ "$EARLY_STATE" = "running" ] ||
+	{ [ "$EARLY_STATE" = "finished" ] && [ "${EARLY_RESULTS:-0}" -gt 0 ]; }; then
+	_pass "progress.state right after POST is not an empty \"finished\" ($EARLY_STATE, ${EARLY_RESULTS:-0} results)"
+else
+	_fail "early progress state" \
+		"got state=$EARLY_STATE with ${EARLY_RESULTS:-0} results" \
+		"amuled's queue-empty-at-start raw=100 is leaking through unmasked"
+fi
 _assert_json_eq '.progress.kind | type' string 'progress.kind is a string'
 
 # --- 4. Poll /search/{id}/results until we get hits (max ~10 s). --
@@ -863,6 +901,9 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	# And it is gone for everyone, not just the session that closed it --
 	# a second instance re-reads the same core state. This is what a
 	# second amulegui would have shown had it still been open.
+	if [ "$HAVE_SECOND_INSTANCE" -eq 0 ]; then
+		echo "  SKIP  close: second-instance cross-check (no amuleapi binary)"
+	else
 	SECOND2_CONFIG_DIR=$(mktemp -d -t amuleapi_19_close_second.XXXXXX)
 	SECOND2_LOG=$(mktemp -t amuleapi_19_close_second_log.XXXXXX)
 	"$AMULEAPI_BIN" --config-dir="$SECOND2_CONFIG_DIR" \
@@ -893,6 +934,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	kill "$SECOND2_PID" >/dev/null 2>&1
 	wait "$SECOND2_PID" 2>/dev/null
 	rm -rf "$SECOND2_CONFIG_DIR" "$SECOND2_LOG"
+	fi # HAVE_SECOND_INSTANCE -- close cross-check
 
 	# Its results are unaddressable afterwards, too -- the bucket is freed,
 	# not merely hidden from the listing.
@@ -903,6 +945,9 @@ else
 	_fail "close setup" "POST /search did not return a search_id ($CLOSE_RES)"
 fi
 
+if [ "$HAVE_SECOND_INSTANCE" -eq 0 ]; then
+	echo "  SKIP  12.1 foreign-search stop (no amuleapi binary; set AMULEAPI_BIN)"
+else
 # --- 12.1 A foreign search must be stoppable, not just visible. ----
 # Found by driving two clients against one daemon and using the other as
 # an oracle: GET /api/v0/search enumerates live core state, so it lists
@@ -967,6 +1012,7 @@ fi
 kill "$FOREIGN_PID" >/dev/null 2>&1
 wait "$FOREIGN_PID" 2>/dev/null
 rm -rf "$FOREIGN_CONFIG_DIR" "$FOREIGN_LOG"
+fi # HAVE_SECOND_INSTANCE -- section 12.1
 
 # --- 13. A failed search start must not wedge discovery. -----------
 # amulegui defers EC_OP_SEARCH_LIST-driven tab creation while it has a

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -32,7 +32,22 @@ set -o pipefail
 HOST=${HOST:-localhost:4713}
 ADMIN_PASS=${ADMIN_PASS:-adminpass}
 CONFIG_DIR=${AMULEAPI_CONFIG_DIR:-/tmp/amuleapi-regtest}
-BIN=${AMULEAPI_BIN:-$(cd "$(dirname "$0")/../../.." && pwd)/build-macos/src/webapi/amuleapi}
+# Locate the amuleapi binary the sub-instances need. Deliberately NOT falling
+# back to PATH: an installed package would silently be tested in place of the
+# working tree, which is worse than not finding anything. Set AMULEAPI_BIN to
+# point somewhere else on purpose.
+_find_amuleapi_bin() {
+	local root=$1 c
+	for c in . build build-macos build-linux _build cmake-build-debug cmake-build-release; do
+		if [ -x "$root/$c/src/webapi/amuleapi" ]; then
+			echo "$root/$c/src/webapi/amuleapi"
+			return 0
+		fi
+	done
+	return 1
+}
+
+BIN=${AMULEAPI_BIN:-$(_find_amuleapi_bin "$(cd "$(dirname "$0")/../../.." && pwd)")}
 LOG=${AMULEAPI_LOG:-/tmp/amuleapi.log}
 
 FAIL_COUNT=0
@@ -57,7 +72,7 @@ if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 if [ ! -x "$BIN" ]; then
-	_die "amuleapi binary not found at $BIN. Set AMULEAPI_BIN to override."
+	_die "no usable amuleapi binary (BIN=[$BIN]). Set AMULEAPI_BIN to override."
 fi
 
 echo "amuleapi 25-cors smoke @ $HOST (bin=$BIN config=$CONFIG_DIR)"

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -166,10 +166,26 @@ _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/dir
 _assert_status 400 "DELETE (no path parameter) → 400"
 
 # --- 4. Add a real directory, then read it back. ---------------------
+#
+# `real` means real to amuled: it stats the path itself, so the mktemp directory
+# above exists for the daemon only when the daemon shares this filesystem.
+# Against a containerised or remote one everything below is rejected as
+# not_found, so probe once and say so instead of failing seven assertions.
 SCRATCH_ENC=$(jq -rn --arg p "$SCRATCH_DIR" '$p|@uri')
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
 	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":true}" "$HOST/api/v0/shared/directories"
+SCRATCH_REJECTION=$(printf '%s' "$CURL_BODY" |
+	jq -r "[.rejected[] | select(.path==\"$SCRATCH_DIR\")][0].reason" 2>/dev/null)
+SHARE_FS_VISIBLE=1
+if [ "$SCRATCH_REJECTION" = "not_found" ]; then
+	SHARE_FS_VISIBLE=0
+	echo "  SKIP  the assertions that need amuled to see $SCRATCH_DIR"
+	echo "        (it stats paths itself; run this against a daemon on this host,"
+	echo "         or set the scratch path to one the daemon can reach)"
+fi
+
+if [ "$SHARE_FS_VISIBLE" -eq 1 ]; then
 _assert_status 200 "POST (add scratch dir, recursive) → 200"
 _assert_json_eq '.ok' 'true' "POST reports ok"
 _assert_json_eq '.rejected | length' '0' "POST rejected nothing"
@@ -194,8 +210,11 @@ _assert_json_eq \
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$SCRATCH_DIR\")][0].recursive" 'false' \
 	"re-add updated the recursive flag"
+fi # SHARE_FS_VISIBLE -- section 4
 
 # --- 5. Server-side validation of a path the client cannot check. ----
+# The bogus-path half does not need a visible scratch dir: a path that exists
+# nowhere is rejected either way.
 BOGUS="$SCRATCH_DIR/definitely-not-here"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
 	-d "{\"path\":\"$BOGUS\"}" "$HOST/api/v0/shared/directories"
@@ -204,14 +223,15 @@ _assert_json_eq \
 	"[.rejected[] | select(.path==\"$BOGUS\")][0].reason" 'not_found' \
 	"nonexistent path rejected as not_found"
 
-# The valid entry must survive a sibling's rejection.
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
-_assert_json_eq \
-	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
-	"rejection did not discard the valid entry"
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$BOGUS\")] | length" '0' \
 	"rejected path was not stored"
+if [ "$SHARE_FS_VISIBLE" -eq 1 ]; then
+# The valid entry must survive a sibling's rejection.
+_assert_json_eq \
+	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
+	"rejection did not discard the valid entry"
 
 # --- 6. Remove it again. --------------------------------------------
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -222,15 +242,19 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '0' \
 	"deleted directory is gone"
+fi # SHARE_FS_VISIBLE -- sections 5b and 6
 
+# Never configured, whether or not the scratch dir ever was.
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/shared/directories?path=$SCRATCH_ENC"
 _assert_status 404 "DELETE (path not configured) → 404"
 
 # --- Summary. -------------------------------------------------------
 echo
+SKIP_NOTE=""
+[ "$SHARE_FS_VISIBLE" -eq 0 ] && SKIP_NOTE=" (local-filesystem share assertions skipped)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0
 fi
 echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -244,8 +244,13 @@ fi
 # shared parser, which is well above MaxConnections -- asking for the whole
 # store instead would silently return only the first 500 records and look like
 # a maintenance failure.
+#
+# The empty and all-zero hashes are excluded, matching what
+# ReconcileKnownClientsLocked() skips: the all-zero one is the placeholder a peer
+# reports before sending its real hash, and folding those in would collapse
+# every unidentified peer into one fabricated record.
 LIVE_HASHES=$(curl -s --max-time 10 "${AUTH[@]}" "$HOST/api/v0/clients?limit=500" \
-	| jq -r '.clients[].user_hash // empty' | sort -u)
+	| jq -r '.clients[].user_hash // empty | select(. != "" and (test("^0+$") | not))' | sort -u)
 if [ -n "$LIVE_HASHES" ]; then
 	_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
 	MISSING=0

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -36,11 +36,27 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # follows the script's own location so anyone who checks the repo out
 # elsewhere works without editing this file.
 ROOT="${AMULEAPI_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
-BIN="${AMULEAPI_BIN:-$ROOT/build-macos/src/webapi/amuleapi}"
+# Locate the amuleapi binary the sub-instances need. Deliberately NOT falling
+# back to PATH: an installed package would silently be tested in place of the
+# working tree, which is worse than not finding anything. Set AMULEAPI_BIN to
+# point somewhere else on purpose.
+_find_amuleapi_bin() {
+	local root=$1 c
+	for c in . build build-macos build-linux _build cmake-build-debug cmake-build-release; do
+		if [ -x "$root/$c/src/webapi/amuleapi" ]; then
+			echo "$root/$c/src/webapi/amuleapi"
+			return 0
+		fi
+	done
+	return 1
+}
+
+BIN="${AMULEAPI_BIN:-$(_find_amuleapi_bin "$ROOT")}"
+echo "bin=$BIN"
 
 if [ ! -x "$BIN" ]; then
-	echo "FATAL: amuleapi binary not found at $BIN" >&2
-	echo "       set AMULEAPI_BIN env var to point at it." >&2
+	echo "FATAL: no usable amuleapi binary (BIN=[$BIN]); looked under $ROOT" >&2
+	echo "       set AMULEAPI_BIN to point at one." >&2
 	exit 2
 fi
 


### PR DESCRIPTION
Four causes across five scripts, none of which says anything about the daemon under test, all of which report a product failure.

33-known-clients builds its list of live peers from `.clients[].user_hash` and asserts every one of them has a known-clients row, without excluding the placeholders ReconcileKnownClientsLocked() skips on purpose: the empty hash and the all-zero one a peer reports before it has sent its real hash. Folding those in would collapse every unidentified peer into one fabricated record sharing a session count and a first-seen. So the check fails whenever an unidentified peer happens to be connected and passes when none is, which reads as an intermittent maintenance regression. Observed against a daemon whose only two connected peers had not identified yet: 2 of 40 assertions failed, while the store was demonstrably being maintained -- six rows with counted sessions in a config directory that started empty.

19-search, 25-cors and run-all.sh defaulted AMULEAPI_BIN to `$ROOT/build-macos/src/webapi/amuleapi`. That is one contributor's build directory hardcoded as the fallback: it exists on no other machine, so 19-search failed three assertions with "could not obtain a token" and the log line was a missing path. Resolve it over the conventional build directories instead, in-tree included. Deliberately not over PATH: an installed package would silently be tested in place of the working tree, which is worse than finding nothing. When nothing is found, 19-search skips its three second-instance sections and the other two say so with the path they looked under; run-all.sh also prints the binary it resolved, which it never did.

19-search also asserted `.progress.state == "running"` on the first poll after POST /search. The window it guards is amuled reporting raw=100 before its server queue is populated, which surfaces as `finished` with an EMPTY result list -- but a search that genuinely completed first, on a local hit or a warm queue, is also `finished`, and the flat comparison failed on exactly that. Accept `finished` when results are present; keep failing on the empty case.

31-shared-directories plants a `mktemp -d` directory and adds it as a share root. amuled stats those paths itself -- a REST client cannot stat the core's filesystem -- so the directory only exists for the daemon when the daemon shares the machine running the test. Against a containerised or remote amuled every path came back rejected as not_found and seven assertions failed. Probe once and skip only the assertions that need the daemon to see it: the nonexistent-path rejection and the delete-what-was-never-configured case do not, and still run. The summary says when that half was skipped rather than reporting a clean pass over half the coverage, and the EXIT trap still restores the original share roots.

Verified against an unmodified daemon that cannot see the test's filesystem and has no local build: 19-search 4/136 failed -> 125/125 passed with three sections skipped, 31-shared-directories 7/26 failed -> 15/15 passed with one half skipped, 33-known-clients 2 of 40 failed -> 29/29 passed.