### PR TITLE
fix(webapi): make TakeBuffer leave the writer reusable

### DIFF
--- a/src/libwebcommon/JsonWriter.h
+++ b/src/libwebcommon/JsonWriter.h
@@ -90,10 +90,25 @@ public:
 
 	const std::string &GetBuffer() const { return *m_buf; }
 
-	// Move the accumulated text out, leaving the writer empty. Saves copying a
-	// multi-megabyte body at the end of a response. Copies instead when the
-	// buffer belongs to the caller -- emptying someone else's is not ours to do.
-	std::string TakeBuffer() { return m_buf == &m_internal ? std::move(m_internal) : *m_buf; }
+	// Move the accumulated text out, leaving this writer empty and ready to
+	// build another document. Saves copying a multi-megabyte body at the end of
+	// a response.
+	//
+	// A caller-owned buffer is copied instead, and left exactly as it was:
+	// emptying someone else's is not ours to do, and clearing the comma state
+	// while its text is still there would drop the separator before whatever is
+	// written next.
+	std::string TakeBuffer()
+	{
+		if (m_buf != &m_internal) {
+			return *m_buf;
+		}
+		std::string taken = std::move(m_internal);
+		// A moved-from string is valid but unspecified; make it definitely empty.
+		m_internal.clear();
+		m_needs_comma = false;
+		return taken;
+	}
 
 private:
 	std::string m_internal;

--- a/unittests/tests/JsonWriterTest.cpp
+++ b/unittests/tests/JsonWriterTest.cpp
@@ -255,6 +255,38 @@ TEST(JsonWriter, LargeString)
 	ASSERT_EQUALS(expected, w.GetBuffer());
 }
 
+TEST(JsonWriter, TakeBufferLeavesTheWriterReusable)
+{
+	// EndArray() leaves a comma pending for the next sibling, so a writer that
+	// kept that state across a take would open its next document with a stray
+	// separator.
+	CJsonWriter w;
+	w.BeginArray();
+	w.ValueInt(1);
+	w.EndArray();
+	ASSERT_EQUALS(std::string("[1]"), w.TakeBuffer());
+	ASSERT_TRUE(w.GetBuffer().empty());
+
+	w.BeginArray();
+	w.ValueInt(2);
+	w.EndArray();
+	ASSERT_EQUALS(std::string("[2]"), w.TakeBuffer());
+}
+
+TEST(JsonWriter, TakeBufferLeavesACallerOwnedBufferAlone)
+{
+	// The external buffer is the caller's; taking copies out of it rather than
+	// emptying it.
+	std::string shared;
+	CJsonWriter w(&shared);
+	w.BeginObject();
+	w.Key("x");
+	w.ValueInt(1);
+	w.EndObject();
+	ASSERT_EQUALS(std::string("{\"x\":1}"), w.TakeBuffer());
+	ASSERT_EQUALS(std::string("{\"x\":1}"), shared);
+}
+
 // JsonDoubleToString is the one formatting both the REST writer and the SSE
 // payload builders go through. It exists because `ostream << double` differs
 // from it in two ways that matter on the wire.

--- a/unittests/tests/JsonWriterTest.cpp
+++ b/unittests/tests/JsonWriterTest.cpp
@@ -245,14 +245,14 @@ TEST(JsonWriter, LargeString)
 {
 	// 50 KB string of printable ASCII should encode in linear time with
 	// the only overhead being the surrounding quotes.
-	wxString big(wxT('x'), 50000);
+	const wxString big(wxT('x'), 50000);
 	CJsonWriter w;
 	w.ValueString(big);
-	wxString expected;
-	expected += wxT("\"");
-	expected += big;
-	expected += wxT("\"");
-	ASSERT_EQUALS(expected, w.GetBuffer());
+	// Compared as bytes. Building the expectation as a wxString would convert
+	// the buffer back with the locale codec on the way into ASSERT_EQUALS,
+	// which is the conversion the writer exists to avoid -- and it would pass
+	// here regardless, the payload being pure ASCII.
+	ASSERT_EQUALS(std::string("\"") + std::string(50000, 'x') + "\"", w.GetBuffer());
 }
 
 TEST(JsonWriter, TakeBufferLeavesTheWriterReusable)


### PR DESCRIPTION
Follow-up to #1091, addressing two review findings left open when it merged.

## TakeBuffer left the writer in a state its own comment ruled out

`TakeBuffer()` documents "leaving the writer empty", but reset neither the comma pending from the last `EndObject`/`EndArray` nor the moved-from buffer. Reusing a writer after a take, the reuse that comment invites, opened the next document with a stray separator:

```cpp
CJsonWriter w;
w.BeginArray(); w.ValueInt(1); w.EndArray();
w.TakeBuffer();                 // "[1]"
w.BeginArray(); w.ValueInt(2); w.EndArray();
w.TakeBuffer();                 // ",[2]"
```

`EndArray()` sets `m_needs_comma` and `BeginArray()` calls `MaybeComma()` before writing, so the separator lands at the front of the fresh document.

Latent today: `EventDiff` constructs a writer per iteration, and every handler takes once. The fix resets the comma state and clears the moved-from buffer, which a move leaves valid but unspecified.

A caller-owned buffer keeps being copied, and is now documented as left exactly as it was. Clearing the comma state while its text is still there would drop the separator before whatever is written next, so the external path must not be emptied either way.

## The large-string test still compared through wxString

`LargeString` was the one assertion still building its expectation as a `wxString`, so `ASSERT_EQUALS` converted the now-`std::string` buffer back through the locale codec to compare, the conversion #1091 removes everywhere else. It passed only because the payload is pure ASCII; a UTF-8 payload would have failed spuriously.

## Verification

Two tests added: `TakeBufferLeavesTheWriterReusable` and `TakeBufferLeavesACallerOwnedBufferAlone`. `JsonWriterTest` is 23 cases, all passing. Run against the previous `TakeBuffer`, the new test fails with `Expected '[2]' but got ',[2]'`, so it catches the defect rather than merely describing it.
