### PR TITLE
fix(amuleapi): cap glibc's malloc arenas so a request's peak is not retained per pool thread

### DIFF
--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -49,6 +49,14 @@
 #include <iostream>
 #include <thread>
 
+// mallopt. Guarded because macOS has no <malloc.h>; M_ARENA_MAX below then
+// gates the call on the libc actually providing it.
+#if defined(__has_include)
+#if __has_include(<malloc.h>)
+#include <malloc.h>
+#endif
+#endif
+
 IMPLEMENT_APP(CamuleapiApp)
 
 namespace
@@ -86,6 +94,40 @@ void HandleEcConnectionLost()
 {
 	g_ecConnectionLost.store(true, std::memory_order_release);
 	g_shutdownRequested.store(true, std::memory_order_release);
+}
+
+// Bound glibc's per-thread malloc arenas: it hands out up to 8 x ncores (the
+// *host's* cores, which a container quota does not lower) and a non-main arena
+// never returns its high-water mark, so one handler's peak becomes permanent
+// RSS once per pool thread.
+//
+// 2 reserves nothing for the refresher -- reuse_arena() rotates main_arena in
+// too -- it buys a second lock domain and half the churn in an mmap'd arena
+// madvise can reclaim. An explicit MALLOC_ARENA_MAX or glibc.malloc.arena_max
+// wins; a zero or empty one does not, since glibc rejects it (minval 1) and
+// falls back to its own default.
+void CapMallocArenas()
+{
+#if defined(M_ARENA_MAX)
+	// Base 0, not 10: glibc's tunable parser takes hex and octal, so a base-10
+	// read of MALLOC_ARENA_MAX=0x8 gives 0 and we would cap over an operator
+	// who set 8. A value glibc itself rejects still parses as 0 here, which is
+	// what makes the cap apply to it.
+	const char *env = std::getenv("MALLOC_ARENA_MAX");
+	if (env && std::strtol(env, nullptr, 0) > 0) {
+		return;
+	}
+	const char *tunables = std::getenv("GLIBC_TUNABLES");
+	if (tunables) {
+		static const char key[] = "glibc.malloc.arena_max=";
+		const char *hit = std::strstr(tunables, key);
+		if (hit && std::strtol(hit + sizeof(key) - 1, nullptr, 0) > 0) {
+			return;
+		}
+	}
+	// M_ARENA_MAX does not set no_dyn_threshold, unlike M_MMAP_THRESHOLD.
+	mallopt(M_ARENA_MAX, 2);
+#endif
 }
 
 } // namespace
@@ -170,6 +212,10 @@ bool CamuleapiApp::OnCmdLineParsed(wxCmdLineParser &parser)
 
 bool CamuleapiApp::OnInit()
 {
+	// Before any secondary thread exists: an arena is assigned on a thread's
+	// first malloc and cached in its TLS, so a later cap cannot move it.
+	CapMallocArenas();
+
 	if (!CaMuleExternalConnector::OnInit()) {
 		return false;
 	}


### PR DESCRIPTION
glibc gives each thread its own malloc arena on first allocation and caches it in TLS for the thread's life, up to 8 x ncores of them -- counted from the host's cores, which a container's CPU quota does not lower. A non-main arena does not return its high-water mark on its own: heap_trim only recedes the top of an arena's last heap, free pages below a live chunk stay mapped, and arenas never rebalance. So a request handler's peak becomes permanent RSS, once per thread of the handler pool -- and pool threads are picked per request, so sequential requests are enough to pin one arena after another.

Measured on an 11 906-file library, 16 concurrent GET /shared, on top of the allocation fixes in the rest of this series:

                      VmHWM    RSS after   median latency
  without             281 MB     199 MB        1.53 s
  with (this)         166 MB      88 MB        1.56 s

So it halves the remaining peak for no measurable latency, and it is the one lever that works without knowing anything about what the handlers allocate.

2 rather than 1, and not because it reserves the main arena for the refresher: once the limit is reached reuse_arena() round-robins the whole arena list with main_arena in it, so about half the pool shares it. What 2 buys over 1 is a second lock domain, and half the churn in an mmap'd arena that madvise can return rather than all of it in the brk() heap, which only trims from the top. Higher values were measured, not assumed: 4 came out slightly slower than 2 as well as larger.

An explicit MALLOC_ARENA_MAX or glibc.malloc.arena_max wins, since glibc reads those before OnInit runs. A zero or empty value does not: glibc rejects it for minval 1 and falls back to its default, so treating it as an operator choice would leave neither the cap nor the override.

A malloc_trim(0) per refresher tick was measured alongside this and dropped. It walks every arena and madvises what is free, taking steady-state RSS from 88 MB to 36 MB -- but the pages have to be faulted back in, and with the per-request peak already small that cost 22 % on the median of the heaviest endpoint (1.56 s -> 1.90 s). It was worth it when a single response allocated ~63 MB of transients; it is not now that the same response allocates a few.

Reducing kHandlerPoolThreads from 16 would cut the multiplier at source but was also rejected: handlers block on the EC future, so a smaller pool buys head-of-line blocking bounded by the EC read timeout, on a daemon whose log already shows EC stalls.