### PR TITLE
fix(amuleapi): make the CState callback contract enforceable, not just documented

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3474,7 +3474,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 		return *r;
 	// Pointers into the live map rather than copies; see HandleSharedList.
 	CHttpServer::Response resp;
-	m_state.WithFiles([&](const webapi::FileMap &files) {
+	// Named captures; see HandleSharedList.
+	m_state.WithFiles([&resp, &params, include_completed](const webapi::FileMap &files) {
 		std::vector<const webapi::FileSnapshot *> ptrs;
 		ptrs.reserve(files.size());
 		for (const auto &entry : files) {
@@ -3760,7 +3761,10 @@ CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Reques
 	// handed, so ListResponseFromPtrsUnlocked's "must not re-enter CState"
 	// contract holds.
 	CHttpServer::Response resp;
-	m_state.WithFiles([&](const webapi::FileMap &files) {
+	// Named captures rather than [&]: [&] would pull `this` in, putting
+	// m_state within reach of a callback that must not touch it. kComps is
+	// static, so it is in scope without being captured.
+	m_state.WithFiles([&resp, &params](const webapi::FileMap &files) {
 		std::vector<const webapi::FileSnapshot *> ptrs;
 		ptrs.reserve(files.size());
 		for (const auto &entry : files) {
@@ -4859,7 +4863,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 		ecids.push_back(d.ecid);
 		hashes_cleared.push_back(d.hash);
 	} else {
-		m_state.WithFiles([&](const webapi::FileMap &files) {
+		// Named captures; see HandleSharedList.
+		m_state.WithFiles([&ecids, &hashes_cleared](const webapi::FileMap &files) {
 			for (const auto &entry : files) {
 				const webapi::FileSnapshot &d = entry.second;
 				if (d.is_downloading && d.download.status == "completed") {

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -24,6 +24,9 @@
 
 #include "State.h"
 
+#include <cstdlib>  // std::abort
+#include <iostream> // std::cerr
+
 #include <cstdio>
 #include <ctime>
 
@@ -166,9 +169,30 @@ std::vector<SearchResult> CState::Search(std::uint32_t search_id) const
 	return out;
 }
 
+// See CState::ReentryGuard in State.h for why this aborts rather than
+// returning, and why it runs before the lock rather than after it.
+thread_local const CState *CState::t_in_callback = nullptr;
+
+CState::ReentryGuard::ReentryGuard(const CState *self)
+: m_prev(t_in_callback)
+{
+	if (t_in_callback == self) {
+		std::cerr << "amuleapi: FATAL CState callback re-entered the same CState; "
+			     "this would deadlock on a non-recursive lock\n";
+		std::abort();
+	}
+	t_in_callback = self;
+}
+
+CState::ReentryGuard::~ReentryGuard()
+{
+	t_in_callback = m_prev;
+}
+
 void CState::MutateSearch(
 	std::uint32_t search_id, const std::function<void(std::map<std::uint32_t, SearchResult> &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	auto it = m_searches.find(search_id);
 	if (it != m_searches.end())
@@ -432,6 +456,7 @@ void CState::WriteCategories(std::vector<CategorySnapshot> c)
 
 void CState::MutateServers(const std::function<void(std::map<std::uint32_t, ServerSnapshot> &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_servers);
 }
@@ -446,6 +471,7 @@ std::vector<FriendSnapshot> CState::Friends() const
 }
 void CState::MutateFriends(const std::function<void(std::map<std::uint32_t, FriendSnapshot> &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_friends);
 }
@@ -484,6 +510,7 @@ std::uint32_t CState::ChatCursor() const
 
 void CState::MutateChats(const std::function<void(std::vector<ChatSessionSnapshot> &, std::uint32_t &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_chats, m_chat_cursor);
 }
@@ -691,18 +718,21 @@ bool CState::FindSharedByEcid(std::uint32_t ecid, FileSnapshot &out) const
 // at the end of the mutate window.
 void CState::MutateDownloads(const std::function<void(FileMap &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_files);
 }
 
 void CState::MutateShared(const std::function<void(FileMap &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_files);
 }
 
 void CState::MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn)
 {
+	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_clients);
 }

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1467,8 +1467,43 @@ public:
 	//! retain the reference. For readers wanting a few fields per file, or
 	//! pointers to sort and page -- a FileSnapshot is 848 bytes plus a heap
 	//! allocation per string, so copying the collection out is never cheap.
+	// Re-entrancy detector for the callback accessors below.
+	//
+	// Every WithX() / MutateX() runs a caller-supplied callback while holding
+	// m_mu. Calling back into the same CState from inside one takes that
+	// non-recursive std::shared_timed_mutex a second time: undefined
+	// behaviour, and in practice a hang -- immediately on the exclusive
+	// paths, and on the shared ones as soon as a writer is queued, because
+	// the implementation stops admitting new readers to avoid starving it.
+	//
+	// The rule was documentation only, so a violation surfaced as a wedged
+	// daemon under load rather than as a test failure -- the callbacks are
+	// pure today, but nothing stopped the next edit from reaching for
+	// m_state. Enforced in Release as well as Debug, and aborting rather
+	// than returning, for the reason the Session dtor gives in
+	// HttpServer.cpp: assert() is stripped by NDEBUG, and the alternative
+	// here is not a wrong answer but a process that stops responding with
+	// nothing in the log. The thread would deadlock on the next line
+	// regardless; this way it leaves a message and a core instead.
+	//
+	// Constructed BEFORE the lock, deliberately. A re-entrant call blocks on
+	// the mutex it can never obtain, so a guard placed after the lock would
+	// never run for the one case it exists to catch.
+	class ReentryGuard
+	{
+	public:
+		explicit ReentryGuard(const CState *self);
+		~ReentryGuard();
+		ReentryGuard(const ReentryGuard &) = delete;
+		ReentryGuard &operator=(const ReentryGuard &) = delete;
+
+	private:
+		const CState *m_prev;
+	};
+
 	template <class F> void WithFiles(F &&fn) const
 	{
+		const ReentryGuard guard(this);
 		std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 		fn(static_cast<const FileMap &>(m_files));
 	}
@@ -1520,6 +1555,7 @@ public:
 	//! into CState, and must not retain the reference.
 	template <class F> void WithKnownClients(F &&fn) const
 	{
+		const ReentryGuard guard(this);
 		std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 		fn(static_cast<const std::vector<KnownClientSnapshot> &>(m_known_clients));
 	}
@@ -1696,6 +1732,10 @@ public:
 
 private:
 	mutable std::shared_timed_mutex m_mu;
+	// Which CState this thread is currently inside a callback of, so the
+	// guard can tell "re-entered the same instance" (a deadlock) from
+	// "touched a different one" (harmless -- a different mutex).
+	static thread_local const CState *t_in_callback;
 
 	bool m_has_first_snapshot = false;
 	bool m_ec_connected = false;

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <cstdint>
 #include <map>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -904,6 +905,58 @@ TEST(State, ResetListsClearsAll)
 	ASSERT_EQUALS(static_cast<size_t>(0), Downloads(s).size());
 	ASSERT_EQUALS(static_cast<size_t>(0), s.Clients().size());
 	ASSERT_EQUALS(static_cast<size_t>(0), Shared(s).size());
+}
+
+// The callback accessors run caller code while holding m_mu, which is not
+// recursive. These pin the two halves of that contract that can be checked
+// without deadlocking the test: a nested call on a DIFFERENT instance is a
+// different mutex and must stay legal, and the guard must unwind so a second
+// sequential call still works. Re-entering the SAME instance aborts by
+// design, so it is not exercised here -- see CState::ReentryGuard.
+TEST(State, CallbackOnADifferentStateInstanceIsAllowed)
+{
+	CState a;
+	CState b;
+	a.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 1;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	// b's callback reads a: a different CState, so a different mutex, and
+	// nothing to deadlock on. The guard must not confuse the two.
+	std::size_t seen = 0;
+	b.MutateClients([&a, &seen](std::map<std::uint32_t, ClientSnapshot> &) {
+		a.WithFiles([&seen](const FileMap &files) { seen = files.size(); });
+	});
+	ASSERT_EQUALS(static_cast<size_t>(1), seen);
+}
+
+TEST(State, CallbackGuardUnwindsSoLaterCallsStillWork)
+{
+	CState s;
+	s.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 7;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+	std::size_t first = 0, second = 0;
+	s.WithFiles([&first](const FileMap &files) { first = files.size(); });
+	s.WithFiles([&second](const FileMap &files) { second = files.size(); });
+	ASSERT_EQUALS(static_cast<size_t>(1), first);
+	ASSERT_EQUALS(static_cast<size_t>(1), second);
+
+	// And an exception escaping a callback must not leave the guard set.
+	try {
+		s.WithFiles([](const FileMap &) { throw std::runtime_error("boom"); });
+	} catch (const std::runtime_error &) {
+		// expected
+	}
+	std::size_t after = 0;
+	s.WithFiles([&after](const FileMap &files) { after = files.size(); });
+	ASSERT_EQUALS(static_cast<size_t>(1), after);
 }
 
 TEST(State, ConcurrentReadersDontTearSnapshot)


### PR DESCRIPTION
Follow-up to #1092.

That PR moved the whole `/shared` and `/downloads` serialisation path inside `CState`'s read lock. It is safe as written — I checked structurally rather than by inspection: `CState` is reachable only through a dispatcher member, and `WriteSharedObject` / `WriteDownloadObject` are free functions with no global or singleton anywhere in `src/webapi`, so they *cannot* re-enter.

But the rule keeping it safe was a comment, and its violation is not a wrong answer. `m_mu` is a `std::shared_timed_mutex`, which is not recursive: a callback that calls back into the same `CState` hangs the daemon — immediately on the exclusive paths, and on the shared ones as soon as a writer is queued, because the implementation stops admitting readers rather than starve it.

**That failure mode is invisible to tests.** A shared→shared re-entry with nothing contending usually just works, so it passes CI and wedges a busy node instead.

## The change

A `ReentryGuard` on all nine callback accessors — both `WithX()` readers and all seven `MutateX()` writers. The writers carry the same hazard and, holding the lock exclusively, deadlock without needing any contention at all.

Three details worth reviewing:

**Constructed before the lock, not after.** A re-entrant call blocks on a mutex it can never obtain, so a guard placed after the lock would never run for the one case it exists to catch. I got this wrong first time.

**Aborts rather than returns, in Release as well as Debug** — following the `Session` dtor in `HttpServer.cpp`, for the reason given there: `assert()` is stripped by NDEBUG, and the alternative here is not a wrong result but a process that stops responding with nothing in the log. The thread would deadlock on the next line anyway; this way it leaves a message and a core.

**Keyed on the instance**, so a callback touching a *different* `CState` — a different mutex, nothing to deadlock on — stays legal.

Also narrows the three `WithFiles()` lambdas from `[&]` to named captures. `[&]` pulls `this` in, leaving `m_state` within reach of a callback that must not touch it.

## Verification

Built a probe against the real `State.cpp` object and confirmed the guard fires on **both** shapes — exclusive→shared and shared→shared — each aborting with the message rather than hanging (exit 134, SIGABRT).

Two new tests cover what can be checked without deliberately aborting: a nested call on a *different* instance stays legal, and the guard unwinds correctly — including when an exception escapes a callback — so later calls still work.

38/38 tests, clang-format and clang-tidy Tier-2 clean with 0 compiler errors.
