### PR TITLE
test(amuleapi): account for skipped checks, and stop the smokes resolving silently

### DIFF
--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -29,12 +29,17 @@ ADMIN_PASS=${ADMIN_PASS:-adminpass}
 
 FAIL_COUNT=0
 TEST_COUNT=0
+# Skips are counted apart from TEST_COUNT, never folded into it: a skipped
+# check is coverage that did not happen, and adding it to the passed tally
+# would report the absence of a check as a check that succeeded.
+SKIP_COUNT=0
 
 CURL_BODY_FILE=$(mktemp -t amuleapi_04_read_downloads_shared_body.XXXXXX)
 trap 'rm -f "$CURL_BODY_FILE"' EXIT
 
 _die()  { echo "FATAL: $*" >&2; exit 2; }
 _pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
 _fail() {
 	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
 	echo "  FAIL  $1"
@@ -234,7 +239,7 @@ if [ "$COUNT" -gt 0 ]; then
 		_assert_json_eq '[.clients[] | select(.a4af == null)] | length' 0 "every row has an a4af flag"
 		_assert_json_eq '[.clients[] | select(has("parts"))] | length' 0 "no parts bitmap without include_parts"
 	else
-		echo "  SKIP  row-shape checks: no peer is connected to the download"
+		_skip "row-shape checks: no peer is connected to the download"
 	fi
 
 	# Opt-in bitmaps are exactly part_count long for a row that has one.
@@ -246,7 +251,7 @@ if [ "$COUNT" -gt 0 ]; then
 		_assert_json_eq "[.clients[] | select(has(\"parts\")) | select((.parts | length) != $PARTCOUNT)] | length" \
 			0 "every parts bitmap ($DLBITMAPS of them) is exactly part_count entries"
 	else
-		echo "  SKIP  parts-length check: no row carries a bitmap"
+		_skip "parts-length check: no row carries a bitmap"
 	fi
 
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?include_parts=maybe"
@@ -402,7 +407,7 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared/{hash} carries rating'
 	SHPARTCOUNT=$(printf '%s' "$CURL_BODY" | jq -r '.part_count')
 
-	# --- 6d. GET /shared/{hash}/clients: the upload-side half of the
+	# --- 6c. GET /shared/{hash}/clients: the upload-side half of the
 	# per-file client rows (issue #984). Same handler and same row shape as
 	# the download side asserted above; what differs is which collection the
 	# hash must belong to, which is what the 404 below pins down.
@@ -424,7 +429,7 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		_assert_json_eq '[.clients[] | select(has("parts"))] | length' 0 \
 			"no parts bitmap on the shared route without include_parts"
 	else
-		echo "  SKIP  shared-side row-shape checks: no peer is downloading the shared file"
+		_skip "shared-side row-shape checks: no peer is downloading the shared file"
 	fi
 
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/$SHASH/clients?include_parts=true"
@@ -434,7 +439,7 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		_assert_json_eq "[.clients[] | select(has(\"parts\")) | select((.parts | length) != $SHPARTCOUNT)] | length" \
 			0 "every shared-side parts bitmap ($SHBITMAPS of them) is exactly part_count entries"
 	else
-		echo "  SKIP  shared-side parts-length check: no row carries a bitmap"
+		_skip "shared-side parts-length check: no row carries a bitmap"
 	fi
 
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/$SHASH/clients?include_parts=maybe"
@@ -468,7 +473,7 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		_assert_json_eq '[.clients[] | {ecid, role, a4af}] | sort | tojson' "$DL_ROWS" \
 			"both routes return the same rows for a downloading+shared hash"
 	else
-		echo "  SKIP  same-rows check: no hash is both downloading and shared"
+		_skip "same-rows check: no hash is both downloading and shared"
 	fi
 
 	# The 404 pair is the only difference between the two routes: each hash
@@ -478,20 +483,20 @@ if [ "$SHCOUNT" -gt 0 ]; then
 			"$HOST/api/v0/downloads/$SHARED_ONLY_HASH/clients"
 		_assert_status 404 "a shared-only hash is a 404 on /downloads/{hash}/clients"
 	else
-		echo "  SKIP  shared-only 404 check: every shared file is also downloading"
+		_skip "shared-only 404 check: every shared file is also downloading"
 	fi
-
-	# Shared-only sub-resource: an unknown hash is a 404 here just as it is
-	# on the download side.
-	_curl -H "Authorization: Bearer $TOKEN" \
-		"$HOST/api/v0/shared/baadbaadbaadbaadbaadbaadbaadbaad/clients"
-	_assert_status 404 "unknown hash on /shared/{hash}/clients → 404"
 fi
 
-# --- 6c. /shared/{hash} missing-hash 404. -------------------------
+# --- 6d. Missing-hash 404s on the shared routes. -------------------
+# Both use a hash that exists nowhere, so neither needs a shared file and
+# both belong outside the "has entries" gate above: on a daemon sharing
+# nothing these are still the checks that pin the routes down.
 _curl -H "Authorization: Bearer $TOKEN" \
 	"$HOST/api/v0/shared/baadbaadbaadbaadbaadbaadbaadbaad"
 _assert_status 404 "GET /shared/{nonexistent-hash} → 404"
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/shared/baadbaadbaadbaadbaadbaadbaadbaad/clients"
+_assert_status 404 "unknown hash on /shared/{hash}/clients → 404"
 
 # --- 7. Method gate. DELETE is method-gated on the /shared collection
 # (no bulk-unshare endpoint); the /downloads collection now accepts a bulk
@@ -502,8 +507,10 @@ _assert_status 405 "DELETE /api/v0/shared → 405"
 
 # --- Summary. -----------------------------------------------------
 echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0
 fi
 echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"

--- a/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
+++ b/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
@@ -33,13 +33,17 @@ TEST_HASH="0031c9cba65c50dd2015c184b2ca2c88"
 
 FAIL_COUNT=0
 TEST_COUNT=0
+# Skips are counted apart from TEST_COUNT, never folded into it: a skipped
+# check is coverage that did not happen, and adding it to the passed tally
+# would report the absence of a check as a check that succeeded.
+SKIP_COUNT=0
 
 CURL_BODY_FILE=$(mktemp -t amuleapi_13_downloads_delete_clear_body.XXXXXX)
 trap 'rm -f "$CURL_BODY_FILE"' EXIT
 
 _die()  { echo "FATAL: $*" >&2; exit 2; }
 _pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
-_skip() { TEST_COUNT=$((TEST_COUNT+1)); echo "  SKIP  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
 _fail() {
 	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
 	echo "  FAIL  $1"
@@ -286,8 +290,10 @@ fi
 
 # --- Summary. -----------------------------------------------------
 echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0
 fi
 echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -49,15 +49,27 @@ EC_PASSWORD=${EC_PASSWORD:-amule}
 # back to PATH: an installed package would silently be tested in place of the
 # working tree, which is worse than not finding anything. Set AMULEAPI_BIN to
 # point somewhere else on purpose.
+#
+# Any build*/ directory counts, not a fixed list of three: per-branch and
+# per-arch trees are normal, and a name this function has never heard of used
+# to mean a silent skip. Where several exist the NEWEST wins -- picking the
+# first match let a stale build/ supply the binary while the tree under test
+# was built somewhere else, which is the one failure mode that produces a
+# confident wrong answer rather than a missing one. Unmatched globs stay
+# literal and fail the -x test, so no nullglob is needed.
 _find_amuleapi_bin() {
-	local root=$1 c
-	for c in . build build-macos build-linux _build cmake-build-debug cmake-build-release; do
-		if [ -x "$root/$c/src/webapi/amuleapi" ]; then
-			echo "$root/$c/src/webapi/amuleapi"
-			return 0
+	local root=$1 c best=
+	for c in "$root"/src/webapi/amuleapi \
+		"$root"/build*/src/webapi/amuleapi \
+		"$root"/_build/src/webapi/amuleapi \
+		"$root"/cmake-build-*/src/webapi/amuleapi; do
+		[ -x "$c" ] || continue
+		if [ -z "$best" ] || [ "$c" -nt "$best" ]; then
+			best=$c
 		fi
 	done
-	return 1
+	[ -n "$best" ] || return 1
+	echo "$best"
 }
 
 AMULEAPI_BIN=${AMULEAPI_BIN:-$(_find_amuleapi_bin "$(cd "$(dirname "$0")/../../.." && pwd)")}
@@ -68,6 +80,11 @@ if [ -x "${AMULEAPI_BIN:-/nonexistent}" ]; then
 else
 	HAVE_SECOND_INSTANCE=0
 fi
+# Counted so the summary cannot report a clean pass over a partial run:
+# every section below that skips increments this, and a non-zero count
+# is spelled out next to the OK line.
+SKIP_COUNT=0
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
 
 # A query likely to return results on any operator's daemon connected
 # to ed2k. "ubuntu" is a safe choice — well-seeded across the network.
@@ -267,7 +284,7 @@ if [ "$HAVE_GUEST" = "1" ]; then
 fi
 
 if [ "$HAVE_SECOND_INSTANCE" -eq 0 ]; then
-	echo "  SKIP  3.2 cross-session discovery (no amuleapi binary; set AMULEAPI_BIN)"
+	_skip "3.2 cross-session discovery (no amuleapi binary; set AMULEAPI_BIN)"
 else
 # --- 3.2 Cross-session discovery: a second amuleapi instance against the
 # same amuled sees $FIRST_SID even though it never called POST /search
@@ -902,7 +919,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	# a second instance re-reads the same core state. This is what a
 	# second amulegui would have shown had it still been open.
 	if [ "$HAVE_SECOND_INSTANCE" -eq 0 ]; then
-		echo "  SKIP  close: second-instance cross-check (no amuleapi binary)"
+		_skip "close: second-instance cross-check (no amuleapi binary)"
 	else
 	SECOND2_CONFIG_DIR=$(mktemp -d -t amuleapi_19_close_second.XXXXXX)
 	SECOND2_LOG=$(mktemp -t amuleapi_19_close_second_log.XXXXXX)
@@ -946,7 +963,7 @@ else
 fi
 
 if [ "$HAVE_SECOND_INSTANCE" -eq 0 ]; then
-	echo "  SKIP  12.1 foreign-search stop (no amuleapi binary; set AMULEAPI_BIN)"
+	_skip "12.1 foreign-search stop (no amuleapi binary; set AMULEAPI_BIN)"
 else
 # --- 12.1 A foreign search must be stoppable, not just visible. ----
 # Found by driving two clients against one daemon and using the other as
@@ -1319,8 +1336,10 @@ _assert_json_eq '[.servers[]? | .tcp_flags | has("related_search")] | all' true 
 
 # --- Summary. -----------------------------------------------------
 echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT section(s) skipped: no second amuleapi instance)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0
 fi
 echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"

--- a/unittests/curl-tests/amuleapi/24-sse-resync.sh
+++ b/unittests/curl-tests/amuleapi/24-sse-resync.sh
@@ -31,6 +31,14 @@ ADMIN_PASS=${ADMIN_PASS:-adminpass}
 BIN=${AMULEAPI_BIN:?orchestrator must export AMULEAPI_BIN}
 CONFIG_DIR=${AMULEAPI_CONFIG_DIR:?orchestrator must export AMULEAPI_CONFIG_DIR}
 LOG=${AMULEAPI_LOG:-/tmp/amuleapi.log}
+# The daemon this smoke drives. Defaults are the orchestrator's, but every
+# value is overridable so the suite can be pointed at a daemon that is not
+# on the stock EC port; hardcoding them here made that impossible.
+EC_HOST=${EC_HOST:-127.0.0.1}
+EC_PORT=${EC_PORT:-4712}
+EC_PASSWORD=${EC_PASSWORD:-amule}
+# The HTTP port the rewritten config must bind is the one $HOST names.
+HTTP_PORT=${HOST##*:}
 
 FAIL_COUNT=0
 TEST_COUNT=0
@@ -69,12 +77,12 @@ sleep 1
 cat > "$CONFIG_DIR/amuleapi.conf" <<EOF
 [Server]
 BindAddress=127.0.0.1
-Port=4713
+Port=$HTTP_PORT
 
 [EC]
-Host=127.0.0.1
-Port=4712
-Password=amule
+Host=$EC_HOST
+Port=$EC_PORT
+Password=$EC_PASSWORD
 
 [Auth]
 LoginFailureWindowSeconds=60
@@ -85,7 +93,7 @@ LoginLockoutSeconds=300
 EventBusRingCapacity=4
 EOF
 "$BIN" --config-dir="$CONFIG_DIR" \
-	--host=127.0.0.1 --port=4712 \
+	--host="$EC_HOST" --port="$EC_PORT" \
 	> "$LOG" 2>&1 &
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
 	if curl -s -o /dev/null --max-time 1 "$HOST/api/v0/version" 2>/dev/null; then

--- a/unittests/curl-tests/amuleapi/24-sse-resync.sh
+++ b/unittests/curl-tests/amuleapi/24-sse-resync.sh
@@ -34,13 +34,17 @@ LOG=${AMULEAPI_LOG:-/tmp/amuleapi.log}
 
 FAIL_COUNT=0
 TEST_COUNT=0
+# Skips are counted apart from TEST_COUNT, never folded into it: a skipped
+# check is coverage that did not happen, and adding it to the passed tally
+# would report the absence of a check as a check that succeeded.
+SKIP_COUNT=0
 
 SSE=$(mktemp -t amuleapi_24-sse-resync.XXXXXX)
 trap 'rm -f "$SSE"' EXIT
 
 _die()  { echo "FATAL: $*" >&2; exit 2; }
 _pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
-_skip() { TEST_COUNT=$((TEST_COUNT+1)); echo "  SKIP  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
 _fail() {
 	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
 	echo "  FAIL  $1"
@@ -265,8 +269,10 @@ fi
 
 # --- Summary. -----------------------------------------------------
 echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0
 fi
 echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -62,6 +62,14 @@ _find_amuleapi_bin() {
 ROOT=${AMULEAPI_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
 BIN=${AMULEAPI_BIN:-$(_find_amuleapi_bin "$ROOT")}
 LOG=${AMULEAPI_LOG:-/tmp/amuleapi.log}
+# The daemon this smoke drives. Defaults are the orchestrator's, but every
+# value is overridable so the suite can be pointed at a daemon that is not
+# on the stock EC port; hardcoding them here made that impossible.
+EC_HOST=${EC_HOST:-127.0.0.1}
+EC_PORT=${EC_PORT:-4712}
+EC_PASSWORD=${EC_PASSWORD:-amule}
+# The HTTP port the rewritten config must bind is the one $HOST names.
+HTTP_PORT=${HOST##*:}
 
 FAIL_COUNT=0
 TEST_COUNT=0
@@ -102,14 +110,14 @@ _rewrite_cors_and_restart() {
 	cat > "$CONFIG_DIR/amuleapi.conf" <<EOF
 [Server]
 BindAddress=127.0.0.1
-Port=4713
+Port=$HTTP_PORT
 AllowCORS=$allow
 CorsOriginAllowlist=$allowlist
 
 [EC]
-Host=127.0.0.1
-Port=4712
-Password=amule
+Host=$EC_HOST
+Port=$EC_PORT
+Password=$EC_PASSWORD
 
 [Auth]
 LoginFailureWindowSeconds=60
@@ -117,7 +125,7 @@ LoginFailureThreshold=5
 LoginLockoutSeconds=300
 EOF
 	"$BIN" --config-dir="$CONFIG_DIR" \
-		--host=127.0.0.1 --port=4712 \
+		--host="$EC_HOST" --port="$EC_PORT" \
 		> "$LOG" 2>&1 &
 	# Wait for /version to respond.
 	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -36,18 +36,31 @@ CONFIG_DIR=${AMULEAPI_CONFIG_DIR:-/tmp/amuleapi-regtest}
 # back to PATH: an installed package would silently be tested in place of the
 # working tree, which is worse than not finding anything. Set AMULEAPI_BIN to
 # point somewhere else on purpose.
+#
+# Any build*/ directory counts, not a fixed list of three: per-branch and
+# per-arch trees are normal, and a name this function has never heard of used
+# to mean a silent skip. Where several exist the NEWEST wins -- picking the
+# first match let a stale build/ supply the binary while the tree under test
+# was built somewhere else, which is the one failure mode that produces a
+# confident wrong answer rather than a missing one. Unmatched globs stay
+# literal and fail the -x test, so no nullglob is needed.
 _find_amuleapi_bin() {
-	local root=$1 c
-	for c in . build build-macos build-linux _build cmake-build-debug cmake-build-release; do
-		if [ -x "$root/$c/src/webapi/amuleapi" ]; then
-			echo "$root/$c/src/webapi/amuleapi"
-			return 0
+	local root=$1 c best=
+	for c in "$root"/src/webapi/amuleapi \
+		"$root"/build*/src/webapi/amuleapi \
+		"$root"/_build/src/webapi/amuleapi \
+		"$root"/cmake-build-*/src/webapi/amuleapi; do
+		[ -x "$c" ] || continue
+		if [ -z "$best" ] || [ "$c" -nt "$best" ]; then
+			best=$c
 		fi
 	done
-	return 1
+	[ -n "$best" ] || return 1
+	echo "$best"
 }
 
-BIN=${AMULEAPI_BIN:-$(_find_amuleapi_bin "$(cd "$(dirname "$0")/../../.." && pwd)")}
+ROOT=${AMULEAPI_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}
+BIN=${AMULEAPI_BIN:-$(_find_amuleapi_bin "$ROOT")}
 LOG=${AMULEAPI_LOG:-/tmp/amuleapi.log}
 
 FAIL_COUNT=0
@@ -72,7 +85,7 @@ if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 if [ ! -x "$BIN" ]; then
-	_die "no usable amuleapi binary (BIN=[$BIN]). Set AMULEAPI_BIN to override."
+	_die "no usable amuleapi binary under $ROOT. Set AMULEAPI_BIN to point at one."
 fi
 
 echo "amuleapi 25-cors smoke @ $HOST (bin=$BIN config=$CONFIG_DIR)"

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -29,6 +29,10 @@ TEST_LINK="ed2k://|file|ubuntu-24.04.4-desktop-amd64.iso|6655619072|0031C9CBA65C
 
 FAIL_COUNT=0
 TEST_COUNT=0
+# Skips are counted apart from TEST_COUNT, never folded into it: a skipped
+# check is coverage that did not happen, and adding it to the passed tally
+# would report the absence of a check as a check that succeeded.
+SKIP_COUNT=0
 SSE=$(mktemp -t amuleapi_26_rfc_followup_endpoints_sse.XXXXXX)
 trap '
 	rm -f "$SSE"
@@ -44,7 +48,7 @@ trap '
 
 _die()  { echo "FATAL: $*" >&2; exit 2; }
 _pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
-_skip() { TEST_COUNT=$((TEST_COUNT+1)); echo "  SKIP  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
 _fail() {
 	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
 	echo "  FAIL  $1"
@@ -392,7 +396,7 @@ if [ -n "$FIRST_CLIENT" ]; then
 			"a /clients object is missing upload_file_name/download_file_name or it is not a string"
 	fi
 else
-	_pass "/clients base filename-field check skipped (no peers connected)"
+	_skip "/clients base filename-field check (no peers connected)"
 fi
 
 # --- 9b. /clients/{ecid} detail (issue #422). --------------------
@@ -418,7 +422,7 @@ if [ -n "$FIRST_ECID" ]; then
 		_fail "clients detail shape" "missing detail fields: $DETAIL"
 	fi
 else
-	_pass "/clients/{ecid} detail 200 skipped (no peers connected)"
+	_skip "/clients/{ecid} detail 200 (no peers connected)"
 fi
 # Unknown ecid → 404 (0xFFFFFFFF is effectively never a live ECID)
 RC=$(curl -s -o /dev/null -w "%{http_code}" "${H_AUTH[@]}" "$HOST/api/v0/clients/4294967295")
@@ -506,8 +510,10 @@ fi
 
 # --- Summary. -----------------------------------------------------
 echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0
 fi
 echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -171,6 +171,12 @@ _assert_status 400 "DELETE (no path parameter) → 400"
 # above exists for the daemon only when the daemon shares this filesystem.
 # Against a containerised or remote one everything below is rejected as
 # not_found, so probe once and say so instead of failing seven assertions.
+#
+# not_readable counts as the same setup problem. The core distinguishes the
+# two (EC_SHAREDDIR_ERR_*: 1 = missing or not a directory, 2 = unreadable),
+# and a same-host daemon running as another user hits the second one on the
+# 0700 directory mktemp -d just created. Either way the daemon cannot take
+# this path, which is the condition the assertions below depend on.
 SCRATCH_ENC=$(jq -rn --arg p "$SCRATCH_DIR" '$p|@uri')
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
@@ -178,12 +184,15 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: applicat
 SCRATCH_REJECTION=$(printf '%s' "$CURL_BODY" |
 	jq -r "[.rejected[] | select(.path==\"$SCRATCH_DIR\")][0].reason" 2>/dev/null)
 SHARE_FS_VISIBLE=1
-if [ "$SCRATCH_REJECTION" = "not_found" ]; then
+case "$SCRATCH_REJECTION" in
+not_found | not_readable)
 	SHARE_FS_VISIBLE=0
-	echo "  SKIP  the assertions that need amuled to see $SCRATCH_DIR"
-	echo "        (it stats paths itself; run this against a daemon on this host,"
-	echo "         or set the scratch path to one the daemon can reach)"
-fi
+	echo "  SKIP  the assertions that need amuled to take $SCRATCH_DIR ($SCRATCH_REJECTION)"
+	echo "        (it stats paths itself; run this against a daemon on this host"
+	echo "         and as a user that can read the path, or set the scratch path"
+	echo "         to one the daemon can reach)"
+	;;
+esac
 
 if [ "$SHARE_FS_VISIBLE" -eq 1 ]; then
 _assert_status 200 "POST (add scratch dir, recursive) → 200"

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -47,10 +47,15 @@ ADMIN_PASS=${ADMIN_PASS:-adminpass}
 
 FAIL_COUNT=0
 TEST_COUNT=0
+# Skips are counted apart from TEST_COUNT, never folded into it: a skipped
+# section is coverage that did not happen, and adding it to the passed tally
+# would report the absence of a check as a check that succeeded.
+SKIP_COUNT=0
 AUTH=()
 
 _die()  { echo "FATAL: $*" >&2; exit 2; }
 _pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
 _fail() {
 	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
 	echo "  FAIL  $1"
@@ -198,7 +203,7 @@ if [ "${TOTAL:-0}" -gt 0 ]; then
 		_fail "metadata pairing" "$MISMATCH record(s) have one without the other"
 	fi
 else
-	echo "  SKIP  record-shape assertions (the store is empty)"
+	_skip "record-shape assertions (the store is empty)"
 fi
 
 # --- 4b. The store is maintained, not re-read. ---------------------
@@ -226,10 +231,10 @@ if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
 	else
 		# An online but idle peer is legitimately static, and cannot be told
 		# apart from a stale cache here. Only a moving one proves the patch.
-		echo "  SKIP  live-total check (the online peer is not transferring)"
+		_skip "live-total check (the online peer is not transferring)"
 	fi
 else
-	echo "  SKIP  live-total check (no peer is connected)"
+	_skip "live-total check (no peer is connected)"
 fi
 
 # --- 4c. Every connected peer has a row. ---------------------------
@@ -249,7 +254,9 @@ fi
 # ReconcileKnownClientsLocked() skips: the all-zero one is the placeholder a peer
 # reports before sending its real hash, and folding those in would collapse
 # every unidentified peer into one fabricated record.
-LIVE_HASHES=$(curl -s --max-time 10 "${AUTH[@]}" "$HOST/api/v0/clients?limit=500" \
+LIVE_CLIENTS_JSON=$(curl -s --max-time 10 "${AUTH[@]}" "$HOST/api/v0/clients?limit=500")
+LIVE_TOTAL=$(printf '%s' "$LIVE_CLIENTS_JSON" | jq -r '.clients | length' 2>/dev/null)
+LIVE_HASHES=$(printf '%s' "$LIVE_CLIENTS_JSON" \
 	| jq -r '.clients[].user_hash // empty | select(. != "" and (test("^0+$") | not))' | sort -u)
 if [ -n "$LIVE_HASHES" ]; then
 	_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
@@ -274,8 +281,14 @@ if [ -n "$LIVE_HASHES" ]; then
 	else
 		_fail "online flag" "no record is flagged online while peers are connected"
 	fi
+elif [ "${LIVE_TOTAL:-0}" -gt 0 ]; then
+	# Connected, but nothing to look up: every peer is still on the
+	# placeholder hash the filter above drops. Saying "no peer is
+	# connected" here would describe the opposite of what happened, and
+	# this is exactly the population the filter exists for.
+	_skip "per-peer row check ($LIVE_TOTAL peer(s) connected, none identified yet)"
 else
-	echo "  SKIP  per-peer row check (no peer is connected)"
+	_skip "per-peer row check (no peer is connected)"
 fi
 
 # --- 5. Caching. ---------------------------------------------------
@@ -299,8 +312,10 @@ for m in POST PUT DELETE PATCH; do
 done
 
 echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
-	echo "33-known-clients: all $TEST_COUNT assertions passed"
+	echo "33-known-clients: all $TEST_COUNT assertions passed$SKIP_NOTE"
 	exit 0
 fi
 echo "33-known-clients: $FAIL_COUNT of $TEST_COUNT assertions FAILED"

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -40,25 +40,40 @@ ROOT="${AMULEAPI_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 # back to PATH: an installed package would silently be tested in place of the
 # working tree, which is worse than not finding anything. Set AMULEAPI_BIN to
 # point somewhere else on purpose.
+#
+# Any build*/ directory counts, not a fixed list of three: per-branch and
+# per-arch trees are normal, and a name this function has never heard of used
+# to mean a silent skip. Where several exist the NEWEST wins -- picking the
+# first match let a stale build/ supply the binary while the tree under test
+# was built somewhere else, which is the one failure mode that produces a
+# confident wrong answer rather than a missing one. Unmatched globs stay
+# literal and fail the -x test, so no nullglob is needed.
 _find_amuleapi_bin() {
-	local root=$1 c
-	for c in . build build-macos build-linux _build cmake-build-debug cmake-build-release; do
-		if [ -x "$root/$c/src/webapi/amuleapi" ]; then
-			echo "$root/$c/src/webapi/amuleapi"
-			return 0
+	local root=$1 c best=
+	for c in "$root"/src/webapi/amuleapi \
+		"$root"/build*/src/webapi/amuleapi \
+		"$root"/_build/src/webapi/amuleapi \
+		"$root"/cmake-build-*/src/webapi/amuleapi; do
+		[ -x "$c" ] || continue
+		if [ -z "$best" ] || [ "$c" -nt "$best" ]; then
+			best=$c
 		fi
 	done
-	return 1
+	[ -n "$best" ] || return 1
+	echo "$best"
 }
 
 BIN="${AMULEAPI_BIN:-$(_find_amuleapi_bin "$ROOT")}"
-echo "bin=$BIN"
 
 if [ ! -x "$BIN" ]; then
-	echo "FATAL: no usable amuleapi binary (BIN=[$BIN]); looked under $ROOT" >&2
+	echo "FATAL: no usable amuleapi binary under $ROOT." >&2
 	echo "       set AMULEAPI_BIN to point at one." >&2
 	exit 2
 fi
+# Print what was resolved, not what was requested: with several build
+# trees around, which one this run actually exercised is the first thing
+# to check when a result looks wrong.
+echo "bin=$BIN"
 
 # One stable 256-bit JWT secret (64 hex chars) reused by every phase's
 # daemon. See run_phase: a fixed secret makes a brief instance overlap

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -65,6 +65,12 @@ _find_amuleapi_bin() {
 
 BIN="${AMULEAPI_BIN:-$(_find_amuleapi_bin "$ROOT")}"
 
+# The daemon every phase talks to. Overridable so the whole suite can be
+# pointed at a daemon that is not on the stock EC port.
+EC_HOST=${EC_HOST:-127.0.0.1}
+EC_PORT=${EC_PORT:-4712}
+EC_PASSWORD=${EC_PASSWORD:-amule}
+
 if [ ! -x "$BIN" ]; then
 	echo "FATAL: no usable amuleapi binary under $ROOT." >&2
 	echo "       set AMULEAPI_BIN to point at one." >&2
@@ -133,7 +139,7 @@ run_phase() {
 	# amuleapi has no --password: it takes the EC credential from the
 	# ephemeral token the core writes when it spawns amuleapi, or from
 	# amuleapi.conf. Nothing spawns it here, so seed the config file.
-	sed -i'.bak' "s|^Password=.*|Password=amule|" /tmp/amuleapi-regtest/amuleapi.conf
+	sed -i'.bak' "s|^Password=.*|Password=$EC_PASSWORD|" /tmp/amuleapi-regtest/amuleapi.conf
 	rm -f /tmp/amuleapi-regtest/amuleapi.conf.bak
 	# 27-static-frontend exercises the static-frontend serve path. It
 	# plants symlinks + an oversized file into StaticRoot during the
@@ -156,7 +162,7 @@ run_phase() {
 		rm -f /tmp/amuleapi-regtest/amuleapi.conf.bak
 	fi
 	"$BIN" --config-dir=/tmp/amuleapi-regtest \
-		--host=127.0.0.1 --port=4712 \
+		--host="$EC_HOST" --port="$EC_PORT" \
 		> /tmp/amuleapi.log 2>&1 &
 	# Poll /version until the daemon is ready instead of guessing the
 	# cold-start time. The first EC GET_UPDATE roundtrip can take a
@@ -178,6 +184,7 @@ run_phase() {
 	# so the smoke doesn't depend on the operator's library already
 	# holding a shared file. Unset is fine unless a phase needs it.
 	AMULEAPI_BIN="$BIN" \
+	EC_HOST="$EC_HOST" EC_PORT="$EC_PORT" EC_PASSWORD="$EC_PASSWORD" \
 	AMULEAPI_CONFIG_DIR=/tmp/amuleapi-regtest \
 	AMULEAPI_LOG=/tmp/amuleapi.log \
 	AMULE_SHARED_DIR="${AMULE_SHARED_DIR:-}" \


### PR DESCRIPTION
Follow-ups to the review of #1093, plus the suite-wide accounting problem that review surfaced.

**Binary resolution.** `_find_amuleapi_bin` searched a fixed list of seven directories, three of them build trees. Any other name, such as a per-branch or per-arch tree, resolved to nothing, and in 19-search that is a skip rather than a failure, so three sections went missing on a machine that had a perfectly good binary. It now matches `build*/`, and where several candidates exist the newest wins: taking the first match ranked `.` and `build/` ahead of `build-macos`/`build-linux`, so a stale `build/` could supply the second-instance binary while the tree under test was built elsewhere. That is the one failure mode of the three that yields a confident wrong answer instead of a missing one. Unmatched globs stay literal and fail the `-x` test, so no `nullglob` is needed. On the tree this was developed against, which carries a 25-day-old `build-macos` beside a current `build-release`, the old lookup picks the stale one and the new lookup picks the current one.

**Skip accounting.** The suite had three ways of accounting for a skip and only one was honest. 13, 24 and 26 defined `_skip() { TEST_COUNT=$((TEST_COUNT+1)); ... }`, so a skipped check landed in the passed tally and `OK: N/N passed` counted coverage that never ran; 26 went further and reported two skipped checks through `_pass` outright. 04 and 33 emitted bare `echo` lines no counter saw, so their summaries claimed an unqualified pass over a partial run. 19 had the same gap. All of them now use one shape: a `SKIP_COUNT` kept apart from `TEST_COUNT`, a `_skip` helper, and a `SKIP_NOTE` appended to the OK line only. A skipped check is coverage that did not happen, so it is never a pass and never a failure; it is counted and named. 31 already reported its skip and is left alone rather than churned.

**Two fixes in 04 that are not about accounting.** Its new block ran 6b, 6d, 6c in file order; the labels now ascend. And the unknown-hash 404 on `/shared/{hash}/clients` sat inside the "has shared entries" gate although it uses a hash that exists nowhere, so on a daemon sharing nothing, the case the check is most worth having, it never ran. It moves out to join the other missing-hash 404, both now in one section outside the gate.

**Rejection reasons.** 31-shared-directories probed only for `not_found`. The core distinguishes two reasons (`EC_SHAREDDIR_ERR_*`: 1 = missing or not a directory, 2 = unreadable, rendered as `not_found` and `not_readable`), and a daemon on this host running as another user hits the second one on the 0700 directory `mktemp -d` just created, so that setup still failed all of section 4. Both are now treated as the same setup problem, and the one seen is named.

**Peer reporting.** 33-known-clients printed "no peer is connected" whenever the placeholder filter emptied the hash list. When every connected peer is still unidentified, exactly the population that filter was written for, that describes the opposite of what happened. It now reads the client count alongside the hashes and says which case it is.

**Diagnostics.** 25-cors printed `BIN=[]` on a failed resolution and never named the directory it searched; run-all printed `bin=` before deciding whether it had one. Both now report the search root when they fail and the resolved path when they succeed.

The lookup helper stays duplicated across the three scripts rather than moving to a sourced file: self-containment is the convention here, with `_curl` and `_assert_status` duplicated across 32 and 31 scripts respectively, and it is what lets an operator copy one script to a server and run it. The three copies are byte-identical.

**Following the daemon off the stock EC port.** 24-sse-resync and 25-cors each rewrite `amuleapi.conf` and relaunch the daemon mid-script, and both wrote a literal `[EC] Host=127.0.0.1` / `Port=4712` / `Password=amule` plus a literal `Server Port=4713`, then relaunched with `--host=127.0.0.1 --port=4712`. Every other value in those scripts is overridable, so the hardcoding stayed invisible until a daemon sat anywhere else: the rewritten config pointed the relaunched instance at a port with nothing on it and the script died at its own bounce, 24 as "admin login failed after bounce" and 25 as "daemon did not come back up after restart". Neither message names the port. They now take `EC_HOST`/`EC_PORT`/`EC_PASSWORD` with the defaults 19-search already used, and derive the HTTP port from `$HOST` instead of repeating 4713. run-all.sh owns the same three, uses them for its own launch and its password seed, and exports them to every phase, so pointing the whole suite at another daemon is one variable. Against a daemon moved to EC 4912 the current 24 and 25 both abort at the bounce while these pass 11/11 and 21/21.

Verified by a full `run-all.sh` against a daemon connected to ed2k with a populated share directory: all 38 scripts exit 0. The accounting shows up in that run as `OK: 102/102 passed (5 check(s) skipped)` for 04, `OK: 25/25 passed (2 check(s) skipped)` for 13, where it previously claimed 27/27 passed, and `all 40 assertions passed (1 check(s) skipped)` for 33. The eight skips are all environmental: no completed download, no peer transferring, no parts bitmap. 04 on a daemon sharing nothing runs 11 checks against the previous 10, the extra one being the lifted 404. 31 fails 7 of 30 against a `not_readable` scratch directory before this change and passes 19 of 19 with the skip noted after. `bash -n` passes on all 40 scripts in both suites.
