### PR TITLE
perf(amuleapi): skip the SSE diff once nothing is listening

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -172,7 +172,7 @@ curl -N -H "Authorization: Bearer $TOKEN" \
 
 Unknown channel names in the query are silently ignored — forward-compatibility hedge for future event families. The token cap on the filter set is 32 to bound the memory the parser allocates; passing more is silently truncated.
 
-The synthetic `resync` event (see below) is ALWAYS delivered regardless of the filter. Its purpose is to signal a cache invalidation that the client cannot opt out of.
+The `resync` event (see below) is ALWAYS delivered regardless of the filter. Its purpose is to signal a cache invalidation that the client cannot opt out of.
 
 Mirror your filter in the bootstrap: only `GET` the REST collections matching the channels you subscribed to. Pulling a collection whose channel you filtered out leaves that snapshot silently stale — it never receives updates from the stream.
 
@@ -211,13 +211,21 @@ data: {"reason":"gap","since_id":<old cursor>,"newest_id":<new cursor>}
 
 ```
 
-`reason` is `"gap"` (events evicted from the ring before the subscriber read them) or `"restart"` (subscriber's id was past the bus's newest — only possible after a daemon restart). On either, the client's correct response is:
+`reason` is one of:
+
+- `"gap"` — events were evicted from the ring before the subscriber read them.
+- `"restart"` — the subscriber's id was past the bus's newest, only possible after a daemon restart.
+- `"idle"` — the daemon stopped diffing because nothing had been subscribed for several ticks, so no collection change is represented on the bus for that period. A cursor from before it cannot be trusted however in-range it looks — and it may well still be in range, because the chat publisher keeps ids moving regardless.
+
+On any of them, the client's correct response is:
 
 1. Wipe its in-memory cache of whatever REST collections it tracked.
 2. Re-GET those collections from the REST surface.
 3. Continue accepting events from the new id.
 
-Both `since_id` and `newest_id` are uint64. The client never has to compute them — it should treat them as opaque and use `id:` on subsequent events.
+`gap` and `restart` are synthesised per subscriber, at connect, and carry `since_id` and `newest_id` — both uint64, opaque; the client never has to compute them and should use `id:` on subsequent events.
+
+`idle` is published on the bus instead, by the tick that resumes diffing, and carries only `reason`: it is broadcast rather than addressed at one subscriber, so there is no single cursor to report, and the frame's own `id:` is the new one. The order matters — the tick re-establishes its baseline first and announces afterwards, so a client re-GETs against state that is already current. Announcing at connect instead would leave the changes of the intervening tick in neither the client's GET nor any event.
 
 ## Event catalog
 
@@ -582,7 +590,7 @@ Three things produce it: [`DELETE /api/v0/search/{id}`](REFERENCE.md#delete-apiv
 
 ### Filter-bypass: `resync`
 
-The synthetic `resync` event has no underscore prefix — it doesn't belong to any of the channel buckets above and is always delivered regardless of `?channels=`. Documented under [Reconnect and Last-Event-ID](#reconnect-and-last-event-id).
+`resync` has no underscore prefix — it doesn't belong to any of the channel buckets above and is always delivered regardless of `?channels=`, whether it was synthesised for one subscriber or published on the bus. Documented under [Reconnect and Last-Event-ID](#reconnect-and-last-event-id).
 
 ## Single-publisher invariant
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -10409,11 +10409,12 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 	auto event_channel = [](const std::string &name) -> std::string {
 		// Event naming convention: every bus event MUST contain at
 		// least one underscore — the prefix before the first `_`
-		// identifies the channel. The only no-underscore name on
-		// the wire is `resync`, which bypasses this filter entirely
-		// (synthetic per-subscriber, never via EventBus::Publish).
-		// Future bare-token events need explicit channel mapping or
-		// must always bypass like `resync`.
+		// identifies the channel. The only no-underscore name is
+		// `resync`, which the caller bypasses by name: it reaches the
+		// wire both synthesised per subscriber and published on the
+		// bus, and a cache invalidation is not opt-out-able either
+		// way. Future bare-token events need explicit channel mapping
+		// or must always bypass like `resync`.
 		const auto us = name.find('_');
 		if (us == std::string::npos)
 			return name;
@@ -10444,6 +10445,11 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 	auto event_passes_filter = [&](const std::string &name) {
 		if (!channels_set)
 			return true;
+		// A cache invalidation is not opt-out-able, and this one arrives over
+		// the bus rather than synthesised per subscriber, so it has to bypass
+		// here as well as in the reconnect path.
+		if (name == "resync")
+			return true;
 		return channel_filter.count(event_channel(name)) > 0;
 	};
 
@@ -10462,11 +10468,16 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 	//  - parsed > NewestId → stale id from a prior daemon process
 	//    (ids reset to 1 on restart); emit `resync` (reason=restart)
 	//    and start from NewestId.
+	// Registers this session for the life of the stream, so the refresher knows
+	// to resume diffing.
+	webapi::CEventBus::Subscription subscription(m_app.EventBus());
+
 	std::uint64_t since_id;
 	const std::string lei = FindHeaderCaseInsensitive(req.headers, "Last-Event-ID");
 	const std::uint64_t newest = m_app.EventBus().NewestId();
 	const std::uint64_t oldest = m_app.EventBus().OldestId();
 	if (lei.empty()) {
+		// No cursor to invalidate: the client GETs the collections itself.
 		since_id = newest;
 	} else {
 		char *end = nullptr;

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -593,6 +593,14 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 	constexpr unsigned kEcFailExitAfter = 300;
 	unsigned ec_consecutive_failures = 0;
 	bool ec_warn_logged = false;
+	// Diffing stops only after a few consecutive ticks with nothing
+	// subscribed. A client that drops and comes straight back -- a page
+	// reload, a proxy hiccup -- must not suspend anything: resuming costs it
+	// the `resync` below, and re-seeding every collection is the most
+	// expensive thing this daemon can be asked to do. Ticks inside the grace
+	// keep publishing, so the returning client replays them instead.
+	constexpr unsigned kIdleTicksBeforeSuspend = 5;
+	unsigned idle_ticks = 0;
 	while (!g_shutdownRequested.load(std::memory_order_acquire)) {
 		const auto cycle_start = std::chrono::steady_clock::now();
 		if (was_failed) {
@@ -608,7 +616,27 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 			// here, NOT inside RefresherTick — so mutation handlers
 			// calling RefresherTick inline from the HTTP thread
 			// don't race with this loop's diff walk.
-			webapi::EmitDiffsForEventBus(*this, m_state);
+			//
+			// Skipped once nothing has been subscribed for a while --
+			// see CEventBus's subscriber accounting. The first tick
+			// back re-baselines silently and then announces, instead
+			// of emitting one event per record.
+			if (m_event_bus->SubscriberCount() == 0) {
+				if (idle_ticks < kIdleTicksBeforeSuspend) {
+					++idle_ticks;
+					webapi::EmitDiffsForEventBus(*this, m_state);
+				} else {
+					m_event_bus->MarkSuspended();
+				}
+			} else {
+				idle_ticks = 0;
+				if (m_event_bus->TakeSuspended()) {
+					webapi::PrimeDiffBaseline(*this, m_state);
+					m_event_bus->Publish("resync", "{\"reason\":\"idle\"}");
+				} else {
+					webapi::EmitDiffsForEventBus(*this, m_state);
+				}
+			}
 		} else {
 			m_state.MarkTickFailure();
 			was_failed = true;

--- a/src/webapi/EventBus.cpp
+++ b/src/webapi/EventBus.cpp
@@ -175,4 +175,15 @@ bool CEventBus::IsShutdown() const
 	return m_shutdown.load(std::memory_order_acquire);
 }
 
+CEventBus::Subscription::Subscription(CEventBus &bus)
+: m_bus(bus)
+{
+	m_bus.m_subscribers.fetch_add(1, std::memory_order_acq_rel);
+}
+
+CEventBus::Subscription::~Subscription()
+{
+	m_bus.m_subscribers.fetch_sub(1, std::memory_order_acq_rel);
+}
+
 } // namespace webapi

--- a/src/webapi/EventBus.h
+++ b/src/webapi/EventBus.h
@@ -142,6 +142,44 @@ public:
 	// between Drain calls and exit cleanly.
 	bool IsShutdown() const;
 
+	// --- Subscriber accounting ---------------------------------------
+	//
+	// A tick's diff means snapshotting every collection and comparing it with
+	// the previous tick, which on a large library is most of the refresher's
+	// work. Once nothing has been subscribed for a few ticks there is nobody to
+	// send the result to, so the refresher skips it and records that
+	// (MarkSuspended). Nothing is lost -- subscribers read the same state over
+	// REST -- but no collection change is represented on the bus for that
+	// period, and a client reconnecting with a Last-Event-ID cannot tell: its
+	// cursor can even still be in range, since the chat publisher runs outside
+	// this gate and keeps ids moving. The tick that resumes publishes a
+	// `resync` for that, after re-baselining, so a client re-GETs against a
+	// baseline that is already current -- emitting it at connect instead would
+	// leave a tick's worth of changes in neither the GET nor an event.
+
+	// RAII registration for one SSE session.
+	class Subscription
+	{
+	public:
+		explicit Subscription(CEventBus &bus);
+		~Subscription();
+		Subscription(const Subscription &) = delete;
+		Subscription &operator=(const Subscription &) = delete;
+
+	private:
+		CEventBus &m_bus;
+	};
+
+	std::size_t SubscriberCount() const { return m_subscribers.load(std::memory_order_acquire); }
+
+	// Record that a tick's diff was skipped for want of a subscriber.
+	void MarkSuspended() { m_suspended.store(true, std::memory_order_release); }
+
+	// Read and clear the suspended flag. True obliges the refresher to
+	// re-baseline silently first: diffing against a pre-idle snapshot would
+	// emit one event per record.
+	bool TakeSuspended() { return m_suspended.exchange(false, std::memory_order_acq_rel); }
+
 private:
 	const std::size_t m_capacity;
 	mutable std::mutex m_mu;
@@ -149,6 +187,8 @@ private:
 	std::deque<Event> m_ring;
 	std::atomic<std::uint64_t> m_next_id{ 1 };
 	std::atomic<bool> m_shutdown{ false };
+	std::atomic<std::size_t> m_subscribers{ 0 };
+	std::atomic<bool> m_suspended{ false };
 };
 
 } // namespace webapi

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -80,6 +80,11 @@ SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state, std::uin
 // diff on the next 1-second tick instead of immediately.
 void EmitDiffsForEventBus(CamuleapiApp &app, const CState &state);
 
+// Bring the diff baseline up to the current state without publishing. Used on
+// the first tick after diffs were skipped, which would otherwise emit one event
+// per record; whoever subscribed during the gap gets `resync` instead.
+void PrimeDiffBaseline(CamuleapiApp &app, const CState &state);
+
 // Sub-tick helpers exposed for testing. The Refresher uses these
 // internally; the unit test calls them against hand-crafted
 // CECPacket fixtures to pin the EC-tag-to-State mapping without

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -389,4 +389,12 @@ void EmitDiffsForEventBus(CamuleapiApp &app, const CState &state)
 	EmitDiffsAndUpdate(app.EventBus(), app.LastSeenForEvents(), state);
 }
 
+void PrimeDiffBaseline(CamuleapiApp &app, const CState &state)
+{
+	// Same walk into a bus nobody reads -- diverting the events is what keeps
+	// this short, instead of a `publish` flag through every emitter.
+	CEventBus scratch(CEventBus::kMinCapacity);
+	EmitDiffsAndUpdate(scratch, app.LastSeenForEvents(), state);
+}
+
 } // namespace webapi

--- a/unittests/curl-tests/amuleapi/23-sse-replay.sh
+++ b/unittests/curl-tests/amuleapi/23-sse-replay.sh
@@ -103,6 +103,12 @@ fi
 
 # Trigger one more mutation while NO subscriber is open. This event
 # must be replayed to SSE2 once it reconnects with Last-Event-ID.
+#
+# The 4 s gap below is deliberately inside the refresher's grace period for
+# an unsubscribed bus: it keeps diffing for a few ticks so a client that
+# drops and returns replays instead of resyncing. A longer gap here would
+# suspend the diff, and the assertion would then be testing the opposite
+# contract -- covered by 24-sse-resync's `idle` case.
 echo "    info: DELETE while disconnected..."
 curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads/$TEST_HASH" > /dev/null

--- a/unittests/curl-tests/amuleapi/24-sse-resync.sh
+++ b/unittests/curl-tests/amuleapi/24-sse-resync.sh
@@ -115,8 +115,19 @@ ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 # its next tick — guarantee OldestId climbs above 1. Each op is spaced
 # past one tick so the refresher can't coalesce an add+delete pair
 # into a no-op. End on a delete so the queue is clean for test 4.
+#
+# A subscriber has to be attached for all of it. The refresher stops diffing
+# once nothing has been subscribed for a few ticks, and this loop runs for
+# ~17 s, so without one the ring would never rotate and the gap case below
+# would be unreachable -- Last-Event-ID: 1 would land above an empty bus's
+# newest and report `restart` instead.
 FILL_LINK="ed2k://|file|ubuntu-24.04.4-desktop-amd64.iso|6655619072|0031C9CBA65C50DD2015C184B2CA2C88|/"
 FILL_HASH="0031c9cba65c50dd2015c184b2ca2c88"
+FILL_SUB=$(mktemp -t amuleapi_24_fillsub.XXXXXX)
+(curl -s -m 30 -N -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/events" > "$FILL_SUB" 2>&1) &
+FILL_PID=$!
+sleep 1
 for _ in 1 2 3 4; do
 	curl -s -o /dev/null -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 		-H "Content-Type: application/json" \
@@ -126,8 +137,12 @@ for _ in 1 2 3 4; do
 		"$HOST/api/v0/downloads/$FILL_HASH"
 	sleep 2
 done
-# Final settle so the last download_removed is in the ring.
+# Final settle so the last download_removed is in the ring, then drop the
+# subscriber that kept the refresher diffing.
 sleep 1
+kill $FILL_PID 2>/dev/null
+wait $FILL_PID 2>/dev/null
+rm -f "$FILL_SUB"
 
 # --- 1. resync(reason=gap) — Last-Event-ID below OldestId. -------
 #
@@ -273,6 +288,60 @@ if [ "$LOG_EVENT_COUNT" -ge 1 ]; then
 	fi
 else
 	_skip "log_appended observable in smoke window (amuled logs are sparse; EventDiffTest covers the wiring)"
+fi
+
+# --- 5. resync(reason=idle) — the diff was skipped while nobody -----
+# was subscribed, so no cursor from before that period is meaningful even
+# when it is still in range. Published on the bus by the tick that resumes,
+# after it re-establishes its baseline, rather than synthesised at connect:
+# announcing first would put the client's re-GET before the baseline was
+# rebuilt and lose whatever changed in between.
+#
+# Also asserts the filter bypass. `resync` carries no channel prefix, so a
+# subscriber that asked for one unrelated channel must still receive it --
+# a cache invalidation is not something a client can opt out of.
+#
+# The cursor starts in range, because `idle` is precisely the case where a
+# client's id is valid and still cannot be trusted -- but it may not stay that
+# way. The ring is 16 slots (EventBusRingCapacity=4 is clamped up to
+# CEventBus::kMinCapacity), test 4 leaves the ISO in the queue so every tick
+# publishes, and the grace ticks below keep publishing while nobody is
+# subscribed. On a daemon with a source or two that is enough to evict the
+# cursor, in which case connecting also synthesises a `resync(gap)` first. So
+# scan every resync frame for the one this section is about rather than taking
+# the first.
+: > "$SSE"
+(curl -s -m 4 -N -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/events" >> "$SSE" 2>&1) &
+PID=$!
+sleep 3
+kill $PID 2>/dev/null
+wait $PID 2>/dev/null
+IDLE_CURSOR=$(grep "^id: " "$SSE" | tail -1 | sed 's/^id: //')
+[ -n "$IDLE_CURSOR" ] || IDLE_CURSOR=1
+
+echo "    info: idling past the suspend threshold (cursor $IDLE_CURSOR)..."
+sleep 9
+
+: > "$SSE"
+(curl -s -m 6 -N \
+	-H "Last-Event-ID: $IDLE_CURSOR" \
+	-H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/events?channels=servers" >> "$SSE" 2>&1) &
+PID=$!
+sleep 4
+kill $PID 2>/dev/null
+wait $PID 2>/dev/null
+
+RESYNCS=$(awk '/^event: resync$/{f=1;next} f&&/^data: /{sub(/^data: /,"");print;f=0}' "$SSE")
+IDLE_DATA=$(printf '%s\n' "$RESYNCS" | jq -c 'select(.reason == "idle")' 2>/dev/null | head -1)
+if [ -n "$IDLE_DATA" ]; then
+	_pass "resync(idle) fires on reconnect after the diff was suspended"
+	_pass "resync(idle) reached a subscriber filtered to ?channels=servers (bypass holds)"
+else
+	_fail "resync(idle) event" \
+		"no resync frame with reason=idle after idling past the threshold" \
+		"cursor was $IDLE_CURSOR; resync frames seen: $(printf '%s' "$RESYNCS" | tr '\n' ' ')"
 fi
 
 # --- Summary. -----------------------------------------------------


### PR DESCRIPTION
EmitDiffsForEventBus ran on every tick regardless of whether anything was subscribed. The diff snapshots every collection and compares it against the previous tick, which on a large library is most of what the refresher thread does: measured on an 11 906-file node with no client connected at all, that thread accounted for 96 % of the process's CPU (647 of 673 ticks per minute), producing events nobody would ever read. Gated on a subscriber count kept on the bus itself, via an RAII Subscription the SSE handler holds for the life of the stream, that idle cost drops to 56 ticks per 40 s from 385.

The gate waits for five consecutive unsubscribed ticks rather than one. A client that drops and comes straight back -- a page reload, a proxy hiccup -- would otherwise suspend the diff and be told to resync on return, and re-seeding every collection is the most expensive thing this daemon can be asked to do. Ticks inside the grace keep publishing, so the returning client replays them instead. Genuine idleness is measured in minutes, so the CPU win is unaffected.

Suspending has one observable consequence: no collection change is represented on the bus for that period, and a client reconnecting with a Last-Event-ID cannot tell. Its cursor can even still be in range, because the chat publisher runs outside this gate and keeps ids moving. The tick that resumes answers that -- it re-establishes the diff baseline and then publishes `resync` with a third reason, "idle", beside "gap" and "restart".

Re-baselining is not optional: without it the first live tick would diff against a pre-idle snapshot and emit one event per record. PrimeDiffBaseline re-runs the same walk with the events directed into a throwaway bus, which brings the baseline up to date without publishing and without a `publish` flag threaded through every emitter.

The order of those two steps is the correctness argument. Announcing at connect -- which is where the other two reasons are synthesised, per subscriber -- would put the client's re-GET before the baseline was rebuilt, so a change landing in between would be absorbed silently by the priming and appear in neither the GET nor any later event. A `shared_removed` lost that way leaves a ghost row until something else touches the file. Publishing after the priming closes the window by construction. It also means a client that connected without a cursor needs the resync just as much as one that resumed: it is in the same window, having GET the collections before the baseline was rebuilt.

Being on the bus rather than synthesised also means it now goes through the `?channels=` filter, which maps a bare token to itself and would have dropped it. EVENTS.md promises in two places that resync is never filtered, so the filter bypasses it by name.

Tests: 24-sse-resync now holds a subscriber open across its ring-fill loop. That loop runs ~17 s with nothing attached, so the diff would suspend partway, the ring would never rotate, and its `gap` case would silently become a `restart` case. A fifth section covers `reason:"idle"` end to end -- idle past the threshold, reconnect on a cursor the reconnect path accepts, and assert the frame reaches a subscriber filtered to an unrelated channel. It scans every resync frame rather than the first: the ring is 16 slots (the configured 4 is clamped up to kMinCapacity), the grace ticks keep publishing while nobody is subscribed, and on a daemon with a source or two that evicts the cursor, so connecting synthesises a `resync(gap)` ahead of the one being asserted. 23-sse-replay's four-second gap is inside the grace period and so still replays rather than resyncs; that dependency is now written down at the site instead of holding by accident.