### PR TITLE
fix(web-ui): cap virtual tables on phones, show a loading state

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -393,7 +393,15 @@ table.data.virtual td.name .name-select { width: 100%; max-width: 100%; }
 .placeholder {
   padding: 40px 16px; text-align: center; color: var(--text-dim);
 }
-.placeholder-loading::after { content: ""; }
+/* kind="loading" grows a spinner; order:-1 puts it above the text. */
+.placeholder-loading { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+.placeholder-loading::after {
+  content: ""; order: -1; width: 22px; height: 22px; border-radius: 50%;
+  border: 2px solid var(--border); border-top-color: var(--accent);
+  animation: spin 700ms linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .placeholder-loading::after { animation: none; } }
 .placeholder-error { color: var(--bad); }
 
 /* --- cards / forms --- */
@@ -874,7 +882,11 @@ table.data.virtual td.name .name-select { width: 100%; max-width: 100%; }
   .split-view .net-pane, .split-view .net-pane-body, .split-top > .card, .split-view > .card,
   .fill-view .pane-fill, .fill-view .pane-fill .net-pane-body { flex: 0 0 auto; }
   .splitter { display: none; }
-  .split-view .table-wrap.virtual, .fill-view .table-wrap.virtual { flex: none; min-height: 0; max-height: 60vh; }
+  /* !important beats the inline max-height VirtualTable writes ("none" for
+     these callers, since the flex rules above own the height on desktop).
+     Uncapped, the wrap grows to fit every row and the row window — computed
+     from clientHeight — renders the whole list. */
+  .split-view .table-wrap.virtual, .fill-view .table-wrap.virtual { flex: none; min-height: 0; max-height: 60vh !important; }
   /* Networks: no splitter on phones — restore the inter-pane gap, let the
      bottom pane flow, and give the log box back its own height cap. */
   .net-split { gap: 16px; }

--- a/src/webapi/static/js/components.js
+++ b/src/webapi/static/js/components.js
@@ -32,6 +32,15 @@ export function Placeholder({ kind, children }) {
   return html`<div class=${"placeholder placeholder-" + kind}>${children}</div>`;
 }
 
+// Body of a list that has no rows. A `data` collection reads undefined until
+// its snapshot lands and [] once it is known empty; the caller passes that as
+// `loading` so a pending fetch doesn't claim "nothing here yet".
+export function listPlaceholder(loading, emptyMsg) {
+  return loading
+    ? html`<${Placeholder} kind="loading">${t("app_loading")}<//>`
+    : html`<${Placeholder} kind="info">${emptyMsg}<//>`;
+}
+
 // Relative, like BASE in api.js: it has to survive a reverse-proxy subpath.
 const FLAG_BASE = window.location.pathname.replace(/\/?$/, "/") + "flags/";
 const REGIONS = (() => {

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -67,6 +67,9 @@ export const data = {
     seedBuffers.clear();
     collections.clear();
     listenersAttached.clear();
+    // Unpublish the rows too, so after the next login a view spins instead of
+    // showing the dead session's list until the new snapshot lands.
+    for (const k of active) store.set(k, undefined);
     active.clear();
     statusActive = false;
     sseFails = 0;
@@ -98,6 +101,11 @@ async function seed(key) {
     publish(key);
   } catch (e) {
     console.error("seed " + key + " failed", e);
+    // An unset key means "still loading", so a first seed that never lands
+    // would spin forever: fall back to empty (the poll loop retries). Guarded
+    // on unset so a failed refresh() keeps its rows, and on active so a 401 —
+    // which runs stop() before rejecting here — stays torn down.
+    if (active.has(key) && store.get(key) === undefined) store.set(key, []);
   } finally {
     seedBuffers.delete(key); // flip to direct-apply
   }

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -6,7 +6,7 @@
 import { api } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { Badge, Placeholder, CountryCell, toast } from "../components.js";
+import { Badge, listPlaceholder, CountryCell, toast } from "../components.js";
 import { searches } from "../searches.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker, ipNum } from "../table.js";
 import { formatBytes, formatSpeed } from "../format.js";
@@ -113,13 +113,15 @@ export const IDENT_FILTERS = ["all", ...IDENT_STATES].map((v) => [v, t("download
 // Live `clients` collection (GET /clients seed + SSE client_added/updated/
 // removed). register/ensure are idempotent, so every consumer can just call
 // this; the resource starts on the first mount and stays live from then on.
+// Returns the raw store value: undefined until the first snapshot lands, []
+// once there are known to be no peers (see ClientTable's `loading`).
 export function useClients() {
   useEffect(() => {
     data.register({ key: "clients", eventPrefix: "client", id: "ecid",
       list: () => api.get("clients").then((r) => r.clients || []) });
     data.ensure("clients");
   }, []);
-  return useStore("clients") || [];
+  return useStore("clients");
 }
 
 // Compact status icons (replacing the ident/obfuscation/friend columns). Each
@@ -157,7 +159,10 @@ export function stateBadge(s) {
 // (biggest transfer first), so only the column key is a prop. `toolbar` is
 // whatever filter controls the caller wants left of the picker. Returns the
 // two siblings so the caller keeps owning the layout box around them.
-export function ClientTable({ rows, prefsKey, defaultHidden, defaultSort, toolbar, toolbarCls = "toolbar" }) {
+// `loading` (useClients() still undefined) makes empty `rows` mean "not seeded
+// yet" rather than "no peers".
+export function ClientTable({ rows, prefsKey, defaultHidden, defaultSort, toolbar, toolbarCls = "toolbar",
+                              loading = false }) {
   const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
     useTablePrefs(prefsKey, { sortKey: defaultSort, sortDir: -1, hidden: defaultHidden });
 
@@ -179,7 +184,7 @@ export function ClientTable({ rows, prefsKey, defaultHidden, defaultSort, toolba
                      sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                      widths=${widths} onResize=${setWidth}
                      maxHeight="none"
-                     empty=${html`<${Placeholder} kind="info">${t("downloads_peer_empty")}<//>`} />`;
+                     empty=${listPlaceholder(loading, t("downloads_peer_empty"))} />`;
 }
 
 // Per-file peer table for the detail panels. Rows are the live clients whose
@@ -193,14 +198,14 @@ export function FileClients({ hash, prefsKey, defaultHidden, defaultSort }) {
   const [ident, setIdent] = useState("all");
   const [q, setQ] = useState("");
 
-  let rows = clients.filter((c) => c.download_file_hash === hash || c.upload_file_hash === hash);
+  let rows = (clients || []).filter((c) => c.download_file_hash === hash || c.upload_file_hash === hash);
   if (ident !== "all") rows = rows.filter((c) => c.ident_state === ident);
   if (q) { const match = textMatcher(q); rows = rows.filter((c) => match((c.name || "") + " " + fileNameOf(c))); }
 
   return html`
     <div class="detail-clients">
       <${ClientTable} rows=${rows} prefsKey=${prefsKey} defaultHidden=${defaultHidden}
-                      defaultSort=${defaultSort}
+                      defaultSort=${defaultSort} loading=${clients === undefined}
                       toolbar=${ClientFilters({ ident, setIdent, q, setQ })} />
     </div>`;
 }

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -22,7 +22,8 @@ const TAB_HIDDEN = {
 const TAB_SORT = { all: "downloaded", downloads: "downloaded", uploads: "uploaded" };
 
 export default function ClientsPanel() {
-  const clients = useClients();
+  const raw = useClients(); // undefined until the first snapshot lands
+  const clients = raw || [];
   const [filter, setFilter] = useState("all"); // direction tab: all / downloads / uploads
   const [ident, setIdent] = useState("all");
   const [q, setQ] = useState("");
@@ -52,6 +53,7 @@ export default function ClientsPanel() {
         <div class="net-pane-body">
           <${ClientTable} key=${filter} rows=${list} prefsKey=${"clients_" + filter}
                           defaultHidden=${TAB_HIDDEN[filter]} defaultSort=${TAB_SORT[filter]}
+                          loading=${raw === undefined}
                           toolbarCls="toolbar pane-toolbar"
                           toolbar=${ClientFilters({ ident, setIdent, q, setQ })} />
         </div>

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -40,7 +40,7 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
 
   if (!hash) return null;
   if (gone) return html`<div class="detail-panel"><${Placeholder} kind="info">${t("downloads_detail_gone")}<//></div>`;
-  if (!detail) return html`<div class="detail-panel"><${Placeholder} kind="info">${t("downloads_detail_loading")}<//></div>`;
+  if (!detail) return html`<div class="detail-panel"><${Placeholder} kind="loading">${t("downloads_detail_loading")}<//></div>`;
 
   const d = detail;
   const src = d.sources || {};

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -6,7 +6,7 @@
 import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { ProgressBar, Badge, Placeholder, Tabs, toast, confirmDialog, PRIORITIES, prioValue, prioLabel } from "../components.js";
+import { ProgressBar, Badge, listPlaceholder, Tabs, toast, confirmDialog, PRIORITIES, prioValue, prioLabel } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatFreeSpace, formatSpeed } from "../format.js";
 import { Icon } from "../icons.js";
@@ -19,7 +19,11 @@ const STATUS_FILTERS = ["all", "downloading", "waiting", "paused", "stopped", "c
   .map((v) => [v, t("downloads_status_" + v)]);
 
 export default function Downloads({ isGuest }) {
-  const downloads = useStore("downloads") || [];
+  // undefined until the first snapshot lands, [] once the queue is known
+  // empty; listPlaceholder tells the two apart.
+  const rawDownloads = useStore("downloads");
+  const downloads = rawDownloads || [];
+  const loading = rawDownloads === undefined;
   // Not bound as `status`: bulk() below already uses that name for a partfile state.
   const disk = (useStore("status") || {}).disk || {};
   const [categories, setCategories] = useState([]);
@@ -274,10 +278,11 @@ export default function Downloads({ isGuest }) {
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort} onRowClick=${onRowClick}
                          widths=${widths} onResize=${setWidth}
                          maxHeight="none"
-                         empty=${html`<${Placeholder} kind="info">${t("downloads_empty")}<//>`} />
+                         empty=${listPlaceholder(loading, t("downloads_empty"))} />
+        ${loading ? null : html`
         <div class="totals-line">
           <span>${tn("downloads_files_count", list.length)}</span>${" · "}<span>${t("downloads_size")} ${formatBytes(size)}</span>${" · "}<span>${t("downloads_col_done")} ${formatBytes(done)}</span>${" · "}<span>${t("downloads_speed")} ${formatSpeed(speed)}</span>${freeSpace ? html`${" · "}<span>${t("common_free_space")} ${freeSpace}</span>` : ""}
-        </div>
+        </div>`}
       </div>
     </section>`}>
         <${DownloadDetail} hash=${detailHash} isGuest=${isGuest} categories=${categories}

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -10,7 +10,7 @@ import { api } from "../api.js";
 import { data } from "../events.js";
 import { store } from "../store.js";
 import { html, useState, useEffect, useRef, useStore } from "../dom.js";
-import { Tabs, Placeholder, toast, confirmDialog, CountryCell } from "../components.js";
+import { Tabs, listPlaceholder, toast, confirmDialog, CountryCell } from "../components.js";
 import { VirtualTable, sortRows, useTablePrefs, ColumnPicker, ipNum } from "../table.js";
 import { Chart } from "../charts.js";
 import { formatInt, formatTimestamp } from "../format.js";
@@ -124,7 +124,11 @@ function NetworkConnectButton({ network }) {
 
 // --- ED2K tab: server list, live via the SSE "servers" channel ------------
 function ServersPanel({ isGuest }) {
-  const servers = useStore("servers") || [];
+  // undefined until the first snapshot lands, [] once the list is known
+  // empty; listPlaceholder tells the two apart.
+  const rawServers = useStore("servers");
+  const servers = rawServers || [];
+  const loading = rawServers === undefined;
   const status = useStore("status");
   const ed2k = status && status.ed2k;
   const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
@@ -276,7 +280,7 @@ function ServersPanel({ isGuest }) {
     <${VirtualTable} columns=${shown} rows=${list} rowKey=${(s) => s.ecid} rowClass=${rowClass}
                      sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                      widths=${widths} onResize=${setWidth}
-                     empty=${html`<${Placeholder} kind="info">${t("networks_server_empty")}<//>`} />`;
+                     empty=${listPlaceholder(loading, t("networks_server_empty"))} />`;
 }
 
 // --- Kad tab: connect toggle, bootstrap, live nodes graph -----------------

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -5,7 +5,7 @@
 
 import { api } from "../api.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { Badge, Placeholder, Tabs, CommentsList, ratingLabel, toast } from "../components.js";
+import { Badge, Placeholder, listPlaceholder, Tabs, CommentsList, ratingLabel, toast } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatDuration, formatInt } from "../format.js";
 import { Icon } from "../icons.js";
@@ -359,7 +359,7 @@ function ResultsPane({ tab, categories }) {
                      sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort}
                      widths=${widths} onResize=${setWidth}
                      maxHeight="none"
-                     empty=${html`<${Placeholder} kind="info">${t("search_empty")}<//>`} />
+                     empty=${listPlaceholder(running, t("search_empty"))} />
     ${commentsFor ? html`<${ResultComments} result=${commentsFor} onClose=${() => setCommentsFor(null)} />` : null}`;
 }
 

--- a/src/webapi/static/js/views/shared-detail.js
+++ b/src/webapi/static/js/views/shared-detail.js
@@ -58,7 +58,7 @@ export function SharedDetail({ hash }) {
 
   if (!hash) return null;
   if (gone) return html`<div class="detail-panel"><${Placeholder} kind="info">${t("shared_detail_gone")}<//></div>`;
-  if (!detail) return html`<div class="detail-panel"><${Placeholder} kind="info">${t("shared_detail_loading")}<//></div>`;
+  if (!detail) return html`<div class="detail-panel"><${Placeholder} kind="loading">${t("shared_detail_loading")}<//></div>`;
 
   const s = detail;
   const media = s.media;

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -7,7 +7,7 @@
 import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { Placeholder, toast, confirmDialog } from "../components.js";
+import { listPlaceholder, toast, confirmDialog } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatFreeSpace, formatInt, formatSpeed, formatTimestamp, twin } from "../format.js";
 import { t, tn, terr } from "../i18n.js";
@@ -18,7 +18,11 @@ const PRIORITIES = ["auto", "very_low", "low", "normal", "high", "release"]
   .map((v) => [v, t("shared_prio_" + v)]);
 
 export default function Shared({ isGuest }) {
-  const shared = useStore("shared") || [];
+  // undefined until the first snapshot lands, [] once the share is known
+  // empty; listPlaceholder tells the two apart.
+  const rawShared = useStore("shared");
+  const shared = rawShared || [];
+  const loading = rawShared === undefined;
   const disk = (useStore("status") || {}).disk || {};
   const [selection, setSelection] = useState(() => new Set());
   const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
@@ -201,10 +205,11 @@ export default function Shared({ isGuest }) {
                          sortKey=${sortKey} sortDir=${sortDir} onSort=${toggleSort} onRowClick=${onRowClick}
                          widths=${widths} onResize=${setWidth}
                          maxHeight="none"
-                         empty=${html`<${Placeholder} kind="info">${t("shared_empty")}<//>`} />
+                         empty=${listPlaceholder(loading, t("shared_empty"))} />
+        ${loading ? null : html`
         <div class="totals-line">
           <span>${tn("shared_files_count", list.length)}</span>${" · "}<span>${t("shared_size")} ${formatBytes(size)}</span>${" · "}<span>${t("shared_transferred")} ${formatBytes(xs) + " / " + formatBytes(xt)}</span>${" · "}<span>${t("shared_upload_speed")} ${formatSpeed(up)}</span>${freeSpace ? html`${" · "}<span>${t("common_free_space")} ${freeSpace}</span>` : ""}
-        </div>
+        </div>`}
     </section>`}>
         <${SharedDetail} hash=${detailHash} />
       <//>


### PR DESCRIPTION
A share of 11906 files made the Shared files page hang on a phone and look empty for seconds on the desktop. Two independent causes, both fixed here.

Virtualization silently switched itself off on narrow viewports. VirtualTable writes its maxHeight prop as an inline style, and shared, downloads, search and the peer table all pass "none" because on desktop the .split-view / .fill-view flex rules own the height. Under @media (max-width: 860px) that flex is turned off and the 60vh cap was supposed to take over, but a stylesheet declaration cannot beat an inline one: the wrap grew to fit every row (452 000 px measured), and the row window, computed from clientHeight, rendered the whole list -- 11906 rows, 238 378 DOM nodes, ~88 s of blocked main thread, re-diffed twice a second by the SSE publish throttle, so it never recovered. Marking that cap !important restores the invariant that the wrap is always a bounded scroll container, and cannot be defeated by a future call site. Measured after: 22 rows, 701 nodes, 1 ms.

The lists also could not tell "not seeded yet" from "empty". A collection from the data layer reads undefined until its snapshot lands and [] once it is known empty, and every view collapsed both with `|| []`, so during the fetch the table claimed "Nothing here yet." next to a "0 files" totals line -- 7 s of it on a throttled link. Views now keep the distinction and pass it to a new listPlaceholder() helper, which picks a spinner or the caller's empty message; the totals line is hidden while loading. Search reuses the `running` flag it already had, and the peer table takes it as a prop so both of its consumers stay correct. .placeholder-loading::after was an empty hook, so it also grows an actual spinner (honouring prefers-reduced-motion), which every existing kind="loading" site inherits. The text reuses the existing app_loading key, so no new translations.

Two guards keep the new state honest: a first seed that fails publishes once so the view falls back to the empty state instead of spinning forever, and stop() unpublishes the rows so a re-login shows the spinner rather than the dead session's list.

Verified with chrome-devtools on all five table views at 390x844 (cap 506 px, 17-22 rows, scrolling still virtualized) and on the loading path with the response delayed and with it failing.